### PR TITLE
FLINK-9623][runtime] Move zipping logic out of blobservice

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -26,17 +26,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.operators.GenericDataSinkBase;
 import org.apache.flink.api.common.operators.Operator;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Visitable;
 import org.apache.flink.util.Visitor;
 
@@ -342,20 +337,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 */
 	public void registerCachedFile(String name, DistributedCacheEntry entry) throws IOException {
 		if (!this.cacheFile.containsKey(name)) {
-			try {
-				URI u = new URI(entry.filePath);
-				if (!u.getPath().startsWith("/")) {
-					u = new File(entry.filePath).toURI();
-				}
-				FileSystem fs = FileSystem.get(u);
-				if (fs.exists(new Path(u.getPath()))) {
-					this.cacheFile.put(name, new DistributedCacheEntry(u.toString(), entry.isExecutable));
-				} else {
-					throw new IOException("File " + u.toString() + " doesn't exist.");
-				}
-			} catch (URISyntaxException ex) {
-				throw new IOException("Invalid path: " + entry.filePath, ex);
-			}
+			this.cacheFile.put(name, entry);
 		} else {
 			throw new IOException("cache file " + name + "already exists!");
 		}

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -27,11 +27,20 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -166,9 +175,76 @@ public class FileUtilsTest {
 		assertFalse(parent.exists());
 	}
 
+	@Test
+	public void testCompression() throws IOException {
+		final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
+			+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
+			+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
+			+ "Und ihre vorgeschriebne Reise Vollendet sie mit Donnergang. Ihr Anblick\n"
+			+ "gibt den Engeln Staerke, Wenn keiner Sie ergruenden mag; die unbegreiflich\n"
+			+ "hohen Werke Sind herrlich wie am ersten Tag.\n"
+			+ "GABRIEL: Und schnell und unbegreiflich schnelle Dreht sich umher der Erde\n"
+			+ "Pracht; Es wechselt Paradieseshelle Mit tiefer, schauervoller Nacht. Es\n"
+			+ "schaeumt das Meer in breiten Fluessen Am tiefen Grund der Felsen auf, Und\n"
+			+ "Fels und Meer wird fortgerissen Im ewig schnellem Sphaerenlauf.\n"
+			+ "MICHAEL: Und Stuerme brausen um die Wette Vom Meer aufs Land, vom Land\n"
+			+ "aufs Meer, und bilden wuetend eine Kette Der tiefsten Wirkung rings umher.\n"
+			+ "Da flammt ein blitzendes Verheeren Dem Pfade vor des Donnerschlags. Doch\n"
+			+ "deine Boten, Herr, verehren Das sanfte Wandeln deines Tags.";
+
+		final java.nio.file.Path compressDir = tmp.newFolder("compressDir").toPath();
+		final java.nio.file.Path extractDir = tmp.newFolder("extractDir").toPath();
+
+		final java.nio.file.Path originalDir = Paths.get("rootDir");
+		final java.nio.file.Path emptySubDir = originalDir.resolve("emptyDir");
+		final java.nio.file.Path fullSubDir = originalDir.resolve("fullDir");
+		final java.nio.file.Path file1 = originalDir.resolve("file1");
+		final java.nio.file.Path file2 = originalDir.resolve("file2");
+		final java.nio.file.Path file3 = fullSubDir.resolve("file3");
+
+		Files.createDirectory(compressDir.resolve(originalDir));
+		Files.createDirectory(compressDir.resolve(emptySubDir));
+		Files.createDirectory(compressDir.resolve(fullSubDir));
+		Files.copy(new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file1));
+		Files.createFile(compressDir.resolve(file2));
+		Files.copy(new ByteArrayInputStream(testFileContent.getBytes(StandardCharsets.UTF_8)), compressDir.resolve(file3));
+
+		final Path zip = FileUtils.compressDirectory(
+			new Path(compressDir.resolve(originalDir).toString()),
+			new Path(compressDir.resolve(originalDir) + ".zip"));
+
+		FileUtils.expandDirectory(zip, new Path(extractDir.toAbsolutePath().toString()));
+
+		assertDirEquals(compressDir.resolve(originalDir), extractDir.resolve(originalDir));
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
+
+	private static void assertDirEquals(java.nio.file.Path expected, java.nio.file.Path actual) throws IOException {
+		assertEquals(Files.isDirectory(expected), Files.isDirectory(actual));
+		assertEquals(expected.getFileName(), actual.getFileName());
+
+		if (Files.isDirectory(expected)) {
+			List<java.nio.file.Path> expectedContents = Files.list(expected)
+				.sorted(Comparator.comparing(java.nio.file.Path::toString))
+				.collect(Collectors.toList());
+			List<java.nio.file.Path> actualContents = Files.list(actual)
+				.sorted(Comparator.comparing(java.nio.file.Path::toString))
+				.collect(Collectors.toList());
+
+			assertEquals(expectedContents.size(), actualContents.size());
+
+			for (int x = 0; x < expectedContents.size(); x++) {
+				assertDirEquals(expectedContents.get(x), actualContents.get(x));
+			}
+		} else {
+			byte[] expectedBytes = Files.readAllBytes(expected);
+			byte[] actualBytes = Files.readAllBytes(actual);
+			assertArrayEquals(expectedBytes, actualBytes);
+		}
+	}
 
 	private static void generateRandomDirs(File dir, int numFiles, int numDirs, int depth) throws IOException {
 		// generate the random files

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -23,14 +23,17 @@ import org.apache.flink.api.common.aggregators.AggregatorRegistry;
 import org.apache.flink.api.common.aggregators.AggregatorWithName;
 import org.apache.flink.api.common.aggregators.ConvergenceCriterion;
 import org.apache.flink.api.common.aggregators.LongSumAggregator;
-import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
+import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.distributions.DataDistribution;
 import org.apache.flink.api.common.operators.util.UserCodeWrapper;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.AlgorithmOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.optimizer.dag.TempMode;
 import org.apache.flink.optimizer.plan.BulkIterationPlanNode;
@@ -78,12 +81,18 @@ import org.apache.flink.runtime.operators.chaining.ChainedDriver;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.apache.flink.runtime.operators.util.LocalStrategy;
 import org.apache.flink.runtime.operators.util.TaskConfig;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.Visitor;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -91,7 +100,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * This component translates the optimizer's resulting {@link org.apache.flink.optimizer.plan.OptimizedPlan}
@@ -105,6 +114,8 @@ import java.util.Map.Entry;
  * are created for the plan nodes, on the way back up, the nodes connect their predecessors.
  */
 public class JobGraphGenerator implements Visitor<PlanNode> {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(JobGraphGenerator.class);
 	
 	public static final String MERGE_ITERATION_AUX_TASKS_KEY = "compiler.merge-iteration-aux";
 	
@@ -243,11 +254,13 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			vertex.setSlotSharingGroup(sharingGroup);
 		}
 
-		// add registered cache file into job configuration
-		for (Entry<String, DistributedCacheEntry> e : program.getOriginalPlan().getCachedFiles()) {
-			graph.addUserArtifact(e.getKey(), e.getValue());
-		}
 
+		Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts =
+			program.getOriginalPlan().getCachedFiles().stream()
+			.map(entry -> Tuple2.of(entry.getKey(), entry.getValue()))
+			.collect(Collectors.toList());
+		addUserArtifactEntries(userArtifacts, graph);
+		
 		// release all references again
 		this.vertices = null;
 		this.chainedTasks = null;
@@ -258,6 +271,35 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 
 		// return job graph
 		return graph;
+	}
+
+	public static void addUserArtifactEntries(Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts, JobGraph jobGraph) {
+		if (!userArtifacts.isEmpty()) {
+			try {
+				java.nio.file.Path tmpDir = Files.createTempDirectory("flink-distributed-cache-" + jobGraph.getJobID());
+				for (Tuple2<String, DistributedCache.DistributedCacheEntry> originalEntry : userArtifacts) {
+					Path filePath = new Path(originalEntry.f1.filePath);
+					boolean isLocalDir = false;
+					try {
+						FileSystem sourceFs = filePath.getFileSystem();
+						isLocalDir = !sourceFs.isDistributedFS() && sourceFs.getFileStatus(filePath).isDir();
+					} catch (IOException ioe) {
+						LOG.warn("Could not determine whether {} denotes a local path.", filePath, ioe);
+					}
+					// zip local directories because we only support file uploads
+					DistributedCache.DistributedCacheEntry entry;
+					if (isLocalDir) {
+						Path zip = FileUtils.compressDirectory(filePath, new Path(tmpDir.toString(), filePath.getName() + ".zip"));
+						entry = new DistributedCache.DistributedCacheEntry(zip.toString(), originalEntry.f1.isExecutable, true);
+					} else {
+						entry = new DistributedCache.DistributedCacheEntry(filePath.toString(), originalEntry.f1.isExecutable, false);
+					}
+					jobGraph.addUserArtifact(originalEntry.f0, entry);
+				}
+			} catch (IOException ioe) {
+				throw new FlinkRuntimeException("Could not compress distributed-cache artifacts.", ioe);
+			}
+		}
 	}
 
 	/**

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/plantranslate/JobGraphGeneratorTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/plantranslate/JobGraphGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.optimizer.plantranslate;
 
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.aggregators.LongSumAggregator;
+import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -36,13 +37,28 @@ import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class JobGraphGeneratorTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
 
 	/**
 	 * Verifies that the resources are merged correctly for chained operators when
@@ -205,5 +221,55 @@ public class JobGraphGeneratorTest {
 		assertTrue(feedbackVertex.getMinResources().equals(resource5));
 		assertTrue(sinkVertex.getPreferredResources().equals(resource6));
 		assertTrue(iterationSyncVertex.getMinResources().equals(resource3));
+	}
+
+	@Test
+	public void testArtifactCompression() throws IOException {
+		Path plainFile1 = tmp.newFile("plainFile1").toPath();
+		Path plainFile2 = tmp.newFile("plainFile2").toPath();
+
+		Path directory1 = tmp.newFolder("directory1").toPath();
+		Files.createDirectory(directory1.resolve("containedFile1"));
+
+		Path directory2 = tmp.newFolder("directory2").toPath();
+		Files.createDirectory(directory2.resolve("containedFile2"));
+
+		JobGraph jb = new JobGraph();
+
+		final String executableFileName = "executableFile";
+		final String nonExecutableFileName = "nonExecutableFile";
+		final String executableDirName = "executableDir";
+		final String nonExecutableDirName = "nonExecutableDIr";
+
+		Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> originalArtifacts = Arrays.asList(
+			Tuple2.of(executableFileName, new DistributedCache.DistributedCacheEntry(plainFile1.toString(), true)),
+			Tuple2.of(nonExecutableFileName, new DistributedCache.DistributedCacheEntry(plainFile2.toString(), false)),
+			Tuple2.of(executableDirName, new DistributedCache.DistributedCacheEntry(directory1.toString(), true)),
+			Tuple2.of(nonExecutableDirName, new DistributedCache.DistributedCacheEntry(directory2.toString(), false))
+		);
+
+		JobGraphGenerator.addUserArtifactEntries(originalArtifacts, jb);
+
+		Map<String, DistributedCache.DistributedCacheEntry> submittedArtifacts = jb.getUserArtifacts();
+
+		DistributedCache.DistributedCacheEntry executableFileEntry = submittedArtifacts.get(executableFileName);
+		assertState(executableFileEntry, true, false);
+
+		DistributedCache.DistributedCacheEntry nonExecutableFileEntry = submittedArtifacts.get(nonExecutableFileName);
+		assertState(nonExecutableFileEntry, false, false);
+
+		DistributedCache.DistributedCacheEntry executableDirEntry = submittedArtifacts.get(executableDirName);
+		assertState(executableDirEntry, true, true);
+
+		DistributedCache.DistributedCacheEntry nonExecutableDirEntry = submittedArtifacts.get(nonExecutableDirName);
+		assertState(nonExecutableDirEntry, false, true);
+	}
+
+	private static void assertState(DistributedCache.DistributedCacheEntry entry, boolean isExecutable, boolean isZipped) throws IOException {
+		assertNotNull(entry);
+		assertEquals(isExecutable, entry.isExecutable);
+		assertEquals(isZipped, entry.isZipped);
+		org.apache.flink.core.fs.Path filePath = new org.apache.flink.core.fs.Path(entry.filePath);
+		assertFalse(filePath.getFileSystem().getFileStatus(filePath).isDir());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -637,7 +637,8 @@ public class JobGraph implements Serializable {
 						new DistributedCache.DistributedCacheEntry(
 							userArtifact.getValue().filePath,
 							userArtifact.getValue().isExecutable,
-							InstantiationUtil.serializeObject(key)),
+							InstantiationUtil.serializeObject(key),
+							userArtifact.getValue().isZipped),
 						jobConfiguration);
 				}
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.FileUtils;
-import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -34,7 +32,6 @@ import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
 
-import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,15 +39,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import static org.apache.flink.runtime.blob.BlobCachePutTest.verifyDeletedEventually;
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
@@ -466,44 +458,6 @@ public class BlobClientTest extends TestLogger {
 	@Test
 	public void testUploadJarFilesHelper() throws Exception {
 		uploadJarFile(getBlobServer(), getBlobClientConfig());
-	}
-
-	@Test
-	public void testDirectoryUploading() throws IOException {
-		final File newFolder = temporaryFolder.newFolder();
-		final File file1 = File.createTempFile("pre", "suff", newFolder);
-		FileUtils.writeFileUtf8(file1, "Test content");
-		final File file2 = File.createTempFile("pre", "suff", newFolder);
-		FileUtils.writeFileUtf8(file2, "Test content 2");
-
-		final Map<String, File> files = new HashMap<>();
-		files.put(file1.getName(), file1);
-		files.put(file2.getName(), file2);
-
-		BlobKey key;
-		final JobID jobId = new JobID();
-		final InetSocketAddress inetAddress = new InetSocketAddress("localhost", getBlobServer().getPort());
-		try (
-			BlobClient client = new BlobClient(
-				inetAddress, getBlobClientConfig())) {
-
-			key = client.uploadFile(jobId, new Path(newFolder.getPath()));
-		}
-
-		final File file = getBlobServer().getFile(jobId, (PermanentBlobKey) key);
-
-		try (ZipInputStream zis = new ZipInputStream(new FileInputStream(file))) {
-			ZipEntry entry;
-			while ((entry = zis.getNextEntry()) != null) {
-				String fileName = entry.getName().replaceFirst("/", "");
-				final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-				IOUtils.copyBytes(zis, outputStream, false);
-
-				assertEquals(FileUtils.readFileUtf8(files.get(fileName)),
-					new String(outputStream.toByteArray(), StandardCharsets.UTF_8));
-				zis.closeEntry();
-			}
-		}
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
@@ -28,9 +28,11 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
-public class JobGraphTest {
+public class JobGraphTest extends TestLogger {
 
 	@Test
 	public void testSerialization() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
@@ -27,6 +26,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -156,10 +156,7 @@ public class StreamingJobGraphGenerator {
 
 		configureCheckpointing();
 
-		// add registered cache file into job configuration
-		for (Tuple2<String, DistributedCache.DistributedCacheEntry> e : streamGraph.getEnvironment().getCachedFiles()) {
-			jobGraph.addUserArtifact(e.f0, e.f1);
-		}
+		JobGraphGenerator.addUserArtifactEntries(streamGraph.getEnvironment().getCachedFiles(), jobGraph);
 
 		// set the ExecutionConfig last when it has been finalized
 		try {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -19,8 +19,6 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.cache.DistributedCache;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.JobExecutor;
@@ -77,10 +75,6 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 		}
 
 		jobGraph.setClasspaths(new ArrayList<>(classPaths));
-
-		for (Tuple2<String, DistributedCache.DistributedCacheEntry> file : cacheFile) {
-			jobGraph.addUserArtifact(file.f0, file.f1);
-		}
 
 		return jobExecutor.executeJobBlocking(jobGraph);
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR moves the zipping logic for local user directory artifacts out of the blobservice.
Instead, directories are explicitly zipped by the `JobGraphGenerators` when compiling the graph.
The zipping code was generalized and moved from `FileCache` and `BlobClient` to `FileUtils`.

Additionally, `JobGraphTest` now extends `TestLogger`.

## Brief change log

* move zip compression/expansion as general utility methods to `FileUtils`
* modify `[Streaming]JobGraphGenerator` to zip local user directory artifacts before registering them with the graph
* adjust `FileCacheDirectoryTest` to not manually create a mock zip file
* extend documentation of `FileCache`
* extend documentation of `DistributedCache`
* remove setting of user-artifacts in `TestStreamEnvironment` since it is redundant
* remove odd verification/normalization code in `Plan#registerCachedFile`, changes are covered by JobGraphGenerators

## Verifying this change

* zip compression/expansion is covered by new tests in `FileUtils`
* handling of local user directory artifacts by JobGraphGenerators covered by new tests in `JobGraphGeneratorTest`
* general functionality is covered by DistributedCache and Python API tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
