### PR TITLE
[FLINK-9513] Implement TTL state wrappers factory and serializer for value with TTL

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
@@ -1,0 +1,204 @@
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Base class for composite serializers.
+ *
+ * <p>This class serializes a list of objects
+ *
+ * @param <T> type of custom serialized value
+ */
+@SuppressWarnings("unchecked")
+public abstract class CompositeSerializer<T> extends TypeSerializer<T> {
+	private final List<TypeSerializer> originalSerializers;
+
+	protected CompositeSerializer(List<TypeSerializer> originalSerializers) {
+		Preconditions.checkNotNull(originalSerializers);
+		this.originalSerializers = originalSerializers;
+	}
+
+	protected abstract T composeValue(List values);
+
+	protected abstract List decomposeValue(T v);
+
+	protected abstract CompositeSerializer<T> createSerializerInstance(List<TypeSerializer> originalSerializers);
+
+	private T composeValueInternal(List values) {
+		Preconditions.checkArgument(values.size() == originalSerializers.size());
+		return composeValue(values);
+	}
+
+	private List decomposeValueInternal(T v) {
+		List values = decomposeValue(v);
+		Preconditions.checkArgument(values.size() == originalSerializers.size());
+		return values;
+	}
+
+	private CompositeSerializer<T> createSerializerInstanceInternal(List<TypeSerializer> originalSerializers) {
+		Preconditions.checkArgument(originalSerializers.size() == originalSerializers.size());
+		return createSerializerInstance(originalSerializers);
+	}
+
+	@Override
+	public CompositeSerializer<T> duplicate() {
+		return createSerializerInstanceInternal(originalSerializers.stream()
+			.map(TypeSerializer::duplicate)
+			.collect(Collectors.toList()));
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return originalSerializers.stream().allMatch(TypeSerializer::isImmutableType);
+	}
+
+	@Override
+	public T createInstance() {
+		return composeValueInternal(originalSerializers.stream()
+			.map(TypeSerializer::createInstance)
+			.collect(Collectors.toList()));
+	}
+
+	@Override
+	public T copy(T from) {
+		List originalValues = decomposeValueInternal(from);
+		return composeValueInternal(
+			IntStream.range(0, originalSerializers.size())
+				.mapToObj(i -> originalSerializers.get(i).copy(originalValues.get(i)))
+				.collect(Collectors.toList()));
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		List originalFromValues = decomposeValueInternal(from);
+		List originalReuseValues = decomposeValueInternal(reuse);
+		return composeValueInternal(
+			IntStream.range(0, originalSerializers.size())
+				.mapToObj(i -> originalSerializers.get(i).copy(originalFromValues.get(i), originalReuseValues.get(i)))
+				.collect(Collectors.toList()));
+	}
+
+	@Override
+	public int getLength() {
+		return originalSerializers.stream().allMatch(s -> s.getLength() >= 0) ?
+			originalSerializers.stream().mapToInt(TypeSerializer::getLength).sum() : -1;
+	}
+
+	@Override
+	public void serialize(T record, DataOutputView target) throws IOException {
+		List originalValues = decomposeValueInternal(record);
+		for (int i = 0; i < originalSerializers.size(); i++) {
+			originalSerializers.get(i).serialize(originalValues.get(i), target);
+		}
+	}
+
+	@Override
+	public T deserialize(DataInputView source) throws IOException {
+		List originalValues = new ArrayList();
+		for (TypeSerializer typeSerializer : originalSerializers) {
+			originalValues.add(typeSerializer.deserialize(source));
+		}
+		return composeValueInternal(originalValues);
+	}
+
+	@Override
+	public T deserialize(T reuse, DataInputView source) throws IOException {
+		List originalValues = new ArrayList();
+		List originalReuseValues = decomposeValueInternal(reuse);
+		for (int i = 0; i < originalSerializers.size(); i++) {
+			originalValues.add(originalSerializers.get(i).deserialize(originalReuseValues.get(i), source));
+		}
+		return composeValueInternal(originalValues);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		for (TypeSerializer typeSerializer : originalSerializers) {
+			typeSerializer.copy(source, target);
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return originalSerializers.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof CompositeSerializer) {
+			CompositeSerializer<?> other = (CompositeSerializer<?>) obj;
+			return other.canEqual(this) && originalSerializers.equals(other.originalSerializers);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof CompositeSerializer;
+	}
+
+	@Override
+	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		return new CompositeTypeSerializerConfigSnapshot(originalSerializers.toArray(new TypeSerializer[]{ })) {
+			@Override
+			public int getVersion() {
+				return 0;
+			}
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		if (configSnapshot instanceof CompositeTypeSerializerConfigSnapshot) {
+			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousSerializersAndConfigs =
+				((CompositeTypeSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+
+			if (previousSerializersAndConfigs.size() == originalSerializers.size()) {
+
+				List<TypeSerializer> convertSerializers = new ArrayList<>();
+				boolean requiresMigration = false;
+				CompatibilityResult<Object> compatResult;
+				int i = 0;
+				for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> f : previousSerializersAndConfigs) {
+					compatResult = CompatibilityUtil.resolveCompatibilityResult(
+						f.f0,
+						UnloadableDummyTypeSerializer.class,
+						f.f1,
+						originalSerializers.get(i));
+
+					if (compatResult.isRequiresMigration()) {
+						requiresMigration = true;
+
+						if (compatResult.getConvertDeserializer() != null) {
+							convertSerializers.add(new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer()));
+						} else {
+							return CompatibilityResult.requiresMigration();
+						}
+					}
+
+					i++;
+				}
+
+				if (!requiresMigration) {
+					return CompatibilityResult.compatible();
+				} else {
+					return CompatibilityResult.requiresMigration(
+						createSerializerInstanceInternal(convertSerializers));
+				}
+			}
+		}
+
+		return CompatibilityResult.requiresMigration();
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
@@ -184,14 +184,16 @@ public abstract class CompositeSerializer<T> extends TypeSerializer<T> {
 
 	@Override
 	public int hashCode() {
-		return Arrays.hashCode(fieldSerializers);
+		return 31 * Boolean.hashCode(precomputed.immutableTargetType) + Arrays.hashCode(fieldSerializers);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof CompositeSerializer) {
 			CompositeSerializer<?> other = (CompositeSerializer<?>) obj;
-			return other.canEqual(this) && Arrays.equals(fieldSerializers, other.fieldSerializers);
+			return other.canEqual(this) &&
+				Arrays.equals(fieldSerializers, other.fieldSerializers) &&
+				precomputed.immutableTargetType == other.precomputed.immutableTargetType;
 		} else {
 			return false;
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
@@ -163,6 +163,10 @@ public class CompositeSerializerTest {
 			super(isImmutableTargetType, fieldSerializers);
 		}
 
+		TestListCompositeSerializer(PrecomputedParameters precomputed, TypeSerializer<?>... fieldSerializers) {
+			super(precomputed, fieldSerializers);
+		}
+
 		@Override
 		public List<Object> createInstance(@Nonnull Object... values) {
 			return Arrays.asList(values);
@@ -170,7 +174,7 @@ public class CompositeSerializerTest {
 
 		@Override
 		protected void setField(@Nonnull List<Object> value, int index, Object fieldValue) {
-			if (immutableTargetType) {
+			if (precomputed.immutable) {
 				throw new UnsupportedOperationException("Type is immutable");
 			} else {
 				value.set(index, fieldValue);
@@ -183,8 +187,9 @@ public class CompositeSerializerTest {
 		}
 
 		@Override
-		protected CompositeSerializer<List<Object>> createSerializerInstance(TypeSerializer<?>... originalSerializers) {
-			return new TestListCompositeSerializer(immutableTargetType, originalSerializers);
+		protected CompositeSerializer<List<Object>> createSerializerInstance(
+			PrecomputedParameters precomputed, TypeSerializer<?>... originalSerializers) {
+			return new TestListCompositeSerializer(precomputed, originalSerializers);
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test suite for {@link CompositeSerializer}. */
+public class CompositeSerializerTest {
+	private static final ExecutionConfig execConf = new ExecutionConfig();
+
+	private static final List<Tuple2<TypeSerializer<?>, Object[]>> TEST_FIELD_SERIALIZERS = Arrays.asList(
+		Tuple2.of(BooleanSerializer.INSTANCE, new Object[] { true, false }),
+		Tuple2.of(LongSerializer.INSTANCE, new Object[] { 1L, 23L }),
+		Tuple2.of(StringSerializer.INSTANCE, new Object[] { "teststr1", "teststr2" }),
+		Tuple2.of(TypeInformation.of(Pojo.class).createSerializer(execConf),
+			new Object[] { new Pojo(3, new String[] { "123", "456" }), new Pojo(6, new String[] {  }) })
+	);
+
+	@Test
+	public void testSingleFieldSerializer() {
+		TEST_FIELD_SERIALIZERS.forEach(t -> {
+			@SuppressWarnings("unchecked")
+			TypeSerializer<Object>[] fieldSerializers = new TypeSerializer[] { t.f0 };
+			List<Object>[] instances = Arrays.stream(t.f1)
+				.map(Arrays::asList)
+				.toArray((IntFunction<List<Object>[]>) List[]::new);
+			runTests(t.f0.getLength(), fieldSerializers, instances);
+		});
+	}
+
+	@Test
+	public void testPairFieldSerializer() {
+		TEST_FIELD_SERIALIZERS.forEach(t1 ->
+			TEST_FIELD_SERIALIZERS.forEach(t2 -> {
+				@SuppressWarnings("unchecked")
+				TypeSerializer<Object>[] fieldSerializers = new TypeSerializer[] { t1.f0, t2.f0 };
+				List<Object>[] instances = IntStream.range(0, t1.f1.length)
+					.mapToObj(i -> Arrays.asList(t1.f1[i], t2.f1[i]))
+					.toArray((IntFunction<List<Object>[]>) List[]::new);
+				runTests(getLength(fieldSerializers), fieldSerializers, instances);
+			}));
+	}
+
+	@Test
+	public void testAllFieldSerializer() {
+		@SuppressWarnings("unchecked")
+		TypeSerializer<Object>[] fieldSerializers = TEST_FIELD_SERIALIZERS.stream()
+			.map(t -> (TypeSerializer<Object>) t.f0)
+			.toArray((IntFunction<TypeSerializer<Object>[]>) TypeSerializer[]::new);
+		List<Object>[] instances = IntStream.range(0, TEST_FIELD_SERIALIZERS.get(0).f1.length)
+			.mapToObj(CompositeSerializerTest::getTestCase)
+			.toArray((IntFunction<List<Object>[]>) List[]::new);
+		runTests(getLength(fieldSerializers), fieldSerializers, instances);
+	}
+
+	// needs to be Arrays.ArrayList for all tests
+	private static List<Object> getTestCase(int index) {
+		return Arrays.asList(TEST_FIELD_SERIALIZERS.stream()
+			.map(t -> t.f1[index])
+			.toArray(Object[]::new));
+	}
+
+	private static int getLength(TypeSerializer<Object>[] fieldSerializers) {
+		return Arrays.stream(fieldSerializers).allMatch(fs -> fs.getLength() > 0) ?
+			Arrays.stream(fieldSerializers).mapToInt(TypeSerializer::getLength).sum() : -1;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void runTests(
+		int length,
+		TypeSerializer<Object>[] fieldSerializers,
+		List<Object> ... instances) {
+		try {
+			for (boolean immutability : Arrays.asList(true, false)) {
+				TypeSerializer<List<Object>> serializer = new TestListCompositeSerializer(immutability, fieldSerializers);
+				CompositeSerializerTestInstance test = new CompositeSerializerTestInstance(serializer, length, instances);
+				test.testAll();
+			}
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	private static class Pojo {
+		public int f1;
+		public String[] f2;
+
+		private Pojo(int f1, String[] f2) {
+			this.f1 = f1;
+			this.f2 = f2;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Pojo pojo = (Pojo) o;
+			return f1 == pojo.f1 &&
+				Arrays.equals(f2, pojo.f2);
+		}
+
+		@Override
+		public int hashCode() {
+
+			int result = Objects.hash(f1);
+			result = 31 * result + Arrays.hashCode(f2);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo{" +
+				"f1=" + f1 +
+				", f2=" + Arrays.toString(f2) +
+				'}';
+		}
+	}
+
+	private static class TestListCompositeSerializer extends CompositeSerializer<List<Object>> {
+		TestListCompositeSerializer(boolean isImmutableTargetType, TypeSerializer<?>... fieldSerializers) {
+			super(isImmutableTargetType, fieldSerializers);
+		}
+
+		@Override
+		public List<Object> createInstance(@Nonnull Object... values) {
+			return Arrays.asList(values);
+		}
+
+		@Override
+		protected void setField(@Nonnull List<Object> value, int index, Object fieldValue) {
+			if (isImmutableTargetType) {
+				throw new UnsupportedOperationException("Type is immutable");
+			} else {
+				value.set(index, fieldValue);
+			}
+		}
+
+		@Override
+		protected Object getField(@Nonnull List<Object> value, int index) {
+			return value.get(index);
+		}
+
+		@Override
+		protected CompositeSerializer<List<Object>> createSerializerInstance(TypeSerializer<?>... originalSerializers) {
+			return new TestListCompositeSerializer(isImmutableTargetType, originalSerializers);
+		}
+	}
+
+	private static class CompositeSerializerTestInstance extends SerializerTestInstance<List<Object>> {
+		@SuppressWarnings("unchecked")
+		CompositeSerializerTestInstance(
+			TypeSerializer<List<Object>> serializer,
+			int length,
+			List<Object> ... testData) {
+			super(serializer, getCls(testData[0]), length, testData);
+		}
+
+		private static Class<List<Object>> getCls(List<Object> instance) {
+			return TypeExtractor.getForObject(instance).getTypeClass();
+		}
+
+		protected void deepEquals(String message, List<Object> should, List<Object> is) {
+			assertEquals(message, should, is);
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
@@ -170,7 +170,7 @@ public class CompositeSerializerTest {
 
 		@Override
 		protected void setField(@Nonnull List<Object> value, int index, Object fieldValue) {
-			if (isImmutableTargetType) {
+			if (immutableTargetType) {
 				throw new UnsupportedOperationException("Type is immutable");
 			} else {
 				value.set(index, fieldValue);
@@ -184,7 +184,7 @@ public class CompositeSerializerTest {
 
 		@Override
 		protected CompositeSerializer<List<Object>> createSerializerInstance(TypeSerializer<?>... originalSerializers) {
-			return new TestListCompositeSerializer(isImmutableTargetType, originalSerializers);
+			return new TestListCompositeSerializer(immutableTargetType, originalSerializers);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -48,7 +48,8 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	KeyedStateBackend<K>,
 	Snapshotable<SnapshotResult<KeyedStateHandle>, Collection<KeyedStateHandle>>,
 	Closeable,
-	CheckpointListener {
+	CheckpointListener,
+	KeyedStateFactory{
 
 	/** {@link TypeSerializer} for our key. */
 	protected final TypeSerializer<K> keySerializer;
@@ -132,21 +133,6 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		lastState = null;
 		keyValueStatesByName.clear();
 	}
-
-	/**
-	 * Creates and returns a new {@link State}.
-	 *
-	 * @param namespaceSerializer TypeSerializer for the state namespace.
-	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
-	 *
-	 * @param <N> The type of the namespace.
-	 * @param <SV> The type of the stored state value.
-	 * @param <S> The type of the public API state.
-	 * @param <IS> The type of internal state.
-	 */
-	public abstract <N, SV, S extends State, IS extends S> IS createState(
-		TypeSerializer<N> namespaceSerializer,
-		StateDescriptor<S, SV> stateDesc) throws Exception;
 
 	/**
 	 * @see KeyedStateBackend

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -48,8 +48,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	KeyedStateBackend<K>,
 	Snapshotable<SnapshotResult<KeyedStateHandle>, Collection<KeyedStateHandle>>,
 	Closeable,
-	CheckpointListener,
-	KeyedStateFactory{
+	CheckpointListener {
 
 	/** {@link TypeSerializer} for our key. */
 	protected final TypeSerializer<K> keySerializer;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  *
  * @param <K> The key by which state is keyed.
  */
-public interface KeyedStateBackend<K> extends InternalKeyContext<K>, Disposable {
+public interface KeyedStateBackend<K> extends InternalKeyContext<K>, KeyedStateFactory, Disposable {
 
 	/**
 	 * Sets the current key that is used for partitioned state.
@@ -70,7 +70,7 @@ public interface KeyedStateBackend<K> extends InternalKeyContext<K>, Disposable 
 	 *
 	 * @param namespaceSerializer The serializer used for the namespace type of the state
 	 * @param stateDescriptor The identifier for the state. This contains name and can create a default state value.
-	 *    
+	 *
 	 * @param <N> The type of the namespace.
 	 * @param <S> The type of the state.
 	 *
@@ -84,7 +84,7 @@ public interface KeyedStateBackend<K> extends InternalKeyContext<K>, Disposable 
 
 	/**
 	 * Creates or retrieves a partitioned state backed by this state backend.
-	 * 
+	 *
 	 * TODO: NOTE: This method does a lot of work caching / retrieving states just to update the namespace.
 	 *       This method should be removed for the sake of namespaces being lazily fetched from the keyed
 	 *       state backend, or being set on the state directly.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/** This factory produces concrete state objects in backends. */
+public interface KeyedStateFactory {
+	/**
+	 * Creates and returns a new {@link State}.
+	 *
+	 * @param namespaceSerializer TypeSerializer for the state namespace.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <N> The type of the namespace.
+	 * @param <SV> The type of the stored state value.
+	 * @param <S> The type of the public API state.
+	 * @param <IS> The type of internal state.
+	 */
+	<N, SV, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
@@ -21,11 +21,12 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
 
-/** This factory produces concrete state objects in backends. */
+/** This factory produces concrete internal state objects. */
 public interface KeyedStateFactory {
 	/**
-	 * Creates and returns a new {@link State}.
+	 * Creates and returns a new {@link InternalKvState}.
 	 *
 	 * @param namespaceSerializer TypeSerializer for the state namespace.
 	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -43,7 +43,6 @@ import java.util.stream.Stream;
 /**
  * This state factory wraps state objects, produced by backends, with TTL logic.
  */
-@SuppressWarnings("unchecked")
 public class TtlStateFactory {
 	public static <N, SV, S extends State, IS extends S> IS createStateAndWrapWithTtlIfEnabled(
 		TypeSerializer<N> namespaceSerializer,
@@ -99,6 +98,7 @@ public class TtlStateFactory {
 		return stateFactory.createState(namespaceSerializer, stateDesc);
 	}
 
+	@SuppressWarnings("unchecked")
 	private <N, SV, S extends State, IS extends S> IS createValueState(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc) throws Exception {
@@ -109,6 +109,7 @@ public class TtlStateFactory {
 			ttlConfig, timeProvider, stateDesc.getSerializer());
 	}
 
+	@SuppressWarnings("unchecked")
 	private <T, N, SV, S extends State, IS extends S> IS createListState(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc) throws Exception {
@@ -120,6 +121,7 @@ public class TtlStateFactory {
 			ttlConfig, timeProvider, listStateDesc.getSerializer());
 	}
 
+	@SuppressWarnings("unchecked")
 	private <UK, UV, N, SV, S extends State, IS extends S> IS createMapState(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc) throws Exception {
@@ -133,6 +135,7 @@ public class TtlStateFactory {
 			ttlConfig, timeProvider, mapStateDesc.getSerializer());
 	}
 
+	@SuppressWarnings("unchecked")
 	private <N, SV, S extends State, IS extends S> IS createReducingState(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc) throws Exception {
@@ -146,6 +149,7 @@ public class TtlStateFactory {
 			ttlConfig, timeProvider, stateDesc.getSerializer());
 	}
 
+	@SuppressWarnings("unchecked")
 	private <IN, OUT, N, SV, S extends State, IS extends S> IS createAggregatingState(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc) throws Exception {
@@ -160,7 +164,7 @@ public class TtlStateFactory {
 			ttlConfig, timeProvider, stateDesc.getSerializer(), ttlAggregateFunction);
 	}
 
-	@SuppressWarnings("deprecation")
+	@SuppressWarnings({"deprecation", "unchecked"})
 	private <T, N, SV, S extends State, IS extends S> IS createFoldingState(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc) throws Exception {
@@ -184,6 +188,7 @@ public class TtlStateFactory {
 			super(true, userValueSerializer, LongSerializer.INSTANCE);
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public TtlValue<T> createInstance(@Nonnull Object ... values) {
 			Preconditions.checkArgument(values.length == 2);
@@ -200,6 +205,7 @@ public class TtlStateFactory {
 			return index == 0 ? v.getUserValue() : v.getLastAccessTimestamp();
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		protected CompositeSerializer<TtlValue<T>> createSerializerInstance(TypeSerializer<?> ... originalSerializers) {
 			Preconditions.checkNotNull(originalSerializers);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl;
+
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.CompositeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyedStateFactory;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This state factory wraps state objects, produced by backends, with TTL logic.
+ */
+public class TtlStateFactory {
+	public static <N, SV, S extends State, IS extends S> IS createStateAndWrapWithTtlIfEnabled(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc,
+		KeyedStateFactory originalStateFactory,
+		TtlConfig ttlConfig,
+		TtlTimeProvider timeProvider) throws Exception {
+		return ttlConfig.getTtlUpdateType() == TtlUpdateType.Disabled ?
+			originalStateFactory.createState(namespaceSerializer, stateDesc) :
+			new TtlStateFactory(originalStateFactory, ttlConfig, timeProvider)
+				.createState(namespaceSerializer, stateDesc);
+	}
+
+	private final Map<Class<? extends StateDescriptor>, StateFactory> stateFactories;
+
+	private final KeyedStateFactory originalStateFactory;
+	private final TtlConfig ttlConfig;
+	private final TtlTimeProvider timeProvider;
+
+	private TtlStateFactory(KeyedStateFactory originalStateFactory, TtlConfig ttlConfig, TtlTimeProvider timeProvider) {
+		this.originalStateFactory = originalStateFactory;
+		this.ttlConfig = ttlConfig;
+		this.timeProvider = timeProvider;
+		this.stateFactories = createStateFactories();
+	}
+
+	private Map<Class<? extends StateDescriptor>, StateFactory> createStateFactories() {
+		return Stream.of(
+			Tuple2.of(ValueStateDescriptor.class, (StateFactory) this::createValueState),
+			Tuple2.of(ListStateDescriptor.class, (StateFactory) this::createListState),
+			Tuple2.of(MapStateDescriptor.class, (StateFactory) this::createMapState),
+			Tuple2.of(ReducingStateDescriptor.class, (StateFactory) this::createReducingState),
+			Tuple2.of(AggregatingStateDescriptor.class, (StateFactory) this::createAggregatingState),
+			Tuple2.of(FoldingStateDescriptor.class, (StateFactory) this::createFoldingState)
+		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+	}
+
+	private interface StateFactory {
+		<N, SV, S extends State, IS extends S> IS create(
+			TypeSerializer<N> namespaceSerializer,
+			StateDescriptor<S, SV> stateDesc) throws Exception;
+	}
+
+	private <N, SV, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		StateFactory stateFactory = stateFactories.get(stateDesc.getClass());
+		if (stateFactory == null) {
+			String message = String.format("State %s is not supported by %s",
+				stateDesc.getClass(), TtlStateFactory.class);
+			throw new FlinkRuntimeException(message);
+		}
+		return stateFactory.create(namespaceSerializer, stateDesc);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <N, SV, S extends State, IS extends S> IS createValueState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		SV defVal = stateDesc.getDefaultValue();
+		TtlValue<SV> ttlDefVal = defVal == null ? null : new TtlValue<>(defVal, Long.MAX_VALUE);
+		ValueStateDescriptor<TtlValue<SV>> ttlDescriptor = new ValueStateDescriptor<>(
+			stateDesc.getName(), new TtlSerializer<>(stateDesc.getSerializer()), ttlDefVal);
+		return (IS) new TtlValueState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T, N, SV, S extends State, IS extends S> IS createListState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		ListStateDescriptor<T> listStateDesc = (ListStateDescriptor<T>) stateDesc;
+		ListStateDescriptor<TtlValue<T>> ttlDescriptor = new ListStateDescriptor<>(
+			stateDesc.getName(), new TtlSerializer<>(listStateDesc.getElementSerializer()));
+		return (IS) new TtlListState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, listStateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <UK, UV, N, SV, S extends State, IS extends S> IS createMapState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		MapStateDescriptor<UK, UV> mapStateDesc = (MapStateDescriptor<UK, UV>) stateDesc;
+		MapStateDescriptor<UK, TtlValue<UV>> ttlDescriptor = new MapStateDescriptor<>(
+			stateDesc.getName(),
+			mapStateDesc.getKeySerializer(),
+			new TtlSerializer<>(mapStateDesc.getValueSerializer()));
+		return (IS) new TtlMapState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, mapStateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <N, SV, S extends State, IS extends S> IS createReducingState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		ReducingStateDescriptor<SV> reducingStateDesc = (ReducingStateDescriptor<SV>) stateDesc;
+		ReducingStateDescriptor<TtlValue<SV>> ttlDescriptor = new ReducingStateDescriptor<>(
+			stateDesc.getName(),
+			new TtlReduceFunction<>(reducingStateDesc.getReduceFunction(), ttlConfig, timeProvider),
+			new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlReducingState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <IN, OUT, N, SV, S extends State, IS extends S> IS createAggregatingState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		AggregatingStateDescriptor<IN, SV, OUT> aggregatingStateDescriptor =
+			(AggregatingStateDescriptor<IN, SV, OUT>) stateDesc;
+		TtlAggregateFunction<IN, SV, OUT> ttlAggregateFunction = new TtlAggregateFunction<>(
+			aggregatingStateDescriptor.getAggregateFunction(), ttlConfig, timeProvider);
+		AggregatingStateDescriptor<IN, TtlValue<SV>, OUT> ttlDescriptor = new AggregatingStateDescriptor<>(
+			stateDesc.getName(), ttlAggregateFunction, new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlAggregatingState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer(), ttlAggregateFunction);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T, N, SV, S extends State, IS extends S> IS createFoldingState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		FoldingStateDescriptor<T, SV> foldingStateDescriptor = (FoldingStateDescriptor<T, SV>) stateDesc;
+		SV initAcc = stateDesc.getDefaultValue();
+		TtlValue<SV> ttlInitAcc = initAcc == null ? null : new TtlValue<>(initAcc, Long.MAX_VALUE);
+		FoldingStateDescriptor<T, TtlValue<SV>> ttlDescriptor = new FoldingStateDescriptor<>(
+			stateDesc.getName(),
+			ttlInitAcc,
+			new TtlFoldFunction<>(foldingStateDescriptor.getFoldFunction(), ttlConfig, timeProvider),
+			new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlFoldingState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer());
+	}
+
+	private static class TtlSerializer<T> extends CompositeSerializer<TtlValue<T>> {
+		TtlSerializer(TypeSerializer<T> userValueSerializer) {
+			super(Arrays.asList(userValueSerializer, new LongSerializer()));
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		protected TtlValue<T> composeValue(List values) {
+			return new TtlValue<>((T) values.get(0), (Long) values.get(1));
+		}
+
+		@Override
+		protected List decomposeValue(TtlValue<T> v) {
+			return Arrays.asList(v.getUserValue(), v.getExpirationTimestamp());
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		protected CompositeSerializer<TtlValue<T>> createSerializerInstance(List<TypeSerializer> typeSerializers) {
+			return new TtlSerializer<>(typeSerializers.get(0));
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -188,6 +188,10 @@ public class TtlStateFactory {
 			super(true, userValueSerializer, LongSerializer.INSTANCE);
 		}
 
+		TtlSerializer(PrecomputedParameters precomputed, TypeSerializer<?> ... fieldSerializers) {
+			super(precomputed, fieldSerializers);
+		}
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public TtlValue<T> createInstance(@Nonnull Object ... values) {
@@ -207,10 +211,12 @@ public class TtlStateFactory {
 
 		@SuppressWarnings("unchecked")
 		@Override
-		protected CompositeSerializer<TtlValue<T>> createSerializerInstance(TypeSerializer<?> ... originalSerializers) {
+		protected CompositeSerializer<TtlValue<T>> createSerializerInstance(
+			PrecomputedParameters precomputed,
+			TypeSerializer<?> ... originalSerializers) {
 			Preconditions.checkNotNull(originalSerializers);
 			Preconditions.checkArgument(originalSerializers.length == 2);
-			return new TtlSerializer<>((TypeSerializer<T>) originalSerializers[0]);
+			return new TtlSerializer<>(precomputed, (TypeSerializer<T>) originalSerializers[0]);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTest.java
@@ -29,12 +29,7 @@ import java.util.stream.StreamSupport;
 
 /** Test suite for collection methods of {@link TtlMapState}. */
 public class TtlMapStateTest extends
-	TtlStateTestBase<TtlMapState<?, String, Integer, String>, Map<Integer, String>, Set<Map.Entry<Integer, String>>> {
-
-	@Override
-	TtlMapState<?, String, Integer, String> createState() {
-		return new TtlMapState<>(new MockInternalMapState<>(), ttlConfig, timeProvider, null);
-	}
+	TtlMapStateTestBase<Map<Integer, String>, Set<Map.Entry<Integer, String>>> {
 
 	@Override
 	void initTestValues() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTestBase.java
@@ -18,25 +18,16 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-/** Test suite for per element methods of {@link TtlMapState}. */
-public class TtlMapStatePerElementTest extends TtlMapStateTestBase<String, String> {
-	private static final int TEST_KEY = 1;
-	private static final String TEST_VAL1 = "test value1";
-	private static final String TEST_VAL2 = "test value2";
-	private static final String TEST_VAL3 = "test value3";
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
+abstract class TtlMapStateTestBase<UV, GV>
+	extends TtlStateTestBase<TtlMapState<?, String, Integer, String>, UV, GV> {
 	@Override
-	void initTestValues() {
-		updater = v -> ttlState.put(TEST_KEY, v);
-		getter = () -> ttlState.get(TEST_KEY);
-		originalGetter = () -> ttlState.original.get(TEST_KEY);
-
-		updateEmpty = TEST_VAL1;
-		updateUnexpired = TEST_VAL2;
-		updateExpired = TEST_VAL3;
-
-		getUpdateEmpty = TEST_VAL1;
-		getUnexpired = TEST_VAL2;
-		getUpdateExpired = TEST_VAL3;
+	TtlMapState<?, String, Integer, String> createState() {
+		MapStateDescriptor<Integer, String> mapStateDesc =
+			new MapStateDescriptor<>("TtlTestMapState", IntSerializer.INSTANCE, StringSerializer.INSTANCE);
+		return (TtlMapState<?, String, Integer, String>) wrapMockState(mapStateDesc);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlReducingStateTest.java
@@ -19,21 +19,15 @@
 package org.apache.flink.runtime.state.ttl;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.state.internal.InternalReducingState;
 
 import java.util.List;
 
 /** Test suite for {@link TtlReducingState}. */
 public class TtlReducingStateTest
 	extends TtlMergingStateBase.TtlIntegerMergingStateBase<TtlReducingState<?, String, Integer>, Integer, Integer> {
-	@Override
-	TtlReducingState<?, String, Integer> createState() {
-		ReduceFunction<TtlValue<Integer>> ttlReduceFunction = new TtlReduceFunction<>(REDUCE, ttlConfig, timeProvider);
-		return new TtlReducingState<>(
-			new MockInternalReducingState<>(ttlReduceFunction), ttlConfig, timeProvider, null);
-	}
-
 	@Override
 	void initTestValues() {
 		updater = v -> ttlState.add(v);
@@ -50,34 +44,17 @@ public class TtlReducingStateTest
 	}
 
 	@Override
+	TtlReducingState<?, String, Integer> createState() {
+		ReducingStateDescriptor<Integer> aggregatingStateDes =
+			new ReducingStateDescriptor<>("TtlTestReducingState", REDUCE, IntSerializer.INSTANCE);
+		return (TtlReducingState<?, String, Integer>) wrapMockState(aggregatingStateDes);
+	}
+
+	@Override
 	Integer getMergeResult(
 		List<Tuple2<String, Integer>> unexpiredUpdatesToMerge,
 		List<Tuple2<String, Integer>> finalUpdatesToMerge) {
 		return getIntegerMergeResult(unexpiredUpdatesToMerge, finalUpdatesToMerge);
-	}
-
-	private static class MockInternalReducingState<K, N, T>
-		extends MockInternalMergingState<K, N, T, T, T> implements InternalReducingState<K, N, T> {
-		private final ReduceFunction<T> reduceFunction;
-
-		private MockInternalReducingState(ReduceFunction<T> reduceFunction) {
-			this.reduceFunction = reduceFunction;
-		}
-
-		@Override
-		public T get() {
-			return getInternal();
-		}
-
-		@Override
-		public void add(T value) throws Exception {
-			updateInternal(reduceFunction.reduce(get(), value));
-		}
-
-		@Override
-		T mergeState(T t, T nAcc) throws Exception {
-			return reduceFunction.reduce(t, nAcc);
-		}
 	}
 
 	private static final ReduceFunction<Integer> REDUCE = (v1, v2) -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlValueStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlValueStateTest.java
@@ -18,18 +18,14 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 /** Test suite for {@link TtlValueState}. */
 public class TtlValueStateTest extends TtlStateTestBase<TtlValueState<?, String, String>, String, String> {
 	private static final String TEST_VAL1 = "test value1";
 	private static final String TEST_VAL2 = "test value2";
 	private static final String TEST_VAL3 = "test value3";
-
-	@Override
-	TtlValueState<?, String, String> createState() {
-		return new TtlValueState<>(new MockInternalValueState<>(), ttlConfig, timeProvider, null);
-	}
 
 	@Override
 	void initTestValues() {
@@ -46,17 +42,10 @@ public class TtlValueStateTest extends TtlStateTestBase<TtlValueState<?, String,
 		getUpdateExpired = TEST_VAL3;
 	}
 
-	private static class MockInternalValueState<K, N, T>
-		extends MockInternalKvState<K, N, T> implements InternalValueState<K, N, T> {
-
-		@Override
-		public T value() {
-			return getInternal();
-		}
-
-		@Override
-		public void update(T value) {
-			updateInternal(value);
-		}
+	@Override
+	TtlValueState<?, String, String> createState() {
+		ValueStateDescriptor<String> valueStateDesc =
+			new ValueStateDescriptor<>("TtlValueTestState", StringSerializer.INSTANCE);
+		return (TtlValueState<?, String, String>) wrapMockState(valueStateDesc);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalAggregatingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalAggregatingState.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+
+/** In memory mock internal aggregating state. */
+class MockInternalAggregatingState<K, N, IN, ACC, OUT>
+	extends MockInternalMergingState<K, N, IN, ACC, OUT> implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+	private final AggregateFunction<IN, ACC, OUT> aggregateFunction;
+
+	private MockInternalAggregatingState(AggregateFunction<IN, ACC, OUT> aggregateFunction) {
+		this.aggregateFunction = aggregateFunction;
+	}
+
+	@Override
+	public OUT get() {
+		return aggregateFunction.getResult(getInternal());
+	}
+
+	@Override
+	public void add(IN value) {
+		updateInternal(aggregateFunction.add(value,  getInternal()));
+	}
+
+	@Override
+	ACC mergeState(ACC acc, ACC nAcc) {
+		return aggregateFunction.merge(acc, nAcc);
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <IN, OUT, N, ACC, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, ACC> stateDesc) {
+		AggregatingStateDescriptor<IN, ACC, OUT> aggregatingStateDesc =
+			(AggregatingStateDescriptor<IN, ACC, OUT>) stateDesc;
+		return (IS) new MockInternalAggregatingState<>(aggregatingStateDesc.getAggregateFunction());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalFoldingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalFoldingState.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalFoldingState;
+
+/** In memory mock internal folding state. */
+@SuppressWarnings("deprecation")
+class MockInternalFoldingState<K, N, T, ACC>
+	extends MockInternalKvState<K, N, ACC> implements InternalFoldingState<K, N, T, ACC> {
+	private final FoldFunction<T, ACC> foldFunction;
+
+	private MockInternalFoldingState(FoldFunction<T, ACC> foldFunction) {
+		this.foldFunction = foldFunction;
+	}
+
+	@Override
+	public ACC get() {
+		return getInternal();
+	}
+
+	@Override
+	public void add(T value) throws Exception {
+		updateInternal(foldFunction.fold(get(), value));
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <T, N, ACC, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, ACC> stateDesc) {
+		FoldingStateDescriptor<T, ACC> foldingStateDesc = (FoldingStateDescriptor<T, ACC>) stateDesc;
+		return (IS) new MockInternalFoldingState<>(foldingStateDesc.getFoldFunction());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalKvState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalKvState.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalKvState;
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+/** In memory mock internal state base class. */
 class MockInternalKvState<K, N, T> implements InternalKvState<K, N, T> {
 	private Map<N, T> namespacedValues = new HashMap<>();
 	private T defaultNamespaceValue;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalListState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalListState.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** In memory mock internal list state. */
+class MockInternalListState<K, N, T>
+	extends MockInternalMergingState<K, N, T, List<T>, Iterable<T>>
+	implements InternalListState<K, N, T> {
+
+	private MockInternalListState() {
+		super(ArrayList::new);
+	}
+
+	@Override
+	public void update(List<T> elements) {
+		updateInternal(elements);
+	}
+
+	@Override
+	public void addAll(List<T> elements) {
+		getInternal().addAll(elements);
+	}
+
+	@Override
+	List<T> mergeState(List<T> acc, List<T> nAcc) {
+		acc = new ArrayList<>(acc);
+		acc.addAll(nAcc);
+		return acc;
+	}
+
+	@Override
+	public Iterable<T> get() {
+		return getInternal();
+	}
+
+	@Override
+	public void add(T element) {
+		getInternal().add(element);
+	}
+
+	@Override
+	public void clear() {
+		getInternal().clear();
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		return (IS) new MockInternalListState<>();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
@@ -16,19 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-class MockInternalMapState<K, N, UK, UV>
+/** In memory mock internal map state. */
+public class MockInternalMapState<K, N, UK, UV>
 	extends MockInternalKvState<K, N, Map<UK, UV>>
 	implements InternalMapState<K, N, UK, UV> {
 
-	MockInternalMapState() {
+	private MockInternalMapState() {
 		super(HashMap::new);
 	}
 
@@ -84,5 +88,12 @@ class MockInternalMapState<K, N, UK, UV>
 	@Override
 	public Iterator<Map.Entry<UK, UV>> iterator() {
 		return entries().iterator();
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		return (IS) new MockInternalMapState<>();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMergingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMergingState.java
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
 import org.apache.flink.runtime.state.internal.InternalMergingState;
 
 import java.util.Collection;
 import java.util.function.Supplier;
 
+/** In memory mock internal merging state base class. */
 abstract class MockInternalMergingState<K, N, IN, ACC, OUT>
 	extends MockInternalKvState<K, N, ACC> implements InternalMergingState<K, N, IN, ACC, OUT> {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalReducingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalReducingState.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+
+/** In memory mock internal reducing state. */
+class MockInternalReducingState<K, N, T>
+	extends MockInternalMergingState<K, N, T, T, T> implements InternalReducingState<K, N, T> {
+	private final ReduceFunction<T> reduceFunction;
+
+	private MockInternalReducingState(ReduceFunction<T> reduceFunction) {
+		this.reduceFunction = reduceFunction;
+	}
+
+	@Override
+	public T get() {
+		return getInternal();
+	}
+
+	@Override
+	public void add(T value) throws Exception {
+		updateInternal(reduceFunction.reduce(get(), value));
+	}
+
+	@Override
+	T mergeState(T t, T nAcc) throws Exception {
+		return reduceFunction.reduce(t, nAcc);
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		ReducingStateDescriptor<T> reducingStateDesc = (ReducingStateDescriptor<T>) stateDesc;
+		return (IS) new MockInternalReducingState<>(reducingStateDesc.getReduceFunction());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalValueState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalValueState.java
@@ -16,27 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
-/** Test suite for per element methods of {@link TtlMapState}. */
-public class TtlMapStatePerElementTest extends TtlMapStateTestBase<String, String> {
-	private static final int TEST_KEY = 1;
-	private static final String TEST_VAL1 = "test value1";
-	private static final String TEST_VAL2 = "test value2";
-	private static final String TEST_VAL3 = "test value3";
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+/** In memory mock internal value state. */
+class MockInternalValueState<K, N, T>
+	extends MockInternalKvState<K, N, T> implements InternalValueState<K, N, T> {
 
 	@Override
-	void initTestValues() {
-		updater = v -> ttlState.put(TEST_KEY, v);
-		getter = () -> ttlState.get(TEST_KEY);
-		originalGetter = () -> ttlState.original.get(TEST_KEY);
+	public T value() {
+		return getInternal();
+	}
 
-		updateEmpty = TEST_VAL1;
-		updateUnexpired = TEST_VAL2;
-		updateExpired = TEST_VAL3;
+	@Override
+	public void update(T value) {
+		updateInternal(value);
+	}
 
-		getUpdateEmpty = TEST_VAL1;
-		getUnexpired = TEST_VAL2;
-		getUpdateExpired = TEST_VAL3;
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		return (IS) new MockInternalValueState<>();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyedStateFactory;
+import org.apache.flink.runtime.state.ttl.TtlStateFactory;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** State factory which produces in memory mock state objects. */
+public class MockKeyedStateFactory implements KeyedStateFactory {
+	@SuppressWarnings("deprecation")
+	private static final Map<Class<? extends StateDescriptor>, KeyedStateFactory> STATE_FACTORIES =
+		Stream.of(
+			Tuple2.of(ValueStateDescriptor.class, (KeyedStateFactory) MockInternalValueState::createState),
+			Tuple2.of(ListStateDescriptor.class, (KeyedStateFactory) MockInternalListState::createState),
+			Tuple2.of(MapStateDescriptor.class, (KeyedStateFactory) MockInternalMapState::createState),
+			Tuple2.of(ReducingStateDescriptor.class, (KeyedStateFactory) MockInternalReducingState::createState),
+			Tuple2.of(AggregatingStateDescriptor.class, (KeyedStateFactory) MockInternalAggregatingState::createState),
+			Tuple2.of(FoldingStateDescriptor.class, (KeyedStateFactory) MockInternalFoldingState::createState)
+		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+	@Override
+	public <N, SV, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		KeyedStateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
+		if (stateFactory == null) {
+			String message = String.format("State %s is not supported by %s",
+				stateDesc.getClass(), TtlStateFactory.class);
+			throw new FlinkRuntimeException(message);
+		}
+		return stateFactory.createState(namespaceSerializer, stateDesc);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a state factory for wrapping state objects with TTL logic and serialiser of user value with expiration timestamp.
NOTE: This PR is based on #6186 and only last commit 99994dedb9a20244a2addd337617778b17fe8349 makes difference with it and needs review.

## Brief change log

  - abstract state creation in backends with `KeyedStateFactory` interface
  - add `TtlStateFactory`
  - add `CompositeSerializer`

## Verifying this change

This change is a trivial addition without any test coverage in this PR and should be covered together with TTL feature activation by final integration and e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (not yet)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (not yet)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable at the moment)
