### PR TITLE
[FLINK-9543][METRICS] Expose JobMaster ID to metric system

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -334,9 +334,10 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 			LOG.debug("Starting Dispatcher REST endpoint.");
 			webMonitorEndpoint.start();
 
+			final ResourceID resourceManagerID = ResourceID.generate();
 			resourceManager = createResourceManager(
 				configuration,
-				ResourceID.generate(),
+				resourceManagerID,
 				rpcService,
 				highAvailabilityServices,
 				heartbeatServices,
@@ -345,7 +346,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 				clusterInformation,
 				webMonitorEndpoint.getRestBaseUrl());
 
-			jobManagerMetricGroup = MetricUtils.instantiateJobManagerMetricGroup(metricRegistry, rpcService.getAddress());
+			jobManagerMetricGroup = MetricUtils.instantiateJobManagerMetricGroup(metricRegistry, rpcService.getAddress(), resourceManagerID.getResourceIdString());
 
 			final HistoryServerArchivist historyServerArchivist = HistoryServerArchivist.createHistoryServerArchivist(configuration, webMonitorEndpoint);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -39,10 +39,12 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 	private final Map<JobID, JobManagerJobMetricGroup> jobs = new HashMap<>();
 
 	private final String hostname;
+	private final String jobManagerId;
 
-	public JobManagerMetricGroup(MetricRegistry registry, String hostname) {
+	public JobManagerMetricGroup(MetricRegistry registry, String hostname, String jobManagerId) {
 		super(registry, registry.getScopeFormats().getJobManagerFormat().formatScope(hostname), null);
 		this.hostname = hostname;
+		this.jobManagerId = jobManagerId;
 	}
 
 	public String hostname() {
@@ -102,6 +104,7 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 	@Override
 	protected void putVariables(Map<String, String> variables) {
 		variables.put(ScopeFormat.SCOPE_HOST, hostname);
+		variables.put(ScopeFormat.SCOPE_JOBMANAGER_ID, jobManagerId);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -62,9 +63,10 @@ public class UnregisteredMetricGroups {
 	 */
 	public static class UnregisteredJobManagerMetricGroup extends JobManagerMetricGroup {
 		private static final String DEFAULT_HOST_NAME = "UnregisteredHost";
+		private static final String DEFAULT_JOBMANAGER_ID = ResourceID.generate().getResourceIdString();
 
 		private UnregisteredJobManagerMetricGroup() {
-			super(NoOpMetricRegistry.INSTANCE, DEFAULT_HOST_NAME);
+			super(NoOpMetricRegistry.INSTANCE, DEFAULT_HOST_NAME, DEFAULT_JOBMANAGER_ID);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
@@ -70,6 +70,10 @@ public abstract class ScopeFormat {
 
 	public static final String SCOPE_HOST = asVariable("host");
 
+	// ----- Job Manager ----
+
+	public static final String SCOPE_JOBMANAGER_ID = asVariable("jm_id");
+
 	// ----- Task Manager ----
 
 	public static final String SCOPE_TASKMANAGER_ID = asVariable("tm_id");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -57,10 +57,12 @@ public class MetricUtils {
 
 	public static JobManagerMetricGroup instantiateJobManagerMetricGroup(
 			final MetricRegistry metricRegistry,
-			final String hostname) {
+			final String hostname,
+			final String jobManagerId) {
 		final JobManagerMetricGroup jobManagerMetricGroup = new JobManagerMetricGroup(
 			metricRegistry,
-			hostname);
+			hostname,
+			jobManagerId);
 
 		MetricGroup statusGroup = jobManagerMetricGroup.addGroup(METRIC_GROUP_STATUS_NAME);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -296,7 +296,9 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 				// bring up the ResourceManager(s)
 				LOG.info("Starting ResourceManger");
+				final ResourceID resourceManagerID = ResourceID.generate();
 				resourceManagerRunner = startResourceManager(
+					resourceManagerID,
 					configuration,
 					haServices,
 					heartbeatServices,
@@ -356,7 +358,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 				// bring up the dispatcher that launches JobManagers when jobs submitted
 				LOG.info("Starting job dispatcher(s) for JobManger");
 
-				this.jobManagerMetricGroup = MetricUtils.instantiateJobManagerMetricGroup(metricRegistry, "localhost");
+				this.jobManagerMetricGroup = MetricUtils.instantiateJobManagerMetricGroup(metricRegistry, "localhost", resourceManagerID.getResourceIdString());
 
 				final HistoryServerArchivist historyServerArchivist = HistoryServerArchivist.createHistoryServerArchivist(configuration, dispatcherRestEndpoint);
 
@@ -762,6 +764,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	}
 
 	protected ResourceManagerRunner startResourceManager(
+		    ResourceID resourceId,
 			Configuration configuration,
 			HighAvailabilityServices haServices,
 			HeartbeatServices heartbeatServices,
@@ -770,7 +773,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 			ClusterInformation clusterInformation) throws Exception {
 
 		final ResourceManagerRunner resourceManagerRunner = new ResourceManagerRunner(
-			ResourceID.generate(),
+			resourceId,
 			FlinkResourceManager.RESOURCE_MANAGER_NAME + '_' + UUID.randomUUID(),
 			configuration,
 			resourceManagerRpcService,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -2517,7 +2517,8 @@ object JobManager {
 
     val jobManagerMetricGroup = MetricUtils.instantiateJobManagerMetricGroup(
       metricRegistry,
-      configuration.getString(JobManagerOptions.ADDRESS))
+      configuration.getString(JobManagerOptions.ADDRESS),
+      ResourceID.generate.getResourceIdString)
 
     (instanceManager,
       scheduler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -46,7 +47,8 @@ public class JobManagerGroupTest extends TestLogger {
 	@Test
 	public void addAndRemoveJobs() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
+		String jobManagerId = ResourceID.generate().getResourceIdString();
+		final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost", jobManagerId);
 
 		final JobID jid1 = new JobID();
 		final JobID jid2 = new JobID();
@@ -78,7 +80,8 @@ public class JobManagerGroupTest extends TestLogger {
 	@Test
 	public void testCloseClosesAll() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
+		String jobManagerId = ResourceID.generate().getResourceIdString();
+		final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost", jobManagerId);
 
 		final JobID jid1 = new JobID();
 		final JobID jid2 = new JobID();
@@ -104,7 +107,8 @@ public class JobManagerGroupTest extends TestLogger {
 	@Test
 	public void testGenerateScopeDefault() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
+		String jobManagerId = ResourceID.generate().getResourceIdString();
+		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost", jobManagerId);
 
 		assertArrayEquals(new String[]{"localhost", "jobmanager"}, group.getScopeComponents());
 		assertEquals("localhost.jobmanager.name", group.getMetricIdentifier("name"));
@@ -117,8 +121,8 @@ public class JobManagerGroupTest extends TestLogger {
 		Configuration cfg = new Configuration();
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM, "constant.<host>.foo.<host>");
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
-
-		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "host");
+		String jobManagerId = ResourceID.generate().getResourceIdString();
+		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "host", jobManagerId);
 
 		assertArrayEquals(new String[]{"constant", "host", "foo", "host"}, group.getScopeComponents());
 		assertEquals("constant.host.foo.host.name", group.getMetricIdentifier("name"));
@@ -129,7 +133,8 @@ public class JobManagerGroupTest extends TestLogger {
 	@Test
 	public void testCreateQueryServiceMetricInfo() {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		JobManagerMetricGroup jm = new JobManagerMetricGroup(registry, "host");
+		String jobManagerId = ResourceID.generate().getResourceIdString();
+		JobManagerMetricGroup jm = new JobManagerMetricGroup(registry, "host", jobManagerId);
 
 		QueryScopeInfo.JobManagerQueryScopeInfo info = jm.createQueryServiceMetricInfo(new DummyCharacterFilter());
 		assertEquals("", info.scope);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
@@ -40,8 +41,9 @@ public class JobManagerJobGroupTest extends TestLogger {
 	@Test
 	public void testGenerateScopeDefault() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+		String jobManagerId = ResourceID.generate().getResourceIdString();
 
-		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName");
+		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName", jobManagerId);
 		JobMetricGroup jmGroup = new JobManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 
 		assertArrayEquals(
@@ -61,10 +63,11 @@ public class JobManagerJobGroupTest extends TestLogger {
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM, "abc");
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "some-constant.<job_name>");
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+		String jobManagerId = ResourceID.generate().getResourceIdString();
 
 		JobID jid = new JobID();
 
-		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName");
+		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName", jobManagerId);
 		JobMetricGroup jmGroup = new JobManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 
 		assertArrayEquals(
@@ -84,10 +87,11 @@ public class JobManagerJobGroupTest extends TestLogger {
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM, "peter");
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+		String jobManagerId = ResourceID.generate().getResourceIdString();
 
 		JobID jid = new JobID();
 
-		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName");
+		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName", jobManagerId);
 		JobMetricGroup jmGroup = new JobManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 
 		assertArrayEquals(
@@ -105,7 +109,9 @@ public class JobManagerJobGroupTest extends TestLogger {
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		JobManagerMetricGroup jm = new JobManagerMetricGroup(registry, "host");
+		String jobManagerId = ResourceID.generate().getResourceIdString();
+
+		JobManagerMetricGroup jm = new JobManagerMetricGroup(registry, "host", jobManagerId);
 		JobManagerJobMetricGroup jmj = new JobManagerJobMetricGroup(registry, jm, jid, "jobname");
 
 		QueryScopeInfo.JobQueryScopeInfo info = jmj.createQueryServiceMetricInfo(new DummyCharacterFilter());


### PR DESCRIPTION
## What is the purpose of the change
This pull request makes flink can expose JM_ID to metric system

## Brief change log

  - Expose JobMaster ID to metric system

## Verifying this change

  - Expose JobMaster ID to metric system

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
