### PR TITLE
[FLINK-9695] [mesos] Add option for Mesos executor to forcefully pull Docker images

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -18,6 +18,11 @@
             <td></td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.tasks.container.docker.force-pull-image</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Instruct the docker containerizer to forcefully pull the image rather than reuse a cached version.</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.container.docker.parameters</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Custom parameters to be passed into docker run command when using the docker containerizer. Comma separated list of "key=value" pairs. The "value" may contain '='.</td>

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -270,6 +270,8 @@ May be set to -1 to disable this feature.
 
 `mesos.resourcemanager.tasks.uris`: A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers. (**NO DEFAULT**)
 
+`mesos.resourcemanager.tasks.container.docker.force-pull-image`: Instruct the docker containerizer to forcefully pull the image rather than reuse a cached version. (**DEFAULT**: false)
+
 `mesos.resourcemanager.tasks.hostname`: Optional value to define the TaskManager's hostname. The pattern `_TASK_` is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. `_TASK_.flink-service.mesos`) for name lookups. (**NO DEFAULT**)
 
 `mesos.resourcemanager.tasks.bootstrap-cmd`: A command which is executed before the TaskManager is started (**NO DEFAULT**).

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -317,7 +317,8 @@ public class LaunchableMesosWorker implements LaunchableTask {
 					.setDocker(Protos.ContainerInfo.DockerInfo.newBuilder()
 						.addAllParameters(params.dockerParameters())
 						.setNetwork(Protos.ContainerInfo.DockerInfo.Network.HOST)
-						.setImage(params.containerImageName().get()));
+						.setImage(params.containerImageName().get())
+						.setForcePullImage(params.dockerForcePullImage()));
 				break;
 
 			default:

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -666,6 +666,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 				new HashMap<>(taskManagerParameters.containeredParameters().taskManagerEnv())),
 			taskManagerParameters.containerVolumes(),
 			taskManagerParameters.dockerParameters(),
+			taskManagerParameters.dockerForcePullImage(),
 			taskManagerParameters.constraints(),
 			taskManagerParameters.command(),
 			taskManagerParameters.bootstrapCommand(),

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -107,6 +107,12 @@ public class MesosTaskManagerParameters {
 		.withDescription("Custom parameters to be passed into docker run command when using the docker containerizer." +
 			" Comma separated list of \"key=value\" pairs. The \"value\" may contain '='.");
 
+	public static final ConfigOption<Boolean> MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE =
+		key("mesos.resourcemanager.tasks.container.docker.force-pull-image")
+		.defaultValue(false)
+		.withDescription("Instruct the docker containerizer to forcefully pull the image rather than" +
+			" reuse a cached version.");
+
 	public static final ConfigOption<String> MESOS_CONSTRAINTS_HARD_HOSTATTR =
 		key("mesos.constraints.hard.hostattribute")
 		.noDefaultValue()
@@ -135,6 +141,8 @@ public class MesosTaskManagerParameters {
 
 	private final List<Protos.Parameter> dockerParameters;
 
+	private final boolean dockerForcePullImage;
+
 	private final List<ConstraintEvaluator> constraints;
 
 	private final String command;
@@ -153,6 +161,7 @@ public class MesosTaskManagerParameters {
 			ContaineredTaskManagerParameters containeredParameters,
 			List<Protos.Volume> containerVolumes,
 			List<Protos.Parameter> dockerParameters,
+			boolean dockerForcePullImage,
 			List<ConstraintEvaluator> constraints,
 			String command,
 			Option<String> bootstrapCommand,
@@ -166,6 +175,7 @@ public class MesosTaskManagerParameters {
 		this.containeredParameters = Preconditions.checkNotNull(containeredParameters);
 		this.containerVolumes = Preconditions.checkNotNull(containerVolumes);
 		this.dockerParameters = Preconditions.checkNotNull(dockerParameters);
+		this.dockerForcePullImage = dockerForcePullImage;
 		this.constraints = Preconditions.checkNotNull(constraints);
 		this.command = Preconditions.checkNotNull(command);
 		this.bootstrapCommand = Preconditions.checkNotNull(bootstrapCommand);
@@ -225,6 +235,13 @@ public class MesosTaskManagerParameters {
 	}
 
 	/**
+	 * Get Docker option to force pull image.
+	 */
+	public boolean dockerForcePullImage() {
+		return dockerForcePullImage;
+	}
+
+	/**
 	 * Get the placement constraints.
 	 */
 	public List<ConstraintEvaluator> constraints() {
@@ -269,6 +286,7 @@ public class MesosTaskManagerParameters {
 			", containeredParameters=" + containeredParameters +
 			", containerVolumes=" + containerVolumes +
 			", dockerParameters=" + dockerParameters +
+			", dockerForcePullImage=" + dockerForcePullImage +
 			", constraints=" + constraints +
 			", taskManagerHostName=" + taskManagerHostname +
 			", command=" + command +
@@ -329,6 +347,8 @@ public class MesosTaskManagerParameters {
 
 		Option<String> uriParamsOpt = Option.<String>apply(flinkConfig.getString(MESOS_TM_URIS));
 
+		boolean dockerForcePullImage = flinkConfig.getBoolean(MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE);
+
 		List<Protos.Volume> containerVolumes = buildVolumes(containerVolOpt);
 
 		List<Protos.Parameter> dockerParameters = buildDockerParameters(dockerParamsOpt);
@@ -350,6 +370,7 @@ public class MesosTaskManagerParameters {
 			containeredParameters,
 			containerVolumes,
 			dockerParameters,
+			dockerForcePullImage,
 			constraints,
 			tmCommand,
 			tmBootstrapCommand,

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -251,6 +251,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 				containeredParams,
 				Collections.<Protos.Volume>emptyList(),
 				Collections.<Protos.Parameter>emptyList(),
+				false,
 				Collections.<ConstraintEvaluator>emptyList(),
 				"",
 				Option.<String>empty(),

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -279,7 +279,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
 				1.0, 1, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
-				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(),
+				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
 				Option.<String>empty(), Collections.<String>emptyList());
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -142,6 +142,31 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 		assertEquals(params.uris().size(), 0);
 	}
 
+	public void testForcePullImageTrue() {
+		Configuration config = new Configuration();
+		config.setBoolean(MesosTaskManagerParameters.MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE, true);
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.dockerForcePullImage(), true);
+	}
+
+	@Test
+	public void testForcePullImageFalse() {
+		Configuration config = new Configuration();
+		config.setBoolean(MesosTaskManagerParameters.MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE, false);
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.dockerForcePullImage(), false);
+	}
+
+	@Test
+	public void testForcePullImageDefault() {
+		Configuration config = new Configuration();
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.dockerForcePullImage(), false);
+	}
+
 	@Test
 	public void givenTwoConstraintsInConfigShouldBeParsed() throws Exception {
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request introduces an option for Mesos executor to forcefully pull Docker images

## Brief change log

* A new parameter ```mesos.resourcemanager.tasks.container.docker.force-pull-image``` was introduced

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests that verify correctness of behavior of new parameter
  - Manually verified behavior by running Flink in Mesos with Docker containerizer and 2 task managers.  Confirmed that when a task started on a node where the task image already resided, an existing cached image was used when ```mesos.resourcemanager.tasks.container.docker.force-pull-image``` was left out or set to ```false```.  Confirmed that fresh image was pulled and used over a cached image when ```mesos.resourcemanager.tasks.container.docker.force-pull-image``` was set to ```true```.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
