### PR TITLE
[FLINK-9601][state]Try to reuse the snapshotData array as the partitioned destination only when its capacity is enough

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -196,6 +196,8 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 			super(
 				new CopyOnWriteStateTable.StateTableEntry[stateTableSize],
 				stateTableSize,
+				// We have made sure that the snapshotData is big enough to hold the flattened entries in
+				// CopyOnWriteStateTable#snapshotTableArrays(), we can safely reuse it as the destination array here.
 				snapshotData,
 				keyGroupRange,
 				totalKeyGroups,


### PR DESCRIPTION
## What is the purpose of the change

In `CopyOnWriteStateTableSnapshot`, we only reuse the `snapshotData` as the partitioned destination array when it's capacity enough is enough.

## Brief change log

  - *Try to reuse the snapshotData array as the partitioned destination on when it's capacity is enough.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

   No
