### PR TITLE
[docs] Replaced deprecated `high-availability.storageDir` parameter from doc

### DIFF
--- a/docs/ops/jobmanager_high_availability.md
+++ b/docs/ops/jobmanager_high_availability.md
@@ -93,7 +93,7 @@ In order to start an HA-cluster add the following configuration keys to `conf/fl
 - **Storage directory** (required): JobManager metadata is persisted in the file system *storageDir* and only a pointer to this state is stored in ZooKeeper.
 
     <pre>
-high-availability.zookeeper.storageDir: hdfs:///flink/recovery
+high-availability.storageDir: hdfs:///flink/recovery
     </pre>
 
     The `storageDir` stores all metadata needed to recover a JobManager failure.
@@ -109,7 +109,7 @@ high-availability: zookeeper
 high-availability.zookeeper.quorum: localhost:2181
 high-availability.zookeeper.path.root: /flink
 high-availability.cluster-id: /cluster_one # important: customize per cluster
-high-availability.zookeeper.storageDir: hdfs:///flink/recovery</pre>
+high-availability.storageDir: hdfs:///flink/recovery</pre>
 
 2. **Configure masters** in `conf/masters`:
 
@@ -191,7 +191,7 @@ This means that the application can be restarted 9 times for failed attempts bef
    <pre>
 high-availability: zookeeper
 high-availability.zookeeper.quorum: localhost:2181
-high-availability.zookeeper.storageDir: hdfs:///flink/recovery
+high-availability.storageDir: hdfs:///flink/recovery
 high-availability.zookeeper.path.root: /flink
 yarn.application-attempts: 10</pre>
 


### PR DESCRIPTION
## What is the purpose of the change

Replace depricated paramater [high-availability.zookpeer.storageDir](https://github.com/apache/flink/blob/0deaa3b1b997442a92d605102bab59bcd28a4db3/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java#L1077) with [high-availability.storageDir](https://github.com/apache/flink/blob/009e9fe4e9a24ccad949d75d745f9a1d8cf3ae98/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java#L70) in HA setup doc.


## Brief change log

one-line change to replace parameter


## Verifying this change

This change is a trivial rework / code cleanup

## Does this pull request potentially affect one of the following parts:

no

## Documentation

  - Does this pull request introduce a new feature? ( no)
