### PR TITLE
[FLINK-9622] Do not swallow exceptions in FileUtils#copy

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -254,7 +254,7 @@ public class LocalFileSystem extends FileSystem {
 		}
 		else {
 			File parent = file.getParentFile();
-			return (parent == null || mkdirsInternal(parent)) && file.mkdir();
+			return (parent == null || mkdirsInternal(parent)) && (file.mkdir() || file.isDirectory());
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Tests for the {@link FileUtils}.
  */
-public class FileUtilsTest {
+public class FileUtilsTest extends TestLogger {
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
@@ -23,9 +23,11 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.MiniClusterResourceConfiguration;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -48,7 +50,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for distributing files with {@link org.apache.flink.api.common.cache.DistributedCache} via HDFS.
  */
-public class DistributedCacheDfsTest {
+public class DistributedCacheDfsTest extends TestLogger {
 
 	private static final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
 		+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
@@ -128,7 +130,7 @@ public class DistributedCacheDfsTest {
 
 		env.fromElements(1)
 			.map(new TestMapFunction())
-			.print();
+			.addSink(new DiscardingSink<>());
 
 		env.execute("Distributed Cache Via Blob Test Program");
 	}


### PR DESCRIPTION
## What is the purpose of the change

This commit lets `IOExceptions` originating from `FileUtil#copy` bubble up instead of swallowing them.

This PR is based on #6243.

## Verifying this change

- Trivial fix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
