### PR TITLE
[FLINK-9633][checkpoint] Use savepoint path's file system to create checkpoint output stream

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
@@ -126,7 +126,7 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 			final Path path = decodePathFromReference(reference);
 
 			return new FsCheckpointStorageLocation(
-					fileSystem,
+					path.getFileSystem(),
 					path,
 					path,
 					path,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
@@ -126,5 +127,10 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 				", reference=" + reference +
 				", fileStateSizeThreshold=" + fileStateSizeThreshold +
 				'}';
+	}
+
+	@VisibleForTesting
+	public FileSystem getFileSystem() {
+		return fileSystem;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This PR fixes Flink doesn't use the savepoint path's filesystem to create the output stream on TM side.*

## Brief change log

  - *Use Savepoint path's file system to create checkpoint output stream.*


## Verifying this change

  - *Added `StreamTaskTest#testTriggerSavepointWhenTheFileSystemIsDifferentWithCheckpoint()` to verify the changes*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - No
