### PR TITLE
[FLINK-9563]: Using a custom sink function for tests in CEPITCase instead of writing to disk

### DIFF
--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -206,7 +206,7 @@ public class CEPITCase extends AbstractTestBase {
 			Tuple2.of(new Event(4, "end", 4.0), 10L),
 			Tuple2.of(new Event(5, "middle", 5.0), 7L),
 			// last element for high final watermark
-			Tuple2.of(new Event(6, "middle", 5.0), 100L)
+			Tuple2.of(new Event(5, "middle", 5.0), 100L)
 		).assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Tuple2<Event, Long>>() {
 
 			@Override
@@ -345,8 +345,8 @@ public class CEPITCase extends AbstractTestBase {
 					StringBuilder builder = new StringBuilder();
 
 					builder.append(pattern.get("start").get(0).getId()).append(",")
-							.append(pattern.get("middle").get(0).getId()).append(",")
-							.append(pattern.get("end").get(0).getId());
+						.append(pattern.get("middle").get(0).getId()).append(",")
+						.append(pattern.get("end").get(0).getId());
 
 					return builder.toString();
 				}
@@ -497,8 +497,12 @@ public class CEPITCase extends AbstractTestBase {
 
 		resultList.sort(Comparator.comparing(either -> either.toString()));
 
-		List<Either<String, String>> expected = Arrays.asList(Either.Left.of("1.0"), Either.Left.of("2.0"),
-												Either.Left.of("2.0"), Either.Right.of("2.0,2.0,2.0"));
+		List<Either<String, String>> expected = Arrays.asList(
+			Either.Left.of("1.0"),
+			Either.Left.of("2.0"),
+			Either.Left.of("2.0"),
+			Either.Right.of("2.0,2.0,2.0")
+		);
 
 		assertEquals(expected, resultList);
 	}
@@ -567,7 +571,12 @@ public class CEPITCase extends AbstractTestBase {
 
 		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		List<String> expected = Arrays.asList("1,5,6\n1,2,3\n4,5,6\n1,2,6".split("\n"));
+		List<String> expected = Arrays.asList(
+			"1,5,6",
+			"1,2,3",
+			"4,5,6",
+			"1,2,6"
+		);
 
 		expected.sort(String::compareTo);
 
@@ -658,7 +667,10 @@ public class CEPITCase extends AbstractTestBase {
 
 		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		List<String> expected = Arrays.asList("1,6,4\n1,5,4".split("\n"));
+		List<String> expected = Arrays.asList(
+			"1,6,4",
+			"1,5,4"
+		);
 
 		expected.sort(String::compareTo);
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -60,15 +60,15 @@ public class CEPITCase extends AbstractTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStream<Event> input = env.fromElements(
-				new Event(1, "barfoo", 1.0),
-				new Event(2, "start", 2.0),
-				new Event(3, "foobar", 3.0),
-				new SubEvent(4, "foo", 4.0, 1.0),
-				new Event(5, "middle", 5.0),
-				new SubEvent(6, "middle", 6.0, 2.0),
-				new SubEvent(7, "bar", 3.0, 3.0),
-				new Event(42, "42", 42.0),
-				new Event(8, "end", 1.0)
+			new Event(1, "barfoo", 1.0),
+			new Event(2, "start", 2.0),
+			new Event(3, "foobar", 3.0),
+			new SubEvent(4, "foo", 4.0, 1.0),
+			new Event(5, "middle", 5.0),
+			new SubEvent(6, "middle", 6.0, 2.0),
+			new SubEvent(7, "bar", 3.0, 3.0),
+			new Event(42, "42", 42.0),
+			new Event(8, "end", 1.0)
 		);
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
@@ -78,22 +78,22 @@ public class CEPITCase extends AbstractTestBase {
 				return value.getName().equals("start");
 			}
 		})
-				.followedByAny("middle").subtype(SubEvent.class).where(
-						new SimpleCondition<SubEvent>() {
-
-							@Override
-							public boolean filter(SubEvent value) throws Exception {
-								return value.getName().equals("middle");
-							}
-						}
-				)
-				.followedByAny("end").where(new SimpleCondition<Event>() {
+		.followedByAny("middle").subtype(SubEvent.class).where(
+				new SimpleCondition<SubEvent>() {
 
 					@Override
-					public boolean filter(Event value) throws Exception {
-						return value.getName().equals("end");
+					public boolean filter(SubEvent value) throws Exception {
+						return value.getName().equals("middle");
 					}
-				});
+				}
+			)
+		.followedByAny("end").where(new SimpleCondition<Event>() {
+
+			@Override
+			public boolean filter(Event value) throws Exception {
+				return value.getName().equals("end");
+			}
+		});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
 
@@ -102,8 +102,8 @@ public class CEPITCase extends AbstractTestBase {
 				StringBuilder builder = new StringBuilder();
 
 				builder.append(pattern.get("start").get(0).getId()).append(",")
-						.append(pattern.get("middle").get(0).getId()).append(",")
-						.append(pattern.get("end").get(0).getId());
+					.append(pattern.get("middle").get(0).getId()).append(",")
+					.append(pattern.get("end").get(0).getId());
 
 				return builder.toString();
 			}
@@ -126,21 +126,21 @@ public class CEPITCase extends AbstractTestBase {
 		env.setParallelism(2);
 
 		DataStream<Event> input = env.fromElements(
-				new Event(1, "barfoo", 1.0),
-				new Event(2, "start", 2.0),
-				new Event(3, "start", 2.1),
-				new Event(3, "foobar", 3.0),
-				new SubEvent(4, "foo", 4.0, 1.0),
-				new SubEvent(3, "middle", 3.2, 1.0),
-				new Event(42, "start", 3.1),
-				new SubEvent(42, "middle", 3.3, 1.2),
-				new Event(5, "middle", 5.0),
-				new SubEvent(2, "middle", 6.0, 2.0),
-				new SubEvent(7, "bar", 3.0, 3.0),
-				new Event(42, "42", 42.0),
-				new Event(3, "end", 2.0),
-				new Event(2, "end", 1.0),
-				new Event(42, "end", 42.0)
+			new Event(1, "barfoo", 1.0),
+			new Event(2, "start", 2.0),
+			new Event(3, "start", 2.1),
+			new Event(3, "foobar", 3.0),
+			new SubEvent(4, "foo", 4.0, 1.0),
+			new SubEvent(3, "middle", 3.2, 1.0),
+			new Event(42, "start", 3.1),
+			new SubEvent(42, "middle", 3.3, 1.2),
+			new Event(5, "middle", 5.0),
+			new SubEvent(2, "middle", 6.0, 2.0),
+			new SubEvent(7, "bar", 3.0, 3.0),
+			new Event(42, "42", 42.0),
+			new Event(3, "end", 2.0),
+			new Event(2, "end", 1.0),
+			new Event(42, "end", 42.0)
 		).keyBy(new KeySelector<Event, Integer>() {
 
 			@Override
@@ -156,22 +156,22 @@ public class CEPITCase extends AbstractTestBase {
 				return value.getName().equals("start");
 			}
 		})
-				.followedByAny("middle").subtype(SubEvent.class).where(
-						new SimpleCondition<SubEvent>() {
-
-							@Override
-							public boolean filter(SubEvent value) throws Exception {
-								return value.getName().equals("middle");
-							}
-						}
-				)
-				.followedByAny("end").where(new SimpleCondition<Event>() {
+			.followedByAny("middle").subtype(SubEvent.class).where(
+				new SimpleCondition<SubEvent>() {
 
 					@Override
-					public boolean filter(Event value) throws Exception {
-						return value.getName().equals("end");
+					public boolean filter(SubEvent value) throws Exception {
+						return value.getName().equals("middle");
 					}
-				});
+				}
+			)
+			.followedByAny("end").where(new SimpleCondition<Event>() {
+
+				@Override
+				public boolean filter(Event value) throws Exception {
+					return value.getName().equals("end");
+				}
+			});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
 
@@ -180,8 +180,8 @@ public class CEPITCase extends AbstractTestBase {
 				StringBuilder builder = new StringBuilder();
 
 				builder.append(pattern.get("start").get(0).getId()).append(",")
-						.append(pattern.get("middle").get(0).getId()).append(",")
-						.append(pattern.get("end").get(0).getId());
+					.append(pattern.get("middle").get(0).getId()).append(",")
+					.append(pattern.get("end").get(0).getId());
 
 				return builder.toString();
 			}
@@ -205,13 +205,13 @@ public class CEPITCase extends AbstractTestBase {
 
 		// (Event, timestamp)
 		DataStream<Event> input = env.fromElements(
-				Tuple2.of(new Event(1, "start", 1.0), 5L),
-				Tuple2.of(new Event(2, "middle", 2.0), 1L),
-				Tuple2.of(new Event(3, "end", 3.0), 3L),
-				Tuple2.of(new Event(4, "end", 4.0), 10L),
-				Tuple2.of(new Event(5, "middle", 5.0), 7L),
-				// last element for high final watermark
-				Tuple2.of(new Event(6, "middle", 5.0), 100L)
+			Tuple2.of(new Event(1, "start", 1.0), 5L),
+			Tuple2.of(new Event(2, "middle", 2.0), 1L),
+			Tuple2.of(new Event(3, "end", 3.0), 3L),
+			Tuple2.of(new Event(4, "end", 4.0), 10L),
+			Tuple2.of(new Event(5, "middle", 5.0), 7L),
+			// last element for high final watermark
+			Tuple2.of(new Event(6, "middle", 5.0), 100L)
 		).assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Tuple2<Event, Long>>() {
 
 			@Override
@@ -253,19 +253,19 @@ public class CEPITCase extends AbstractTestBase {
 		});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(
-				new PatternSelectFunction<Event, String>() {
+			new PatternSelectFunction<Event, String>() {
 
-					@Override
-					public String select(Map<String, List<Event>> pattern) {
-						StringBuilder builder = new StringBuilder();
+				@Override
+				public String select(Map<String, List<Event>> pattern) {
+					StringBuilder builder = new StringBuilder();
 
-						builder.append(pattern.get("start").get(0).getId()).append(",")
-								.append(pattern.get("middle").get(0).getId()).append(",")
-								.append(pattern.get("end").get(0).getId());
+					builder.append(pattern.get("start").get(0).getId()).append(",")
+						.append(pattern.get("middle").get(0).getId()).append(",")
+						.append(pattern.get("end").get(0).getId());
 
-						return builder.toString();
-					}
+					return builder.toString();
 				}
+			}
 		);
 
 		CollectSink.VALUES.clear();
@@ -287,17 +287,17 @@ public class CEPITCase extends AbstractTestBase {
 
 		// (Event, timestamp)
 		DataStream<Event> input = env.fromElements(
-				Tuple2.of(new Event(1, "start", 1.0), 5L),
-				Tuple2.of(new Event(1, "middle", 2.0), 1L),
-				Tuple2.of(new Event(2, "middle", 2.0), 4L),
-				Tuple2.of(new Event(2, "start", 2.0), 3L),
-				Tuple2.of(new Event(1, "end", 3.0), 3L),
-				Tuple2.of(new Event(3, "start", 4.1), 5L),
-				Tuple2.of(new Event(1, "end", 4.0), 10L),
-				Tuple2.of(new Event(2, "end", 2.0), 8L),
-				Tuple2.of(new Event(1, "middle", 5.0), 7L),
-				Tuple2.of(new Event(3, "middle", 6.0), 9L),
-				Tuple2.of(new Event(3, "end", 7.0), 7L)
+			Tuple2.of(new Event(1, "start", 1.0), 5L),
+			Tuple2.of(new Event(1, "middle", 2.0), 1L),
+			Tuple2.of(new Event(2, "middle", 2.0), 4L),
+			Tuple2.of(new Event(2, "start", 2.0), 3L),
+			Tuple2.of(new Event(1, "end", 3.0), 3L),
+			Tuple2.of(new Event(3, "start", 4.1), 5L),
+			Tuple2.of(new Event(1, "end", 4.0), 10L),
+			Tuple2.of(new Event(2, "end", 2.0), 8L),
+			Tuple2.of(new Event(1, "middle", 5.0), 7L),
+			Tuple2.of(new Event(3, "middle", 6.0), 9L),
+			Tuple2.of(new Event(3, "end", 7.0), 7L)
 		).assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Tuple2<Event, Long>>() {
 
 			@Override
@@ -375,17 +375,17 @@ public class CEPITCase extends AbstractTestBase {
 	public void testSimplePatternWithSingleState() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		DataStream<Tuple2<Integer, Integer>> input = env.fromElements(
-				new Tuple2<>(0, 1),
-				new Tuple2<>(0, 2));
+			new Tuple2<>(0, 1),
+			new Tuple2<>(0, 2));
 
 		Pattern<Tuple2<Integer, Integer>, ?> pattern =
-				Pattern.<Tuple2<Integer, Integer>>begin("start")
-						.where(new SimpleCondition<Tuple2<Integer, Integer>>() {
-							@Override
-							public boolean filter(Tuple2<Integer, Integer> rec) throws Exception {
-								return rec.f1 == 1;
-							}
-						});
+			Pattern.<Tuple2<Integer, Integer>>begin("start")
+				.where(new SimpleCondition<Tuple2<Integer, Integer>>() {
+					@Override
+					public boolean filter(Tuple2<Integer, Integer> rec) throws Exception {
+						return rec.f1 == 1;
+					}
+				});
 
 		PatternStream<Tuple2<Integer, Integer>> pStream = CEP.pattern(input, pattern);
 
@@ -440,10 +440,10 @@ public class CEPITCase extends AbstractTestBase {
 
 		// (Event, timestamp)
 		DataStream<Event> input = env.fromElements(
-				Tuple2.of(new Event(1, "start", 1.0), 1L),
-				Tuple2.of(new Event(1, "middle", 2.0), 5L),
-				Tuple2.of(new Event(1, "start", 2.0), 4L),
-				Tuple2.of(new Event(1, "end", 2.0), 6L)
+			Tuple2.of(new Event(1, "start", 1.0), 1L),
+			Tuple2.of(new Event(1, "middle", 2.0), 5L),
+			Tuple2.of(new Event(1, "start", 2.0), 4L),
+			Tuple2.of(new Event(1, "end", 2.0), 6L)
 		).assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Tuple2<Event, Long>>() {
 
 			@Override
@@ -485,25 +485,25 @@ public class CEPITCase extends AbstractTestBase {
 		}).within(Time.milliseconds(3));
 
 		DataStream<Either<String, String>> result = CEP.pattern(input, pattern).select(
-				new PatternTimeoutFunction<Event, String>() {
-					@Override
-					public String timeout(Map<String, List<Event>> pattern, long timeoutTimestamp) throws Exception {
-						return pattern.get("start").get(0).getPrice() + "";
-					}
-				},
-				new PatternSelectFunction<Event, String>() {
-
-					@Override
-					public String select(Map<String, List<Event>> pattern) {
-						StringBuilder builder = new StringBuilder();
-
-						builder.append(pattern.get("start").get(0).getPrice()).append(",")
-								.append(pattern.get("middle").get(0).getPrice()).append(",")
-								.append(pattern.get("end").get(0).getPrice());
-
-						return builder.toString();
-					}
+			new PatternTimeoutFunction<Event, String>() {
+				@Override
+				public String timeout(Map<String, List<Event>> pattern, long timeoutTimestamp) throws Exception {
+					return pattern.get("start").get(0).getPrice() + "";
 				}
+			},
+			new PatternSelectFunction<Event, String>() {
+
+				@Override
+				public String select(Map<String, List<Event>> pattern) {
+					StringBuilder builder = new StringBuilder();
+
+					builder.append(pattern.get("start").get(0).getPrice()).append(",")
+							.append(pattern.get("middle").get(0).getPrice()).append(",")
+							.append(pattern.get("end").get(0).getPrice());
+
+					return builder.toString();
+				}
+			}
 		);
 
 		CollectSink.VALUES.clear();
@@ -534,41 +534,41 @@ public class CEPITCase extends AbstractTestBase {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStream<Event> input = env.fromElements(
-				new Event(1, "start", 1.0),
-				new Event(2, "middle", 2.0),
-				new Event(3, "end", 3.0),
-				new Event(4, "start", 4.0),
-				new Event(5, "middle", 5.0),
-				new Event(6, "end", 6.0)
+			new Event(1, "start", 1.0),
+			new Event(2, "middle", 2.0),
+			new Event(3, "end", 3.0),
+			new Event(4, "start", 4.0),
+			new Event(5, "middle", 5.0),
+			new Event(6, "end", 6.0)
 		);
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start")
-				.where(new SimpleCondition<Event>() {
-					@Override
-					public boolean filter(Event value) throws Exception {
-						return value.getName().equals("start");
-					}
-				})
-				.followedByAny("middle")
-				.where(new SimpleCondition<Event>() {
-					@Override
-					public boolean filter(Event value) throws Exception {
-						return value.getPrice() == 2.0;
-					}
-				})
-				.or(new SimpleCondition<Event>() {
-					@Override
-					public boolean filter(Event value) throws Exception {
-						return value.getPrice() == 5.0;
-					}
-				})
-				.followedByAny("end").where(new SimpleCondition<Event>() {
+			.where(new SimpleCondition<Event>() {
+				@Override
+				public boolean filter(Event value) throws Exception {
+					return value.getName().equals("start");
+				}
+			})
+			.followedByAny("middle")
+			.where(new SimpleCondition<Event>() {
+				@Override
+				public boolean filter(Event value) throws Exception {
+					return value.getPrice() == 2.0;
+				}
+			})
+			.or(new SimpleCondition<Event>() {
+				@Override
+				public boolean filter(Event value) throws Exception {
+					return value.getPrice() == 5.0;
+				}
+			})
+			.followedByAny("end").where(new SimpleCondition<Event>() {
 
-					@Override
-					public boolean filter(Event value) throws Exception {
-						return value.getName().equals("end");
-					}
-				});
+				@Override
+				public boolean filter(Event value) throws Exception {
+					return value.getName().equals("end");
+				}
+			});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
 
@@ -610,14 +610,14 @@ public class CEPITCase extends AbstractTestBase {
 
 		// (Event, timestamp)
 		DataStream<Event> input = env.fromElements(
-				Tuple2.of(new Event(1, "start", 1.0), 5L),
-				Tuple2.of(new Event(2, "middle", 2.0), 1L),
-				Tuple2.of(new Event(3, "end", 3.0), 3L),
-				Tuple2.of(new Event(4, "end", 4.0), 10L),
-				Tuple2.of(new Event(5, "middle", 6.0), 7L),
-				Tuple2.of(new Event(6, "middle", 5.0), 7L),
-				// last element for high final watermark
-				Tuple2.of(new Event(7, "middle", 5.0), 100L)
+			Tuple2.of(new Event(1, "start", 1.0), 5L),
+			Tuple2.of(new Event(2, "middle", 2.0), 1L),
+			Tuple2.of(new Event(3, "end", 3.0), 3L),
+			Tuple2.of(new Event(4, "end", 4.0), 10L),
+			Tuple2.of(new Event(5, "middle", 6.0), 7L),
+			Tuple2.of(new Event(6, "middle", 5.0), 7L),
+			// last element for high final watermark
+			Tuple2.of(new Event(7, "middle", 5.0), 100L)
 		).assignTimestampsAndWatermarks(new AssignerWithPunctuatedWatermarks<Tuple2<Event, Long>>() {
 
 			@Override
@@ -661,19 +661,19 @@ public class CEPITCase extends AbstractTestBase {
 		});
 
 		DataStream<String> result = CEP.pattern(input, pattern, comparator).select(
-				new PatternSelectFunction<Event, String>() {
+			new PatternSelectFunction<Event, String>() {
 
-					@Override
-					public String select(Map<String, List<Event>> pattern) {
-						StringBuilder builder = new StringBuilder();
+				@Override
+				public String select(Map<String, List<Event>> pattern) {
+					StringBuilder builder = new StringBuilder();
 
-						builder.append(pattern.get("start").get(0).getId()).append(",")
-								.append(pattern.get("middle").get(0).getId()).append(",")
-								.append(pattern.get("end").get(0).getId());
+					builder.append(pattern.get("start").get(0).getId()).append(",")
+							.append(pattern.get("middle").get(0).getId()).append(",")
+							.append(pattern.get("end").get(0).getId());
 
-						return builder.toString();
-					}
+					return builder.toString();
 				}
+			}
 		);
 
 		CollectSink.VALUES.clear();
@@ -701,19 +701,19 @@ public class CEPITCase extends AbstractTestBase {
 	public void testSimpleAfterMatchSkip() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		DataStream<Tuple2<Integer, String>> input = env.fromElements(
-				new Tuple2<>(1, "a"),
-				new Tuple2<>(2, "a"),
-				new Tuple2<>(3, "a"),
-				new Tuple2<>(4, "a"));
+			new Tuple2<>(1, "a"),
+			new Tuple2<>(2, "a"),
+			new Tuple2<>(3, "a"),
+			new Tuple2<>(4, "a"));
 
 		Pattern<Tuple2<Integer, String>, ?> pattern =
-				Pattern.<Tuple2<Integer, String>>begin("start", AfterMatchSkipStrategy.skipPastLastEvent())
-						.where(new SimpleCondition<Tuple2<Integer, String>>() {
-							@Override
-							public boolean filter(Tuple2<Integer, String> rec) throws Exception {
-								return rec.f1.equals("a");
-							}
-						}).times(2);
+			Pattern.<Tuple2<Integer, String>>begin("start", AfterMatchSkipStrategy.skipPastLastEvent())
+				.where(new SimpleCondition<Tuple2<Integer, String>>() {
+					@Override
+					public boolean filter(Tuple2<Integer, String> rec) throws Exception {
+						return rec.f1.equals("a");
+					}
+				}).times(2);
 
 		PatternStream<Tuple2<Integer, String>> pStream = CEP.pattern(input, pattern);
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -27,9 +27,9 @@ import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -109,15 +110,11 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		});
 
-		CollectSink.VALUES.clear();
+		List<String> resultList = new ArrayList<>();
 
-		result.addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
-
-		CollectSink.VALUES.sort(String::compareTo);
-
-		assertEquals(Arrays.asList("2,6,8"), CollectSink.VALUES);
+		assertEquals(Arrays.asList("2,6,8"), resultList);
 	}
 
 	@Test
@@ -187,15 +184,13 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		});
 
-		CollectSink.VALUES.clear();
+		List<String> resultList = new ArrayList<>();
 
-		result.addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
+		resultList.sort(String::compareTo);
 
-		CollectSink.VALUES.sort(String::compareTo);
-
-		assertEquals(Arrays.asList("2,2,2", "3,3,3", "42,42,42"), CollectSink.VALUES);
+		assertEquals(Arrays.asList("2,2,2", "3,3,3", "42,42,42"), resultList);
 	}
 
 	@Test
@@ -268,15 +263,13 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		);
 
-		CollectSink.VALUES.clear();
+		List<String> resultList = new ArrayList<>();
 
-		result.addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
+		resultList.sort(String::compareTo);
 
-		CollectSink.VALUES.sort(String::compareTo);
-
-		assertEquals(Arrays.asList("1,5,4"), CollectSink.VALUES);
+		assertEquals(Arrays.asList("1,5,4"), resultList);
 	}
 
 	@Test
@@ -345,30 +338,28 @@ public class CEPITCase extends AbstractTestBase {
 		});
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(
-				new PatternSelectFunction<Event, String>() {
+			new PatternSelectFunction<Event, String>() {
 
-					@Override
-					public String select(Map<String, List<Event>> pattern) {
-						StringBuilder builder = new StringBuilder();
+				@Override
+				public String select(Map<String, List<Event>> pattern) {
+					StringBuilder builder = new StringBuilder();
 
-						builder.append(pattern.get("start").get(0).getId()).append(",")
-								.append(pattern.get("middle").get(0).getId()).append(",")
-								.append(pattern.get("end").get(0).getId());
+					builder.append(pattern.get("start").get(0).getId()).append(",")
+							.append(pattern.get("middle").get(0).getId()).append(",")
+							.append(pattern.get("end").get(0).getId());
 
-						return builder.toString();
-					}
+					return builder.toString();
 				}
+			}
 		);
 
-		CollectSink.VALUES.clear();
+		List<String> resultList = new ArrayList<>();
 
-		result.addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
+		resultList.sort(String::compareTo);
 
-		CollectSink.VALUES.sort(String::compareTo);
-
-		assertEquals(Arrays.asList("1,1,1", "2,2,2"), CollectSink.VALUES);
+		assertEquals(Arrays.asList("1,1,1", "2,2,2"), resultList);
 	}
 
 	@Test
@@ -396,15 +387,11 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		});
 
-		CollectSink.VALUES.clear();
+		List<Tuple2<Integer, Integer>> resultList = new ArrayList<>();
 
-		result.map(Tuple2::toString).addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
-
-		CollectSink.VALUES.sort(String::compareTo);
-
-		assertEquals(Arrays.asList("(0,1)"), CollectSink.VALUES);
+		assertEquals(Arrays.asList(new Tuple2<>(0, 1)), resultList);
 	}
 
 	@Test
@@ -423,13 +410,11 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		});
 
-		CollectSink.VALUES.clear();
+		List<Integer> resultList = new ArrayList<>();
 
-		result.map(val -> val.toString()).addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
-
-		assertEquals(Arrays.asList("3"), CollectSink.VALUES);
+		assertEquals(Arrays.asList(3), resultList);
 	}
 
 	@Test
@@ -498,30 +483,24 @@ public class CEPITCase extends AbstractTestBase {
 					StringBuilder builder = new StringBuilder();
 
 					builder.append(pattern.get("start").get(0).getPrice()).append(",")
-							.append(pattern.get("middle").get(0).getPrice()).append(",")
-							.append(pattern.get("end").get(0).getPrice());
+						.append(pattern.get("middle").get(0).getPrice()).append(",")
+						.append(pattern.get("end").get(0).getPrice());
 
 					return builder.toString();
 				}
 			}
 		);
 
-		CollectSink.VALUES.clear();
+		List<Either<String, String>> resultList = new ArrayList<>();
 
-		result.map(new MapFunction<Either<String, String>, String>() {
-			@Override
-			public String map(Either<String, String> value) throws Exception {
-				return value.toString();
-			}
-		}).addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
+		resultList.sort(Comparator.comparing(either -> either.toString()));
 
-		CollectSink.VALUES.sort(String::compareTo);
+		List<Either<String, String>> expected = Arrays.asList(Either.Left.of("1.0"), Either.Left.of("2.0"),
+												Either.Left.of("2.0"), Either.Right.of("2.0,2.0,2.0"));
 
-		List<String> expected = Arrays.asList("Left(1.0)\nLeft(2.0)\nLeft(2.0)\nRight(2.0,2.0,2.0)".split("\n"));
-
-		assertEquals(expected, CollectSink.VALUES);
+		assertEquals(expected, resultList);
 	}
 
 	/**
@@ -577,25 +556,24 @@ public class CEPITCase extends AbstractTestBase {
 				StringBuilder builder = new StringBuilder();
 
 				builder.append(pattern.get("start").get(0).getId()).append(",")
-						.append(pattern.get("middle").get(0).getId()).append(",")
-						.append(pattern.get("end").get(0).getId());
+					.append(pattern.get("middle").get(0).getId()).append(",")
+					.append(pattern.get("end").get(0).getId());
 
 				return builder.toString();
 			}
 		});
 
-		CollectSink.VALUES.clear();
+		List<String> resultList = new ArrayList<>();
 
-		result.addSink(new CollectSink());
-
-		env.execute();
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
 		List<String> expected = Arrays.asList("1,5,6\n1,2,3\n4,5,6\n1,2,6".split("\n"));
 
 		expected.sort(String::compareTo);
-		CollectSink.VALUES.sort(String::compareTo);
 
-		assertEquals(expected, CollectSink.VALUES);
+		resultList.sort(String::compareTo);
+
+		assertEquals(expected, resultList);
 	}
 
 	/**
@@ -668,26 +646,25 @@ public class CEPITCase extends AbstractTestBase {
 					StringBuilder builder = new StringBuilder();
 
 					builder.append(pattern.get("start").get(0).getId()).append(",")
-							.append(pattern.get("middle").get(0).getId()).append(",")
-							.append(pattern.get("end").get(0).getId());
+						.append(pattern.get("middle").get(0).getId()).append(",")
+						.append(pattern.get("end").get(0).getId());
 
 					return builder.toString();
 				}
 			}
 		);
 
-		CollectSink.VALUES.clear();
+		List<String> resultList = new ArrayList<>();
 
-		result.addSink(new CollectSink());
-
-		env.execute();
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
 		List<String> expected = Arrays.asList("1,6,4\n1,5,4".split("\n"));
 
 		expected.sort(String::compareTo);
-		CollectSink.VALUES.sort(String::compareTo);
 
-		assertEquals(expected, CollectSink.VALUES);
+		resultList.sort(String::compareTo);
+
+		assertEquals(expected, resultList);
 	}
 
 	private static class CustomEventComparator implements EventComparator<Event> {
@@ -724,32 +701,14 @@ public class CEPITCase extends AbstractTestBase {
 			}
 		});
 
-		CollectSink.VALUES.clear();
+		List<Tuple2<Integer, String>> resultList = new ArrayList<>();
 
-		result.map(new MapFunction<Tuple2<Integer, String>, String>() {
-			@Override
-			public String map(Tuple2<Integer, String> value) throws Exception {
-				return value.toString();
-			}
-		}).addSink(new CollectSink());
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
 
-		env.execute();
+		resultList.sort(Comparator.comparing(tuple2 -> tuple2.toString()));
 
-		CollectSink.VALUES.sort(String::compareTo);
+		List<Tuple2<Integer, String>> expected = Arrays.asList(Tuple2.of(1, "a"), Tuple2.of(3, "a"));
 
-		List<String> expected = Arrays.asList("(1,a)\n(3,a)".split("\n"));
-
-		assertEquals(expected, CollectSink.VALUES);
+		assertEquals(expected, resultList);
 	}
-
-	private static class CollectSink implements SinkFunction<String> {
-
-		public static final List<String> VALUES = new ArrayList<>();
-
-		@Override
-		public synchronized void invoke(String value) throws Exception {
-			VALUES.add(value);
-		}
-	}
-
 }


### PR DESCRIPTION
## What is the purpose of the change

This change modifies the CEPITCase integration test to use a custom sink function to collect and compare test results, instead of writing them to a file. It does not add/remove any constituent tests.

## Brief change log

- Removed Before and After junit annotations
- Added a custom sink function with a static arraylist to collect and compare test results

## Verifying this change

This change is already covered by existing tests, such as CEPITCase, which is the end to end test of the CEP API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
