### PR TITLE
[FLINK-9638][E2E Tests] Add helper script to run single test

### DIFF
--- a/flink-end-to-end-tests/run-single-test.sh
+++ b/flink-end-to-end-tests/run-single-test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# This can be used to run a single test in the context of a test runnner
+# Usage: ./run-single-test.sh test-scripts/my-test-case.sh
+
+if [ $# -eq 0 ]; then
+    echo "Usage: ./run-single-test.sh <path-to-test-script> [<arg1> <arg2> ...]"
+    exit 1
+fi
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd )`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+run_test "$*" "$*"
+
+exit 0


### PR DESCRIPTION
## What is the purpose of the change
This PR adds a helper script `run-single-test.sh` that allows you to run
a single test in the context of the text runner.

This provides you with
* Setup of ENV variables
* cleanup after test
* Nicer output

Usage: `./run-single-test.sh <path-to-test-script> [<arg1> <arg2> ...]`
## Verifying this change

Ran it by hand with different test scripts

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? no yet, will add this to documentation PR that is currently open as well
