### PR TITLE
[FLINK-9665] PrometheusReporter does not properly unregister metrics

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -193,13 +193,37 @@ public class PrometheusReporter implements MetricReporter {
 		}
 	}
 
+	private static void removeMetric(Metric metric, List<String> dimensionValues, Collector collector) {
+		if (metric instanceof Gauge) {
+			((io.prometheus.client.Gauge) collector).remove(toArray(dimensionValues));
+		} else if (metric instanceof Counter) {
+			((io.prometheus.client.Gauge) collector).remove(toArray(dimensionValues));
+		} else if (metric instanceof Meter) {
+			((io.prometheus.client.Gauge) collector).remove(toArray(dimensionValues));
+		} else if (metric instanceof Histogram) {
+			((HistogramSummaryProxy) collector).remove(dimensionValues);
+		} else {
+			LOG.warn("Cannot remove unknown metric type: {}. This indicates that the metric type is not supported by this reporter.",
+				metric.getClass().getName());
+		}
+	}
+
 	@Override
 	public void notifyOfRemovedMetric(final Metric metric, final String metricName, final MetricGroup group) {
+
+		List<String> dimensionValues = new LinkedList<>();
+		for (final Map.Entry<String, String> dimension : group.getAllVariables().entrySet()) {
+			dimensionValues.add(CHARACTER_FILTER.filterCharacters(dimension.getValue()));
+		}
+
 		final String scopedMetricName = getScopedName(metricName, group);
 		synchronized (this) {
 			final AbstractMap.SimpleImmutableEntry<Collector, Integer> collectorWithCount = collectorsWithCountByMetricName.get(scopedMetricName);
 			final Integer count = collectorWithCount.getValue();
 			final Collector collector = collectorWithCount.getKey();
+
+			removeMetric(metric, dimensionValues, collector);
+
 			if (count == 1) {
 				try {
 					CollectorRegistry.defaultRegistry.unregister(collector);
@@ -293,6 +317,10 @@ public class PrometheusReporter implements MetricReporter {
 
 		void addChild(final Histogram histogram, final List<String> labelValues) {
 			histogramsByLabelValues.put(labelValues, histogram);
+		}
+
+		void remove(final List<String> labelValues) {
+			histogramsByLabelValues.remove(labelValues);
 		}
 
 		private void addSamples(final List<String> labelValues, final Histogram histogram, final List<MetricFamilySamples.Sample> samples) {

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -166,14 +166,14 @@ public class PrometheusReporterTest extends TestLogger {
 	public void metricIsRemovedWhenCollectorIsNotUnregisteredYet() throws UnirestException {
 		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER);
 
-		String metricName = "numRecordsOut";
+		String metricName = "metric";
 
 		Counter metric1 = new SimpleCounter();
-		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup1 = new FrontMetricGroup<>(1, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_1"));
+		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup1 = new FrontMetricGroup<>(0, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_1"));
 		reporter.notifyOfAddedMetric(metric1, metricName, metricGroup1);
 
 		Counter metric2 = new SimpleCounter();
-		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup2 = new FrontMetricGroup<>(2, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_2"));
+		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup2 = new FrontMetricGroup<>(0, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_2"));
 		reporter.notifyOfAddedMetric(metric2, metricName, metricGroup2);
 
 		reporter.notifyOfRemovedMetric(metric1, metricName, metricGroup1);

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.metrics.prometheus;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
@@ -31,6 +32,7 @@ import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.util.TestLogger;
 
@@ -51,6 +53,7 @@ import static org.apache.flink.metrics.prometheus.PrometheusReporter.ARG_PORT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -157,6 +160,27 @@ public class PrometheusReporterTest extends TestLogger {
 			assertThat(response, containsString(
 				summaryName + "{" + DIMENSIONS + ",quantile=\"" + quantile + "\",} " + quantile + "\n"));
 		}
+	}
+
+	@Test
+	public void metricIsRemovedWhenCollectorIsNotUnregisteredYet() throws UnirestException {
+		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER);
+
+		String metricName = "numRecordsOut";
+
+		Counter metric1 = new SimpleCounter();
+		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup1 = new FrontMetricGroup<>(1, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_1"));
+		reporter.notifyOfAddedMetric(metric1, metricName, metricGroup1);
+
+		Counter metric2 = new SimpleCounter();
+		FrontMetricGroup<TaskManagerJobMetricGroup> metricGroup2 = new FrontMetricGroup<>(2, new TaskManagerJobMetricGroup(registry, tmMetricGroup, JobID.generate(), "job_2"));
+		reporter.notifyOfAddedMetric(metric2, metricName, metricGroup2);
+
+		reporter.notifyOfRemovedMetric(metric1, metricName, metricGroup1);
+
+		String response = pollMetrics(reporter.getPort()).getBody();
+
+		assertThat(response, not(containsString("job_1")));
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Prometheus metrics from canceled jobs are not always correctly cleaned up. This patch aims to remedy this

## Brief change log

- always unregister childs from collectors in notifyOfRemovedMetric so that no metrics stay behind when a job gets canceled but the collector does not get unregistered

## Verifying this change

I added a metricIsRemovedWhenCollectorIsNotUnregisteredYet test to PrometheusReporterTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?: no
  - If yes, how is the feature documented?: not applicable
