### PR TITLE
[FLINK-9524][Table API & SQL] check whether a clean-up timer is expeired in ProcTimeBoundedRangeOver…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
@@ -132,6 +132,14 @@ class ProcTimeBoundedRangeOver(
 
     val currentTime = timestamp - 1
     var i = 0
+    // get the list of elements of current proctime
+    val currentElements = rowMapState.get(currentTime)
+
+    // Expired clean-up timers pass the needToCleanupState() check.
+    // Perform a null check to verify that we have data to process.
+    if (null == currentElements) {
+      return
+    }
 
     // initialize the accumulators
     var accumulators = accumulatorState.value()
@@ -172,8 +180,7 @@ class ProcTimeBoundedRangeOver(
       i += 1
     }
 
-    // get the list of elements of current proctime
-    val currentElements = rowMapState.get(currentTime)
+
     // add current elements to aggregator. Multiple elements might
     // have arrived in the same proctime
     // the same accumulator value will be computed for all elements

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -244,6 +244,21 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     verify(expectedOutput, result, new RowResultSortComparator())
 
+    // test for clean-up timer NPE
+    testHarness.setProcessingTime(20000)
+
+    // timer registered for 23000
+    testHarness.processElement(new StreamRecord(
+      CRow(Row.of(0L: JLong, "ccc", 10L: JLong), change = true)))
+
+    // update clean-up timer to 25500. Previous timer should not clean up
+    testHarness.setProcessingTime(22500)
+    testHarness.processElement(new StreamRecord(
+      CRow(Row.of(0L: JLong, "ccc", 10L: JLong), change = true)))
+
+    // 23000 clean-up timer should fire but not fail with an NPE
+    testHarness.setProcessingTime(23001)
+
     testHarness.close()
   }
 


### PR DESCRIPTION
… to prevent NPE

## What is the purpose of the change
This pull request solve the bug that causes NPE in ProcTimeBoundedRangeOver. Now the onTimer method will check whether the timer is a expired clean-up timer.

## Brief change log
- ProcTimeBoundedRangeOver check whether the timer is a expired clean-up timer. It's done by a null check against the elements within rowMapState. If it's null, it means the timer is an expired clean-up timer and bypass the remained logic. 


## Verifying this change
This change is covered by testProcTimeBoundedRangeOver in OverWindowHarnessTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
