### PR TITLE
[FLINK-9660] [mesos] Allow passing custom artifacts to Mesos workers

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -63,6 +63,11 @@
             <td></td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.tasks.uris</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -268,6 +268,8 @@ May be set to -1 to disable this feature.
 
 `mesos.resourcemanager.tasks.container.docker.parameters`: Custom parameters to be passed into docker run command when using the docker containerizer. Comma separated list of `key=value` pairs. `value` may contain '=' (**NO DEFAULT**)
 
+`mesos.resourcemanager.tasks.uris`: A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers. (**NO DEFAULT**)
+
 `mesos.resourcemanager.tasks.hostname`: Optional value to define the TaskManager's hostname. The pattern `_TASK_` is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. `_TASK_.flink-service.mesos`) for name lookups. (**NO DEFAULT**)
 
 `mesos.resourcemanager.tasks.bootstrap-cmd`: A command which is executed before the TaskManager is started (**NO DEFAULT**).

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -36,6 +36,7 @@ import com.netflix.fenzo.ConstraintEvaluator;
 import com.netflix.fenzo.TaskRequest;
 import com.netflix.fenzo.VMTaskFitnessCalculator;
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.CommandInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -245,6 +246,11 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		// ship additional files
 		for (ContainerSpecification.Artifact artifact : containerSpec.getArtifacts()) {
 			cmd.addUris(Utils.uri(resolver, artifact));
+		}
+
+		// add user-specified URIs
+		for (String uri : params.uris()) {
+			cmd.addUris(CommandInfo.URI.newBuilder().setValue(uri));
 		}
 
 		// propagate environment variables

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -669,7 +669,8 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			taskManagerParameters.constraints(),
 			taskManagerParameters.command(),
 			taskManagerParameters.bootstrapCommand(),
-			taskManagerParameters.getTaskManagerHostname()
+			taskManagerParameters.getTaskManagerHostname(),
+			taskManagerParameters.uris()
 		);
 
 		LOG.debug("LaunchableMesosWorker parameters: {}", params);

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -254,7 +254,8 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 				Collections.<ConstraintEvaluator>emptyList(),
 				"",
 				Option.<String>empty(),
-				Option.<String>empty());
+				Option.<String>empty(),
+				Collections.<String>emptyList());
 
 			TestActorRef<TestingMesosFlinkResourceManager> resourceManagerRef =
 				TestActorRef.create(system, MesosFlinkResourceManager.createActorProps(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -281,7 +281,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				1.0, 1, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(),
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
-				Option.<String>empty());
+				Option.<String>empty(), Collections.<String>emptyList());
 
 			// resource manager
 			rmConfiguration = new ResourceManagerConfiguration(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -122,6 +122,27 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 	}
 
 	@Test
+	public void testUriParameters() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(MesosTaskManagerParameters.MESOS_TM_URIS,
+				"file:///dev/null,http://localhost/test,  test_url ");
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.uris().size(), 3);
+		assertEquals(params.uris().get(0), "file:///dev/null");
+		assertEquals(params.uris().get(1), "http://localhost/test");
+		assertEquals(params.uris().get(2), "test_url");
+	}
+
+	@Test
+	public void testUriParametersDefault() throws Exception {
+		Configuration config = new Configuration();
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.uris().size(), 0);
+	}
+
+	@Test
 	public void givenTwoConstraintsInConfigShouldBeParsed() throws Exception {
 
 		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(withHardHostAttrConstraintConfiguration("cluster:foo,az:eu-west-1"));


### PR DESCRIPTION
## What is the purpose of the change

* This pull request introduces a feature that allows passing custom artifact URIs to Mesos workers

## Brief change log

* A new parameter ```mesos.resourcemanager.tasks.uris``` was introduced

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests that verify correctness of behavior of new parameter
  - Manually verified behavior by running Flink in Mesos with Docker containerizer and 2 task managers.  A private Docker registry was used for taskmanager Docker image.  Confirmed that Mesos was unable to pull the image with default settings.  After that, added ```mesos.resourcemanager.tasks.uris``` parameter with path to local archive containing Docker credentials configuration.  Confirmed the file was extracted to local sandbox of taskmanager Mesos task, and Docker image was successfully pulled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
