### PR TITLE
[FLINK-9686] [kinesis] Enable Kinesis authentication via AssumeRole

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -113,7 +113,7 @@ The above is a simple example of using the consumer. Configuration for the consu
 instance, the configuration keys for which can be found in `ConsumerConfigConstants`. The example
 demonstrates consuming a single Kinesis stream in the AWS region "us-east-1". The AWS credentials are supplied using the basic method in which
 the AWS access key ID and secret access key are directly supplied in the configuration (other options are setting
-`ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, `PROFILE`, and `AUTO`). Also, data is being consumed
+`ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, `PROFILE`, `ASSUME_ROLE`, and `AUTO`). Also, data is being consumed
 from the newest position in the Kinesis stream (the other option will be setting `ConsumerConfigConstants.STREAM_INITIAL_POSITION`
 to `TRIM_HORIZON`, which lets the consumer start reading the Kinesis stream from the earliest record possible).
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -98,6 +98,12 @@ under the License.
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-producer</artifactId>
 			<version>${aws.kinesis-kpl.version}</version>
 		</dependency>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
@@ -70,6 +70,22 @@ public class AWSConfigConstants {
 	/** Optional configuration for profile name if credential provider type is set to be PROFILE. */
 	public static final String AWS_PROFILE_NAME = profileName(AWS_CREDENTIALS_PROVIDER);
 
+	/** The role ARN to use when credential provider type is set to ASSUME_ROLE. */
+	public static final String AWS_ROLE_ARN = roleArn(AWS_CREDENTIALS_PROVIDER);
+
+	/** The role session name to use when credential provider type is set to ASSUME_ROLE. */
+	public static final String AWS_ROLE_SESSION_NAME = roleSessionName(AWS_CREDENTIALS_PROVIDER);
+
+	/** The external ID to use when credential provider type is set to ASSUME_ROLE. */
+	public static final String AWS_ROLE_EXTERNAL_ID = externalId(AWS_CREDENTIALS_PROVIDER);
+
+	/**
+	 * The credentials provider that provides credentials for assuming the role when credential
+	 * provider type is set to ASSUME_ROLE.
+	 * Roles can be nested, so AWS_ROLE_CREDENTIALS_PROVIDER can again be set to "ASSUME_ROLE"
+	 */
+	public static final String AWS_ROLE_CREDENTIALS_PROVIDER = roleCredentialsProvider(AWS_CREDENTIALS_PROVIDER);
+
 	/** The AWS endpoint for Kinesis (derived from the AWS region setting if not set). */
 	public static final String AWS_ENDPOINT = "aws.endpoint";
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
@@ -45,6 +45,9 @@ public class AWSConfigConstants {
 		/** Simply create AWS credentials by supplying the AWS access key ID and AWS secret key in the configuration properties. */
 		BASIC,
 
+		/** Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied. **/
+		ASSUME_ROLE,
+
 		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, PROFILE in the AWS instance metadata. **/
 		AUTO,
 	}
@@ -52,22 +55,53 @@ public class AWSConfigConstants {
 	/** The AWS region of the Kinesis streams to be pulled ("us-east-1" is used if not set). */
 	public static final String AWS_REGION = "aws.region";
 
-	/** The AWS access key ID to use when setting credentials provider type to BASIC. */
-	public static final String AWS_ACCESS_KEY_ID = "aws.credentials.provider.basic.accesskeyid";
-
-	/** The AWS secret key to use when setting credentials provider type to BASIC. */
-	public static final String AWS_SECRET_ACCESS_KEY = "aws.credentials.provider.basic.secretkey";
-
 	/** The credential provider type to use when AWS credentials are required (BASIC is used if not set). */
 	public static final String AWS_CREDENTIALS_PROVIDER = "aws.credentials.provider";
 
+	/** The AWS access key ID to use when setting credentials provider type to BASIC. */
+	public static final String AWS_ACCESS_KEY_ID = accessKeyId(AWS_CREDENTIALS_PROVIDER);
+
+	/** The AWS secret key to use when setting credentials provider type to BASIC. */
+	public static final String AWS_SECRET_ACCESS_KEY = secretKey(AWS_CREDENTIALS_PROVIDER);
+
 	/** Optional configuration for profile path if credential provider type is set to be PROFILE. */
-	public static final String AWS_PROFILE_PATH = "aws.credentials.provider.profile.path";
+	public static final String AWS_PROFILE_PATH = profilePath(AWS_CREDENTIALS_PROVIDER);
 
 	/** Optional configuration for profile name if credential provider type is set to be PROFILE. */
-	public static final String AWS_PROFILE_NAME = "aws.credentials.provider.profile.name";
+	public static final String AWS_PROFILE_NAME = profileName(AWS_CREDENTIALS_PROVIDER);
 
 	/** The AWS endpoint for Kinesis (derived from the AWS region setting if not set). */
 	public static final String AWS_ENDPOINT = "aws.endpoint";
 
+	public static String accessKeyId(String prefix) {
+		return prefix + ".basic.accesskeyid";
+	}
+
+	public static String secretKey(String prefix) {
+		return prefix + ".basic.secretkey";
+	}
+
+	public static String profilePath(String prefix) {
+		return prefix + ".profile.path";
+	}
+
+	public static String profileName(String prefix) {
+		return prefix + ".profile.name";
+	}
+
+	public static String roleArn(String prefix) {
+		return prefix + ".role.arn";
+	}
+
+	public static String roleSessionName(String prefix) {
+		return prefix + ".role.sessionName";
+	}
+
+	public static String externalId(String prefix) {
+		return prefix + ".role.externalId";
+	}
+
+	public static String roleCredentialsProvider(String prefix) {
+		return prefix + ".role.provider";
+	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -128,26 +128,24 @@ public class AWSUtil {
 			credentialProviderType = CredentialProvider.valueOf(configProps.getProperty(configPrefix));
 		}
 
-		AWSCredentialsProvider credentialsProvider;
-
 		switch (credentialProviderType) {
 			case ENV_VAR:
-				credentialsProvider = new EnvironmentVariableCredentialsProvider();
-				break;
+				return new EnvironmentVariableCredentialsProvider();
+
 			case SYS_PROP:
-				credentialsProvider = new SystemPropertiesCredentialsProvider();
-				break;
+				return new SystemPropertiesCredentialsProvider();
+
 			case PROFILE:
 				String profileName = configProps.getProperty(
 						AWSConfigConstants.profileName(configPrefix), null);
 				String profileConfigPath = configProps.getProperty(
 						AWSConfigConstants.profilePath(configPrefix), null);
-				credentialsProvider = (profileConfigPath == null)
+				return (profileConfigPath == null)
 					? new ProfileCredentialsProvider(profileName)
 					: new ProfileCredentialsProvider(profileConfigPath, profileName);
-				break;
+
 			case BASIC:
-				credentialsProvider = new AWSCredentialsProvider() {
+				return new AWSCredentialsProvider() {
 					@Override
 					public AWSCredentials getCredentials() {
 						return new BasicAWSCredentials(
@@ -160,20 +158,18 @@ public class AWSUtil {
 						// do nothing
 					}
 				};
-				break;
+
 			case ASSUME_ROLE:
-				credentialsProvider = new STSProfileCredentialsServiceProvider(new RoleInfo()
+				return new STSProfileCredentialsServiceProvider(new RoleInfo()
 						.withRoleArn(configProps.getProperty(AWSConfigConstants.roleArn(configPrefix)))
 						.withRoleSessionName(configProps.getProperty(AWSConfigConstants.roleSessionName(configPrefix)))
 						.withExternalId(configProps.getProperty(AWSConfigConstants.externalId(configPrefix)))
 						.withLongLivedCredentialsProvider(getCredentialsProvider(configProps, AWSConfigConstants.roleCredentialsProvider(configPrefix))));
-				break;
+
 			default:
 			case AUTO:
-				credentialsProvider = new DefaultAWSCredentialsProviderChain();
+				return new DefaultAWSCredentialsProviderChain();
 		}
-
-		return credentialsProvider;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -111,8 +111,9 @@ public class AWSUtil {
 	 *
 	 * @param configProps the configuration properties
 	 * @param configPrefix the prefix of the config properties for this credentials provider,
-	 *                     e.g. aws.credentials.provider, aws.credentials.provider.role.provider,
-	 *                     and so on.
+	 *                     e.g. aws.credentials.provider for the base credentials provider,
+	 *                     aws.credentials.provider.role.provider for the credentials provider
+	 *                     for assuming a role, and so on.
 	 */
 	private static AWSCredentialsProvider getCredentialsProvider(final Properties configProps, final String configPrefix) {
 		CredentialProvider credentialProviderType;
@@ -163,6 +164,7 @@ public class AWSUtil {
 			case ASSUME_ROLE:
 				final AWSSecurityTokenService baseCredentials = AWSSecurityTokenServiceClientBuilder.standard()
 						.withCredentials(getCredentialsProvider(configProps, AWSConfigConstants.roleCredentialsProvider(configPrefix)))
+						.withRegion(configProps.getProperty(AWSConfigConstants.AWS_REGION))
 						.build();
 				return new STSAssumeRoleSessionCredentialsProvider.Builder(
 						configProps.getProperty(AWSConfigConstants.roleArn(configPrefix)),

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -324,12 +324,7 @@ public class KinesisConfigUtilTest {
 		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, unixTimestamp);
 		testConfig.setProperty(ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT, pattern);
 
-		try {
-			KinesisConfigUtil.validateConsumerConfiguration(testConfig);
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail();
-		}
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Enable `FlinkKinesisProducer` to authenticate via assuming a role.

### Current situation:

FlinkKinesisProducer can authenticate with Kinesis by retrieving credentials via one of the following mechanisms:

* Environment variables
* System properties
* An AWS profile
* Directly provided credentials (`BASIC`)
* AWS's own default heuristic (`AUTO`)

For streaming across AWS accounts, it is considered good practise to enable access to the remote Kinesis stream via a role, rather than passing credentials for the remote account.

### Proposed change:

Add a new credentials provider specifying a role ARN, session name, and an additional credentials provider supplying the credentials for assuming the role.

Config example for assuming role `<role-arn>` with auto-detected credentials:{{}}

```
aws.credentials.provider: ASSUME_ROLE
aws.credentials.provider.role.arn: <role-arn>
aws.credentials.provider.role.sessionName: my-session-name
aws.credentials.provider.role.provider: AUTO
```

`ASSUME_ROLE` credentials providers can be nested, i.e. it is possible to assume a role which in turn is allowed to assume another role:

```
aws.credentials.provider: ASSUME_ROLE
aws.credentials.provider.role.arn: <role-arn>
aws.credentials.provider.role.sessionName: my-session-name
aws.credentials.provider.role.provider: ASSUME_ROLE
aws.credentials.provider.role.provider.role.arn: <nested-role-arn>
aws.credentials.provider.role.provider.role.sessionName: my-nested-session-name
aws.credentials.provider.role.provider.role.provider: AUTO
```

## Brief change log

- Add `aws.credentials.provider` option `ASSUME_ROLE` for authenticating via assuming a role.

## Verifying this change

The feature changed was not covered by tests, and it is hard to add non-trivial tests. It can be verified manually:
* Create an AWS IAM user and a role, and give the user permissions to assume the role.
* Create a Kinesis stream, and give the role permissions to write to this stream, but not the user.
* Set up the config by passing the user's credentials to assume the role
* The Kinesis producer should now be able to write to the stream.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no, although a config option is added.
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs, JavaDocs