### PR TITLE
[FLINK-9684][historyserver] HistoryServer should initialize FileSystem before using it

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -103,6 +103,12 @@ public class HistoryServer {
 		LOG.info("Loading configuration from {}", configDir);
 		final Configuration flinkConfig = GlobalConfiguration.loadConfiguration(configDir);
 
+		try {
+			FileSystem.initialize(flinkConfig);
+		} catch (IOException e) {
+			throw new Exception("Error while setting the default filesystem scheme from configuration.", e);
+		}
+
 		// run the history server
 		SecurityUtils.install(new SecurityConfiguration(flinkConfig));
 


### PR DESCRIPTION
## What is the purpose of the change
*Details explained in https://issues.apache.org/jira/browse/FLINK-9684 . This pull request makes HistoryServer initialize FileSystem before using it. That way HistoryServerArchiveFetcher will be able to talk to secure hdfs correctly.*


## Brief change log

  - *HistoryServer initializes FileSystem before using it*


## Verifying this change
This change added tests and can be verified as follows:

  - *Manually verified the change by running a historyserver with kerberos-secured hdfs cluster.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
