### PR TITLE
[FLINK-9694] Potentially NPE in CompositeTypeSerializerConfigSnapshot constructor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerConfigSnapshot.java
@@ -50,11 +50,13 @@ public abstract class CompositeTypeSerializerConfigSnapshot extends TypeSerializ
 
 		this.nestedSerializersAndConfigs = new ArrayList<>(nestedSerializers.length);
 		for (TypeSerializer<?> nestedSerializer : nestedSerializers) {
-			TypeSerializerConfigSnapshot configSnapshot = nestedSerializer.snapshotConfiguration();
-			this.nestedSerializersAndConfigs.add(
-				new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
-					nestedSerializer.duplicate(),
-					Preconditions.checkNotNull(configSnapshot)));
+			if (nestedSerializer != null) {
+				TypeSerializerConfigSnapshot configSnapshot = nestedSerializer.snapshotConfiguration();
+				this.nestedSerializersAndConfigs.add(
+					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+						nestedSerializer.duplicate(),
+						Preconditions.checkNotNull(configSnapshot)));
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed a NPE in CompositeTypeSerializerConfigSnapshot constructor*

## Brief change log

  - *Add a non-null check in CompositeTypeSerializerConfigSnapshot constructor*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
