### PR TITLE
 [FLINK-9599][rest] RestClient supports FileUploads 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUpload.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUpload.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import java.nio.file.Path;
+
+/**
+ * Client uploading a file.
+ */
+public final class FileUpload {
+	private final Path file;
+	private final String contentType;
+
+	public FileUpload(Path file, String contentType) {
+		this.file = file;
+		this.contentType = contentType;
+	}
+
+	public Path getFile() {
+		return file;
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -109,7 +109,7 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 				final HttpContent httpContent = (HttpContent) msg;
 				currentHttpPostRequestDecoder.offer(httpContent);
 
-				while (currentHttpPostRequestDecoder.hasNext()) {
+				while (httpContent != LastHttpContent.EMPTY_LAST_CONTENT && currentHttpPostRequestDecoder.hasNext()) {
 					final InterfaceHttpData data = currentHttpPostRequestDecoder.next();
 					if (data.getHttpDataType() == InterfaceHttpData.HttpDataType.FileUpload) {
 						final DiskFileUpload fileUpload = (DiskFileUpload) data;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -190,7 +190,7 @@ public class RestClient {
 		objectMapper.writeValue(sw, request);
 		ByteBuf payload = Unpooled.wrappedBuffer(sw.toString().getBytes(ConfigConstants.DEFAULT_CHARSET));
 
-		Request httpRequest = createRequest(targetAddress, targetPort, targetUrl, messageHeaders.getHttpMethod().getNettyHttpMethod(), payload, fileUploads);
+		Request httpRequest = createRequest(targetAddress + ':' + targetPort, targetUrl, messageHeaders.getHttpMethod().getNettyHttpMethod(), payload, fileUploads);
 
 		final JavaType responseType;
 
@@ -207,13 +207,13 @@ public class RestClient {
 		return submitRequest(targetAddress, targetPort, httpRequest, responseType);
 	}
 
-	private static Request createRequest(String targetAddress, int targetPort, String targetUrl, HttpMethod httpMethod, ByteBuf jsonPayload, Collection<FileUpload> fileUploads) throws IOException {
+	private static Request createRequest(String targetAddress, String targetUrl, HttpMethod httpMethod, ByteBuf jsonPayload, Collection<FileUpload> fileUploads) throws IOException {
 		if (fileUploads.isEmpty()) {
 
 			HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, targetUrl, jsonPayload);
 
 			httpRequest.headers()
-				.set(HttpHeaders.Names.HOST, targetAddress + ':' + targetPort)
+				.set(HttpHeaders.Names.HOST, targetAddress)
 				.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE)
 				.add(HttpHeaders.Names.CONTENT_LENGTH, jsonPayload.capacity())
 				.add(HttpHeaders.Names.CONTENT_TYPE, RestConstants.REST_CONTENT_TYPE);
@@ -223,7 +223,7 @@ public class RestClient {
 			HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, targetUrl);
 
 			httpRequest.headers()
-				.set(HttpHeaders.Names.HOST, targetAddress + ':' + targetPort)
+				.set(HttpHeaders.Names.HOST, targetAddress)
 				.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
 
 			// takes care of splitting the request into multiple parts

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -58,6 +58,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHtt
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpClientCodec;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObjectAggregator;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
@@ -189,7 +190,7 @@ public class RestClient {
 		objectMapper.writeValue(sw, request);
 		ByteBuf payload = Unpooled.wrappedBuffer(sw.toString().getBytes(ConfigConstants.DEFAULT_CHARSET));
 
-		Request httpRequest = createRequest(targetAddress, targetPort, targetUrl, messageHeaders.getHttpMethod(), payload, fileUploads);
+		Request httpRequest = createRequest(targetAddress, targetPort, targetUrl, messageHeaders.getHttpMethod().getNettyHttpMethod(), payload, fileUploads);
 
 		final JavaType responseType;
 
@@ -206,10 +207,10 @@ public class RestClient {
 		return submitRequest(targetAddress, targetPort, httpRequest, responseType);
 	}
 
-	private static Request createRequest(String targetAddress, int targetPort, String targetUrl, HttpMethodWrapper httpMethod, ByteBuf jsonPayload, Collection<FileUpload> fileUploads) throws IOException {
+	private static Request createRequest(String targetAddress, int targetPort, String targetUrl, HttpMethod httpMethod, ByteBuf jsonPayload, Collection<FileUpload> fileUploads) throws IOException {
 		if (fileUploads.isEmpty()) {
 
-			HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod.getNettyHttpMethod(), targetUrl, jsonPayload);
+			HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, targetUrl, jsonPayload);
 
 			httpRequest.headers()
 				.set(HttpHeaders.Names.HOST, targetAddress + ':' + targetPort)
@@ -219,7 +220,7 @@ public class RestClient {
 
 			return new SimpleRequest(httpRequest);
 		} else {
-			HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod.getNettyHttpMethod(), targetUrl);
+			HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, targetUrl);
 
 			httpRequest.headers()
 				.set(HttpHeaders.Names.HOST, targetAddress + ':' + targetPort)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
@@ -18,32 +18,10 @@
 
 package org.apache.flink.runtime.rest;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.configuration.WebOptions;
-import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
-import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
-import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
-import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
-import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
-import org.apache.flink.runtime.rest.messages.MessageHeaders;
-import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
-import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.webmonitor.RestfulGateway;
-import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
-import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TestLogger;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import okhttp3.MediaType;
@@ -51,98 +29,24 @@ import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import javax.annotation.Nonnull;
-
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the {@link FileUploadHandler}. Ensures that multipart http messages containing files and/or json are properly
  * handled.
  */
-public class FileUploadHandlerTest extends TestLogger {
+public class FileUploadHandlerTest extends MultipartUploadTestBase {
 
 	private static final ObjectMapper OBJECT_MAPPER = RestMapperUtils.getStrictObjectMapper();
-	private static final Random RANDOM = new Random();
-
-	@ClassRule
-	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-
-	private static RestServerEndpoint serverEndpoint;
-	private static String serverAddress;
-
-	private static MultipartMixedHandler mixedHandler;
-	private static MultipartJsonHandler jsonHandler;
-	private static MultipartFileHandler fileHandler;
-	private static File file1;
-	private static File file2;
-
-	private static Path configuredUploadDir;
-
-	@BeforeClass
-	public static void setup() throws Exception {
-		Configuration config = new Configuration();
-		config.setInteger(RestOptions.PORT, 0);
-		config.setString(RestOptions.ADDRESS, "localhost");
-		configuredUploadDir = TEMPORARY_FOLDER.newFolder().toPath();
-		config.setString(WebOptions.UPLOAD_DIR, configuredUploadDir.toString());
-
-		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
-
-		final String restAddress = "http://localhost:1234";
-		RestfulGateway mockRestfulGateway = TestingRestfulGateway.newBuilder()
-			.setRestAddress(restAddress)
-			.build();
-
-		final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
-			CompletableFuture.completedFuture(mockRestfulGateway);
-
-		file1 = TEMPORARY_FOLDER.newFile();
-		Files.write(file1.toPath(), "hello".getBytes(ConfigConstants.DEFAULT_CHARSET));
-		file2 = TEMPORARY_FOLDER.newFile();
-		Files.write(file2.toPath(), "world".getBytes(ConfigConstants.DEFAULT_CHARSET));
-
-		mixedHandler = new MultipartMixedHandler(CompletableFuture.completedFuture(restAddress), mockGatewayRetriever);
-		jsonHandler = new MultipartJsonHandler(CompletableFuture.completedFuture(restAddress), mockGatewayRetriever);
-		fileHandler = new MultipartFileHandler(CompletableFuture.completedFuture(restAddress), mockGatewayRetriever);
-
-		final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
-			Tuple2.of(mixedHandler.getMessageHeaders(), mixedHandler),
-			Tuple2.of(jsonHandler.getMessageHeaders(), jsonHandler),
-			Tuple2.of(fileHandler.getMessageHeaders(), fileHandler));
-
-		serverEndpoint = new TestRestServerEndpoint(serverConfig, handlers);
-
-		serverEndpoint.start();
-		serverAddress = serverEndpoint.getRestBaseUrl();
-	}
-
-	@AfterClass
-	public static void teardown() throws Exception {
-		if (serverEndpoint != null) {
-			serverEndpoint.close();
-			serverEndpoint = null;
-		}
-	}
 
 	private static Request buildMalformedRequest(String headerUrl) {
 		MultipartBody.Builder builder = new MultipartBody.Builder();
@@ -154,7 +58,7 @@ public class FileUploadHandlerTest extends TestLogger {
 
 	private static Request buildMixedRequestWithUnknownAttribute(String headerUrl) throws IOException {
 		MultipartBody.Builder builder = new MultipartBody.Builder();
-		builder = addJsonPart(builder, RANDOM.nextInt(), "hello");
+		builder = addJsonPart(builder, new TestRequestBody(), "hello");
 		builder = addFilePart(builder);
 		return finalizeRequest(builder, headerUrl);
 	}
@@ -165,15 +69,15 @@ public class FileUploadHandlerTest extends TestLogger {
 		return finalizeRequest(builder, headerUrl);
 	}
 
-	private static Request buildJsonRequest(String headerUrl, int index) throws IOException {
+	private static Request buildJsonRequest(String headerUrl, TestRequestBody json) throws IOException {
 		MultipartBody.Builder builder = new MultipartBody.Builder();
-		builder = addJsonPart(builder, index, FileUploadHandler.HTTP_ATTRIBUTE_REQUEST);
+		builder = addJsonPart(builder, json, FileUploadHandler.HTTP_ATTRIBUTE_REQUEST);
 		return finalizeRequest(builder, headerUrl);
 	}
 
-	private static Request buildMixedRequest(String headerUrl, int index) throws IOException {
+	private static Request buildMixedRequest(String headerUrl, TestRequestBody json) throws IOException {
 		MultipartBody.Builder builder = new MultipartBody.Builder();
-		builder = addJsonPart(builder, index, FileUploadHandler.HTTP_ATTRIBUTE_REQUEST);
+		builder = addJsonPart(builder, json, FileUploadHandler.HTTP_ATTRIBUTE_REQUEST);
 		builder = addFilePart(builder);
 		return finalizeRequest(builder, headerUrl);
 	}
@@ -197,9 +101,7 @@ public class FileUploadHandlerTest extends TestLogger {
 			.addFormDataPart("file2", file2.getName(), filePayload2);
 	}
 
-	private static MultipartBody.Builder addJsonPart(MultipartBody.Builder builder, int index, String attribute) throws IOException {
-		TestRequestBody jsonRequestBody = new TestRequestBody(index);
-
+	private static MultipartBody.Builder addJsonPart(MultipartBody.Builder builder, TestRequestBody jsonRequestBody, String attribute) throws IOException {
 		StringWriter sw = new StringWriter();
 		OBJECT_MAPPER.writeValue(sw, jsonRequestBody);
 
@@ -212,7 +114,7 @@ public class FileUploadHandlerTest extends TestLogger {
 	public void testMixedMultipart() throws Exception {
 		OkHttpClient client = new OkHttpClient();
 
-		Request jsonRequest = buildJsonRequest(mixedHandler.getMessageHeaders().getTargetRestEndpointURL(), RANDOM.nextInt());
+		Request jsonRequest = buildJsonRequest(mixedHandler.getMessageHeaders().getTargetRestEndpointURL(), new TestRequestBody());
 		try (Response response = client.newCall(jsonRequest).execute()) {
 			// explicitly rejected by the test handler implementation
 			assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), response.code());
@@ -224,11 +126,11 @@ public class FileUploadHandlerTest extends TestLogger {
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
 		}
 
-		int mixedId = RANDOM.nextInt();
-		Request mixedRequest = buildMixedRequest(mixedHandler.getMessageHeaders().getTargetRestEndpointURL(), mixedId);
+		TestRequestBody json = new TestRequestBody();
+		Request mixedRequest = buildMixedRequest(mixedHandler.getMessageHeaders().getTargetRestEndpointURL(), json);
 		try (Response response = client.newCall(mixedRequest).execute()) {
 			assertEquals(mixedHandler.getMessageHeaders().getResponseStatusCode().code(), response.code());
-			assertEquals(mixedId, mixedHandler.lastReceivedRequest.index);
+			assertEquals(json, mixedHandler.lastReceivedRequest);
 		}
 	}
 
@@ -236,11 +138,11 @@ public class FileUploadHandlerTest extends TestLogger {
 	public void testJsonMultipart() throws Exception {
 		OkHttpClient client = new OkHttpClient();
 
-		int jsonId = RANDOM.nextInt();
-		Request jsonRequest = buildJsonRequest(jsonHandler.getMessageHeaders().getTargetRestEndpointURL(), jsonId);
+		TestRequestBody json = new TestRequestBody();
+		Request jsonRequest = buildJsonRequest(jsonHandler.getMessageHeaders().getTargetRestEndpointURL(), json);
 		try (Response response = client.newCall(jsonRequest).execute()) {
 			assertEquals(jsonHandler.getMessageHeaders().getResponseStatusCode().code(), response.code());
-			assertEquals(jsonId, jsonHandler.lastReceivedRequest.index);
+			assertEquals(json, jsonHandler.lastReceivedRequest);
 		}
 
 		Request fileRequest = buildFileRequest(jsonHandler.getMessageHeaders().getTargetRestEndpointURL());
@@ -249,7 +151,7 @@ public class FileUploadHandlerTest extends TestLogger {
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
 		}
 
-		Request mixedRequest = buildMixedRequest(jsonHandler.getMessageHeaders().getTargetRestEndpointURL(), RANDOM.nextInt());
+		Request mixedRequest = buildMixedRequest(jsonHandler.getMessageHeaders().getTargetRestEndpointURL(), new TestRequestBody());
 		try (Response response = client.newCall(mixedRequest).execute()) {
 			// FileUploads are outright forbidden
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
@@ -260,7 +162,7 @@ public class FileUploadHandlerTest extends TestLogger {
 	public void testFileMultipart() throws Exception {
 		OkHttpClient client = new OkHttpClient();
 
-		Request jsonRequest = buildJsonRequest(fileHandler.getMessageHeaders().getTargetRestEndpointURL(), RANDOM.nextInt());
+		Request jsonRequest = buildJsonRequest(fileHandler.getMessageHeaders().getTargetRestEndpointURL(), new TestRequestBody());
 		try (Response response = client.newCall(jsonRequest).execute()) {
 			// JSON payload did not match expected format
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
@@ -271,7 +173,7 @@ public class FileUploadHandlerTest extends TestLogger {
 			assertEquals(fileHandler.getMessageHeaders().getResponseStatusCode().code(), response.code());
 		}
 
-		Request mixedRequest = buildMixedRequest(fileHandler.getMessageHeaders().getTargetRestEndpointURL(), RANDOM.nextInt());
+		Request mixedRequest = buildMixedRequest(fileHandler.getMessageHeaders().getTargetRestEndpointURL(), new TestRequestBody());
 		try (Response response = client.newCall(mixedRequest).execute()) {
 			// JSON payload did not match expected format
 			assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code());
@@ -313,227 +215,5 @@ public class FileUploadHandlerTest extends TestLogger {
 			actualUploadDir.isPresent(),
 			"Expected upload directory does not exist.");
 		assertEquals("Not all files were cleaned up.", 0, Files.list(actualUploadDir.get()).count());
-	}
-
-	private static class MultipartMixedHandler extends AbstractRestHandler<RestfulGateway, TestRequestBody, EmptyResponseBody, EmptyMessageParameters> {
-		volatile TestRequestBody lastReceivedRequest = null;
-
-		MultipartMixedHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<RestfulGateway> leaderRetriever) {
-			super(localRestAddress, leaderRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), MultipartMixedHeaders.INSTANCE);
-		}
-
-		@Override
-		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<TestRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
-			MultipartFileHandler.verifyFileUpload(request.getUploadedFiles());
-			this.lastReceivedRequest = request.getRequestBody();
-			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
-		}
-
-		private static final class MultipartMixedHeaders implements MessageHeaders<TestRequestBody, EmptyResponseBody, EmptyMessageParameters> {
-			private static final MultipartMixedHeaders INSTANCE = new MultipartMixedHeaders();
-
-			private MultipartMixedHeaders() {
-			}
-
-			@Override
-			public Class<TestRequestBody> getRequestClass() {
-				return TestRequestBody.class;
-			}
-
-			@Override
-			public Class<EmptyResponseBody> getResponseClass() {
-				return EmptyResponseBody.class;
-			}
-
-			@Override
-			public HttpResponseStatus getResponseStatusCode() {
-				return HttpResponseStatus.OK;
-			}
-
-			@Override
-			public String getDescription() {
-				return "";
-			}
-
-			@Override
-			public EmptyMessageParameters getUnresolvedMessageParameters() {
-				return EmptyMessageParameters.getInstance();
-			}
-
-			@Override
-			public HttpMethodWrapper getHttpMethod() {
-				return HttpMethodWrapper.POST;
-			}
-
-			@Override
-			public String getTargetRestEndpointURL() {
-				return "/test/upload/mixed";
-			}
-
-			@Override
-			public boolean acceptsFileUploads() {
-				return true;
-			}
-		}
-	}
-
-	private static class MultipartJsonHandler extends AbstractRestHandler<RestfulGateway, TestRequestBody, EmptyResponseBody, EmptyMessageParameters> {
-		volatile TestRequestBody lastReceivedRequest = null;
-
-		MultipartJsonHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<RestfulGateway> leaderRetriever) {
-			super(localRestAddress, leaderRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), MultipartJsonHeaders.INSTANCE);
-		}
-
-		@Override
-		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<TestRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
-			Collection<Path> uploadedFiles = request.getUploadedFiles();
-			if (!uploadedFiles.isEmpty()) {
-				throw new RestHandlerException("This handler should not have received file uploads.", HttpResponseStatus.INTERNAL_SERVER_ERROR);
-			}
-			this.lastReceivedRequest = request.getRequestBody();
-			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
-		}
-
-		private static final class MultipartJsonHeaders extends TestHeadersBase<TestRequestBody> {
-			private static final MultipartJsonHeaders INSTANCE = new MultipartJsonHeaders();
-
-			private MultipartJsonHeaders() {
-			}
-
-			@Override
-			public Class<TestRequestBody> getRequestClass() {
-				return TestRequestBody.class;
-			}
-
-			@Override
-			public String getTargetRestEndpointURL() {
-				return "/test/upload/json";
-			}
-
-			@Override
-			public boolean acceptsFileUploads() {
-				return false;
-			}
-		}
-	}
-
-	private static class MultipartFileHandler extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters> {
-
-		MultipartFileHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<RestfulGateway> leaderRetriever) {
-			super(localRestAddress, leaderRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), MultipartFileHeaders.INSTANCE);
-		}
-
-		@Override
-		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
-			verifyFileUpload(request.getUploadedFiles());
-			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
-		}
-
-		static void verifyFileUpload(Collection<Path> uploadedFiles) throws RestHandlerException {
-			try {
-				assertEquals(2, uploadedFiles.size());
-
-				for (Path uploadedFile : uploadedFiles) {
-					File matchingFile;
-					if (uploadedFile.getFileName().toString().equals(file1.getName())) {
-						matchingFile = file1;
-					} else if (uploadedFile.getFileName().toString().equals(file2.getName())) {
-						matchingFile = file2;
-					} else {
-						throw new RestHandlerException("Received file with unknown name " + uploadedFile.getFileName() + '.', HttpResponseStatus.INTERNAL_SERVER_ERROR);
-					}
-
-					byte[] originalContent = Files.readAllBytes(matchingFile.toPath());
-					byte[] receivedContent = Files.readAllBytes(uploadedFile);
-					assertArrayEquals(originalContent, receivedContent);
-				}
-			} catch (Exception e) {
-				// return 505 to differentiate from common BAD_REQUEST responses in this test
-				throw new RestHandlerException("Test verification failed.", HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
-			}
-		}
-
-		private static final class MultipartFileHeaders extends TestHeadersBase<EmptyRequestBody> {
-			private static final MultipartFileHeaders INSTANCE = new MultipartFileHeaders();
-
-			private MultipartFileHeaders() {
-			}
-
-			@Override
-			public Class<EmptyRequestBody> getRequestClass() {
-				return EmptyRequestBody.class;
-			}
-
-			@Override
-			public String getTargetRestEndpointURL() {
-				return "/test/upload/file";
-			}
-
-			@Override
-			public boolean acceptsFileUploads() {
-				return true;
-			}
-		}
-	}
-
-	private abstract static class TestHeadersBase<R extends RequestBody> implements MessageHeaders<R, EmptyResponseBody, EmptyMessageParameters> {
-
-		@Override
-		public Class<EmptyResponseBody> getResponseClass() {
-			return EmptyResponseBody.class;
-		}
-
-		@Override
-		public HttpResponseStatus getResponseStatusCode() {
-			return HttpResponseStatus.OK;
-		}
-
-		@Override
-		public String getDescription() {
-			return "";
-		}
-
-		@Override
-		public EmptyMessageParameters getUnresolvedMessageParameters() {
-			return EmptyMessageParameters.getInstance();
-		}
-
-		@Override
-		public HttpMethodWrapper getHttpMethod() {
-			return HttpMethodWrapper.POST;
-		}
-	}
-
-	private static final class TestRequestBody implements RequestBody {
-		private static final String FIELD_NAME_INDEX = "index";
-
-		@JsonProperty(FIELD_NAME_INDEX)
-		private final int index;
-
-		@JsonCreator
-		TestRequestBody(@JsonProperty(FIELD_NAME_INDEX) int index) {
-			this.index = index;
-		}
-	}
-
-	private static class TestRestServerEndpoint extends RestServerEndpoint {
-
-		private final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers;
-
-		TestRestServerEndpoint(
-			RestServerEndpointConfiguration configuration,
-			List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers) throws IOException {
-			super(configuration);
-			this.handlers = Preconditions.checkNotNull(handlers);
-		}
-
-		@Override
-		protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
-			return handlers;
-		}
-
-		@Override
-		protected void startInternal() {
-		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadTestBase.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test base for verifying support of multipart uploads via REST.
+ */
+public abstract class MultipartUploadTestBase extends TestLogger {
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	private static RestServerEndpoint serverEndpoint;
+	protected static String serverAddress;
+	protected static InetSocketAddress serverSocketAddress;
+
+	protected static MultipartMixedHandler mixedHandler;
+	protected static MultipartJsonHandler jsonHandler;
+	protected static MultipartFileHandler fileHandler;
+	protected static File file1;
+	protected static File file2;
+
+	protected static Path configuredUploadDir;
+
+	@BeforeClass
+	public static void setup() throws Exception {
+		Configuration config = new Configuration();
+		config.setInteger(RestOptions.PORT, 0);
+		config.setString(RestOptions.ADDRESS, "localhost");
+		configuredUploadDir = TEMPORARY_FOLDER.newFolder().toPath();
+		config.setString(WebOptions.UPLOAD_DIR, configuredUploadDir.toString());
+
+		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
+
+		final String restAddress = "http://localhost:1234";
+		RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
+		when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(restAddress));
+
+		final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
+			CompletableFuture.completedFuture(mockRestfulGateway);
+
+		file1 = TEMPORARY_FOLDER.newFile();
+		Files.write(file1.toPath(), "hello".getBytes(ConfigConstants.DEFAULT_CHARSET));
+		file2 = TEMPORARY_FOLDER.newFile();
+		Files.write(file2.toPath(), "world".getBytes(ConfigConstants.DEFAULT_CHARSET));
+
+		mixedHandler = new MultipartMixedHandler(CompletableFuture.completedFuture(restAddress), mockGatewayRetriever);
+		jsonHandler = new MultipartJsonHandler(CompletableFuture.completedFuture(restAddress), mockGatewayRetriever);
+		fileHandler = new MultipartFileHandler(CompletableFuture.completedFuture(restAddress), mockGatewayRetriever);
+
+		final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
+			Tuple2.of(mixedHandler.getMessageHeaders(), mixedHandler),
+			Tuple2.of(jsonHandler.getMessageHeaders(), jsonHandler),
+			Tuple2.of(fileHandler.getMessageHeaders(), fileHandler));
+
+		serverEndpoint = new TestRestServerEndpoint(serverConfig, handlers);
+
+		serverEndpoint.start();
+		serverAddress = serverEndpoint.getRestBaseUrl();
+		serverSocketAddress = serverEndpoint.getServerAddress();
+	}
+
+	@Before
+	public void reset() {
+		mixedHandler.lastReceivedRequest = null;
+		jsonHandler.lastReceivedRequest = null;
+	}
+
+	@AfterClass
+	public static void teardown() throws Exception {
+		if (serverEndpoint != null) {
+			serverEndpoint.close();
+			serverEndpoint = null;
+		}
+	}
+
+	/**
+	 * Handler that accepts a mixed request consisting of a {@link TestRequestBody} and {@link #file1} and {@link #file2}.
+	 */
+	protected static class MultipartMixedHandler extends AbstractRestHandler<RestfulGateway, TestRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+		volatile TestRequestBody lastReceivedRequest = null;
+
+		MultipartMixedHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<RestfulGateway> leaderRetriever) {
+			super(localRestAddress, leaderRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), MultipartMixedHeaders.INSTANCE);
+		}
+
+		@Override
+		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<TestRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
+			MultipartFileHandler.verifyFileUpload(request.getUploadedFiles());
+			this.lastReceivedRequest = request.getRequestBody();
+			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+		}
+
+		private static final class MultipartMixedHeaders implements MessageHeaders<TestRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+			private static final MultipartMixedHeaders INSTANCE = new MultipartMixedHeaders();
+
+			private MultipartMixedHeaders() {
+			}
+
+			@Override
+			public Class<TestRequestBody> getRequestClass() {
+				return TestRequestBody.class;
+			}
+
+			@Override
+			public Class<EmptyResponseBody> getResponseClass() {
+				return EmptyResponseBody.class;
+			}
+
+			@Override
+			public HttpResponseStatus getResponseStatusCode() {
+				return HttpResponseStatus.OK;
+			}
+
+			@Override
+			public String getDescription() {
+				return "";
+			}
+
+			@Override
+			public EmptyMessageParameters getUnresolvedMessageParameters() {
+				return EmptyMessageParameters.getInstance();
+			}
+
+			@Override
+			public HttpMethodWrapper getHttpMethod() {
+				return HttpMethodWrapper.POST;
+			}
+
+			@Override
+			public String getTargetRestEndpointURL() {
+				return "/test/upload/mixed";
+			}
+
+			@Override
+			public boolean acceptsFileUploads() {
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * Handler that accepts a json request consisting of a {@link TestRequestBody}.
+	 */
+	protected static class MultipartJsonHandler extends AbstractRestHandler<RestfulGateway, TestRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+		volatile TestRequestBody lastReceivedRequest = null;
+
+		MultipartJsonHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<RestfulGateway> leaderRetriever) {
+			super(localRestAddress, leaderRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), MultipartJsonHeaders.INSTANCE);
+		}
+
+		@Override
+		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<TestRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
+			Collection<Path> uploadedFiles = request.getUploadedFiles();
+			if (!uploadedFiles.isEmpty()) {
+				throw new RestHandlerException("This handler should not have received file uploads.", HttpResponseStatus.INTERNAL_SERVER_ERROR);
+			}
+			this.lastReceivedRequest = request.getRequestBody();
+			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+		}
+
+		private static final class MultipartJsonHeaders extends TestHeadersBase<TestRequestBody> {
+			private static final MultipartJsonHeaders INSTANCE = new MultipartJsonHeaders();
+
+			private MultipartJsonHeaders() {
+			}
+
+			@Override
+			public Class<TestRequestBody> getRequestClass() {
+				return TestRequestBody.class;
+			}
+
+			@Override
+			public String getTargetRestEndpointURL() {
+				return "/test/upload/json";
+			}
+
+			@Override
+			public boolean acceptsFileUploads() {
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * Handler that accepts a file request consisting of and {@link #file1} and {@link #file2}.
+	 */
+	protected static class MultipartFileHandler extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+
+		MultipartFileHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<RestfulGateway> leaderRetriever) {
+			super(localRestAddress, leaderRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), MultipartFileHeaders.INSTANCE);
+		}
+
+		@Override
+		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
+			verifyFileUpload(request.getUploadedFiles());
+			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+		}
+
+		static void verifyFileUpload(Collection<Path> uploadedFiles) throws RestHandlerException {
+			try {
+				assertEquals(2, uploadedFiles.size());
+
+				for (Path uploadedFile : uploadedFiles) {
+					File matchingFile;
+					if (uploadedFile.getFileName().toString().equals(file1.getName())) {
+						matchingFile = file1;
+					} else if (uploadedFile.getFileName().toString().equals(file2.getName())) {
+						matchingFile = file2;
+					} else {
+						throw new RestHandlerException("Received file with unknown name " + uploadedFile.getFileName() + '.', HttpResponseStatus.INTERNAL_SERVER_ERROR);
+					}
+
+					byte[] originalContent = Files.readAllBytes(matchingFile.toPath());
+					byte[] receivedContent = Files.readAllBytes(uploadedFile);
+					assertArrayEquals(originalContent, receivedContent);
+				}
+			} catch (Exception e) {
+				// return 505 to differentiate from common BAD_REQUEST responses in this test
+				throw new RestHandlerException("Test verification failed.", HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+			}
+		}
+
+		private static final class MultipartFileHeaders extends TestHeadersBase<EmptyRequestBody> {
+			private static final MultipartFileHeaders INSTANCE = new MultipartFileHeaders();
+
+			private MultipartFileHeaders() {
+			}
+
+			@Override
+			public Class<EmptyRequestBody> getRequestClass() {
+				return EmptyRequestBody.class;
+			}
+
+			@Override
+			public String getTargetRestEndpointURL() {
+				return "/test/upload/file";
+			}
+
+			@Override
+			public boolean acceptsFileUploads() {
+				return true;
+			}
+		}
+	}
+
+	private abstract static class TestHeadersBase<R extends RequestBody> implements MessageHeaders<R, EmptyResponseBody, EmptyMessageParameters> {
+
+		@Override
+		public Class<EmptyResponseBody> getResponseClass() {
+			return EmptyResponseBody.class;
+		}
+
+		@Override
+		public HttpResponseStatus getResponseStatusCode() {
+			return HttpResponseStatus.OK;
+		}
+
+		@Override
+		public String getDescription() {
+			return "";
+		}
+
+		@Override
+		public EmptyMessageParameters getUnresolvedMessageParameters() {
+			return EmptyMessageParameters.getInstance();
+		}
+
+		@Override
+		public HttpMethodWrapper getHttpMethod() {
+			return HttpMethodWrapper.POST;
+		}
+	}
+
+	/**
+	 * Simple test {@link RequestBody}.
+	 */
+	protected static final class TestRequestBody implements RequestBody {
+		private static final String FIELD_NAME_INDEX = "index";
+		private static final Random RANDOM = new Random();
+
+		@JsonProperty(FIELD_NAME_INDEX)
+		private final int index;
+
+		TestRequestBody() {
+			this(RANDOM.nextInt());
+		}
+
+		@JsonCreator
+		TestRequestBody(@JsonProperty(FIELD_NAME_INDEX) int index) {
+			this.index = index;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			TestRequestBody that = (TestRequestBody) o;
+			return index == that.index;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(index);
+		}
+
+		@Override
+		public String toString() {
+			return "TestRequestBody{" +
+				"index=" + index +
+				'}';
+		}
+	}
+
+	private static class TestRestServerEndpoint extends RestServerEndpoint {
+
+		private final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers;
+
+		TestRestServerEndpoint(
+			RestServerEndpointConfiguration configuration,
+			List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers) throws IOException {
+			super(configuration);
+			this.handlers = requireNonNull(handlers);
+		}
+
+		@Override
+		protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+			return handlers;
+		}
+
+		@Override
+		protected void startInternal() {
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientMultipartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientMultipartTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.ConfigurationException;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Tests for the multipart functionality of the {@link RestClient}.
+ */
+public class RestClientMultipartTest extends MultipartUploadTestBase {
+
+	private static RestClient restClient;
+
+	@BeforeClass
+	public static void setupClient() throws ConfigurationException {
+		restClient = new RestClient(RestClientConfiguration.fromConfiguration(new Configuration()), TestingUtils.defaultExecutor());
+	}
+
+	@AfterClass
+	public static void teardownClient() {
+		if (restClient != null) {
+			restClient.shutdown(Time.seconds(10));
+		}
+	}
+
+	@Test
+	public void testMixedMultipart() throws Exception {
+		Collection<FileUpload> files = Arrays.asList(new FileUpload(file1.toPath(), "application/octet-stream"), new FileUpload(file2.toPath(), "application/octet-stream"));
+
+		TestRequestBody json = new TestRequestBody();
+		CompletableFuture<EmptyResponseBody> responseFuture = restClient.sendRequest(
+			serverSocketAddress.getHostName(),
+			serverSocketAddress.getPort(),
+			mixedHandler.getMessageHeaders(),
+			EmptyMessageParameters.getInstance(),
+			json,
+			files
+		);
+
+		responseFuture.get();
+		Assert.assertEquals(json, mixedHandler.lastReceivedRequest);
+	}
+
+	@Test
+	public void testJsonMultipart() throws Exception {
+		TestRequestBody json = new TestRequestBody();
+		CompletableFuture<EmptyResponseBody> responseFuture = restClient.sendRequest(
+			serverSocketAddress.getHostName(),
+			serverSocketAddress.getPort(),
+			jsonHandler.getMessageHeaders(),
+			EmptyMessageParameters.getInstance(),
+			json,
+			Collections.emptyList()
+		);
+
+		responseFuture.get();
+		Assert.assertEquals(json, jsonHandler.lastReceivedRequest);
+	}
+
+	@Test
+	public void testFileMultipart() throws Exception {
+		Collection<FileUpload> files = Arrays.asList(new FileUpload(file1.toPath(), "application/octet-stream"), new FileUpload(file2.toPath(), "application/octet-stream"));
+
+		CompletableFuture<EmptyResponseBody> responseFuture = restClient.sendRequest(
+			serverSocketAddress.getHostName(),
+			serverSocketAddress.getPort(),
+			fileHandler.getMessageHeaders(),
+			EmptyMessageParameters.getInstance(),
+			EmptyRequestBody.getInstance(),
+			files
+		);
+
+		responseFuture.get();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR extends the `RestClient` to allow sending multipart messages containing files and an optional json payload.

@tillrohrmann Regarding the previously discussed issue about ´EMPTY_LAST_HTTP_CONTENT`, you can reproduce the issue by reverting the change to the `FileUploadHandler` and running the `RestClientMultipartTest`.

## Brief change log

* rework `FileUploadHandlerTest` into an abstract base class, to re-use classes for the `RestClient`


## Verifying this change

* add `RequestProcess` interface for hiding differences between non-/multipart messages
* refactor `RestClient#sendRequest` into `internalSendRequest` that allows passing a `RequestProcessor`
* see `RestClientMultipartTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
