### PR TITLE
[FLINK-9659][tests] Replace hard-coded sleeps

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -45,7 +45,7 @@ JOB_ID=$($FLINK_DIR/bin/flink run -d -p 4 $TEST_PROGRAM_JAR -outputPath $TEST_DA
 
 wait_job_running ${JOB_ID}
 
-sleep 40
+wait_num_checkpoints "${JOB_ID}" 5
 
 echo "Killing TM"
 
@@ -70,7 +70,7 @@ $FLINK_DIR/bin/taskmanager.sh start
 $FLINK_DIR/bin/taskmanager.sh start
 
 # the job should complete in under 60s because half of the work has been checkpointed
-sleep 100
+wait_job_terminal_state "${JOB_ID}" "FINISHED"
 
 # get truncate information
 # e.g. "xxx xxx DEBUG xxx.BucketingSink  - Writing valid-length file for xxx/out/result8/part-0-0 to specify valid length 74994"


### PR DESCRIPTION
This PR replaces hard-coded sleeps in the bucketing sink end-to-end test.

Instead we use utility functions to wait for specific events, in this case some progress in the job (measured by number of checkpoints) and the job finishing (by waiting for FINISHED state).