### PR TITLE
[FLINK-9674][tests] Replace hard-coded sleeps in QS E2E test 

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -260,9 +260,27 @@ function stop_cluster {
   fi
 }
 
+function wait_for_job_state_transition {
+  local job=$1
+  local initial_state=$2
+  local next_state=$3
+    
+  echo "Waiting for job ($job) to switch from state ${initial_state} to state ${next_state} ..."
+
+  while : ; do
+    N=$(grep -o "($job) switched from state ${initial_state} to ${next_state}" $FLINK_DIR/log/*standalonesession*.log | tail -1)
+
+    if [[ -z $N ]]; then
+      sleep 1
+    else
+      break
+    fi
+  done
+}
+
 function wait_job_running {
   for i in {1..10}; do
-    JOB_LIST_RESULT=$("$FLINK_DIR"/bin/flink list | grep "$1")
+    JOB_LIST_RESULT=$("$FLINK_DIR"/bin/flink list -r | grep "$1")
 
     if [[ "$JOB_LIST_RESULT" == "" ]]; then
       echo "Job ($1) is not yet running."

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -70,7 +70,8 @@ function cleanup {
   jm_kill_all
   rm -rf $TEST_DATA_DIR 2> /dev/null
   revert_default_config
-  rm -rf $FLINK_DIR/log/* 2> /dev/null
+  clean_log_files
+  clean_stdout_files
 }
 
 trap cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -20,8 +20,8 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/queryable_state_base.sh
 
-QUERYABLE_STATE_SERVER_JAR=${TEST_INFRA_DIR}/../../flink-end-to-end-tests/flink-queryable-state-test/target/QsStateProducer.jar
-QUERYABLE_STATE_CLIENT_JAR=${TEST_INFRA_DIR}/../../flink-end-to-end-tests/flink-queryable-state-test/target/QsStateClient.jar
+QUERYABLE_STATE_SERVER_JAR=${END_TO_END_DIR}/flink-queryable-state-test/target/QsStateProducer.jar
+QUERYABLE_STATE_CLIENT_JAR=${END_TO_END_DIR}/flink-queryable-state-test/target/QsStateClient.jar
 
 #####################
 # Test that queryable state works as expected with HA mode when restarting a taskmanager

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -55,6 +55,11 @@ function run_test() {
     clean_log_files
     clean_stdout_files
 
+    backup_config
+    # speeds up TM loss detection
+    set_conf "heartbeat.interval" "2000"
+    set_conf "heartbeat.timeout" "10000"
+
     link_queryable_state_lib
     start_cluster
 
@@ -85,20 +90,23 @@ function run_test() {
         exit 1
     fi
 
-    local current_num_checkpoints=current_num_checkpoints$(get_completed_number_of_checkpoints ${JOB_ID})
-
     kill_random_taskmanager
 
     latest_snapshot_count=$(cat $FLINK_DIR/log/*out* | grep "on snapshot" | tail -n 1 | awk '{print $4}')
     echo "Latest snapshot count was ${latest_snapshot_count}"
 
-    sleep 65 # this is a little longer than the heartbeat timeout so that the TM is gone
+    # wait until the TM loss was detected
+    wait_for_job_state_transition ${JOB_ID} "RESTARTING" "CREATED"
 
     start_and_wait_for_tm
 
+    wait_job_running ${JOB_ID}
+
+    local current_num_checkpoints="$(get_completed_number_of_checkpoints ${JOB_ID})"
     # wait for some more checkpoint to have happened
-    ((current_num_checkpoints+=2))
-    wait_for_number_of_checkpoints ${JOB_ID} ${current_num_checkpoints} 60
+    local expected_num_checkpoints=$((current_num_checkpoints + 5))
+
+    wait_for_number_of_checkpoints ${JOB_ID} ${expected_num_checkpoints} 60
 
     local num_entries_in_map_state_after=$(java -jar ${QUERYABLE_STATE_CLIENT_JAR} \
         --host ${SERVER} \
@@ -135,7 +143,7 @@ function wait_for_number_of_checkpoints {
     local timeout=$3
     local count=0
 
-    echo "Starting to wait for checkpoints"
+    echo "Starting to wait for completion of ${expected_num_checkpoints} checkpoints"
     while (($(get_completed_number_of_checkpoints ${job_id}) < ${expected_num_checkpoints})); do
 
         if [[ ${count} -gt ${timeout} ]]; then


### PR DESCRIPTION
## What is the purpose of the change

This PR replaces a hard-coded sleep in a QueryableState end-to-end test. The test was sleeping for 65 seconds after the TM was restarted, to wait until the restarted.

Instead we now first wait for the job restart procedure to kick in (using a new method to check for state transitions) and then waiting for the job to run.

Additionally
* reduce `heartbeat.timeout` to speed up TM loss detection
* fix `common#wait_job_running` returning true for scheduled jobs, we now pass the `-r` flag
* simplify jar paths in QS test (now relative to END_TO_END_DIR)
* change `test-runner-common#cleanup` to use existing `common#clean_[log|stdout]_files` functions

## Verifying this change

* manually verified