### PR TITLE
[FLINK-9672] Fail fatally if job submission fails on added JobGraph signal

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -322,9 +322,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 	@Override
 	public CompletableFuture<Collection<JobID>> listJobs(Time timeout) {
-		if (jobManagerRunners.isEmpty()) {
-			log.info("empty");
-		}
 		return CompletableFuture.completedFuture(
 			Collections.unmodifiableSet(new HashSet<>(jobManagerRunners.keySet())));
 	}


### PR DESCRIPTION
## What is the purpose of the change

Fail fatally if we cannot recover the job on the `onAddedJobGraph` signal from the `SubmittedJobGraphListener`.

## Verifying this change

- Added `DispatcherTest#testOnAddedJobGraphRecoveryFailure` and `DispatcherTest#testOnAddedJobGraphWithFinishedJob`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
