### PR TITLE
[FLINK-9677][rest] Cleanup encoder after request has been processed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -174,7 +174,12 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 	private void reset() {
 		// destroy() can fail because some data is stored multiple times in the decoder causing an IllegalReferenceCountException
 		// see https://github.com/netty/netty/issues/7814
-		currentHttpPostRequestDecoder.getBodyHttpDatas().clear();
+		try {
+			currentHttpPostRequestDecoder.getBodyHttpDatas().clear();
+		} catch (HttpPostRequestDecoder.NotEnoughDataDecoderException ned) {
+			// this method always fails if not all chunks were offered to the decoder yet
+			LOG.debug("Error while resetting {}.", getClass(), ned);
+		}
 		currentHttpPostRequestDecoder.destroy();
 		currentHttpPostRequestDecoder = null;
 		currentHttpRequest = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -351,14 +351,14 @@ public class RestClient {
 
 		@Override
 		public void writeTo(Channel channel) {
-			channel.writeAndFlush(httpRequest);
+			ChannelFuture future = channel.writeAndFlush(httpRequest);
 			// this should never be false as we explicitly set the encoder to use multipart messages
 			if (bodyRequestEncoder.isChunked()) {
-				channel.writeAndFlush(bodyRequestEncoder);
+				future = channel.writeAndFlush(bodyRequestEncoder);
 			}
 
-			// release data and remove temporary files if they were created
-			bodyRequestEncoder.cleanFiles();
+			// release data and remove temporary files if they were created, once the writing is complete
+			future.addListener((ignored) -> bodyRequestEncoder.cleanFiles());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -52,6 +52,7 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -113,7 +114,9 @@ public class MultipartUploadResource extends ExternalResource {
 			CompletableFuture.completedFuture(mockRestfulGateway);
 
 		file1 = temporaryFolder.newFile();
-		Files.write(file1.toPath(), "hello".getBytes(ConfigConstants.DEFAULT_CHARSET));
+		try (RandomAccessFile rw = new RandomAccessFile(file1, "rw")) {
+			rw.setLength(1024 * 1024 * 64);
+		}
 		file2 = temporaryFolder.newFile();
 		Files.write(file2.toPath(), "world".getBytes(ConfigConstants.DEFAULT_CHARSET));
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes an issue in the `RestClient` where the `HttpPostRequestEncoder` would be closed before the request submission was complete. `Channel#writeAndFlush();` doesn't block which lead to a race condition between the actual writing and `HttpPostRequestEncoder#cleanFiles()`.

Instead we now register a listener on the last `ChannelFuture` to cleanup the encoder once the writing is complete.

## Verifying this change

* `MultipartUploadResource` was modified to also include the upload of a large (64mb) mb file, which is used by `FileUploadHandlerTest` and `RestClientMultipartTest`
