### PR TITLE
[FLINK-9669] Add assignment store interface.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/taskmanagerassignment/TaskManagerAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/taskmanagerassignment/TaskManagerAssignment.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.taskmanagerassignment;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+/**
+ * The assignment of task manager to job.
+ */
+public class TaskManagerAssignment {
+	private final JobID jobID;
+	private final ResourceID resourceID;
+
+	public TaskManagerAssignment(JobID jobID, ResourceID resourceID) {
+		this.jobID = jobID;
+		this.resourceID = resourceID;
+	}
+
+	public JobID getJobID() {
+		return jobID;
+	}
+
+	public ResourceID getResourceID() {
+		return resourceID;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/taskmanagerassignment/TaskManagerAssignmentStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/taskmanagerassignment/TaskManagerAssignmentStore.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.taskmanagerassignment;
+
+import java.util.List;
+
+/**
+ * A store for taskmanager assignment.
+ */
+public interface TaskManagerAssignmentStore {
+	/**
+	 * Start the assignment store.
+	 */
+	void start();
+
+	/**
+	 * Restore assignments from storage.
+	 */
+	List<TaskManagerAssignment> restoreAssignments();
+
+	/**
+	 * Store assignment.
+	 */
+	void put(TaskManagerAssignment assignment);
+
+	/**
+	 * Stop the assignment store.
+	 * @param cleanup if true, clear the assignment store.
+	 */
+	void stop(boolean cleanup);
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull requests is part of process to enable task manager isolation in flink 1.5 session mode.


## Brief change log
  - Add task manager assignment class.
  - Add task manager assignment store interface.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
