### PR TITLE
[FLINK-9711][CLI] Filter only RUNNING jobs when --running option provided in CLI

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -442,7 +442,7 @@ public class CliFrontend {
 		jobDetails.forEach(details -> {
 			if (details.getJobState() == JobStatus.CREATED) {
 				scheduledJobs.add(details);
-			} else if (!details.getJobState().isGloballyTerminalState()) {
+			} else if (details.getJobState() == JobStatus.RUNNING) {
 				runningJobs.add(details);
 			} else {
 				terminatedJobs.add(details);
@@ -450,7 +450,7 @@ public class CliFrontend {
 		});
 
 		if (showRunning || showAll) {
-			if (runningJobs.size() == 0) {
+			if (runningJobs.isEmpty()) {
 				System.out.println("No running jobs.");
 			}
 			else {
@@ -460,7 +460,7 @@ public class CliFrontend {
 			}
 		}
 		if (showScheduled || showAll) {
-			if (scheduledJobs.size() == 0) {
+			if (scheduledJobs.isEmpty()) {
 				System.out.println("No scheduled jobs.");
 			}
 			else {


### PR DESCRIPTION
## What is the purpose of the change

In Flink CLI there's a command list with option --running that according to descriptions "Show only running programs and their JobIDs". However, in practice, it also shows jobs that are in the CANCELED and other states, which does not belong to a RUNNING state.

## Brief change log
  - *filter only RUNNING jobs in CLI if corresponding option is provided*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)
