### PR TITLE
[FLINK-9677][rest] Cleanup encoder after request has been processed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -349,14 +349,14 @@ public class RestClient {
 
 		@Override
 		public void writeTo(Channel channel) {
-			channel.writeAndFlush(httpRequest);
+			ChannelFuture future = channel.writeAndFlush(httpRequest);
 			// this should never be false as we explicitly set the encoder to use multipart messages
 			if (bodyRequestEncoder.isChunked()) {
-				channel.writeAndFlush(bodyRequestEncoder);
+				future = channel.writeAndFlush(bodyRequestEncoder);
 			}
 
-			// release data and remove temporary files if they were created
-			bodyRequestEncoder.cleanFiles();
+			// release data and remove temporary files if they were created, once the writing is complete
+			future.addListener((ignored) -> bodyRequestEncoder.cleanFiles());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -52,6 +52,7 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -113,7 +114,9 @@ public class MultipartUploadResource extends ExternalResource {
 			CompletableFuture.completedFuture(mockRestfulGateway);
 
 		file1 = temporaryFolder.newFile();
-		Files.write(file1.toPath(), "hello".getBytes(ConfigConstants.DEFAULT_CHARSET));
+		try (RandomAccessFile rw = new RandomAccessFile(file1, "rw")) {
+			rw.setLength(1024 * 1024 * 64);
+		}
 		file2 = temporaryFolder.newFile();
 		Files.write(file2.toPath(), "world".getBytes(ConfigConstants.DEFAULT_CHARSET));
 


### PR DESCRIPTION
Backport of #6217.

The `FileUploadHandler` may reject requests before they have been fully received, either due to an exception or because of an unknown attribute. With netty 4.1 this doesn't cause issues, but in 4.0 trailing HTTP contents still have to be handled. Since we reset the handler when encountering an error this content was forwarded to the next handler which crashed the http aggregator.

This PR introduces a flag such that all http contents are swallowed after a failure, until a new `HttpRequest` is received.

@tillrohrmann 