### PR TITLE
[FLINK-9616][metrics] Fix datadog to include shaded deps

### DIFF
--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -66,14 +66,19 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+							<artifactSet>
+								<includes combine.children="append">
+									<include>com.squareup.okhttp3:okhttp</include>
+									<include>com.squareup.okio:okio</include>
+								</includes>
+							</artifactSet>
 							<relocations combine.children="append">
 								<relocation>
-									<pattern>okhttp3</pattern>
+									<pattern>com.squareup.okhttp3</pattern>
 									<shadedPattern>org.apache.flink.shaded.okhttp3</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>okio</pattern>
+									<pattern>com.squareup.okio</pattern>
 									<shadedPattern>org.apache.flink.shaded.okio</shadedPattern>
 								</relocation>
 							</relocations>


### PR DESCRIPTION
## What is the purpose of the change

This fixes a broken build that wasn't properly including a shaded in the jar it builds. This causes the instantiation of DatadogHttpReporter to fail and with no easy way to fix since the dependencies exist on a shaded import path.

## Brief change log

- Changes the build to properly included the shaded dependencies


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

However, it can be validated by:
```
cd flink-metrics/flink-metrics-datadog
mvn package
jar tf target/flink-metrics-datadog-1.6-SNAPSHOT.jar
```

And then seeing the expected okhttp3 and okio dependencies being included in the resulting jar.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, but brings in line with documented behavior here: https://ci.apache.org/projects/flink/flink-docs-release-1.5/monitoring/metrics.html#datadog-orgapacheflinkmetricsdatadogdatadoghttpreporter
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
