### PR TITLE
[FLINK-8650] Tests for WINDOW clause and documentation update

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -115,6 +115,10 @@ The following BNF-grammar describes the superset of supported SQL features in ba
 
 {% highlight sql %}
 
+insert:
+  INSERT INTO tableReference
+  query
+  
 query:
   values
   | {
@@ -139,7 +143,8 @@ select:
   [ WHERE booleanExpression ]
   [ GROUP BY { groupItem [, groupItem ]* } ]
   [ HAVING booleanExpression ]
-
+  [ WINDOW windowName AS windowSpec [, windowName AS windowSpec ]* ]
+  
 selectWithoutFrom:
   SELECT [ ALL | DISTINCT ]
   { * | projectItem [, projectItem ]* }
@@ -176,9 +181,20 @@ groupItem:
   | ROLLUP '(' expression [, expression ]* ')'
   | GROUPING SETS '(' groupItem [, groupItem ]* ')'
 
-insert:
-  INSERT INTO tableReference
-  query
+windowRef:
+      windowName
+  |   windowSpec
+
+windowSpec:
+      [ windowName ]
+      '('
+      [ ORDER BY orderItem [, orderItem ]* ]
+      [ PARTITION BY expression [, expression ]* ]
+      [
+          RANGE numericOrIntervalExpression {PRECEDING}
+      |   ROWS numericExpression {PRECEDING}
+      ]
+      ')'
 
 {% endhighlight %}
 
@@ -302,6 +318,13 @@ SELECT COUNT(amount) OVER (
   ORDER BY proctime
   ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
 FROM Orders
+
+SELECT COUNT(amount) OVER w, SUM(amount) OVER w
+FROM Orders 
+WINDOW w AS (
+  PARTITION BY user
+  ORDER BY proctime
+  ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)  
 {% endhighlight %}
       </td>
     </tr>

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
@@ -44,7 +44,16 @@ class OverWindowTest extends TableTestBase {
       "sum(DISTINCT c) OVER (PARTITION BY b ORDER BY proctime ROWS BETWEEN 2 preceding AND " +
       "CURRENT ROW) as sum2 " +
       "from MyTable"
-
+    val sql2 = "SELECT " +
+      "b, " +
+      "count(a) OVER w as cnt1, " +
+      "sum(a) OVER w as sum1, " +
+      "count(DISTINCT a) OVER w as cnt2, " +
+      "sum(DISTINCT c) OVER w as sum2 " +
+      "from MyTable WINDOW w AS (PARTITION BY b ORDER BY proctime ROWS BETWEEN 2 preceding " +
+      "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
+    
     val expected =
       unaryNode(
         "DataStreamCalc",
@@ -76,6 +85,14 @@ class OverWindowTest extends TableTestBase {
       "sum(DISTINCT a) OVER (PARTITION BY c ORDER BY proctime ROWS BETWEEN 2 preceding AND " +
       "CURRENT ROW) as sum1 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(DISTINCT a) OVER w as cnt1, " +
+      "sum(DISTINCT a) OVER (PARTITION BY c ORDER BY proctime ROWS BETWEEN 2 preceding AND " +
+      "CURRENT ROW) as sum1 " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY proctime ROWS BETWEEN 2 preceding " +
+      "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -107,7 +124,15 @@ class OverWindowTest extends TableTestBase {
       "sum(a) OVER (PARTITION BY c ORDER BY proctime ROWS BETWEEN 2 preceding AND " +
       "CURRENT ROW) as sum1 " +
       "from MyTable"
-
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER (PARTITION BY c ORDER BY proctime ROWS BETWEEN 2 preceding AND " +
+      "CURRENT ROW) as cnt1, " +
+      "sum(a) OVER w as sum1 " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY proctime ROWS BETWEEN 2 preceding " +
+      "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
+    
     val expected =
       unaryNode(
         "DataStreamCalc",
@@ -136,6 +161,13 @@ class OverWindowTest extends TableTestBase {
         "  AVG(c) OVER (PARTITION BY a ORDER BY proctime " +
         "    RANGE BETWEEN INTERVAL '2' HOUR PRECEDING AND CURRENT ROW) AS avgA " +
         "FROM MyTable"
+    val sqlQuery2 =
+      "SELECT a, " +
+        "  AVG(c) OVER w AS avgA " +
+        "FROM MyTable " +
+        "WINDOW w AS (PARTITION BY a ORDER BY proctime " +
+        "RANGE BETWEEN INTERVAL '2' HOUR PRECEDING AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sqlQuery, sqlQuery2)
 
     val expected =
       unaryNode(
@@ -173,6 +205,13 @@ class OverWindowTest extends TableTestBase {
         "  COUNT(c) OVER (ORDER BY proctime " +
         "    RANGE BETWEEN INTERVAL '10' SECOND PRECEDING AND CURRENT ROW) " +
         "FROM MyTable"
+    val sqlQuery2 =
+      "SELECT a, " +
+        "  COUNT(c) OVER w " +
+        "FROM MyTable " +
+        "WINDOW w AS (ORDER BY proctime RANGE BETWEEN INTERVAL '10' SECOND PRECEDING " +
+        "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sqlQuery, sqlQuery2)
 
     val expected =
       unaryNode(
@@ -201,6 +240,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY proctime ROWS BETWEEN 2 preceding AND " +
       "CURRENT ROW)" +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w " +
+      "from MyTable WINDOW w AS (ORDER BY proctime ROWS BETWEEN 2 preceding " +
+      "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -229,6 +274,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY proctime RANGE UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (PARTITION BY c ORDER BY proctime RANGE UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w as cnt1, " +
+      "sum(a) OVER (PARTITION BY c ORDER BY proctime RANGE UNBOUNDED preceding) as cnt2 " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY proctime RANGE UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -257,6 +308,11 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY proctime ROWS BETWEEN UNBOUNDED preceding AND " +
       "CURRENT ROW) " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY proctime ROWS UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -281,6 +337,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY proctime RANGE UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (ORDER BY proctime RANGE UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER (ORDER BY proctime RANGE UNBOUNDED preceding) as cnt1, " +
+      "sum(a) OVER w as cnt2 " +
+      "from MyTable WINDOW w AS(ORDER BY proctime RANGE UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -308,6 +370,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY proctime ROWS BETWEEN UNBOUNDED preceding AND " +
       "CURRENT ROW) " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w " +
+      "from MyTable WINDOW w AS (ORDER BY proctime ROWS BETWEEN UNBOUNDED preceding " +
+      "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -331,6 +399,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY rowtime ROWS BETWEEN 5 preceding AND " +
       "CURRENT ROW) " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY rowtime ROWS BETWEEN 5 preceding " +
+      "AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -359,7 +433,13 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY rowtime " +
       "RANGE BETWEEN INTERVAL '1' SECOND  preceding AND CURRENT ROW) " +
       "from MyTable"
-
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY rowtime RANGE " +
+      "BETWEEN INTERVAL '1' SECOND  preceding AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
+    
     val expected =
       unaryNode(
         "DataStreamCalc",
@@ -387,6 +467,11 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY rowtime ROWS BETWEEN 5 preceding AND " +
       "CURRENT ROW) " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w " +
+      "from MyTable WINDOW w AS (ORDER BY rowtime ROWS BETWEEN 5 preceding AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -414,6 +499,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY rowtime " +
       "RANGE BETWEEN INTERVAL '1' SECOND  preceding AND CURRENT ROW) as cnt1 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w as cnt1 " +
+      "from MyTable WINDOW w AS (ORDER BY rowtime RANGE " +
+      "BETWEEN INTERVAL '1' SECOND  preceding AND CURRENT ROW)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -441,6 +532,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (PARTITION BY c ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER (PARTITION BY c ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt1, " +
+      "sum(a) OVER w as cnt2 " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY rowtime RANGE UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -469,6 +566,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY rowtime ROWS UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (PARTITION BY c ORDER BY rowtime ROWS UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w as cnt1, " +
+      "sum(a) OVER (PARTITION BY c ORDER BY rowtime ROWS UNBOUNDED preceding) as cnt2 " +
+      "from MyTable WINDOW w AS (PARTITION BY c ORDER BY rowtime ROWS UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -510,6 +613,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER (ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt1, " +
+      "sum(a) OVER w as cnt2 " +
+      "from MyTable WINDOW w AS (ORDER BY rowtime RANGE UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -537,6 +646,12 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (ORDER BY rowtime ROWS UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (ORDER BY rowtime ROWS UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+    val sql2 = "SELECT " +
+      "c, " +
+      "count(a) OVER w as cnt1, " +
+      "sum(a) OVER (ORDER BY rowtime ROWS UNBOUNDED preceding) as cnt2 " +
+      "from MyTable WINDOW w AS (ORDER BY rowtime ROWS UNBOUNDED preceding)"
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
 
     val expected =
       unaryNode(
@@ -567,6 +682,44 @@ class OverWindowTest extends TableTestBase {
           "CAST(w0$o1), null) AS cnt2"
         )
       )
+    streamUtil.verifySql(sql, expected)
+  }
+
+  @Test
+  def testProcTimeBoundedPartitionedRowsOverDifferentWindows() = {
+    val sql = "SELECT " +
+      "a, " +
+      "SUM(c) OVER (PARTITION BY a ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW), " +
+      "MIN(c) OVER (PARTITION BY a ORDER BY proctime ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) " +
+      "FROM MyTable"
+    val sql2 = "SELECT " +
+      "a, " +
+      "SUM(c) OVER w1, " +
+      "MIN(c) OVER w2 " +
+      "FROM MyTable " +
+      "WINDOW w1 AS (PARTITION BY a ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)," +
+      "w2 AS (PARTITION BY a ORDER BY proctime ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)"
+
+    streamUtil.verifySqlPlansIdentical(sql, sql2)
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamOverAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "c", "proctime")
+          ),
+          term("partitionBy", "a"),
+          term("orderBy", "proctime"),
+          term("rows", "BETWEEN 3 PRECEDING AND CURRENT ROW"),
+          term("select", "a", "c", "proctime", "COUNT(c) AS w0$o0",
+            "$SUM0(c) AS w0$o1")
+        ),
+        term("select", "a", "CASE(>(w0$o0, 0)", "CAST(w0$o1), null) AS EXPR$1", "w1$o0 AS EXPR$2")
+      )
+
     streamUtil.verifySql(sql, expected)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -280,10 +280,23 @@ case class StreamTableTestUtil() extends TableTestUtil {
     verifyTable(tableEnv.sqlQuery(query), expected)
   }
 
+  def verifySqlPlansIdentical(query1: String, queries: String*): Unit = {
+    val resultTable1 = tableEnv.sqlQuery(query1)
+    queries.foreach(s => verify2Tables(resultTable1, tableEnv.sqlQuery(s)))
+  }
+
   def verifyTable(resultTable: Table, expected: String): Unit = {
     val relNode = resultTable.getRelNode
     val optimized = tableEnv.optimize(relNode, updatesAsRetraction = false)
     verifyString(expected, optimized)
+  }
+
+  def verify2Tables(resultTable1: Table, resultTable2: Table): Unit = {
+    val relNode1 = resultTable1.getRelNode
+    val optimized1 = tableEnv.optimize(relNode1, updatesAsRetraction = false)
+    val relNode2 = resultTable2.getRelNode
+    val optimized2 = tableEnv.optimize(relNode2, updatesAsRetraction = false)
+    assertEquals(RelOptUtil.toString(optimized1), RelOptUtil.toString(optimized2))
   }
 
   def verifyJavaSql(query: String, expected: String): Unit = {


### PR DESCRIPTION
## What is the purpose of the change
This PR adds test and documentation coverage of WINDOW clause

## Brief change log

  - *Test that the same queries but with different specification of windows have the same plan*
  - *Mentioning in doc WINDOW syntax* 


## Verifying this change

This change added tests and can be verified as follows:
via running of org.apache.flink.table.api.stream.sql.OverWindowTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

