### PR TITLE
[FLINK-9585] Logger in ZooKeeperStateHandleStore is public and non-final

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -82,7 +82,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class ZooKeeperStateHandleStore<T extends Serializable> {
 
-	public static Logger LOG = LoggerFactory.getLogger(ZooKeeperStateHandleStore.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperStateHandleStore.class);
 
 	/** Curator ZooKeeper client */
 	private final CuratorFramework client;


### PR DESCRIPTION
## What is the purpose of the change

*This pull request mark Logger in ZooKeeperStateHandleStore as private and final*


## Brief change log

  - *Changed Logger in `ZooKeeperStateHandleStore` from `public` to `private final`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
