### PR TITLE
[FLINK-9699] [table] Add api to replace registered table

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -458,7 +458,7 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 
 		DataStreamSource<Row> source = env.fromCollection(rowCollection);
 
-		tEnv.registerDataStreamInternal("testFlinkTable", source);
+		tEnv.registerDataStreamInternal("testFlinkTable", source, false);
 		tEnv.registerTableSink(
 			"cassandraTable",
 			new String[]{"f0", "f1", "f2"},

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
@@ -60,7 +60,7 @@ class StreamTableEnvironment(
   def fromDataStream[T](dataStream: DataStream[T]): Table = {
 
     val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream)
+    registerDataStreamInternal(name, dataStream, false)
     scan(name)
   }
 
@@ -85,7 +85,7 @@ class StreamTableEnvironment(
       .toArray
 
     val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream, exprs)
+    registerDataStreamInternal(name, dataStream, exprs, false)
     scan(name)
   }
 
@@ -104,7 +104,25 @@ class StreamTableEnvironment(
   def registerDataStream[T](name: String, dataStream: DataStream[T]): Unit = {
 
     checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream)
+    registerDataStreamInternal(name, dataStream, false)
+  }
+
+  /**
+    * Registers or replace the given [[DataStream]] as table in the
+    * [[TableEnvironment]]'s catalog.
+    * Registered tables can be referenced in SQL queries.
+    *
+    * The field names of the [[Table]] are automatically derived
+    * from the type of the [[DataStream]].
+    *
+    * @param name The name under which the [[DataStream]] is registered in the catalog.
+    * @param dataStream The [[DataStream]] to register.
+    * @tparam T The type of the [[DataStream]] to register.
+    */
+  def registerOrReplaceDataStream[T](name: String, dataStream: DataStream[T]): Unit = {
+
+    checkValidTableName(name)
+    registerDataStreamInternal(name, dataStream, true)
   }
 
   /**
@@ -130,7 +148,18 @@ class StreamTableEnvironment(
       .toArray
 
     checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream, exprs)
+    registerDataStreamInternal(name, dataStream, exprs, false)
+  }
+
+  def registerOrReplaceDataStream[T](name: String,
+                                     dataStream: DataStream[T],
+                                     fields: String): Unit = {
+    val exprs = ExpressionParser
+      .parseExpressionList(fields)
+      .toArray
+
+    checkValidTableName(name)
+    registerDataStreamInternal(name, dataStream, exprs, true)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
@@ -53,12 +53,13 @@ class BatchTableEnvironment(
     *
     * @param dataSet The [[DataSet]] to be converted.
     * @tparam T The type of the [[DataSet]].
+    * @param replace whether to replace the registered table
     * @return The converted [[Table]].
     */
   def fromDataSet[T](dataSet: DataSet[T]): Table = {
 
     val name = createUniqueTableName()
-    registerDataSetInternal(name, dataSet.javaSet)
+    registerDataSetInternal(name, dataSet.javaSet, false)
     scan(name)
   }
 
@@ -80,7 +81,7 @@ class BatchTableEnvironment(
   def fromDataSet[T](dataSet: DataSet[T], fields: Expression*): Table = {
 
     val name = createUniqueTableName()
-    registerDataSetInternal(name, dataSet.javaSet, fields.toArray)
+    registerDataSetInternal(name, dataSet.javaSet, fields.toArray, false)
     scan(name)
   }
 
@@ -94,11 +95,30 @@ class BatchTableEnvironment(
     * @param name The name under which the [[DataSet]] is registered in the catalog.
     * @param dataSet The [[DataSet]] to register.
     * @tparam T The type of the [[DataSet]] to register.
+    * @param replace whether to replace the registered table
     */
   def registerDataSet[T](name: String, dataSet: DataSet[T]): Unit = {
 
     checkValidTableName(name)
-    registerDataSetInternal(name, dataSet.javaSet)
+    registerDataSetInternal(name, dataSet.javaSet, false)
+  }
+
+  /**
+    * Registers or replace the given [[DataSet]] as table in the
+    * [[TableEnvironment]]'s catalog.
+    * Registered tables can be referenced in SQL queries.
+    *
+    * The field names of the [[Table]] are automatically derived from the type of the [[DataSet]].
+    *
+    * @param name The name under which the [[DataSet]] is registered in the catalog.
+    * @param dataSet The [[DataSet]] to register.
+    * @tparam T The type of the [[DataSet]] to register.
+    * @param replace whether to replace the registered table
+    */
+  def registerOrReplaceDataSet[T](name: String, dataSet: DataSet[T]): Unit = {
+
+    checkValidTableName(name)
+    registerDataSetInternal(name, dataSet.javaSet, true)
   }
 
   /**
@@ -121,7 +141,30 @@ class BatchTableEnvironment(
   def registerDataSet[T](name: String, dataSet: DataSet[T], fields: Expression*): Unit = {
 
     checkValidTableName(name)
-    registerDataSetInternal(name, dataSet.javaSet, fields.toArray)
+    registerDataSetInternal(name, dataSet.javaSet, fields.toArray, false)
+  }
+
+  /**
+    * Registers the given [[DataSet]] as table with specified field names in the
+    * [[TableEnvironment]]'s catalog.
+    * Registered tables can be referenced in SQL queries.
+    *
+    * Example:
+    *
+    * {{{
+    *   val set: DataSet[(String, Long)] = ...
+    *   tableEnv.registerOrReplaceDataSet("myTable", set, 'a, 'b)
+    * }}}
+    *
+    * @param name The name under which the [[DataSet]] is registered in the catalog.
+    * @param dataSet The [[DataSet]] to register.
+    * @param fields The field names of the registered table.
+    * @tparam T The type of the [[DataSet]] to register.
+    */
+  def registerOrReplaceDataSet[T](name: String, dataSet: DataSet[T], fields: Expression*): Unit = {
+
+    checkValidTableName(name)
+    registerDataSetInternal(name, dataSet.javaSet, fields.toArray, true)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
@@ -60,7 +60,7 @@ class StreamTableEnvironment(
   def fromDataStream[T](dataStream: DataStream[T]): Table = {
 
     val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream.javaStream)
+    registerDataStreamInternal(name, dataStream.javaStream, false)
     scan(name)
   }
 
@@ -82,7 +82,7 @@ class StreamTableEnvironment(
   def fromDataStream[T](dataStream: DataStream[T], fields: Expression*): Table = {
 
     val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray)
+    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray, false)
     scan(name)
   }
 
@@ -101,7 +101,7 @@ class StreamTableEnvironment(
   def registerDataStream[T](name: String, dataStream: DataStream[T]): Unit = {
 
     checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream.javaStream)
+    registerDataStreamInternal(name, dataStream.javaStream, false)
   }
 
   /**
@@ -124,7 +124,15 @@ class StreamTableEnvironment(
   def registerDataStream[T](name: String, dataStream: DataStream[T], fields: Expression*): Unit = {
 
     checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray)
+    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray, false)
+  }
+
+  def registerOrReplaceDataStream[T](name: String,
+                                     dataStream: DataStream[T],
+                                     fields: Expression*): Unit = {
+
+    checkValidTableName(name)
+    registerDataStreamInternal(name, dataStream.javaStream, fields.toArray, true)
   }
 
   /**

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -71,6 +71,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 			// Calcite converts to decimals and strings with equal length
 			"1,Test ,true,1944-02-24,12.4444444444444445\n";
 		compareResultAsText(results, expected);
+
 	}
 
 	@Test
@@ -94,6 +95,17 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 			"14,Comment#8\n" + "15,Comment#9\n" + "16,Comment#10\n" +
 			"17,Comment#11\n" + "18,Comment#12\n" + "19,Comment#13\n" +
 			"20,Comment#14\n" + "21,Comment#15\n";
+		compareResultAsText(results, expected);
+
+		// replace table
+		ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		in = tableEnv.fromDataSet(ds, "a,b,c");
+		tableEnv.registerOrReplaceTable("T", in);
+
+		result = tableEnv.sqlQuery(sqlQuery);
+		resultSet = tableEnv.toDataSet(result, Row.class);
+		results = resultSet.collect();
+		expected = "1,Hi\n" + "2,Hello\n" + "3,Hello world\n";
 		compareResultAsText(results, expected);
 	}
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -40,20 +40,26 @@ class MockTableEnvironment extends TableEnvironment(new TableConfig) {
 
   override protected def getBuiltInPhysicalOptRuleSet: RuleSet = ???
 
-  override def registerTableSink(
+  override def registerTableSinkInternal(
       name: String,
       fieldNames: Array[String],
       fieldTypes: Array[TypeInformation[_]],
-      tableSink: TableSink[_]): Unit = ???
+      tableSink: TableSink[_],
+      replace: Boolean): Unit = ???
 
-  override def registerTableSink(name: String, tableSink: TableSink[_]): Unit = ???
+  override def registerTableSinkInternal(name: String,
+                                         tableSink: TableSink[_],
+                                         replace: Boolean): Unit = ???
 
   override protected def createUniqueTableName(): String = ???
 
-  override protected def registerTableSourceInternal(name: String, tableSource: TableSource[_])
+  override protected def registerTableSourceInternal(name: String,
+                                                     tableSource: TableSource[_],
+                                                     replace: Boolean = false)
     : Unit = ???
 
   override def explain(table: Table): String = ???
 
   override def connect(connectorDescriptor: ConnectorDescriptor): TableDescriptor = ???
+
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is adding api to replace registered table. This is useful in the notebook scenairo where user will run the same piece code multiple times.

## Brief change log

  - Just add several new api in `BatchTableEnvironment`


## Verifying this change

Tests is added in `JavaSqlITCase`,  `JavaTableSourceITCase.java`, `TableSinkITCase.scala`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (JavaDocs)
