### PR TITLE
[FLINK-9610] [flink-connector-kafka-base] Add Kafka Partitioner that uses the hash of the provided key.

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkKeyHashPartitioner.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkKeyHashPartitioner.java
@@ -45,7 +45,7 @@ public class FlinkKeyHashPartitioner<T> extends FlinkKafkaPartitioner<T> {
 			partitions != null && partitions.length > 0,
 			"Partitions of the target topic is empty.");
 
-		return partitions[hash(key) % partitions.length];
+		return partitions[Math.abs(hash(key)) % partitions.length];
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkKeyHashPartitioner.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/partitioner/FlinkKeyHashPartitioner.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.partitioner;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * A partitioner that uses the hash of the provided key to distribute
+ * the values over the partitions as evenly as possible.
+ * This partitioner ensures that all records with the same key will be sent to
+ * the same Kafka partition.
+ *
+ * <p>Note that this will cause a lot of network connections to be created between
+ * all the Flink instances and all the Kafka brokers.
+ */
+@PublicEvolving
+public class FlinkKeyHashPartitioner<T> extends FlinkKafkaPartitioner<T> {
+
+	private static final long serialVersionUID = -2006468063065010594L;
+
+	@Override
+	public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
+		Preconditions.checkArgument(
+			partitions != null && partitions.length > 0,
+			"Partitions of the target topic is empty.");
+
+		return partitions[hash(key) % partitions.length];
+	}
+
+	/**
+	 * The overridable implementation of the hashing algorithm.
+	 * @param key The key of the provided record on which the partition selection is based. (key can be null!)
+	 * @return The hash value for the provided key.
+	 */
+	protected int hash(@Nullable byte[] key) {
+		return Arrays.hashCode(key);
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKeyHashPartitionerTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKeyHashPartitionerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKeyHashPartitioner;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link FlinkKeyHashPartitioner}.
+ */
+public class FlinkKeyHashPartitionerTest {
+
+	@Test
+	public void testMoreFlinkThanBrokers() {
+		FlinkKeyHashPartitioner<String> part = new FlinkKeyHashPartitioner<>();
+
+		int[] partitions = new int[]{0, 1};
+
+		part.open(0, 4);
+		Assert.assertEquals(0, part.partition("abc", "abc1".getBytes(), null, null, partitions));
+
+		part.open(1, 4);
+		Assert.assertEquals(1, part.partition("abc", "abc2".getBytes(), null, null, partitions));
+
+		part.open(2, 4);
+		Assert.assertEquals(0, part.partition("abc", "abc3".getBytes(), null, null, partitions));
+		Assert.assertEquals(0, part.partition("abc", "abc3".getBytes(), null, null, partitions)); // check if it is changing ;)
+
+		part.open(3, 4);
+		Assert.assertEquals(1, part.partition("abc", "abc4".getBytes(), null, null, partitions));
+	}
+
+	@Test
+	public void testFewerPartitions() {
+		FlinkKeyHashPartitioner<String> part = new FlinkKeyHashPartitioner<>();
+
+		int[] partitions = new int[]{0, 1, 2, 3, 4};
+		part.open(0, 2);
+		Assert.assertEquals(4, part.partition("abc1", "abc1".getBytes(), null, null, partitions));
+		Assert.assertEquals(4, part.partition("abc1", "abc1".getBytes(), null, null, partitions));
+
+		// The resulting kafka partition is dependent ONLY on the key
+		part.open(1, 2);
+		Assert.assertEquals(4, part.partition("abc1", "abc1".getBytes(), null, null, partitions));
+		Assert.assertEquals(4, part.partition("abc1", "abc1".getBytes(), null, null, partitions));
+	}
+
+	@Test
+	public void testSameNumber() {
+		FlinkKeyHashPartitioner<String> part = new FlinkKeyHashPartitioner<>();
+		int[] partitions = new int[]{0, 1, 2};
+
+		part.open(0, 3);
+		Assert.assertEquals(0, part.partition("abc", "abc2".getBytes(), null, null, partitions));
+
+		part.open(1, 3);
+		Assert.assertEquals(0, part.partition("abc", "abc2".getBytes(), null, null, partitions));
+
+		part.open(2, 3);
+		Assert.assertEquals(0, part.partition("abc", "abc2".getBytes(), null, null, partitions));
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the simple feature of being able to route records into Kafka using a key based partitioning.

## Brief change log

- Added the FlinkKeyHashPartitioner class with some tests.

## Verifying this change

This change added tests and can be verified as follows:
- Use this instead of the FlinkFixedPartitioner while instantiating the FlinkKafkaProducer. Also add an KeyedSerializationSchema implementation that returns the right key that is to be used.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector:  no 

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
