### PR TITLE
[FLINK-9619][YARN] Eagerly close the connection with task manager when the container is completed

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -335,8 +335,9 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 						// Container completed unexpectedly ~> start a new one
 						final Container container = yarnWorkerNode.getContainer();
 						requestYarnContainer(container.getResource(), yarnWorkerNode.getContainer().getPriority());
-						closeTaskManagerConnection(resourceId, new Exception(containerStatus.getDiagnostics()));
 					}
+					// Eagerly close the connection with task manager.
+					closeTaskManagerConnection(resourceId, new Exception(containerStatus.getDiagnostics()));
 				}
 			}
 		);


### PR DESCRIPTION
## What is the purpose of the change

*We should always eagerly close the connection with task manager when the container is completed.*


## Brief change log

  - *Eagerly close the connection with task manager when the container is completed*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - No
