### PR TITLE
WIP: [FLINK-9431]Introduce time bounded condition to cep

### DIFF
--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
@@ -322,6 +322,17 @@ class Pattern[T , F <: T](jPattern: JPattern[T, F]) {
     Pattern[T, T](jPattern.followedByAny(name))
   }
 
+  /**
+    * Appends a new pattern to the existing one. This pattern describes a situation
+    * that the match will reach the {@link org.apache.flink.cep.nfa.State.StateType#Final}
+    * with the time (processing or event) fulfills the condition bounded.
+    *
+    * @param name Name of the new pattern
+    * @return A new pattern which is appended to this one
+    */
+  def timeEnd(name: String): Pattern[T, T] = {
+    Pattern[T, T](jPattern.timeEnd(name))
+  }
 
   /**
     * Specifies that this pattern is optional for a final match of the pattern

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
@@ -56,6 +56,10 @@ public class State<T> implements Serializable {
 		return stateType == StateType.Final;
 	}
 
+	public boolean isTimeEnd() {
+		return stateType == StateType.TimeEnd;
+	}
+
 	public boolean isStart() {
 		return stateType == StateType.Start;
 	}
@@ -142,6 +146,7 @@ public class State<T> implements Serializable {
 		Start, // the state is a starting state for the NFA
 		Final, // the state is a final state for the NFA
 		Normal, // the state is neither a start nor a final state
-		Stop
+		TimeEnd, // the state is bounded with a time condition
+		Stop // the state will lead to the partial match to be discarded
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
@@ -318,6 +318,18 @@ public class Pattern<T, F extends T> {
 	}
 
 	/**
+	 * Appends a new pattern to the existing one. This pattern describes a situation
+	 * that the match will reach the {@link org.apache.flink.cep.nfa.State.StateType#Final}
+	 * with the time (processing or event) fulfills the condition bounded.
+	 *
+	 * @param name Name of the new pattern
+	 * @return A new pattern which is appended to this one
+	 */
+	public Pattern<T, T> timeEnd(final String name) {
+		return new Pattern<>(name, this, ConsumingStrategy.SKIP_TILL_TIME_REACHED, afterMatchSkipStrategy);
+	}
+
+	/**
 	 * Specifies that this pattern is optional for a final match of the pattern
 	 * sequence to happen.
 	 *

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Quantifier.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Quantifier.java
@@ -150,6 +150,7 @@ public class Quantifier {
 		STRICT,
 		SKIP_TILL_NEXT,
 		SKIP_TILL_ANY,
+		SKIP_TILL_TIME_REACHED,
 
 		NOT_FOLLOW,
 		NOT_NEXT

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
@@ -36,11 +36,23 @@ public class AndCondition<T> extends IterativeCondition<T> {
 	public AndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
 		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
 		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+		Preconditions.checkArgument(!((this.left.isTimeCondition() && !this.right.isTimeCondition())
+			|| (!this.left.isTimeCondition() && this.right.isTimeCondition())), "timeCondition cannot combine with event driven condition.");
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
 		return left.filter(value, ctx) && right.filter(value, ctx);
+	}
+
+	@Override
+	public boolean filter(long timestamp, Context<T> ctx) throws Exception {
+		return  left.filter(timestamp, ctx) && right.filter(timestamp, ctx);
+	}
+
+	@Override
+	public boolean isTimeCondition() {
+		return this.left.isTimeCondition() && this.right.isTimeCondition();
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
@@ -81,6 +81,20 @@ public abstract class IterativeCondition<T> implements Function, Serializable {
 	 */
 	public abstract boolean filter(T value, Context<T> ctx) throws Exception;
 
+	public boolean filter(long timestamp, Context<T> ctx) throws Exception {
+		return false;
+	}
+
+	/**
+	 * Flag indicates whether the condition only accepts the timestamp for evaluation.
+	 * If the result is true it means the condition will be evaluated with the null event,
+	 * It should works with timeEnd pattern.
+	 * @return {@code true} for the condition which is time bounded, and {@code false} for not.
+	 */
+	public boolean isTimeCondition() {
+		return false;
+	}
+
 	/**
 	 * The context used when evaluating the {@link IterativeCondition condition}.
 	 */

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
@@ -34,7 +34,17 @@ public class NotCondition<T> extends IterativeCondition<T> {
 	}
 
 	@Override
+	public boolean isTimeCondition() {
+		return original != null && this.original.isTimeCondition();
+	}
+
+	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
 		return original != null && !original.filter(value, ctx);
+	}
+
+	@Override
+	public boolean filter(long timestamp, Context<T> ctx) throws Exception {
+		return original != null && !original.filter(timestamp, ctx);
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
@@ -36,11 +36,23 @@ public class OrCondition<T> extends IterativeCondition<T> {
 	public OrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
 		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
 		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+		Preconditions.checkArgument(!((this.left.isTimeCondition() && !this.right.isTimeCondition())
+			|| (!this.left.isTimeCondition() && this.right.isTimeCondition())), "timeCondition cannot combine with event driven condition.");
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
 		return left.filter(value, ctx) || right.filter(value, ctx);
+	}
+
+	@Override
+	public boolean filter(long timestamp, Context<T> ctx) throws Exception {
+		return  left.filter(timestamp, ctx) || right.filter(timestamp, ctx);
+	}
+
+	@Override
+	public boolean isTimeCondition() {
+		return this.left.isTimeCondition() && this.right.isTimeCondition();
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
@@ -402,13 +402,13 @@ public class NFAITCase extends TestLogger {
 
 		for (StreamRecord<Event> event: events) {
 
-			Collection<Tuple2<Map<String, List<Event>>, Long>> timeoutPatterns =
-				nfa.advanceTime(sharedBuffer, nfaState, event.getTimestamp());
+			Tuple2<Collection<Tuple2<Map<String, List<Event>>, Long>>, Collection<Map<String, List<Event>>>> result =
+				nfa.advanceTime(sharedBuffer, nfaState, event.getTimestamp(), AfterMatchSkipStrategy.noSkip());
 			Collection<Map<String, List<Event>>> matchedPatterns =
 				nfa.process(sharedBuffer, nfaState, event.getValue(), event.getTimestamp());
 
 			resultingPatterns.addAll(matchedPatterns);
-			resultingTimeoutPatterns.addAll(timeoutPatterns);
+			resultingTimeoutPatterns.addAll(result.f0);
 		}
 
 		assertEquals(1, resultingPatterns.size());
@@ -2340,7 +2340,7 @@ public class NFAITCase extends TestLogger {
 		nfa.process(sharedBuffer, nfaState, end1, 6);
 
 		//pruning element
-		nfa.advanceTime(sharedBuffer, nfaState, 10);
+		nfa.advanceTime(sharedBuffer, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
 		assertEquals(1, nfaState.getComputationStates().size());
 		assertEquals("start", nfaState.getComputationStates().peek().getCurrentStateName());
@@ -2384,7 +2384,7 @@ public class NFAITCase extends TestLogger {
 		nfa.process(sharedBuffer, nfaState, end1, 6);
 
 		//pruning element
-		nfa.advanceTime(sharedBuffer, nfaState, 10);
+		nfa.advanceTime(sharedBuffer, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
 		assertEquals(1, nfaState.getComputationStates().size());
 		assertEquals("start", nfaState.getComputationStates().peek().getCurrentStateName());
@@ -2430,7 +2430,7 @@ public class NFAITCase extends TestLogger {
 		nfa.process(sharedBuffer, nfaState, end1, 6);
 
 		//pruning element
-		nfa.advanceTime(sharedBuffer, nfaState, 10);
+		nfa.advanceTime(sharedBuffer, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
 		assertEquals(1, nfaState.getComputationStates().size());
 		assertEquals("start", nfaState.getComputationStates().peek().getCurrentStateName());
@@ -2476,7 +2476,7 @@ public class NFAITCase extends TestLogger {
 		nfa.process(sharedBuffer, nfaState, end1, 6);
 
 		//pruning element
-		nfa.advanceTime(sharedBuffer, nfaState, 10);
+		nfa.advanceTime(sharedBuffer, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
 		assertEquals(1, nfaState.getComputationStates().size());
 		assertEquals("start", nfaState.getComputationStates().peek().getCurrentStateName());
@@ -2842,7 +2842,7 @@ public class NFAITCase extends TestLogger {
 		nfa.process(spiedBuffer, nfa.createInitialNFAState(), a, 1);
 		nfa.process(spiedBuffer, nfa.createInitialNFAState(), b, 2);
 		Mockito.verify(spiedBuffer, Mockito.never()).advanceTime(anyLong());
-		nfa.advanceTime(spiedBuffer, nfa.createInitialNFAState(), 2);
+		nfa.advanceTime(spiedBuffer, nfa.createInitialNFAState(), 2, AfterMatchSkipStrategy.noSkip());
 		Mockito.verify(spiedBuffer, Mockito.times(1)).advanceTime(2);
 
 	}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStatusChangeITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStatusChangeITCase.java
@@ -117,14 +117,14 @@ public class NFAStatusChangeITCase {
 		// both the queue of ComputationStatus and eventSharedBuffer have not changed
 		// as the timestamp is within the window
 		nfaState.resetStateChanged();
-		nfa.advanceTime(sharedBuffer, nfaState, 8L);
+		nfa.advanceTime(sharedBuffer, nfaState, 8L, AfterMatchSkipStrategy.noSkip());
 		assertFalse("NFA status should not change as the timestamp is within the window", nfaState.isStateChanged());
 
 		// timeout ComputationStatus will be removed from the queue of ComputationStatus and timeout event will
 		// be removed from eventSharedBuffer as the timeout happens
 		nfaState.resetStateChanged();
-		Collection<Tuple2<Map<String, List<Event>>, Long>> timeoutResults = nfa.advanceTime(sharedBuffer, nfaState, 12L);
-		assertTrue("NFA status should change as timeout happens", nfaState.isStateChanged() && !timeoutResults.isEmpty());
+		Tuple2<Collection<Tuple2<Map<String, List<Event>>, Long>>, Collection<Map<String, List<Event>>>> result = nfa.advanceTime(sharedBuffer, nfaState, 12L, AfterMatchSkipStrategy.noSkip());
+		assertTrue("NFA status should change as timeout happens", nfaState.isStateChanged() && !result.f0.isEmpty());
 	}
 
 	@Test
@@ -183,11 +183,11 @@ public class NFAStatusChangeITCase {
 		NFAState nfaState = nfa.createInitialNFAState();
 
 		nfaState.resetStateChanged();
-		nfa.advanceTime(sharedBuffer, nfaState, 6L);
+		nfa.advanceTime(sharedBuffer, nfaState, 6L, AfterMatchSkipStrategy.noSkip());
 		nfa.process(sharedBuffer, nfaState, new Event(6, "start", 1.0), 6L);
 
 		nfaState.resetStateChanged();
-		nfa.advanceTime(sharedBuffer, nfaState, 17L);
+		nfa.advanceTime(sharedBuffer, nfaState, 17L, AfterMatchSkipStrategy.noSkip());
 		assertTrue(nfaState.isStateChanged());
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
@@ -185,7 +185,7 @@ public class NFATest extends TestLogger {
 
 		SharedBuffer<Event> sharedBuffer = TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
 		for (StreamRecord<Event> streamEvent : inputs) {
-			nfa.advanceTime(sharedBuffer, nfaState, streamEvent.getTimestamp());
+			nfa.advanceTime(sharedBuffer, nfaState, streamEvent.getTimestamp(), AfterMatchSkipStrategy.noSkip());
 			Collection<Map<String, List<Event>>> matchedPatterns = nfa.process(
 				sharedBuffer,
 				nfaState,

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATestUtilities.java
@@ -66,7 +66,7 @@ public class NFATestUtilities {
 
 		SharedBuffer<Event> sharedBuffer = TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
 		for (StreamRecord<Event> inputEvent : inputEvents) {
-			nfa.advanceTime(sharedBuffer, nfaState, inputEvent.getTimestamp());
+			nfa.advanceTime(sharedBuffer, nfaState, inputEvent.getTimestamp(), AfterMatchSkipStrategy.noSkip());
 			Collection<Map<String, List<Event>>> patterns = nfa.process(
 				sharedBuffer,
 				nfaState,


### PR DESCRIPTION
## What is the purpose of the change

In cep the event is now driving the transformation of the NFA, I think the time factor should also be taken into account in some senior.

When a key's data is not endless, and if we want to match the following pattern after we match the `AB` after `B` has appeared for  ten seconds.

```
Pattern.begin("A").followedBy("B").notFollowedBy("C")
``` 
We can not emit the result because there is no branch can lead to the `Final State`, And i think we can add a `TimeEnd` state to describe a pattern that accepts a time condition evaluated by processing time / event time to compare the timestamp in the element we have meant before.

As described in the issue link,  there are two main reason why i introduce this feature

1.  the `notFollowedBy` cant be at the end of the pattern 
2.  the `within` just compare with the element at start, and some key's data may not endless, so we have to evaluate condition not also on event but also on time

## Brief change log

1.  Add the method to distinguish the event driven condition or time drivern condition in `IterativeCondition`
2.  when `advanceTime`, we not only prune the expire element, but also look the time bounded condition


## Verifying this change

This change is already covered by existing cep tests, may be it need a little more about the new api.

This change added tests and can be verified as follows:


## Documentation

  - Does this pull request introduce a new feature? (yes)

