### PR TITLE
[FLINK-8795] Fixed local scala shell for Flip6

### DIFF
--- a/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellLocalStartupITCase.scala
+++ b/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellLocalStartupITCase.scala
@@ -19,12 +19,14 @@
 package org.apache.flink.api.scala
 
 import java.io._
+import java.util.Objects
 
 import org.apache.flink.configuration.{Configuration, CoreOptions}
 import org.apache.flink.runtime.clusterframework.BootstrapTools
+import org.apache.flink.test.util.MiniClusterResource
 import org.apache.flink.util.TestLogger
-import org.junit.{Assert, Rule, Test}
 import org.junit.rules.TemporaryFolder
+import org.junit.{Assert, Rule, Test}
 
 class ScalaShellLocalStartupITCase extends TestLogger {
 
@@ -85,7 +87,13 @@ class ScalaShellLocalStartupITCase extends TestLogger {
     System.setOut(new PrintStream(baos))
 
     val configuration = new Configuration()
-    configuration.setString(CoreOptions.MODE, CoreOptions.LEGACY_MODE)
+    val mode = if (Objects.equals(MiniClusterResource.NEW_CODEBASE,
+      System.getProperty(MiniClusterResource.CODEBASE_KEY))) {
+      CoreOptions.NEW_MODE
+    } else {
+      CoreOptions.LEGACY_MODE
+    }
+    configuration.setString(CoreOptions.MODE, mode)
 
     val dir = temporaryFolder.newFolder()
     BootstrapTools.writeConfiguration(configuration, new File(dir, "flink-conf.yaml"))
@@ -93,7 +101,7 @@ class ScalaShellLocalStartupITCase extends TestLogger {
     val args: Array[String] = Array("local", "--configDir", dir.getAbsolutePath)
 
     //start flink scala shell
-    FlinkShell.bufferedReader = Some(in);
+    FlinkShell.bufferedReader = Some(in)
     FlinkShell.main(args)
 
     baos.flush()


### PR DESCRIPTION
## What is the purpose of the change

Enable to run scala-shell in local mode with new runtime mode.

## Brief change log

- Creating either MiniCluster or StandaloneMiniCluster based on the mode.

## Verifying this change

*(Please pick either of the following options)*

Changed tests to run both on new and legacy runtime.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no /** don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
