### PR TITLE
[FLINK-9603][connector-filesystem] fix part indexing, when part suffix is specified

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -65,6 +65,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -73,6 +75,8 @@ import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTe
 import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
 import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.VALID_LENGTH_SUFFIX;
 import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.checkLocalFs;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for the {@link BucketingSink}.
@@ -898,6 +902,81 @@ public class BucketingSinkTest extends TestLogger {
 
 		dataFileStream.close();
 		inStream.close();
+	}
+
+	@Test
+	public void testThatPartIndexIsIncrementedWhenPartSuffixIsSpecifiedAndPreviousPartFileInProgressState()
+		throws Exception {
+		testThatPartIndexIsIncremented(".my", "part-0-0.my" + IN_PROGRESS_SUFFIX);
+	}
+
+	@Test
+	public void testThatPartIndexIsIncrementedWhenPartSuffixIsSpecifiedAndPreviousPartFileInPendingState()
+		throws Exception {
+		testThatPartIndexIsIncremented(".my", "part-0-0.my" + PENDING_SUFFIX);
+	}
+
+	@Test
+	public void testThatPartIndexIsIncrementedWhenPartSuffixIsSpecifiedAndPreviousPartFileInFinalState()
+		throws Exception {
+		testThatPartIndexIsIncremented(".my", "part-0-0.my");
+	}
+
+	@Test
+	public void testThatPartIndexIsIncrementedWhenPartSuffixIsNotSpecifiedAndPreviousPartFileInProgressState()
+		throws Exception {
+		testThatPartIndexIsIncremented(null, "part-0-0" + IN_PROGRESS_SUFFIX);
+	}
+
+	@Test
+	public void testThatPartIndexIsIncrementedWhenPartSuffixIsNotSpecifiedAndPreviousPartFileInPendingState()
+		throws Exception {
+		testThatPartIndexIsIncremented(null, "part-0-0" + PENDING_SUFFIX);
+	}
+
+	@Test
+	public void testThatPartIndexIsIncrementedWhenPartSuffixIsNotSpecifiedAndPreviousPartFileInFinalState()
+		throws Exception {
+		testThatPartIndexIsIncremented(null, "part-0-0");
+	}
+
+	private void testThatPartIndexIsIncremented(String partSuffix, String existingPartFile) throws Exception {
+		File outDir = tempFolder.newFolder();
+		long inactivityInterval = 100;
+
+		java.nio.file.Path bucket = Paths.get(outDir.getPath());
+		Files.createFile(bucket.resolve(existingPartFile));
+
+		String basePath = outDir.getAbsolutePath();
+		BucketingSink<String> sink = new BucketingSink<String>(basePath)
+			.setBucketer(new BasePathBucketer<>())
+			.setInactiveBucketCheckInterval(inactivityInterval)
+			.setInactiveBucketThreshold(inactivityInterval)
+			.setPartPrefix(PART_PREFIX)
+			.setInProgressPrefix("")
+			.setPendingPrefix("")
+			.setValidLengthPrefix("")
+			.setInProgressSuffix(IN_PROGRESS_SUFFIX)
+			.setPendingSuffix(PENDING_SUFFIX)
+			.setValidLengthSuffix(VALID_LENGTH_SUFFIX)
+			.setPartSuffix(partSuffix)
+			.setBatchSize(0);
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness = createTestSink(sink, 1, 0);
+		testHarness.setup();
+		testHarness.open();
+
+		testHarness.setProcessingTime(0L);
+
+		testHarness.processElement(new StreamRecord<>("test1", 1L));
+
+		testHarness.setProcessingTime(101L);
+		testHarness.snapshot(0, 0);
+		testHarness.notifyOfCompletedCheckpoint(0);
+		sink.close();
+
+		String expectedFileName = partSuffix == null ? "part-0-1" : "part-0-1" + partSuffix;
+		assertThat(Files.exists(bucket.resolve(expectedFileName)), is(true));
 	}
 
 	private static class StreamWriterWithConfigCheck<K, V> extends AvroKeyValueSinkWriter<K, V> {


### PR DESCRIPTION
### What is the purpose of the change:
This pull-request fixes problem of incorrect part file index lookup, when part suffix is specified.
Part file path should be assembled with part suffix, before check on existance

### Brief change log:
when creating new part file, add part suffix to part path before verification on file existence

### Verifying this change:
The following tests, that verify part file indexing, have been added:
- testThatPartIndexIsIncrementedWhenPartSuffixIsSpecifiedAndPreviousPartFileInProgressState
- testThatPartIndexIsIncrementedWhenPartSuffixIsSpecifiedAndPreviousPartFileInPendingState
- testThatPartIndexIsIncrementedWhenPartSuffixIsSpecifiedAndPreviousPartFileInFinalState
- testThatPartIndexIsIncrementedWhenPartSuffixIsNotSpecifiedAndPreviousPartFileInProgressState
- testThatPartIndexIsIncrementedWhenPartSuffixIsNotSpecifiedAndPreviousPartFileInPendingState
- testThatPartIndexIsIncrementedWhenPartSuffixIsNotSpecifiedAndPreviousPartFileInFinalState

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (yes)

### Documentation:
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable at this step)