### PR TITLE
[FLINK-9696] [table] Deep toString for array/map sql types

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -35,7 +35,7 @@ public final class CliStrings {
 
 	public static final String CLI_NAME = "Flink SQL CLI Client";
 	public static final String DEFAULT_MARGIN = " ";
-	public static final String NULL_COLUMN = "(NULL)";
+	public static final String NULL_COLUMN = "null";
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliUtils.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliUtils.java
@@ -26,10 +26,14 @@ import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 
+import java.lang.reflect.Array;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 /**
@@ -93,12 +97,7 @@ public final class CliUtils {
 	public static String[] rowToString(Row row) {
 		final String[] fields = new String[row.getArity()];
 		for (int i = 0; i < row.getArity(); i++) {
-			final Object field = row.getField(i);
-			if (field == null) {
-				fields[i] = CliStrings.NULL_COLUMN;
-			} else {
-				fields[i] = field.toString();
-			}
+			fields[i] = deepToString(row.getField(i));
 		}
 		return fields;
 	}
@@ -109,5 +108,107 @@ public final class CliUtils {
 			typesAsString[i] = types[i].toString();
 		}
 		return typesAsString;
+	}
+
+	public static String deepToString(Object o) {
+		if (o == null) {
+			return CliStrings.NULL_COLUMN;
+		} else if (o instanceof Collection
+			|| o instanceof Map
+			|| o.getClass().isArray()) {
+			StringBuilder stringBuilder = new StringBuilder();
+			deepToString(o, stringBuilder);
+			return stringBuilder.toString();
+		} else {
+			return Objects.toString(o);
+		}
+	}
+
+	public static void deepToString(Object o, StringBuilder sb) {
+		if (o == null) {
+			sb.append(CliStrings.NULL_COLUMN);
+		} else if (o.getClass().isArray()) {
+			Class clazz = o.getClass();
+			if (clazz == byte[].class) {
+				sb.append(Arrays.toString((byte[]) o));
+			} else if (clazz == short[].class) {
+				sb.append(Arrays.toString((short[]) o));
+			} else if (clazz == int[].class) {
+				sb.append(Arrays.toString((int[]) o));
+			} else if (clazz == long[].class) {
+				sb.append(Arrays.toString((long[]) o));
+			} else if (clazz == char[].class) {
+				sb.append(Arrays.toString((char[]) o));
+			} else if (clazz == float[].class) {
+				sb.append(Arrays.toString((float[]) o));
+			} else if (clazz == double[].class) {
+				sb.append(Arrays.toString((double[]) o));
+			} else if (clazz == boolean[].class) {
+				sb.append(Arrays.toString((boolean[]) o));
+			} else {
+				int length = Array.getLength(o);
+				sb.append("[");
+				for (int i = 0; i < length; i++) {
+					deepToString(Array.get(o, i), sb);
+					if (i < length - 1) {
+						sb.append(", ");
+					}
+				}
+				sb.append("]");
+			}
+		} else if (o instanceof Collection) {
+			sb.append("[");
+			Iterator iterator = ((Collection) o).iterator();
+			while (iterator.hasNext()) {
+				Object element = iterator.next();
+				if (element == null) {
+					sb.append(CliStrings.NULL_COLUMN);
+				} else if (element.getClass().isArray()
+					|| element instanceof Collection
+					|| element instanceof Map) {
+					deepToString(element, sb);
+				} else {
+					sb.append(element.toString());
+				}
+				if (iterator.hasNext()) {
+					sb.append(", ");
+				}
+			}
+			sb.append("]");
+		} else if (o instanceof Map) {
+			sb.append("{");
+			Iterator entrySetIterator = ((Map) o).entrySet().iterator();
+			while (entrySetIterator.hasNext()) {
+				Object entry = entrySetIterator.next();
+				Object key = ((Map.Entry) entry).getKey();
+				if (key == null) {
+					sb.append(CliStrings.NULL_COLUMN);
+				} else if (key.getClass().isArray()
+					|| key instanceof Collection
+					|| key instanceof Map) {
+					deepToString(key, sb);
+				} else {
+					sb.append(key);
+				}
+				sb.append("=");
+
+				Object value = ((Map.Entry) entry).getValue();
+				if (value == null) {
+					sb.append(CliStrings.NULL_COLUMN);
+				} else if (value.getClass().isArray()
+					|| value instanceof Collection
+					|| value instanceof Map) {
+					deepToString(value, sb);
+				} else {
+					sb.append(value);
+				}
+				if (entrySetIterator.hasNext()) {
+					sb.append(", ");
+				}
+			}
+			sb.append("}");
+		} else {
+			sb.append(o.toString());
+		}
 	}
 }

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliUtilsTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliUtilsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link CliUtils}.
+ */
+public class CliUtilsTest {
+
+	@Test
+	public void testRowToString() throws IOException {
+		Row result = new Row(10);
+		result.setField(0, null);
+		result.setField(1, "String");
+		result.setField(2, 'c');
+		result.setField(3, false);
+		result.setField(4, 12345.67f);
+		result.setField(5, 12345.67d);
+		result.setField(6, 12345L);
+		result.setField(7, java.sql.Date.valueOf("2018-11-12"));
+		result.setField(8, new int[]{1, 2});
+		result.setField(9, new Row(2));
+		String expected = "[null, String, c, false, "
+			+ "12345.67, 12345.67, 12345, 2018-11-12, [1, 2], null,null]";
+		assertEquals(expected, Arrays.toString(CliUtils.rowToString(result)));
+	}
+
+	@Test
+	public void testDeepToString() {
+		int[][][] array = new int[][][] {{{1, 2}}, {{10, 20, 30, 40}}, {{22, 33, 44, 55, 66}}};
+		assertEquals("[[[1, 2]], [[10, 20, 30, 40]], [[22, 33, 44, 55, 66]]]",
+			CliUtils.deepToString(array));
+
+		Map arrayInsideMap = new HashMap() {{
+			put(new Object[]{1, 2, 3}, new Object[]{5, 6, 7, 8});
+		}};
+		assertEquals("{[1, 2, 3]=[5, 6, 7, 8]}",
+			CliUtils.deepToString(arrayInsideMap));
+
+		Map arrayInsideMapWithNulls = new HashMap() {{
+			put(new Object[]{1, null, 2, 3, null}, new Object[]{5, null, 6, 7});
+		}};
+		assertEquals(CliUtils.deepToString(arrayInsideMapWithNulls),
+			"{[1, null, 2, 3, null]=[5, null, 6, 7]}");
+
+		//could be actual in case of multisets
+		Collection collection = new ArrayList() {{
+			add(1);
+			add(123);
+			add(null);
+		}};
+		assertEquals("[1, 123, null]", CliUtils.deepToString(collection));
+		Object[] collectionInsideArray = new Object[] {
+			new ArrayList<Integer>() {{
+				add(1);
+				add(null);
+				add(3);
+			}},
+			new ArrayList<Integer>() {{
+				add(null);
+				add(2);
+			}}
+		};
+		assertEquals("[[1, null, 3], [null, 2]]",
+			CliUtils.deepToString(collectionInsideArray));
+		Object[] arrayInsideCollectionInsideArray = new Object[] {
+			new ArrayList<int[]>() {{
+				add(new int[]{1});
+				add(new int[]{2, 5, 8});
+			}},
+			new ArrayList<int[]>() {{
+				add(new int[]{3, 8, 13});
+				add(new int[]{11, 16, 21});
+			}}
+		};
+		assertEquals("[[[1], [2, 5, 8]], [[3, 8, 13], [11, 16, 21]]]",
+			CliUtils.deepToString(arrayInsideCollectionInsideArray));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR changes behavior of FlinkSQLClient while printing array/map columns values

## Brief change log

  - *Make it possible to have array/map types human readable in FlinkSQLClient output*

## Verifying this change
`CliUtilsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
