### PR TITLE
[FLINK-9687]Delay the state fetch only when the triggerResult is fire

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -70,11 +70,6 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	/**
 	 * Called when a processing-time timer that was set using the trigger context fires.
 	 *
-	 * <p>Note: This method is not called in case the window does not contain any elements. Thus,
-	 * if you return {@code PURGE} from a trigger method and you expect to do cleanup in a future
-	 * invocation of a timer callback it might be wise to clean any state that you would clean
-	 * in the timer callback.
-	 *
 	 * @param time The timestamp at which the timer fired.
 	 * @param window The window for which the timer fired.
 	 * @param ctx A context object that can be used to register timer callbacks.
@@ -83,11 +78,6 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 
 	/**
 	 * Called when an event-time timer that was set using the trigger context fires.
-	 *
-	 * <p>Note: This method is not called in case the window does not contain any elements. Thus,
-	 * if you return {@code PURGE} from a trigger method and you expect to do cleanup in a future
-	 * invocation of a timer callback it might be wise to clean any state that you would clean
-	 * in the timer callback.
 	 *
 	 * @param time The timestamp at which the timer fired.
 	 * @param window The window for which the timer fired.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -263,16 +263,17 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 			evictingWindowState.setCurrentNamespace(triggerContext.window);
 		}
 
-		Iterable<StreamRecord<IN>> contents = evictingWindowState.get();
+		TriggerResult triggerResult = triggerContext.onEventTime(timer.getTimestamp());
 
-		if (contents != null) {
-			TriggerResult triggerResult = triggerContext.onEventTime(timer.getTimestamp());
-			if (triggerResult.isFire()) {
+		if (triggerResult.isFire()) {
+			Iterable<StreamRecord<IN>> contents = evictingWindowState.get();
+			if (contents != null) {
 				emitWindowContents(triggerContext.window, contents, evictingWindowState);
 			}
-			if (triggerResult.isPurge()) {
-				evictingWindowState.clear();
-			}
+		}
+
+		if (triggerResult.isPurge()) {
+			evictingWindowState.clear();
 		}
 
 		if (windowAssigner.isEventTime() && isCleanupTime(triggerContext.window, timer.getTimestamp())) {
@@ -309,16 +310,17 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 			evictingWindowState.setCurrentNamespace(triggerContext.window);
 		}
 
-		Iterable<StreamRecord<IN>> contents = evictingWindowState.get();
+		TriggerResult triggerResult = triggerContext.onProcessingTime(timer.getTimestamp());
 
-		if (contents != null) {
-			TriggerResult triggerResult = triggerContext.onProcessingTime(timer.getTimestamp());
-			if (triggerResult.isFire()) {
+		if (triggerResult.isFire()) {
+			Iterable<StreamRecord<IN>> contents = evictingWindowState.get();
+			if (contents != null) {
 				emitWindowContents(triggerContext.window, contents, evictingWindowState);
 			}
-			if (triggerResult.isPurge()) {
-				evictingWindowState.clear();
-			}
+		}
+
+		if (triggerResult.isPurge()) {
+			evictingWindowState.clear();
 		}
 
 		if (!windowAssigner.isEventTime() && isCleanupTime(triggerContext.window, timer.getTimestamp())) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -446,19 +446,17 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			mergingWindows = null;
 		}
 
-		ACC contents = null;
-		if (windowState != null) {
-			contents = windowState.get();
-		}
+		TriggerResult triggerResult = triggerContext.onEventTime(timer.getTimestamp());
 
-		if (contents != null) {
-			TriggerResult triggerResult = triggerContext.onEventTime(timer.getTimestamp());
-			if (triggerResult.isFire()) {
+		if (triggerResult.isFire()) {
+			ACC contents = windowState.get();
+			if (contents != null) {
 				emitWindowContents(triggerContext.window, contents);
 			}
-			if (triggerResult.isPurge()) {
-				windowState.clear();
-			}
+		}
+
+		if (triggerResult.isPurge()) {
+			windowState.clear();
 		}
 
 		if (windowAssigner.isEventTime() && isCleanupTime(triggerContext.window, timer.getTimestamp())) {
@@ -494,19 +492,17 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			mergingWindows = null;
 		}
 
-		ACC contents = null;
-		if (windowState != null) {
-			contents = windowState.get();
-		}
+		TriggerResult triggerResult = triggerContext.onProcessingTime(timer.getTimestamp());
 
-		if (contents != null) {
-			TriggerResult triggerResult = triggerContext.onProcessingTime(timer.getTimestamp());
-			if (triggerResult.isFire()) {
+		if (triggerResult.isFire()) {
+			ACC contents = windowState.get();
+			if (contents != null) {
 				emitWindowContents(triggerContext.window, contents);
 			}
-			if (triggerResult.isPurge()) {
-				windowState.clear();
-			}
+		}
+
+		if (triggerResult.isPurge()) {
+			windowState.clear();
 		}
 
 		if (!windowAssigner.isEventTime() && isCleanupTime(triggerContext.window, timer.getTimestamp())) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+import org.mockito.internal.verification.Times;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
@@ -1110,7 +1111,7 @@ public abstract class WindowOperatorContractTest extends TestLogger {
 		timeAdaptor.advanceTime(testHarness, 0L);
 
 		// trigger is not called if there is no more window (timer is silently ignored)
-		timeAdaptor.verifyTriggerCallback(mockTrigger, never(), null, null);
+		timeAdaptor.verifyTriggerCallback(mockTrigger, times(1), null, null);
 
 		verify(mockWindowFunction, never())
 				.process(anyInt(), anyTimeWindow(), anyInternalWindowContext(), anyIntIterable(), WindowOperatorContractTest.<List<Integer>>anyCollector());
@@ -1174,7 +1175,7 @@ public abstract class WindowOperatorContractTest extends TestLogger {
 		timeAdaptor.advanceTime(testHarness, 0L);
 
 		// trigger is not called if there is no more window (timer is silently ignored)
-		timeAdaptor.verifyTriggerCallback(mockTrigger, never(), null, null);
+		timeAdaptor.verifyTriggerCallback(mockTrigger, times(1), null, null);
 
 		verify(mockWindowFunction, never())
 				.process(anyInt(), anyTimeWindow(), anyInternalWindowContext(), anyIntIterable(), WindowOperatorContractTest.<List<Integer>>anyCollector());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
@@ -51,7 +51,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.mockito.internal.verification.Times;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;


### PR DESCRIPTION
## What is the purpose of the change

When the window operator is fired by the event timer or processing timer, it fetch the state content first. I think it only need to fetch the content from windowState when the triggerResult is `Fire`. Due to this change, the windowTest have to adjust that the time of the trigger is not none, and i am not sure this way to change the test case is good. 