### PR TITLE
[FLINK-9311] [pubsub] Added PubSub source connector with support for checkpointing

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -18,6 +18,11 @@
             <td></td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.tasks.container.docker.force-pull-image</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Instruct the docker containerizer to forcefully pull the image rather than reuse a cached version.</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.container.docker.parameters</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Custom parameters to be passed into docker run command when using the docker containerizer. Comma separated list of "key=value" pairs. The "value" may contain '='.</td>

--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -113,7 +113,7 @@ The above is a simple example of using the consumer. Configuration for the consu
 instance, the configuration keys for which can be found in `ConsumerConfigConstants`. The example
 demonstrates consuming a single Kinesis stream in the AWS region "us-east-1". The AWS credentials are supplied using the basic method in which
 the AWS access key ID and secret access key are directly supplied in the configuration (other options are setting
-`ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, `PROFILE`, and `AUTO`). Also, data is being consumed
+`ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, `PROFILE`, `ASSUME_ROLE`, and `AUTO`). Also, data is being consumed
 from the newest position in the Kinesis stream (the other option will be setting `ConsumerConfigConstants.STREAM_INITIAL_POSITION`
 to `TRIM_HORIZON`, which lets the consumer start reading the Kinesis stream from the earliest record possible).
 

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2748,9 +2748,6 @@ A, ABS, ABSOLUTE, ACTION, ADA, ADD, ADMIN, AFTER, ALL, ALLOCATE, ALLOW, ALTER, A
   <tr><td>{% highlight text %}%W{% endhighlight %}</td>
   <td>Weekday name (<code>Sunday</code> .. <code>Saturday</code>)</td>
   </tr>
-  <tr><td>{% highlight text %}%W{% endhighlight %}</td>
-  <td>Weekday name (<code>Sunday</code> .. <code>Saturday</code>)</td>
-  </tr>
   <tr><td>{% highlight text %}%w{% endhighlight %}</td>
   <td>Day of the week (<code>0</code> .. <code>6</code>), where Sunday is the first day of the week</td>
   </tr>

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -465,7 +465,7 @@ format:
       type: VARCHAR
     - name: field2
       type: TIMESTAMP
-  field-deleimiter: ","      # optional: string delimiter "," by default 
+  field-delimiter: ","      # optional: string delimiter "," by default 
   line-delimiter: "\n"       # optional: string delimiter "\n" by default 
   quote-character: '"'       # optional: single character for string values, empty by default
   comment-prefix: '#'        # optional: string to indicate comments, empty by default

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -270,6 +270,8 @@ May be set to -1 to disable this feature.
 
 `mesos.resourcemanager.tasks.uris`: A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers. (**NO DEFAULT**)
 
+`mesos.resourcemanager.tasks.container.docker.force-pull-image`: Instruct the docker containerizer to forcefully pull the image rather than reuse a cached version. (**DEFAULT**: false)
+
 `mesos.resourcemanager.tasks.hostname`: Optional value to define the TaskManager's hostname. The pattern `_TASK_` is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. `_TASK_.flink-service.mesos`) for name lookups. (**NO DEFAULT**)
 
 `mesos.resourcemanager.tasks.bootstrap-cmd`: A command which is executed before the TaskManager is started (**NO DEFAULT**).

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -166,6 +166,10 @@ public class CliFrontend {
 		return copiedConfiguration;
 	}
 
+	public Options getCustomCommandLineOptions() {
+		return customCommandLineOptions;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Execute Actions
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -98,6 +98,12 @@ under the License.
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-producer</artifactId>
 			<version>${aws.kinesis-kpl.version}</version>
 		</dependency>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
@@ -45,6 +45,9 @@ public class AWSConfigConstants {
 		/** Simply create AWS credentials by supplying the AWS access key ID and AWS secret key in the configuration properties. */
 		BASIC,
 
+		/** Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied. **/
+		ASSUME_ROLE,
+
 		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, PROFILE in the AWS instance metadata. **/
 		AUTO,
 	}
@@ -52,22 +55,69 @@ public class AWSConfigConstants {
 	/** The AWS region of the Kinesis streams to be pulled ("us-east-1" is used if not set). */
 	public static final String AWS_REGION = "aws.region";
 
-	/** The AWS access key ID to use when setting credentials provider type to BASIC. */
-	public static final String AWS_ACCESS_KEY_ID = "aws.credentials.provider.basic.accesskeyid";
-
-	/** The AWS secret key to use when setting credentials provider type to BASIC. */
-	public static final String AWS_SECRET_ACCESS_KEY = "aws.credentials.provider.basic.secretkey";
-
 	/** The credential provider type to use when AWS credentials are required (BASIC is used if not set). */
 	public static final String AWS_CREDENTIALS_PROVIDER = "aws.credentials.provider";
 
+	/** The AWS access key ID to use when setting credentials provider type to BASIC. */
+	public static final String AWS_ACCESS_KEY_ID = accessKeyId(AWS_CREDENTIALS_PROVIDER);
+
+	/** The AWS secret key to use when setting credentials provider type to BASIC. */
+	public static final String AWS_SECRET_ACCESS_KEY = secretKey(AWS_CREDENTIALS_PROVIDER);
+
 	/** Optional configuration for profile path if credential provider type is set to be PROFILE. */
-	public static final String AWS_PROFILE_PATH = "aws.credentials.provider.profile.path";
+	public static final String AWS_PROFILE_PATH = profilePath(AWS_CREDENTIALS_PROVIDER);
 
 	/** Optional configuration for profile name if credential provider type is set to be PROFILE. */
-	public static final String AWS_PROFILE_NAME = "aws.credentials.provider.profile.name";
+	public static final String AWS_PROFILE_NAME = profileName(AWS_CREDENTIALS_PROVIDER);
+
+	/** The role ARN to use when credential provider type is set to ASSUME_ROLE. */
+	public static final String AWS_ROLE_ARN = roleArn(AWS_CREDENTIALS_PROVIDER);
+
+	/** The role session name to use when credential provider type is set to ASSUME_ROLE. */
+	public static final String AWS_ROLE_SESSION_NAME = roleSessionName(AWS_CREDENTIALS_PROVIDER);
+
+	/** The external ID to use when credential provider type is set to ASSUME_ROLE. */
+	public static final String AWS_ROLE_EXTERNAL_ID = externalId(AWS_CREDENTIALS_PROVIDER);
+
+	/**
+	 * The credentials provider that provides credentials for assuming the role when credential
+	 * provider type is set to ASSUME_ROLE.
+	 * Roles can be nested, so AWS_ROLE_CREDENTIALS_PROVIDER can again be set to "ASSUME_ROLE"
+	 */
+	public static final String AWS_ROLE_CREDENTIALS_PROVIDER = roleCredentialsProvider(AWS_CREDENTIALS_PROVIDER);
 
 	/** The AWS endpoint for Kinesis (derived from the AWS region setting if not set). */
 	public static final String AWS_ENDPOINT = "aws.endpoint";
 
+	public static String accessKeyId(String prefix) {
+		return prefix + ".basic.accesskeyid";
+	}
+
+	public static String secretKey(String prefix) {
+		return prefix + ".basic.secretkey";
+	}
+
+	public static String profilePath(String prefix) {
+		return prefix + ".profile.path";
+	}
+
+	public static String profileName(String prefix) {
+		return prefix + ".profile.name";
+	}
+
+	public static String roleArn(String prefix) {
+		return prefix + ".role.arn";
+	}
+
+	public static String roleSessionName(String prefix) {
+		return prefix + ".role.sessionName";
+	}
+
+	public static String externalId(String prefix) {
+		return prefix + ".role.externalId";
+	}
+
+	public static String roleCredentialsProvider(String prefix) {
+		return prefix + ".role.provider";
+	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -29,6 +29,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -41,6 +42,8 @@ import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
 import com.fasterxml.jackson.databind.deser.DeserializerFactory;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -99,10 +102,24 @@ public class AWSUtil {
 	 * @return The corresponding AWS Credentials Provider instance
 	 */
 	public static AWSCredentialsProvider getCredentialsProvider(final Properties configProps) {
+		return getCredentialsProvider(configProps, AWSConfigConstants.AWS_CREDENTIALS_PROVIDER);
+	}
+
+	/**
+	 * If the provider is ASSUME_ROLE, then the credentials for assuming this role are determined
+	 * recursively.
+	 *
+	 * @param configProps the configuration properties
+	 * @param configPrefix the prefix of the config properties for this credentials provider,
+	 *                     e.g. aws.credentials.provider for the base credentials provider,
+	 *                     aws.credentials.provider.role.provider for the credentials provider
+	 *                     for assuming a role, and so on.
+	 */
+	private static AWSCredentialsProvider getCredentialsProvider(final Properties configProps, final String configPrefix) {
 		CredentialProvider credentialProviderType;
-		if (!configProps.containsKey(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER)) {
-			if (configProps.containsKey(AWSConfigConstants.AWS_ACCESS_KEY_ID)
-				&& configProps.containsKey(AWSConfigConstants.AWS_SECRET_ACCESS_KEY)) {
+		if (!configProps.containsKey(configPrefix)) {
+			if (configProps.containsKey(AWSConfigConstants.accessKeyId(configPrefix))
+				&& configProps.containsKey(AWSConfigConstants.secretKey(configPrefix))) {
 				// if the credential provider type is not specified, but the Access Key ID and Secret Key are given, it will default to BASIC
 				credentialProviderType = CredentialProvider.BASIC;
 			} else {
@@ -110,35 +127,32 @@ public class AWSUtil {
 				credentialProviderType = CredentialProvider.AUTO;
 			}
 		} else {
-			credentialProviderType = CredentialProvider.valueOf(configProps.getProperty(
-				AWSConfigConstants.AWS_CREDENTIALS_PROVIDER));
+			credentialProviderType = CredentialProvider.valueOf(configProps.getProperty(configPrefix));
 		}
-
-		AWSCredentialsProvider credentialsProvider;
 
 		switch (credentialProviderType) {
 			case ENV_VAR:
-				credentialsProvider = new EnvironmentVariableCredentialsProvider();
-				break;
+				return new EnvironmentVariableCredentialsProvider();
+
 			case SYS_PROP:
-				credentialsProvider = new SystemPropertiesCredentialsProvider();
-				break;
+				return new SystemPropertiesCredentialsProvider();
+
 			case PROFILE:
 				String profileName = configProps.getProperty(
-					AWSConfigConstants.AWS_PROFILE_NAME, null);
+						AWSConfigConstants.profileName(configPrefix), null);
 				String profileConfigPath = configProps.getProperty(
-					AWSConfigConstants.AWS_PROFILE_PATH, null);
-				credentialsProvider = (profileConfigPath == null)
+						AWSConfigConstants.profilePath(configPrefix), null);
+				return (profileConfigPath == null)
 					? new ProfileCredentialsProvider(profileName)
 					: new ProfileCredentialsProvider(profileConfigPath, profileName);
-				break;
+
 			case BASIC:
-				credentialsProvider = new AWSCredentialsProvider() {
+				return new AWSCredentialsProvider() {
 					@Override
 					public AWSCredentials getCredentials() {
 						return new BasicAWSCredentials(
-							configProps.getProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID),
-							configProps.getProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY));
+							configProps.getProperty(AWSConfigConstants.accessKeyId(configPrefix)),
+							configProps.getProperty(AWSConfigConstants.secretKey(configPrefix)));
 					}
 
 					@Override
@@ -146,13 +160,23 @@ public class AWSUtil {
 						// do nothing
 					}
 				};
-				break;
+
+			case ASSUME_ROLE:
+				final AWSSecurityTokenService baseCredentials = AWSSecurityTokenServiceClientBuilder.standard()
+						.withCredentials(getCredentialsProvider(configProps, AWSConfigConstants.roleCredentialsProvider(configPrefix)))
+						.withRegion(configProps.getProperty(AWSConfigConstants.AWS_REGION))
+						.build();
+				return new STSAssumeRoleSessionCredentialsProvider.Builder(
+						configProps.getProperty(AWSConfigConstants.roleArn(configPrefix)),
+						configProps.getProperty(AWSConfigConstants.roleSessionName(configPrefix)))
+						.withExternalId(configProps.getProperty(AWSConfigConstants.externalId(configPrefix)))
+						.withStsClient(baseCredentials)
+						.build();
+
 			default:
 			case AUTO:
-				credentialsProvider = new DefaultAWSCredentialsProviderChain();
+				return new DefaultAWSCredentialsProviderChain();
 		}
-
-		return credentialsProvider;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -324,12 +324,7 @@ public class KinesisConfigUtilTest {
 		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, unixTimestamp);
 		testConfig.setProperty(ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT, pattern);
 
-		try {
-			KinesisConfigUtil.validateConsumerConfiguration(testConfig);
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail();
-		}
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-pubsub/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.6-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-pubsub_${scala.binary.version}</artifactId>
+	<name>flink-connector-pubsub</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<pubsub.version>0.42.1-beta</pubsub.version>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-pubsub</artifactId>
+			<version>${pubsub.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/flink-connectors/flink-connector-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-pubsub/pom.xml
@@ -72,4 +72,40 @@ under the License.
 
 	</dependencies>
 
+    <build>
+        <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>com.google.guava</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.pubsub.shaded.com.google.guava</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google.common.base</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.pubsub.shaded.com.google.common.base</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/flink-connectors/flink-connector-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-pubsub/pom.xml
@@ -36,7 +36,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<pubsub.version>0.42.1-beta</pubsub.version>
+		<pubsub.version>1.31.0</pubsub.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/ParallelPubSubSource.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/ParallelPubSubSource.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+
+
+/**
+ * PubSub Source, this Source will consume PubSub messages from a subscription and Acknowledge them as soon as they have been received.
+ */
+public class ParallelPubSubSource<OUT> extends PubSubSource<OUT> implements ParallelSourceFunction<OUT> {
+	ParallelPubSubSource(SubscriberWrapper subscriberWrapper, DeserializationSchema<OUT> deserializationSchema, PubSubSourceBuilder.Mode mode) {
+		super(subscriberWrapper, deserializationSchema, mode);
+	}
+}

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/PubSubSource.java
@@ -55,26 +55,28 @@ public class PubSubSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase
 
 	/**
 	 * Convenience factory method to return a PubSubSource with default application credentials based on environment variables. ({@link org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider})
-	 * @param projectSubscriptionName The google project and subscription to read from
+	 * @param projectName The name of the google project where the subscription is in
+	 * @param subscriptionName The name of the subscription to read from
 	 * @param deserializationSchema Schema to deserialize the {@link PubsubMessage}
 	 * @param <OUT> The type of messages that will be read
 	 * @return Returns a RichParallelSourceFunction which reads from a PubSub subscription
 	 * @throws Exception exception is thrown when no default application credentials can be found
 	 */
-	public static <OUT> PubSubSource<OUT> withDefaultApplicationCredentials(ProjectSubscriptionName projectSubscriptionName, DeserializationSchema<OUT> deserializationSchema) throws Exception {
-		return withCustomApplicationCredentials(projectSubscriptionName, deserializationSchema, credentialsProviderFromEnvironmentVariables());
+	public static <OUT> PubSubSource<OUT> withDefaultApplicationCredentials(String projectName, String subscriptionName, DeserializationSchema<OUT> deserializationSchema) throws Exception {
+		return withCustomApplicationCredentials(projectName, subscriptionName, deserializationSchema, credentialsProviderFromEnvironmentVariables());
 	}
 
 	/**
 	 * Factory method to return a PubSubSource.
-	 * @param projectSubscriptionName The google project and subscription to read from
+	 * @param projectName The name of the google project where the subscription is in
+	 * @param subscriptionName The name of the subscription to read from
 	 * @param deserializationSchema Schema to deserialize the {@link PubsubMessage}
 	 * @param serializableCredentialsProvider CredentialsProvider used to give the correct permissions to read from PubSub
 	 * @param <OUT> The type of messages that will be read
 	 * @return Returns a RichParallelSourceFunction which reads from a PubSub subscription
 	 */
-	public static <OUT> PubSubSource<OUT> withCustomApplicationCredentials(ProjectSubscriptionName projectSubscriptionName, DeserializationSchema<OUT> deserializationSchema, SerializableCredentialsProvider serializableCredentialsProvider) {
-		return new PubSubSource<>(new SubscriberWrapper(serializableCredentialsProvider, projectSubscriptionName), deserializationSchema);
+	public static <OUT> PubSubSource<OUT> withCustomApplicationCredentials(String projectName, String subscriptionName, DeserializationSchema<OUT> deserializationSchema, SerializableCredentialsProvider serializableCredentialsProvider) {
+		return new PubSubSource<>(new SubscriberWrapper(serializableCredentialsProvider, ProjectSubscriptionName.of(projectName, subscriptionName)), deserializationSchema);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/PubSubSource.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+
+import java.io.IOException;
+
+import static org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider.credentialsProviderFromEnvironmentVariables;
+
+
+/**
+ * PubSub Source, this Source will consume PubSub messages from a subscription and Acknowledge them as soon as they have been received.
+ */
+public class PubSubSource<OUT> extends RichParallelSourceFunction<OUT> implements MessageReceiver {
+	private final DeserializationSchema<OUT> deserializationSchema;
+	private final SubscriberFactory subscriberFactory;
+
+	private transient SourceContext<OUT> sourceContext = null;
+
+	PubSubSource(SubscriberFactory subscriberFactory, DeserializationSchema<OUT> deserializationSchema) {
+		this.deserializationSchema = deserializationSchema;
+		this.subscriberFactory = subscriberFactory;
+	}
+
+	/**
+	 * Convenience factory method to return a PubSubSource with default application credentials based on environment variables. ({@link org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider})
+	 * @param projectSubscriptionName The google project and subscription to read from
+	 * @param deserializationSchema Schema to deserialize the {@link PubsubMessage}
+	 * @param <OUT> The type of messages that will be read
+	 * @return Returns a RichParallelSourceFunction which reads from a PubSub subscription
+	 * @throws Exception exception is thrown when no default application credentials can be found
+	 */
+	public static <OUT> PubSubSource<OUT> withDefaultApplicationCredentials(ProjectSubscriptionName projectSubscriptionName, DeserializationSchema<OUT> deserializationSchema) throws Exception {
+		return withCustomApplicationCredentials(projectSubscriptionName, deserializationSchema, credentialsProviderFromEnvironmentVariables());
+	}
+
+	/**
+	 * Factory method to return a PubSubSource.
+	 * @param projectSubscriptionName The google project and subscription to read from
+	 * @param deserializationSchema Schema to deserialize the {@link PubsubMessage}
+	 * @param serializableCredentialsProvider CredentialsProvider used to give the correct permissions to read from PubSub
+	 * @param <OUT> The type of messages that will be read
+	 * @return Returns a RichParallelSourceFunction which reads from a PubSub subscription
+	 */
+	public static <OUT> PubSubSource<OUT> withCustomApplicationCredentials(ProjectSubscriptionName projectSubscriptionName, DeserializationSchema<OUT> deserializationSchema, SerializableCredentialsProvider serializableCredentialsProvider) {
+		return new PubSubSource<>(new SubscriberFactory(serializableCredentialsProvider, projectSubscriptionName), deserializationSchema);
+	}
+
+	@Override
+	public void open(Configuration configuration) throws Exception {
+		super.open(configuration);
+		subscriberFactory.initialize(this);
+	}
+
+	@Override
+	public void run(SourceContext<OUT> sourceContext) {
+		this.sourceContext = sourceContext;
+		subscriberFactory.startBlocking();
+	}
+
+	@Override
+	public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+		if (sourceContext == null) {
+			consumer.nack();
+			return;
+		}
+
+		sourceContext.collect(uncheckedExceptionDeserialize(message.getData().toByteArray()));
+		consumer.ack();
+	}
+
+	@Override
+	public void cancel() {
+		subscriberFactory.stop();
+	}
+
+	private OUT uncheckedExceptionDeserialize(byte[] bytes) {
+		try {
+			return deserializationSchema.deserialize(bytes);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/PubSubSourceBuilder.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/PubSubSourceBuilder.java
@@ -1,0 +1,134 @@
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+
+import java.io.IOException;
+
+/**
+ * Factory class to create a PubSubSource with custom options.
+ */
+public class PubSubSourceBuilder<OUT> {
+	private SerializableCredentialsProvider serializableCredentialsProvider;
+	private DeserializationSchema<OUT>      deserializationSchema;
+	private String                          projectName;
+	private String                          subscriptionName;
+	private String                          hostAndPort;
+	private Mode                            mode;
+
+	public static <OUT> PubSubSourceBuilder<OUT> builder() {
+		return new PubSubSourceBuilder<>();
+	}
+
+	/**
+	 * Possible modes which represent the guarantees given by the PubSubSource.
+	 */
+	public enum Mode {
+		NONE, ATLEAST_ONCE, EXACTLY_ONCE
+	}
+
+	/**
+	 * Set the mode, possible values NONE, ATLEAST_ONCE, EXACTLY_ONCE.
+	 * EXACTLY_ONCE will run with a parallelism of 1.
+	 * @param mode the mode to use
+	 * @return The current Builder instance
+	 */
+	public PubSubSourceBuilder<OUT> withMode(Mode mode) {
+		this.mode = mode;
+		return this;
+	}
+
+	/**
+	 * Set the credentials.
+	 * If this is not used then the credentials are picked up from the environment variables.
+	 * @param credentials the Credentials needed to connect.
+	 * @return The current Builder instance
+	 */
+	public PubSubSourceBuilder<OUT> withCredentials(Credentials credentials) {
+		this.serializableCredentialsProvider = new SerializableCredentialsProvider(credentials);
+		return this;
+	}
+
+	/**
+	 * Set the CredentialsProvider.
+	 * If this is not used then the credentials are picked up from the environment variables.
+	 * @param credentialsProvider the custom SerializableCredentialsProvider instance.
+	 * @return The current Builder instance
+	 */
+	public PubSubSourceBuilder<OUT> withCredentialsProvider(CredentialsProvider credentialsProvider) throws IOException {
+		return withCredentials(credentialsProvider.getCredentials());
+	}
+
+	/**
+	 * @param deserializationSchema Instance of a DeserializationSchema that converts the OUT into a byte[]
+	 * @return The current Builder instance
+	 */
+	public PubSubSourceBuilder<OUT> withDeserializationSchema(DeserializationSchema<OUT> deserializationSchema) {
+		this.deserializationSchema = deserializationSchema;
+		return this;
+	}
+
+	/**
+	 * @param projectName The name of the project in GoogleCloudPlatform
+	 * @param subscriptionName The name of the subscription in PubSub
+	 * @return The current Builder instance
+	 */
+	public PubSubSourceBuilder<OUT> withProjectSubscriptionName(String projectName, String subscriptionName) {
+		this.projectName = projectName;
+		this.subscriptionName = subscriptionName;
+		return this;
+	}
+
+	/**
+	 * Set the custom hostname/port combination of PubSub.
+	 * The ONLY reason to use this is during tests with the emulator provided by Google.
+	 * @param hostAndPort The combination of hostname and port to connect to ("hostname:1234")
+	 * @return The current instance
+	 */
+	public PubSubSourceBuilder<OUT> withHostAndPort(String hostAndPort) {
+		this.hostAndPort = hostAndPort;
+		return this;
+	}
+
+	/**
+	 * Actually build the desired instance of the PubSubSourceBuilder.
+	 * @return a brand new PubSubSource
+	 * @throws IOException incase of a problem getting the credentials
+	 * @throws IllegalArgumentException incase required fields were not specified.
+	 */
+	public SourceFunction<OUT> build() throws IOException {
+		if (serializableCredentialsProvider == null) {
+			serializableCredentialsProvider = SerializableCredentialsProvider.credentialsProviderFromEnvironmentVariables();
+		}
+		if (deserializationSchema == null) {
+			throw new IllegalArgumentException("The deserializationSchema has not been specified.");
+		}
+		if (projectName == null || subscriptionName == null) {
+			throw new IllegalArgumentException("The ProjectName And SubscriptionName has not been specified.");
+		}
+		if (mode == null) {
+			throw new IllegalArgumentException("The mode has not been specified");
+		}
+
+		SubscriberWrapper subscriberWrapper =
+			new SubscriberWrapper(serializableCredentialsProvider, ProjectSubscriptionName.of(projectName, subscriptionName));
+
+		if (hostAndPort != null) {
+			subscriberWrapper.withHostAndPort(hostAndPort);
+		}
+
+		switch(mode) {
+			default:
+			case NONE:
+			case ATLEAST_ONCE:
+				return new ParallelPubSubSource<>(subscriberWrapper, deserializationSchema, mode);
+			case EXACTLY_ONCE:
+				return new PubSubSource<>(subscriberWrapper, deserializationSchema, mode);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/SubscriberFactory.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/SubscriberFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider;
+
+import com.google.api.core.ApiService;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+
+import java.io.Serializable;
+
+class SubscriberFactory implements Serializable {
+	private final SerializableCredentialsProvider serializableCredentialsProvider;
+	private final String projectId;
+	private final String subscriptionId;
+
+	private transient Subscriber subscriber;
+
+	SubscriberFactory(SerializableCredentialsProvider serializableCredentialsProvider, ProjectSubscriptionName projectSubscriptionName) {
+		this.serializableCredentialsProvider = serializableCredentialsProvider;
+		this.projectId = projectSubscriptionName.getProject();
+		this.subscriptionId = projectSubscriptionName.getSubscription();
+	}
+
+	void initialize(MessageReceiver messageReceiver) {
+		this.subscriber = Subscriber.newBuilder(ProjectSubscriptionName.of(projectId, subscriptionId), messageReceiver)
+									.setCredentialsProvider(serializableCredentialsProvider)
+									.build();
+	}
+
+	void startBlocking() {
+		ApiService apiService = subscriber.startAsync();
+		apiService.awaitRunning();
+
+		if (apiService.state() != ApiService.State.RUNNING) {
+			throw new IllegalStateException("Could not start PubSubSubscriber, ApiService.State: " + apiService.state());
+		}
+		apiService.awaitTerminated();
+	}
+
+	void stop() {
+		subscriber.stopAsync().awaitTerminated();
+	}
+
+	Subscriber getSubscriber() {
+		return subscriber;
+	}
+
+}

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/SubscriberWrapper.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/SubscriberWrapper.java
@@ -26,14 +26,14 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 
 import java.io.Serializable;
 
-class SubscriberFactory implements Serializable {
+class SubscriberWrapper implements Serializable {
 	private final SerializableCredentialsProvider serializableCredentialsProvider;
 	private final String projectId;
 	private final String subscriptionId;
 
 	private transient Subscriber subscriber;
 
-	SubscriberFactory(SerializableCredentialsProvider serializableCredentialsProvider, ProjectSubscriptionName projectSubscriptionName) {
+	SubscriberWrapper(SerializableCredentialsProvider serializableCredentialsProvider, ProjectSubscriptionName projectSubscriptionName) {
 		this.serializableCredentialsProvider = serializableCredentialsProvider;
 		this.projectId = projectSubscriptionName.getProject();
 		this.subscriptionId = projectSubscriptionName.getSubscription();
@@ -62,5 +62,4 @@ class SubscriberFactory implements Serializable {
 	Subscriber getSubscriber() {
 		return subscriber;
 	}
-
 }

--- a/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/common/SerializableCredentialsProvider.java
+++ b/flink-connectors/flink-connector-pubsub/src/main/java/org/apache/flink/streaming/connectors/pubsub/common/SerializableCredentialsProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pubsub.common;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import static com.google.cloud.pubsub.v1.SubscriptionAdminSettings.defaultCredentialsProviderBuilder;
+
+/**
+ * Wrapper class for CredentialsProvider to make it Serializable. This can be used to pass on Credentials to SourceFunctions
+ */
+public class SerializableCredentialsProvider implements CredentialsProvider, Serializable {
+	private final Credentials credentials;
+
+	/**
+	 * @param credentials
+	 */
+	public SerializableCredentialsProvider(Credentials credentials) {
+		this.credentials = credentials;
+	}
+
+	/**
+	 * Creates a SerializableCredentialsProvider for a PubSubSubscription based on environment variables. {@link com.google.cloud.pubsub.v1.SubscriptionAdminSettings}
+	 * @return serializableCredentialsProvider
+	 * @throws IOException thrown by {@link Credentials}
+	 */
+	public static SerializableCredentialsProvider credentialsProviderFromEnvironmentVariables() throws IOException {
+		Credentials credentials = defaultCredentialsProviderBuilder().build().getCredentials();
+		return new SerializableCredentialsProvider(credentials);
+	}
+
+	@Override
+	public Credentials getCredentials() {
+		return credentials;
+	}
+}

--- a/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/PubSubSourceTest.java
+++ b/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/PubSubSourceTest.java
@@ -35,6 +35,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.apache.flink.streaming.connectors.pubsub.PubSubSourceBuilder.Mode.ATLEAST_ONCE;
+import static org.apache.flink.streaming.connectors.pubsub.PubSubSourceBuilder.Mode.EXACTLY_ONCE;
+import static org.apache.flink.streaming.connectors.pubsub.PubSubSourceBuilder.Mode.NONE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -68,7 +71,7 @@ public class PubSubSourceTest {
 
 	@Test
 	public void testOpenWithoutCheckpointing() throws Exception {
-		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema);
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, NONE);
 		pubSubSource.setRuntimeContext(runtimeContext);
 		pubSubSource.open(null);
 
@@ -79,7 +82,7 @@ public class PubSubSourceTest {
 	public void testOpenWithCheckpointing() throws Exception {
 		when(streamingRuntimeContext.isCheckpointingEnabled()).thenReturn(true);
 
-		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema);
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, ATLEAST_ONCE);
 		pubSubSource.setRuntimeContext(streamingRuntimeContext);
 		pubSubSource.open(null);
 
@@ -88,7 +91,7 @@ public class PubSubSourceTest {
 
 	@Test
 	public void testRun() {
-		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema);
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, EXACTLY_ONCE);
 		pubSubSource.run(sourceContext);
 
 		verify(subscriberWrapper, times(1)).startBlocking();
@@ -98,7 +101,7 @@ public class PubSubSourceTest {
 	public void testWithoutCheckpoints() throws Exception {
 		when(deserializationSchema.deserialize(SERIALIZED_MESSAGE)).thenReturn(MESSAGE);
 
-		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema);
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, NONE);
 		pubSubSource.setRuntimeContext(runtimeContext);
 		pubSubSource.open(null);
 
@@ -120,7 +123,7 @@ public class PubSubSourceTest {
 		when(functionInitializationContext.getOperatorStateStore()).thenReturn(operatorStateStore);
 		when(operatorStateStore.getSerializableListState(any(String.class))).thenReturn(null);
 
-		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema);
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, EXACTLY_ONCE);
 		pubSubSource.initializeState(functionInitializationContext);
 		pubSubSource.setRuntimeContext(streamingRuntimeContext);
 		pubSubSource.open(null);
@@ -139,7 +142,7 @@ public class PubSubSourceTest {
 	public void testMessagesAcknowledgedWithPubSubGrpcClient() throws Exception {
 		when(streamingRuntimeContext.isCheckpointingEnabled()).thenReturn(true);
 
-		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema);
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, EXACTLY_ONCE);
 		pubSubSource.setRuntimeContext(streamingRuntimeContext);
 		pubSubSource.open(null);
 
@@ -148,6 +151,22 @@ public class PubSubSourceTest {
 		pubSubSource.acknowledgeSessionIDs(input);
 
 		verify(ackReplyConsumer, times(1)).ack();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testAtleastOnceWithoutCheckpointing() throws Exception {
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, ATLEAST_ONCE);
+		pubSubSource.setRuntimeContext(runtimeContext);
+
+		pubSubSource.open(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testExactlyOnceWithoutCheckpointing() throws Exception {
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberWrapper, deserializationSchema, EXACTLY_ONCE);
+		pubSubSource.setRuntimeContext(runtimeContext);
+
+		pubSubSource.open(null);
 	}
 
 	private PubsubMessage pubSubMessage() {

--- a/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/PubSubSourceTest.java
+++ b/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/PubSubSourceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Test for {@link PubSubSource}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubSourceTest {
+	private static final String MESSAGE = "Message";
+	private static final byte[] SERIALIZED_MESSAGE = MESSAGE.getBytes();
+	@Mock
+	private SubscriberFactory subscriberFactory;
+	@Mock
+	private SourceFunction.SourceContext<String> sourceContext;
+	@Mock
+	private DeserializationSchema<String> deserializationSchema;
+	@Mock
+	private AckReplyConsumer ackReplyConsumer;
+
+	@Test
+	public void testOpen() throws Exception {
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberFactory, deserializationSchema);
+		pubSubSource.open(null);
+
+		verify(subscriberFactory, times(1)).initialize(pubSubSource);
+	}
+
+	@Test
+	public void testRun() {
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberFactory, deserializationSchema);
+		pubSubSource.run(sourceContext);
+
+		verify(subscriberFactory, times(1)).startBlocking();
+	}
+
+	@Test
+	public void testWithoutCheckpoints() throws Exception {
+		when(deserializationSchema.deserialize(SERIALIZED_MESSAGE)).thenReturn(MESSAGE);
+
+		PubSubSource<String> pubSubSource = new PubSubSource<>(subscriberFactory, deserializationSchema);
+		pubSubSource.open(null);
+		pubSubSource.run(sourceContext);
+
+		pubSubSource.receiveMessage(pubSubMessage(), ackReplyConsumer);
+
+		verify(sourceContext, times(1)).collect(MESSAGE);
+		verify(ackReplyConsumer, times(1)).ack();
+	}
+
+	private PubsubMessage pubSubMessage() {
+		return PubsubMessage.newBuilder()
+							.setData(ByteString.copyFrom(SERIALIZED_MESSAGE))
+							.build();
+	}
+}

--- a/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/SubscriberFactoryTest.java
+++ b/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/SubscriberFactoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider;
+
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.apache.flink.api.java.ClosureCleaner.ensureSerializable;
+import static org.apache.flink.streaming.connectors.pubsub.common.SerializableCredentialsProvider.credentialsProviderFromEnvironmentVariables;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for {@link SubscriberFactory}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SubscriberFactoryTest {
+	@Mock
+	private SerializableCredentialsProvider credentialsProvider;
+
+	@Mock
+	private MessageReceiver messageReceiver;
+
+	@Test
+	public void testSerializedSubscriberBuilder() throws Exception {
+		SubscriberFactory factory = new SubscriberFactory(credentialsProviderFromEnvironmentVariables(), ProjectSubscriptionName.of("projectId", "subscriptionId"));
+		ensureSerializable(factory);
+	}
+
+	@Test
+	public void testInitialisation() {
+		SubscriberFactory factory = new SubscriberFactory(credentialsProvider, ProjectSubscriptionName.of("projectId", "subscriptionId"));
+		factory.initialize(messageReceiver);
+
+		assertThat(factory.getSubscriber().getSubscriptionNameString(), is(ProjectSubscriptionName.format("projectId", "subscriptionId")));
+	}
+}

--- a/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/SubscriberWrapperTest.java
+++ b/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/SubscriberWrapperTest.java
@@ -32,10 +32,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Tests for {@link SubscriberFactory}.
+ * Tests for {@link SubscriberWrapper}.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class SubscriberFactoryTest {
+public class SubscriberWrapperTest {
 	@Mock
 	private SerializableCredentialsProvider credentialsProvider;
 
@@ -44,13 +44,13 @@ public class SubscriberFactoryTest {
 
 	@Test
 	public void testSerializedSubscriberBuilder() throws Exception {
-		SubscriberFactory factory = new SubscriberFactory(credentialsProviderFromEnvironmentVariables(), ProjectSubscriptionName.of("projectId", "subscriptionId"));
+		SubscriberWrapper factory = new SubscriberWrapper(credentialsProviderFromEnvironmentVariables(), ProjectSubscriptionName.of("projectId", "subscriptionId"));
 		ensureSerializable(factory);
 	}
 
 	@Test
 	public void testInitialisation() {
-		SubscriberFactory factory = new SubscriberFactory(credentialsProvider, ProjectSubscriptionName.of("projectId", "subscriptionId"));
+		SubscriberWrapper factory = new SubscriberWrapper(credentialsProvider, ProjectSubscriptionName.of("projectId", "subscriptionId"));
 		factory.initialize(messageReceiver);
 
 		assertThat(factory.getSubscriber().getSubscriptionNameString(), is(ProjectSubscriptionName.format("projectId", "subscriptionId")));

--- a/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/TimeoutPubSubSource.java
+++ b/flink-connectors/flink-connector-pubsub/src/test/java/org/apache/flink/streaming/connectors/pubsub/TimeoutPubSubSource.java
@@ -1,0 +1,13 @@
+package org.apache.flink.streaming.connectors.pubsub;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+
+/**
+ *
+ * @param <OUT>
+ */
+public class TimeoutPubSubSource<OUT> extends PubSubSource<OUT> {
+	TimeoutPubSubSource(SubscriberWrapper subscriberWrapper, DeserializationSchema<OUT> deserializationSchema, PubSubSourceBuilder.Mode mode) {
+		super(subscriberWrapper, deserializationSchema, mode);
+	}
+}

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -55,6 +55,7 @@ under the License.
 		<module>flink-connector-nifi</module>
 		<module>flink-connector-cassandra</module>
 		<module>flink-connector-filesystem</module>
+		<module>flink-connector-pubsub</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Base class for composite serializers.
+ *
+ * <p>This class serializes a composite type using array of its field serializers.
+ * Fields are indexed the same way as their serializers.
+ *
+ * @param <T> type of custom serialized value
+ */
+public abstract class CompositeSerializer<T> extends TypeSerializer<T> {
+	private static final long serialVersionUID = 1L;
+
+	/** Serializers for fields which constitute T. */
+	protected final TypeSerializer<Object>[] fieldSerializers;
+
+	final PrecomputedParameters precomputed;
+
+	/** Can be used for user facing constructor. */
+	@SuppressWarnings("unchecked")
+	protected CompositeSerializer(boolean immutableTargetType, TypeSerializer<?> ... fieldSerializers) {
+		this(
+			new PrecomputedParameters(immutableTargetType, (TypeSerializer<Object>[]) fieldSerializers),
+			fieldSerializers);
+	}
+
+	/** Can be used in createSerializerInstance for internal operations. */
+	@SuppressWarnings("unchecked")
+	protected CompositeSerializer(PrecomputedParameters precomputed, TypeSerializer<?> ... fieldSerializers) {
+		this.fieldSerializers = (TypeSerializer<Object>[]) fieldSerializers;
+		this.precomputed = precomputed;
+	}
+
+	/** Create new instance from its fields.  */
+	public abstract T createInstance(@Nonnull Object ... values);
+
+	/** Modify field of existing instance. Supported only by mutable types. */
+	protected abstract void setField(@Nonnull T value, int index, Object fieldValue);
+
+	/** Get field of existing instance. */
+	protected abstract Object getField(@Nonnull T value, int index);
+
+	/** Factory for concrete serializer. */
+	protected abstract CompositeSerializer<T> createSerializerInstance(
+		PrecomputedParameters precomputed,
+		TypeSerializer<?> ... originalSerializers);
+
+	@Override
+	public CompositeSerializer<T> duplicate() {
+		return precomputed.stateful ?
+			createSerializerInstance(precomputed, duplicateFieldSerializers(fieldSerializers)) : this;
+	}
+
+	private static TypeSerializer[] duplicateFieldSerializers(TypeSerializer<Object>[] fieldSerializers) {
+		TypeSerializer[] duplicatedSerializers = new TypeSerializer[fieldSerializers.length];
+		for (int index = 0; index < fieldSerializers.length; index++) {
+			duplicatedSerializers[index] = fieldSerializers[index].duplicate();
+			assert duplicatedSerializers[index] != null;
+		}
+		return duplicatedSerializers;
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return precomputed.immutable;
+	}
+
+	@Override
+	public T createInstance() {
+		Object[] fields = new Object[fieldSerializers.length];
+		for (int index = 0; index < fieldSerializers.length; index++) {
+			fields[index] = fieldSerializers[index].createInstance();
+		}
+		return createInstance(fields);
+	}
+
+	@Override
+	public T copy(T from) {
+		Preconditions.checkNotNull(from);
+		if (isImmutableType()) {
+			return from;
+		}
+		Object[] fields = new Object[fieldSerializers.length];
+		for (int index = 0; index < fieldSerializers.length; index++) {
+			fields[index] = fieldSerializers[index].copy(getField(from, index));
+		}
+		return createInstance(fields);
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		Preconditions.checkNotNull(from);
+		Preconditions.checkNotNull(reuse);
+		if (isImmutableType()) {
+			return from;
+		}
+		Object[] fields = new Object[fieldSerializers.length];
+		for (int index = 0; index < fieldSerializers.length; index++) {
+			fields[index] = fieldSerializers[index].copy(getField(from, index), getField(reuse, index));
+		}
+		return createInstanceWithReuse(fields, reuse);
+	}
+
+	@Override
+	public int getLength() {
+		return precomputed.length;
+	}
+
+	@Override
+	public void serialize(T record, DataOutputView target) throws IOException {
+		Preconditions.checkNotNull(record);
+		Preconditions.checkNotNull(target);
+		for (int index = 0; index < fieldSerializers.length; index++) {
+			fieldSerializers[index].serialize(getField(record, index), target);
+		}
+	}
+
+	@Override
+	public T deserialize(DataInputView source) throws IOException {
+		Preconditions.checkNotNull(source);
+		Object[] fields = new Object[fieldSerializers.length];
+		for (int i = 0; i < fieldSerializers.length; i++) {
+			fields[i] = fieldSerializers[i].deserialize(source);
+		}
+		return createInstance(fields);
+	}
+
+	@Override
+	public T deserialize(T reuse, DataInputView source) throws IOException {
+		Preconditions.checkNotNull(reuse);
+		Preconditions.checkNotNull(source);
+		Object[] fields = new Object[fieldSerializers.length];
+		for (int index = 0; index < fieldSerializers.length; index++) {
+			fields[index] = fieldSerializers[index].deserialize(getField(reuse, index), source);
+		}
+		return precomputed.immutable ? createInstance(fields) : createInstanceWithReuse(fields, reuse);
+	}
+
+	private T createInstanceWithReuse(Object[] fields, T reuse) {
+		for (int index = 0; index < fields.length; index++) {
+			setField(reuse, index, fields[index]);
+		}
+		return reuse;
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		Preconditions.checkNotNull(source);
+		Preconditions.checkNotNull(target);
+		for (TypeSerializer typeSerializer : fieldSerializers) {
+			typeSerializer.copy(source, target);
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * Boolean.hashCode(precomputed.immutableTargetType) + Arrays.hashCode(fieldSerializers);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (canEqual(obj)) {
+			CompositeSerializer<?> other = (CompositeSerializer<?>) obj;
+			return precomputed.immutable == other.precomputed.immutable
+				&& Arrays.equals(fieldSerializers, other.fieldSerializers);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		// as this is an abstract class, we allow equality only between instances of the same class
+		return obj != null && getClass().equals(obj.getClass());
+	}
+
+	@Override
+	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		return new CompositeTypeSerializerConfigSnapshot(fieldSerializers) {
+			@Override
+			public int getVersion() {
+				return 0;
+			}
+		};
+	}
+
+	@Override
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		if (configSnapshot instanceof CompositeTypeSerializerConfigSnapshot) {
+			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousSerializersAndConfigs =
+				((CompositeTypeSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+			if (previousSerializersAndConfigs.size() == fieldSerializers.length) {
+				return ensureFieldCompatibility(previousSerializersAndConfigs);
+			}
+		}
+		return CompatibilityResult.requiresMigration();
+	}
+
+	@SuppressWarnings("unchecked")
+	private CompatibilityResult<T> ensureFieldCompatibility(
+		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousSerializersAndConfigs) {
+		TypeSerializer<Object>[] convertSerializers = new TypeSerializer[fieldSerializers.length];
+		boolean requiresMigration = false;
+		for (int index = 0; index < previousSerializersAndConfigs.size(); index++) {
+			CompatibilityResult<Object> compatResult =
+				resolveFieldCompatibility(previousSerializersAndConfigs, index);
+			if (compatResult.isRequiresMigration()) {
+				requiresMigration = true;
+				if (compatResult.getConvertDeserializer() != null) {
+					convertSerializers[index] = new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer());
+				} else {
+					return CompatibilityResult.requiresMigration();
+				}
+			}
+		}
+		PrecomputedParameters precomputed =
+			new PrecomputedParameters(this.precomputed.immutableTargetType, convertSerializers);
+		return requiresMigration ?
+			CompatibilityResult.requiresMigration(createSerializerInstance(precomputed, convertSerializers)) :
+			CompatibilityResult.compatible();
+	}
+
+	private CompatibilityResult<Object> resolveFieldCompatibility(
+		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousSerializersAndConfigs, int index) {
+		return CompatibilityUtil.resolveCompatibilityResult(
+			previousSerializersAndConfigs.get(index).f0, UnloadableDummyTypeSerializer.class,
+			previousSerializersAndConfigs.get(index).f1, fieldSerializers[index]);
+	}
+
+	/** This class holds composite serializer parameters which can be precomputed in advanced for better performance. */
+	protected static class PrecomputedParameters implements Serializable {
+		private static final long serialVersionUID = 1L;
+
+		/** Whether target type is immutable. */
+		final boolean immutableTargetType;
+
+		/** Whether target type and its fields are immutable. */
+		final boolean immutable;
+
+		/** Byte length of target object in serialized form. */
+		private final int length;
+
+		/** Whether any field serializer is stateful. */
+		final boolean stateful;
+
+		PrecomputedParameters(
+			boolean immutableTargetType,
+			TypeSerializer<Object>[] fieldSerializers) {
+			Preconditions.checkNotNull(fieldSerializers);
+			int totalLength = 0;
+			boolean fieldsImmutable = true;
+			boolean stateful = false;
+			for (TypeSerializer<Object> fieldSerializer : fieldSerializers) {
+				Preconditions.checkNotNull(fieldSerializer);
+				if (fieldSerializer != fieldSerializer.duplicate()) {
+					stateful = true;
+				}
+				if (!fieldSerializer.isImmutableType()) {
+					fieldsImmutable = false;
+				}
+				if (fieldSerializer.getLength() < 0) {
+					totalLength = -1;
+				}
+				totalLength = totalLength >= 0 ? totalLength + fieldSerializer.getLength() : totalLength;
+			}
+
+			this.immutableTargetType = immutableTargetType;
+			this.immutable = immutableTargetType && fieldsImmutable;
+			this.length = totalLength;
+			this.stateful = stateful;
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -254,7 +254,7 @@ public class LocalFileSystem extends FileSystem {
 		}
 		else {
 			File parent = file.getParentFile();
-			return (parent == null || mkdirsInternal(parent)) && file.mkdir();
+			return (parent == null || mkdirsInternal(parent)) && (file.mkdir() || file.isDirectory());
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test suite for {@link CompositeSerializer}. */
+public class CompositeSerializerTest {
+	private static final ExecutionConfig execConf = new ExecutionConfig();
+
+	private static final List<Tuple2<TypeSerializer<?>, Object[]>> TEST_FIELD_SERIALIZERS = Arrays.asList(
+		Tuple2.of(BooleanSerializer.INSTANCE, new Object[] { true, false }),
+		Tuple2.of(LongSerializer.INSTANCE, new Object[] { 1L, 23L }),
+		Tuple2.of(StringSerializer.INSTANCE, new Object[] { "teststr1", "teststr2" }),
+		Tuple2.of(TypeInformation.of(Pojo.class).createSerializer(execConf),
+			new Object[] { new Pojo(3, new String[] { "123", "456" }), new Pojo(6, new String[] {  }) })
+	);
+
+	@Test
+	public void testSingleFieldSerializer() {
+		TEST_FIELD_SERIALIZERS.forEach(t -> {
+			@SuppressWarnings("unchecked")
+			TypeSerializer<Object>[] fieldSerializers = new TypeSerializer[] { t.f0 };
+			List<Object>[] instances = Arrays.stream(t.f1)
+				.map(Arrays::asList)
+				.toArray((IntFunction<List<Object>[]>) List[]::new);
+			runTests(t.f0.getLength(), fieldSerializers, instances);
+		});
+	}
+
+	@Test
+	public void testPairFieldSerializer() {
+		TEST_FIELD_SERIALIZERS.forEach(t1 ->
+			TEST_FIELD_SERIALIZERS.forEach(t2 -> {
+				@SuppressWarnings("unchecked")
+				TypeSerializer<Object>[] fieldSerializers = new TypeSerializer[] { t1.f0, t2.f0 };
+				List<Object>[] instances = IntStream.range(0, t1.f1.length)
+					.mapToObj(i -> Arrays.asList(t1.f1[i], t2.f1[i]))
+					.toArray((IntFunction<List<Object>[]>) List[]::new);
+				runTests(getLength(fieldSerializers), fieldSerializers, instances);
+			}));
+	}
+
+	@Test
+	public void testAllFieldSerializer() {
+		@SuppressWarnings("unchecked")
+		TypeSerializer<Object>[] fieldSerializers = TEST_FIELD_SERIALIZERS.stream()
+			.map(t -> (TypeSerializer<Object>) t.f0)
+			.toArray((IntFunction<TypeSerializer<Object>[]>) TypeSerializer[]::new);
+		List<Object>[] instances = IntStream.range(0, TEST_FIELD_SERIALIZERS.get(0).f1.length)
+			.mapToObj(CompositeSerializerTest::getTestCase)
+			.toArray((IntFunction<List<Object>[]>) List[]::new);
+		runTests(getLength(fieldSerializers), fieldSerializers, instances);
+	}
+
+	// needs to be Arrays.ArrayList for all tests
+	private static List<Object> getTestCase(int index) {
+		return Arrays.asList(TEST_FIELD_SERIALIZERS.stream()
+			.map(t -> t.f1[index])
+			.toArray(Object[]::new));
+	}
+
+	private static int getLength(TypeSerializer<Object>[] fieldSerializers) {
+		return Arrays.stream(fieldSerializers).allMatch(fs -> fs.getLength() > 0) ?
+			Arrays.stream(fieldSerializers).mapToInt(TypeSerializer::getLength).sum() : -1;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void runTests(
+		int length,
+		TypeSerializer<Object>[] fieldSerializers,
+		List<Object> ... instances) {
+		try {
+			for (boolean immutability : Arrays.asList(true, false)) {
+				TypeSerializer<List<Object>> serializer = new TestListCompositeSerializer(immutability, fieldSerializers);
+				CompositeSerializerTestInstance test = new CompositeSerializerTestInstance(serializer, length, instances);
+				test.testAll();
+			}
+		}
+		catch (Exception e) {
+			System.err.println(e.getMessage());
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	private static class Pojo {
+		public int f1;
+		public String[] f2;
+
+		private Pojo(int f1, String[] f2) {
+			this.f1 = f1;
+			this.f2 = f2;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Pojo pojo = (Pojo) o;
+			return f1 == pojo.f1 &&
+				Arrays.equals(f2, pojo.f2);
+		}
+
+		@Override
+		public int hashCode() {
+
+			int result = Objects.hash(f1);
+			result = 31 * result + Arrays.hashCode(f2);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo{" +
+				"f1=" + f1 +
+				", f2=" + Arrays.toString(f2) +
+				'}';
+		}
+	}
+
+	private static class TestListCompositeSerializer extends CompositeSerializer<List<Object>> {
+		TestListCompositeSerializer(boolean isImmutableTargetType, TypeSerializer<?>... fieldSerializers) {
+			super(isImmutableTargetType, fieldSerializers);
+		}
+
+		TestListCompositeSerializer(PrecomputedParameters precomputed, TypeSerializer<?>... fieldSerializers) {
+			super(precomputed, fieldSerializers);
+		}
+
+		@Override
+		public List<Object> createInstance(@Nonnull Object... values) {
+			return Arrays.asList(values);
+		}
+
+		@Override
+		protected void setField(@Nonnull List<Object> value, int index, Object fieldValue) {
+			if (precomputed.immutable) {
+				throw new UnsupportedOperationException("Type is immutable");
+			} else {
+				value.set(index, fieldValue);
+			}
+		}
+
+		@Override
+		protected Object getField(@Nonnull List<Object> value, int index) {
+			return value.get(index);
+		}
+
+		@Override
+		protected CompositeSerializer<List<Object>> createSerializerInstance(
+			PrecomputedParameters precomputed, TypeSerializer<?>... originalSerializers) {
+			return new TestListCompositeSerializer(precomputed, originalSerializers);
+		}
+	}
+
+	private static class CompositeSerializerTestInstance extends SerializerTestInstance<List<Object>> {
+		@SuppressWarnings("unchecked")
+		CompositeSerializerTestInstance(
+			TypeSerializer<List<Object>> serializer,
+			int length,
+			List<Object> ... testData) {
+			super(serializer, getCls(testData[0]), length, testData);
+		}
+
+		private static Class<List<Object>> getCls(List<Object> instance) {
+			return TypeExtractor.getForObject(instance).getTypeClass();
+		}
+
+		protected void deepEquals(String message, List<Object> should, List<Object> is) {
+			assertEquals(message, should, is);
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Tests for the {@link FileUtils}.
  */
-public class FileUtilsTest {
+public class FileUtilsTest extends TestLogger {
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
@@ -23,9 +23,11 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.MiniClusterResourceConfiguration;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -48,7 +50,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for distributing files with {@link org.apache.flink.api.common.cache.DistributedCache} via HDFS.
  */
-public class DistributedCacheDfsTest {
+public class DistributedCacheDfsTest extends TestLogger {
 
 	private static final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
 		+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
@@ -128,7 +130,7 @@ public class DistributedCacheDfsTest {
 
 		env.fromElements(1)
 			.map(new TestMapFunction())
-			.print();
+			.addSink(new DiscardingSink<>());
 
 		env.execute("Distributed Cache Via Blob Test Program");
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -317,7 +317,8 @@ public class LaunchableMesosWorker implements LaunchableTask {
 					.setDocker(Protos.ContainerInfo.DockerInfo.newBuilder()
 						.addAllParameters(params.dockerParameters())
 						.setNetwork(Protos.ContainerInfo.DockerInfo.Network.HOST)
-						.setImage(params.containerImageName().get()));
+						.setImage(params.containerImageName().get())
+						.setForcePullImage(params.dockerForcePullImage()));
 				break;
 
 			default:

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -666,6 +666,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 				new HashMap<>(taskManagerParameters.containeredParameters().taskManagerEnv())),
 			taskManagerParameters.containerVolumes(),
 			taskManagerParameters.dockerParameters(),
+			taskManagerParameters.dockerForcePullImage(),
 			taskManagerParameters.constraints(),
 			taskManagerParameters.command(),
 			taskManagerParameters.bootstrapCommand(),

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -107,6 +107,12 @@ public class MesosTaskManagerParameters {
 		.withDescription("Custom parameters to be passed into docker run command when using the docker containerizer." +
 			" Comma separated list of \"key=value\" pairs. The \"value\" may contain '='.");
 
+	public static final ConfigOption<Boolean> MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE =
+		key("mesos.resourcemanager.tasks.container.docker.force-pull-image")
+		.defaultValue(false)
+		.withDescription("Instruct the docker containerizer to forcefully pull the image rather than" +
+			" reuse a cached version.");
+
 	public static final ConfigOption<String> MESOS_CONSTRAINTS_HARD_HOSTATTR =
 		key("mesos.constraints.hard.hostattribute")
 		.noDefaultValue()
@@ -135,6 +141,8 @@ public class MesosTaskManagerParameters {
 
 	private final List<Protos.Parameter> dockerParameters;
 
+	private final boolean dockerForcePullImage;
+
 	private final List<ConstraintEvaluator> constraints;
 
 	private final String command;
@@ -153,6 +161,7 @@ public class MesosTaskManagerParameters {
 			ContaineredTaskManagerParameters containeredParameters,
 			List<Protos.Volume> containerVolumes,
 			List<Protos.Parameter> dockerParameters,
+			boolean dockerForcePullImage,
 			List<ConstraintEvaluator> constraints,
 			String command,
 			Option<String> bootstrapCommand,
@@ -166,6 +175,7 @@ public class MesosTaskManagerParameters {
 		this.containeredParameters = Preconditions.checkNotNull(containeredParameters);
 		this.containerVolumes = Preconditions.checkNotNull(containerVolumes);
 		this.dockerParameters = Preconditions.checkNotNull(dockerParameters);
+		this.dockerForcePullImage = dockerForcePullImage;
 		this.constraints = Preconditions.checkNotNull(constraints);
 		this.command = Preconditions.checkNotNull(command);
 		this.bootstrapCommand = Preconditions.checkNotNull(bootstrapCommand);
@@ -225,6 +235,13 @@ public class MesosTaskManagerParameters {
 	}
 
 	/**
+	 * Get Docker option to force pull image.
+	 */
+	public boolean dockerForcePullImage() {
+		return dockerForcePullImage;
+	}
+
+	/**
 	 * Get the placement constraints.
 	 */
 	public List<ConstraintEvaluator> constraints() {
@@ -269,6 +286,7 @@ public class MesosTaskManagerParameters {
 			", containeredParameters=" + containeredParameters +
 			", containerVolumes=" + containerVolumes +
 			", dockerParameters=" + dockerParameters +
+			", dockerForcePullImage=" + dockerForcePullImage +
 			", constraints=" + constraints +
 			", taskManagerHostName=" + taskManagerHostname +
 			", command=" + command +
@@ -329,6 +347,8 @@ public class MesosTaskManagerParameters {
 
 		Option<String> uriParamsOpt = Option.<String>apply(flinkConfig.getString(MESOS_TM_URIS));
 
+		boolean dockerForcePullImage = flinkConfig.getBoolean(MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE);
+
 		List<Protos.Volume> containerVolumes = buildVolumes(containerVolOpt);
 
 		List<Protos.Parameter> dockerParameters = buildDockerParameters(dockerParamsOpt);
@@ -350,6 +370,7 @@ public class MesosTaskManagerParameters {
 			containeredParameters,
 			containerVolumes,
 			dockerParameters,
+			dockerForcePullImage,
 			constraints,
 			tmCommand,
 			tmBootstrapCommand,

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -251,6 +251,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 				containeredParams,
 				Collections.<Protos.Volume>emptyList(),
 				Collections.<Protos.Parameter>emptyList(),
+				false,
 				Collections.<ConstraintEvaluator>emptyList(),
 				"",
 				Option.<String>empty(),

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -279,7 +279,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
 				1.0, 1, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
-				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(),
+				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
 				Option.<String>empty(), Collections.<String>emptyList());
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -142,6 +142,31 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 		assertEquals(params.uris().size(), 0);
 	}
 
+	public void testForcePullImageTrue() {
+		Configuration config = new Configuration();
+		config.setBoolean(MesosTaskManagerParameters.MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE, true);
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.dockerForcePullImage(), true);
+	}
+
+	@Test
+	public void testForcePullImageFalse() {
+		Configuration config = new Configuration();
+		config.setBoolean(MesosTaskManagerParameters.MESOS_RM_CONTAINER_DOCKER_FORCE_PULL_IMAGE, false);
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.dockerForcePullImage(), false);
+	}
+
+	@Test
+	public void testForcePullImageDefault() {
+		Configuration config = new Configuration();
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(params.dockerForcePullImage(), false);
+	}
+
 	@Test
 	public void givenTwoConstraintsInConfigShouldBeParsed() throws Exception {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -583,6 +583,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				taskRestore,
 				attemptNumber);
 
+			// null taskRestore to let it be GC'ed
+			taskRestore = null;
+
 			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
 			final CompletableFuture<Acknowledge> submitResultFuture = taskManagerGateway.submitTask(deployment, rpcTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.buffer;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -298,7 +299,11 @@ class LocalBufferPool implements BufferPool {
 			}
 		}
 
-		networkBufferPool.destroyBufferPool(this);
+		try {
+			networkBufferPool.destroyBufferPool(this);
+		} catch (IOException e) {
+			ExceptionUtils.rethrow(e);
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -336,7 +336,7 @@ class LocalBufferPool implements BufferPool {
 			// If there is a registered owner and we have still requested more buffers than our
 			// size, trigger a recycle via the owner.
 			if (owner != null && numberOfRequestedMemorySegments > currentPoolSize) {
-				owner.releaseMemory(numberOfRequestedMemorySegments - numBuffers);
+				owner.releaseMemory(numberOfRequestedMemorySegments - currentPoolSize);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -42,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * The NetworkBufferPool is a fixed size pool of {@link MemorySegment} instances
  * for the network stack.
  *
- * The NetworkBufferPool creates {@link LocalBufferPool}s from which the individual tasks draw
+ * <p>The NetworkBufferPool creates {@link LocalBufferPool}s from which the individual tasks draw
  * the buffers for the network data transfer. When new local buffer pools are created, the
  * NetworkBufferPool dynamically redistributes the buffers between the pools.
  */
@@ -70,7 +70,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 	 * Allocates all {@link MemorySegment} instances managed by this pool.
 	 */
 	public NetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize) {
-		
+
 		this.totalNumberOfMemorySegments = numberOfSegmentsToAllocate;
 		this.memorySegmentSize = segmentSize;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -172,7 +172,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 				}
 			}
 		} catch (Throwable e) {
-			recycleMemorySegments(segments);
+			recycleMemorySegments(segments, numRequiredBuffers);
 			ExceptionUtils.rethrowIOException(e);
 		}
 
@@ -180,8 +180,12 @@ public class NetworkBufferPool implements BufferPoolFactory {
 	}
 
 	public void recycleMemorySegments(List<MemorySegment> segments) throws IOException {
+		recycleMemorySegments(segments, segments.size());
+	}
+
+	private void recycleMemorySegments(List<MemorySegment> segments, int size) throws IOException {
 		synchronized (factoryLock) {
-			numTotalRequiredBuffers -= segments.size();
+			numTotalRequiredBuffers -= size;
 
 			availableMemorySegments.addAll(segments);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -37,6 +39,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The NetworkBufferPool is a fixed size pool of {@link MemorySegment} instances
@@ -112,6 +115,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 				allocatedMb, availableMemorySegments.size(), segmentSize);
 	}
 
+	@Nullable
 	public MemorySegment requestMemorySegment() {
 		return availableMemorySegments.poll();
 	}
@@ -120,7 +124,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 		// Adds the segment back to the queue, which does not immediately free the memory
 		// however, since this happens when references to the global pool are also released,
 		// making the availableMemorySegments queue and its contained object reclaimable
-		availableMemorySegments.add(segment);
+		availableMemorySegments.add(checkNotNull(segment));
 	}
 
 	public List<MemorySegment> requestMemorySegments(int numRequiredBuffers) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -151,7 +151,12 @@ public class NetworkBufferPool implements BufferPoolFactory {
 
 			this.numTotalRequiredBuffers += numRequiredBuffers;
 
-			redistributeBuffers();
+			try {
+				redistributeBuffers();
+			} catch (Throwable t) {
+				this.numTotalRequiredBuffers -= numRequiredBuffers;
+				ExceptionUtils.rethrowIOException(t);
+			}
 		}
 
 		final List<MemorySegment> segments = new ArrayList<>(numRequiredBuffers);
@@ -180,6 +185,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 
 			availableMemorySegments.addAll(segments);
 
+			// note: if this fails, we're fine for the buffer pool since we already recycled the segments
 			redistributeBuffers();
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -134,21 +134,6 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	}
 
 	/**
-	 * Creates and returns a new {@link State}.
-	 *
-	 * @param namespaceSerializer TypeSerializer for the state namespace.
-	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
-	 *
-	 * @param <N> The type of the namespace.
-	 * @param <SV> The type of the stored state value.
-	 * @param <S> The type of the public API state.
-	 * @param <IS> The type of internal state.
-	 */
-	public abstract <N, SV, S extends State, IS extends S> IS createState(
-		TypeSerializer<N> namespaceSerializer,
-		StateDescriptor<S, SV> stateDesc) throws Exception;
-
-	/**
 	 * @see KeyedStateBackend
 	 */
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  *
  * @param <K> The key by which state is keyed.
  */
-public interface KeyedStateBackend<K> extends InternalKeyContext<K>, Disposable {
+public interface KeyedStateBackend<K> extends InternalKeyContext<K>, KeyedStateFactory, Disposable {
 
 	/**
 	 * Sets the current key that is used for partitioned state.
@@ -70,7 +70,7 @@ public interface KeyedStateBackend<K> extends InternalKeyContext<K>, Disposable 
 	 *
 	 * @param namespaceSerializer The serializer used for the namespace type of the state
 	 * @param stateDescriptor The identifier for the state. This contains name and can create a default state value.
-	 *    
+	 *
 	 * @param <N> The type of the namespace.
 	 * @param <S> The type of the state.
 	 *
@@ -84,7 +84,7 @@ public interface KeyedStateBackend<K> extends InternalKeyContext<K>, Disposable 
 
 	/**
 	 * Creates or retrieves a partitioned state backed by this state backend.
-	 * 
+	 *
 	 * TODO: NOTE: This method does a lot of work caching / retrieving states just to update the namespace.
 	 *       This method should be removed for the sake of namespaces being lazily fetched from the keyed
 	 *       state backend, or being set on the state directly.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+
+/** This factory produces concrete internal state objects. */
+public interface KeyedStateFactory {
+	/**
+	 * Creates and returns a new {@link InternalKvState}.
+	 *
+	 * @param namespaceSerializer TypeSerializer for the state namespace.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <N> The type of the namespace.
+	 * @param <SV> The type of the stored state value.
+	 * @param <S> The type of the public API state.
+	 * @param <IS> The type of internal state.
+	 */
+	<N, SV, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
@@ -126,7 +126,7 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 			final Path path = decodePathFromReference(reference);
 
 			return new FsCheckpointStorageLocation(
-					fileSystem,
+					path.getFileSystem(),
 					path,
 					path,
 					path,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
@@ -126,5 +127,10 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 				", reference=" + reference +
 				", fileStateSizeThreshold=" + fileStateSizeThreshold +
 				'}';
+	}
+
+	@VisibleForTesting
+	FileSystem getFileSystem() {
+		return fileSystem;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl;
+
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.CompositeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyedStateFactory;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This state factory wraps state objects, produced by backends, with TTL logic.
+ */
+public class TtlStateFactory {
+	public static <N, SV, S extends State, IS extends S> IS createStateAndWrapWithTtlIfEnabled(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc,
+		KeyedStateFactory originalStateFactory,
+		TtlConfig ttlConfig,
+		TtlTimeProvider timeProvider) throws Exception {
+		Preconditions.checkNotNull(namespaceSerializer);
+		Preconditions.checkNotNull(stateDesc);
+		Preconditions.checkNotNull(originalStateFactory);
+		Preconditions.checkNotNull(ttlConfig);
+		Preconditions.checkNotNull(timeProvider);
+		return ttlConfig.getTtlUpdateType() == TtlConfig.TtlUpdateType.Disabled ?
+			originalStateFactory.createState(namespaceSerializer, stateDesc) :
+			new TtlStateFactory(originalStateFactory, ttlConfig, timeProvider)
+				.createState(namespaceSerializer, stateDesc);
+	}
+
+	private final Map<Class<? extends StateDescriptor>, KeyedStateFactory> stateFactories;
+
+	private final KeyedStateFactory originalStateFactory;
+	private final TtlConfig ttlConfig;
+	private final TtlTimeProvider timeProvider;
+
+	private TtlStateFactory(KeyedStateFactory originalStateFactory, TtlConfig ttlConfig, TtlTimeProvider timeProvider) {
+		this.originalStateFactory = originalStateFactory;
+		this.ttlConfig = ttlConfig;
+		this.timeProvider = timeProvider;
+		this.stateFactories = createStateFactories();
+	}
+
+	@SuppressWarnings("deprecation")
+	private Map<Class<? extends StateDescriptor>, KeyedStateFactory> createStateFactories() {
+		return Stream.of(
+			Tuple2.of(ValueStateDescriptor.class, (KeyedStateFactory) this::createValueState),
+			Tuple2.of(ListStateDescriptor.class, (KeyedStateFactory) this::createListState),
+			Tuple2.of(MapStateDescriptor.class, (KeyedStateFactory) this::createMapState),
+			Tuple2.of(ReducingStateDescriptor.class, (KeyedStateFactory) this::createReducingState),
+			Tuple2.of(AggregatingStateDescriptor.class, (KeyedStateFactory) this::createAggregatingState),
+			Tuple2.of(FoldingStateDescriptor.class, (KeyedStateFactory) this::createFoldingState)
+		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+	}
+
+	private <N, SV, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		KeyedStateFactory stateFactory = stateFactories.get(stateDesc.getClass());
+		if (stateFactory == null) {
+			String message = String.format("State %s is not supported by %s",
+				stateDesc.getClass(), TtlStateFactory.class);
+			throw new FlinkRuntimeException(message);
+		}
+		return stateFactory.createState(namespaceSerializer, stateDesc);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <N, SV, S extends State, IS extends S> IS createValueState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		ValueStateDescriptor<TtlValue<SV>> ttlDescriptor = new ValueStateDescriptor<>(
+			stateDesc.getName(), new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlValueState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T, N, SV, S extends State, IS extends S> IS createListState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		ListStateDescriptor<T> listStateDesc = (ListStateDescriptor<T>) stateDesc;
+		ListStateDescriptor<TtlValue<T>> ttlDescriptor = new ListStateDescriptor<>(
+			stateDesc.getName(), new TtlSerializer<>(listStateDesc.getElementSerializer()));
+		return (IS) new TtlListState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, listStateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <UK, UV, N, SV, S extends State, IS extends S> IS createMapState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		MapStateDescriptor<UK, UV> mapStateDesc = (MapStateDescriptor<UK, UV>) stateDesc;
+		MapStateDescriptor<UK, TtlValue<UV>> ttlDescriptor = new MapStateDescriptor<>(
+			stateDesc.getName(),
+			mapStateDesc.getKeySerializer(),
+			new TtlSerializer<>(mapStateDesc.getValueSerializer()));
+		return (IS) new TtlMapState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, mapStateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <N, SV, S extends State, IS extends S> IS createReducingState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		ReducingStateDescriptor<SV> reducingStateDesc = (ReducingStateDescriptor<SV>) stateDesc;
+		ReducingStateDescriptor<TtlValue<SV>> ttlDescriptor = new ReducingStateDescriptor<>(
+			stateDesc.getName(),
+			new TtlReduceFunction<>(reducingStateDesc.getReduceFunction(), ttlConfig, timeProvider),
+			new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlReducingState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <IN, OUT, N, SV, S extends State, IS extends S> IS createAggregatingState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		AggregatingStateDescriptor<IN, SV, OUT> aggregatingStateDescriptor =
+			(AggregatingStateDescriptor<IN, SV, OUT>) stateDesc;
+		TtlAggregateFunction<IN, SV, OUT> ttlAggregateFunction = new TtlAggregateFunction<>(
+			aggregatingStateDescriptor.getAggregateFunction(), ttlConfig, timeProvider);
+		AggregatingStateDescriptor<IN, TtlValue<SV>, OUT> ttlDescriptor = new AggregatingStateDescriptor<>(
+			stateDesc.getName(), ttlAggregateFunction, new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlAggregatingState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer(), ttlAggregateFunction);
+	}
+
+	@SuppressWarnings({"deprecation", "unchecked"})
+	private <T, N, SV, S extends State, IS extends S> IS createFoldingState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		FoldingStateDescriptor<T, SV> foldingStateDescriptor = (FoldingStateDescriptor<T, SV>) stateDesc;
+		SV initAcc = stateDesc.getDefaultValue();
+		TtlValue<SV> ttlInitAcc = initAcc == null ? null : new TtlValue<>(initAcc, Long.MAX_VALUE);
+		FoldingStateDescriptor<T, TtlValue<SV>> ttlDescriptor = new FoldingStateDescriptor<>(
+			stateDesc.getName(),
+			ttlInitAcc,
+			new TtlFoldFunction<>(foldingStateDescriptor.getFoldFunction(), ttlConfig, timeProvider, initAcc),
+			new TtlSerializer<>(stateDesc.getSerializer()));
+		return (IS) new TtlFoldingState<>(
+			originalStateFactory.createState(namespaceSerializer, ttlDescriptor),
+			ttlConfig, timeProvider, stateDesc.getSerializer());
+	}
+
+	/** Serializer for user state value with TTL. */
+	private static class TtlSerializer<T> extends CompositeSerializer<TtlValue<T>> {
+
+		TtlSerializer(TypeSerializer<T> userValueSerializer) {
+			super(true, userValueSerializer, LongSerializer.INSTANCE);
+		}
+
+		TtlSerializer(PrecomputedParameters precomputed, TypeSerializer<?> ... fieldSerializers) {
+			super(precomputed, fieldSerializers);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public TtlValue<T> createInstance(@Nonnull Object ... values) {
+			Preconditions.checkArgument(values.length == 2);
+			return new TtlValue<>((T) values[0], (long) values[1]);
+		}
+
+		@Override
+		protected void setField(@Nonnull TtlValue<T> v, int index, Object fieldValue) {
+			throw new UnsupportedOperationException("TtlValue is immutable");
+		}
+
+		@Override
+		protected Object getField(@Nonnull TtlValue<T> v, int index) {
+			return index == 0 ? v.getUserValue() : v.getLastAccessTimestamp();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		protected CompositeSerializer<TtlValue<T>> createSerializerInstance(
+			PrecomputedParameters precomputed,
+			TypeSerializer<?> ... originalSerializers) {
+			Preconditions.checkNotNull(originalSerializers);
+			Preconditions.checkArgument(originalSerializers.length == 2);
+			return new TtlSerializer<>(precomputed, (TypeSerializer<T>) originalSerializers[0]);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
@@ -40,8 +42,11 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -50,6 +55,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -66,9 +73,8 @@ public class ExecutionTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotReleaseOnFailedResourceAssignment() throws Exception {
-		final JobVertexID jobVertexId = new JobVertexID();
-		final JobVertex jobVertex = new JobVertex("Test vertex", jobVertexId);
-		jobVertex.setInvokableClass(NoOpInvokable.class);
+		final JobVertex jobVertex = createNoOpJobVertex();
+		final JobVertexID jobVertexId = jobVertex.getID();
 
 		final CompletableFuture<LogicalSlot> slotFuture = new CompletableFuture<>();
 		final ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(1);
@@ -119,9 +125,8 @@ public class ExecutionTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotReleaseOnExecutionCancellationInScheduled() throws Exception {
-		final JobVertexID jobVertexId = new JobVertexID();
-		final JobVertex jobVertex = new JobVertex("Test vertex", jobVertexId);
-		jobVertex.setInvokableClass(NoOpInvokable.class);
+		final JobVertex jobVertex = createNoOpJobVertex();
+		final JobVertexID jobVertexId = jobVertex.getID();
 
 		final SingleSlotTestingSlotOwner slotOwner = new SingleSlotTestingSlotOwner();
 
@@ -169,9 +174,8 @@ public class ExecutionTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotReleaseOnExecutionCancellationInRunning() throws Exception {
-		final JobVertexID jobVertexId = new JobVertexID();
-		final JobVertex jobVertex = new JobVertex("Test vertex", jobVertexId);
-		jobVertex.setInvokableClass(NoOpInvokable.class);
+		final JobVertex jobVertex = createNoOpJobVertex();
+		final JobVertexID jobVertexId = jobVertex.getID();
 
 		final SingleSlotTestingSlotOwner slotOwner = new SingleSlotTestingSlotOwner();
 
@@ -331,22 +335,14 @@ public class ExecutionTest extends TestLogger {
 	 */
 	@Test
 	public void testTerminationFutureIsCompletedAfterSlotRelease() throws Exception {
-		final JobVertexID jobVertexId = new JobVertexID();
-		final JobVertex jobVertex = new JobVertex("Test vertex", jobVertexId);
-		jobVertex.setInvokableClass(NoOpInvokable.class);
+		final JobVertex jobVertex = createNoOpJobVertex();
+		final JobVertexID jobVertexId = jobVertex.getID();
 
 		final SingleSlotTestingSlotOwner slotOwner = new SingleSlotTestingSlotOwner();
-
-		final SimpleSlot slot = new SimpleSlot(
-			slotOwner,
-			new LocalTaskManagerLocation(),
-			0,
-			new SimpleAckingTaskManagerGateway(),
-			null,
-			null);
-
-		final ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(1);
-		slotProvider.addSlot(jobVertexId, 0, CompletableFuture.completedFuture(slot));
+		final ProgrammedSlotProvider slotProvider = createProgrammedSlotProvider(
+			1,
+			Collections.singleton(jobVertexId),
+			slotOwner);
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
 			new JobID(),
@@ -383,6 +379,76 @@ public class ExecutionTest extends TestLogger {
 
 		// check if the returned slot future was completed first
 		restartFuture.get();
+	}
+
+	/**
+	 * Tests that the task restore state is nulled after the {@link Execution} has been
+	 * deployed. See FLINK-9693.
+	 */
+	@Test
+	public void testTaskRestoreStateIsNulledAfterDeployment() throws Exception {
+		final JobVertex jobVertex = createNoOpJobVertex();
+		final JobVertexID jobVertexId = jobVertex.getID();
+
+		final SingleSlotTestingSlotOwner slotOwner = new SingleSlotTestingSlotOwner();
+		final ProgrammedSlotProvider slotProvider = createProgrammedSlotProvider(
+			1,
+			Collections.singleton(jobVertexId),
+			slotOwner);
+
+		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
+			new JobID(),
+			slotProvider,
+			new NoRestartStrategy(),
+			jobVertex);
+
+		ExecutionJobVertex executionJobVertex = executionGraph.getJobVertex(jobVertexId);
+
+		ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
+
+		final Execution execution = executionVertex.getCurrentExecutionAttempt();
+
+		final JobManagerTaskRestore taskRestoreState = new JobManagerTaskRestore(1L, new TaskStateSnapshot());
+		execution.setInitialState(taskRestoreState);
+
+		assertThat(execution.getTaskRestore(), is(notNullValue()));
+
+		// schedule the execution vertex and wait for its deployment
+		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY).get();
+
+		assertThat(execution.getTaskRestore(), is(nullValue()));
+	}
+
+	@Nonnull
+	private JobVertex createNoOpJobVertex() {
+		final JobVertex jobVertex = new JobVertex("Test vertex", new JobVertexID());
+		jobVertex.setInvokableClass(NoOpInvokable.class);
+
+		return jobVertex;
+	}
+
+	@Nonnull
+	private ProgrammedSlotProvider createProgrammedSlotProvider(
+		int parallelism,
+		Collection<JobVertexID> jobVertexIds,
+		SlotOwner slotOwner) {
+		final ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(parallelism);
+
+		for (JobVertexID jobVertexId : jobVertexIds) {
+			for (int i = 0; i < parallelism; i++) {
+				final SimpleSlot slot = new SimpleSlot(
+					slotOwner,
+					new LocalTaskManagerLocation(),
+					0,
+					new SimpleAckingTaskManagerGateway(),
+					null,
+					null);
+
+				slotProvider.addSlot(jobVertexId, 0, CompletableFuture.completedFuture(slot));
+			}
+		}
+
+		return slotProvider;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.util.TestLogger;
+
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
 import org.junit.After;
@@ -47,7 +49,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
-public class LocalBufferPoolTest {
+public class LocalBufferPoolTest extends TestLogger {
 
 	private final static int numBuffers = 1024;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.buffer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,7 +48,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link NetworkBufferPool}.
  */
-public class NetworkBufferPoolTest {
+public class NetworkBufferPoolTest extends TestLogger {
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
@@ -400,7 +401,7 @@ public class NetworkBufferPoolTest {
 		}
 	}
 
-	private final class TestIOException extends IOException {
+	private static final class TestIOException extends IOException {
 		private static final long serialVersionUID = -814705441998024472L;
 	}
 
@@ -483,7 +484,6 @@ public class NetworkBufferPoolTest {
 			globalPool.createBufferPool(10, 10);
 		} finally {
 			globalPool.destroy();
-
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -390,6 +390,10 @@ public class NetworkBufferPoolTest {
 
 		expectedException.expect(IllegalStateException.class);
 		expectedException.expectMessage("destroyed");
-		asyncRequest.sync();
+		try {
+			asyncRequest.sync();
+		} finally {
+			globalPool.destroy();
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -42,6 +42,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests for {@link NetworkBufferPool}.
+ */
 public class NetworkBufferPoolTest {
 
 	@Rule

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTest.java
@@ -29,12 +29,7 @@ import java.util.stream.StreamSupport;
 
 /** Test suite for collection methods of {@link TtlMapState}. */
 public class TtlMapStateTest extends
-	TtlStateTestBase<TtlMapState<?, String, Integer, String>, Map<Integer, String>, Set<Map.Entry<Integer, String>>> {
-
-	@Override
-	TtlMapState<?, String, Integer, String> createState() {
-		return new TtlMapState<>(new MockInternalMapState<>(), ttlConfig, timeProvider, null);
-	}
+	TtlMapStateTestBase<Map<Integer, String>, Set<Map.Entry<Integer, String>>> {
 
 	@Override
 	void initTestValues() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateTestBase.java
@@ -18,25 +18,16 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-/** Test suite for per element methods of {@link TtlMapState}. */
-public class TtlMapStatePerElementTest extends TtlMapStateTestBase<String, String> {
-	private static final int TEST_KEY = 1;
-	private static final String TEST_VAL1 = "test value1";
-	private static final String TEST_VAL2 = "test value2";
-	private static final String TEST_VAL3 = "test value3";
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
+abstract class TtlMapStateTestBase<UV, GV>
+	extends TtlStateTestBase<TtlMapState<?, String, Integer, String>, UV, GV> {
 	@Override
-	void initTestValues() {
-		updater = v -> ttlState.put(TEST_KEY, v);
-		getter = () -> ttlState.get(TEST_KEY);
-		originalGetter = () -> ttlState.original.get(TEST_KEY);
-
-		updateEmpty = TEST_VAL1;
-		updateUnexpired = TEST_VAL2;
-		updateExpired = TEST_VAL3;
-
-		getUpdateEmpty = TEST_VAL1;
-		getUnexpired = TEST_VAL2;
-		getUpdateExpired = TEST_VAL3;
+	TtlMapState<?, String, Integer, String> createState() {
+		MapStateDescriptor<Integer, String> mapStateDesc =
+			new MapStateDescriptor<>("TtlTestMapState", IntSerializer.INSTANCE, StringSerializer.INSTANCE);
+		return (TtlMapState<?, String, Integer, String>) wrapMockState(mapStateDesc);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlReducingStateTest.java
@@ -19,21 +19,15 @@
 package org.apache.flink.runtime.state.ttl;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.state.internal.InternalReducingState;
 
 import java.util.List;
 
 /** Test suite for {@link TtlReducingState}. */
 public class TtlReducingStateTest
 	extends TtlMergingStateBase.TtlIntegerMergingStateBase<TtlReducingState<?, String, Integer>, Integer, Integer> {
-	@Override
-	TtlReducingState<?, String, Integer> createState() {
-		ReduceFunction<TtlValue<Integer>> ttlReduceFunction = new TtlReduceFunction<>(REDUCE, ttlConfig, timeProvider);
-		return new TtlReducingState<>(
-			new MockInternalReducingState<>(ttlReduceFunction), ttlConfig, timeProvider, null);
-	}
-
 	@Override
 	void initTestValues() {
 		updater = v -> ttlState.add(v);
@@ -50,34 +44,17 @@ public class TtlReducingStateTest
 	}
 
 	@Override
+	TtlReducingState<?, String, Integer> createState() {
+		ReducingStateDescriptor<Integer> aggregatingStateDes =
+			new ReducingStateDescriptor<>("TtlTestReducingState", REDUCE, IntSerializer.INSTANCE);
+		return (TtlReducingState<?, String, Integer>) wrapMockState(aggregatingStateDes);
+	}
+
+	@Override
 	Integer getMergeResult(
 		List<Tuple2<String, Integer>> unexpiredUpdatesToMerge,
 		List<Tuple2<String, Integer>> finalUpdatesToMerge) {
 		return getIntegerMergeResult(unexpiredUpdatesToMerge, finalUpdatesToMerge);
-	}
-
-	private static class MockInternalReducingState<K, N, T>
-		extends MockInternalMergingState<K, N, T, T, T> implements InternalReducingState<K, N, T> {
-		private final ReduceFunction<T> reduceFunction;
-
-		private MockInternalReducingState(ReduceFunction<T> reduceFunction) {
-			this.reduceFunction = reduceFunction;
-		}
-
-		@Override
-		public T get() {
-			return getInternal();
-		}
-
-		@Override
-		public void add(T value) throws Exception {
-			updateInternal(reduceFunction.reduce(get(), value));
-		}
-
-		@Override
-		T mergeState(T t, T nAcc) throws Exception {
-			return reduceFunction.reduce(t, nAcc);
-		}
 	}
 
 	private static final ReduceFunction<Integer> REDUCE = (v1, v2) -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlValueStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlValueStateTest.java
@@ -18,18 +18,14 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 /** Test suite for {@link TtlValueState}. */
 public class TtlValueStateTest extends TtlStateTestBase<TtlValueState<?, String, String>, String, String> {
 	private static final String TEST_VAL1 = "test value1";
 	private static final String TEST_VAL2 = "test value2";
 	private static final String TEST_VAL3 = "test value3";
-
-	@Override
-	TtlValueState<?, String, String> createState() {
-		return new TtlValueState<>(new MockInternalValueState<>(), ttlConfig, timeProvider, null);
-	}
 
 	@Override
 	void initTestValues() {
@@ -46,17 +42,10 @@ public class TtlValueStateTest extends TtlStateTestBase<TtlValueState<?, String,
 		getUpdateExpired = TEST_VAL3;
 	}
 
-	private static class MockInternalValueState<K, N, T>
-		extends MockInternalKvState<K, N, T> implements InternalValueState<K, N, T> {
-
-		@Override
-		public T value() {
-			return getInternal();
-		}
-
-		@Override
-		public void update(T value) {
-			updateInternal(value);
-		}
+	@Override
+	TtlValueState<?, String, String> createState() {
+		ValueStateDescriptor<String> valueStateDesc =
+			new ValueStateDescriptor<>("TtlValueTestState", StringSerializer.INSTANCE);
+		return (TtlValueState<?, String, String>) wrapMockState(valueStateDesc);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalAggregatingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalAggregatingState.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+
+/** In memory mock internal aggregating state. */
+class MockInternalAggregatingState<K, N, IN, ACC, OUT>
+	extends MockInternalMergingState<K, N, IN, ACC, OUT> implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+	private final AggregateFunction<IN, ACC, OUT> aggregateFunction;
+
+	private MockInternalAggregatingState(AggregateFunction<IN, ACC, OUT> aggregateFunction) {
+		this.aggregateFunction = aggregateFunction;
+	}
+
+	@Override
+	public OUT get() {
+		return aggregateFunction.getResult(getInternal());
+	}
+
+	@Override
+	public void add(IN value) {
+		updateInternal(aggregateFunction.add(value,  getInternal()));
+	}
+
+	@Override
+	ACC mergeState(ACC acc, ACC nAcc) {
+		return aggregateFunction.merge(acc, nAcc);
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <IN, OUT, N, ACC, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, ACC> stateDesc) {
+		AggregatingStateDescriptor<IN, ACC, OUT> aggregatingStateDesc =
+			(AggregatingStateDescriptor<IN, ACC, OUT>) stateDesc;
+		return (IS) new MockInternalAggregatingState<>(aggregatingStateDesc.getAggregateFunction());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalFoldingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalFoldingState.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalFoldingState;
+
+/** In memory mock internal folding state. */
+@SuppressWarnings("deprecation")
+class MockInternalFoldingState<K, N, T, ACC>
+	extends MockInternalKvState<K, N, ACC> implements InternalFoldingState<K, N, T, ACC> {
+	private final FoldFunction<T, ACC> foldFunction;
+
+	private MockInternalFoldingState(FoldFunction<T, ACC> foldFunction) {
+		this.foldFunction = foldFunction;
+	}
+
+	@Override
+	public ACC get() {
+		return getInternal();
+	}
+
+	@Override
+	public void add(T value) throws Exception {
+		updateInternal(foldFunction.fold(get(), value));
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <T, N, ACC, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, ACC> stateDesc) {
+		FoldingStateDescriptor<T, ACC> foldingStateDesc = (FoldingStateDescriptor<T, ACC>) stateDesc;
+		return (IS) new MockInternalFoldingState<>(foldingStateDesc.getFoldFunction());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalKvState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalKvState.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalKvState;
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+/** In memory mock internal state base class. */
 class MockInternalKvState<K, N, T> implements InternalKvState<K, N, T> {
 	private Map<N, T> namespacedValues = new HashMap<>();
 	private T defaultNamespaceValue;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalListState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalListState.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** In memory mock internal list state. */
+class MockInternalListState<K, N, T>
+	extends MockInternalMergingState<K, N, T, List<T>, Iterable<T>>
+	implements InternalListState<K, N, T> {
+
+	private MockInternalListState() {
+		super(ArrayList::new);
+	}
+
+	@Override
+	public void update(List<T> elements) {
+		updateInternal(elements);
+	}
+
+	@Override
+	public void addAll(List<T> elements) {
+		getInternal().addAll(elements);
+	}
+
+	@Override
+	List<T> mergeState(List<T> acc, List<T> nAcc) {
+		acc = new ArrayList<>(acc);
+		acc.addAll(nAcc);
+		return acc;
+	}
+
+	@Override
+	public Iterable<T> get() {
+		return getInternal();
+	}
+
+	@Override
+	public void add(T element) {
+		getInternal().add(element);
+	}
+
+	@Override
+	public void clear() {
+		getInternal().clear();
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		return (IS) new MockInternalListState<>();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
@@ -16,19 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-class MockInternalMapState<K, N, UK, UV>
+/** In memory mock internal map state. */
+public class MockInternalMapState<K, N, UK, UV>
 	extends MockInternalKvState<K, N, Map<UK, UV>>
 	implements InternalMapState<K, N, UK, UV> {
 
-	MockInternalMapState() {
+	private MockInternalMapState() {
 		super(HashMap::new);
 	}
 
@@ -84,5 +88,12 @@ class MockInternalMapState<K, N, UK, UV>
 	@Override
 	public Iterator<Map.Entry<UK, UV>> iterator() {
 		return entries().iterator();
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		return (IS) new MockInternalMapState<>();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMergingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMergingState.java
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
 import org.apache.flink.runtime.state.internal.InternalMergingState;
 
 import java.util.Collection;
 import java.util.function.Supplier;
 
+/** In memory mock internal merging state base class. */
 abstract class MockInternalMergingState<K, N, IN, ACC, OUT>
 	extends MockInternalKvState<K, N, ACC> implements InternalMergingState<K, N, IN, ACC, OUT> {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalReducingState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalReducingState.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+
+/** In memory mock internal reducing state. */
+class MockInternalReducingState<K, N, T>
+	extends MockInternalMergingState<K, N, T, T, T> implements InternalReducingState<K, N, T> {
+	private final ReduceFunction<T> reduceFunction;
+
+	private MockInternalReducingState(ReduceFunction<T> reduceFunction) {
+		this.reduceFunction = reduceFunction;
+	}
+
+	@Override
+	public T get() {
+		return getInternal();
+	}
+
+	@Override
+	public void add(T value) throws Exception {
+		updateInternal(reduceFunction.reduce(get(), value));
+	}
+
+	@Override
+	T mergeState(T t, T nAcc) throws Exception {
+		return reduceFunction.reduce(t, nAcc);
+	}
+
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		ReducingStateDescriptor<T> reducingStateDesc = (ReducingStateDescriptor<T>) stateDesc;
+		return (IS) new MockInternalReducingState<>(reducingStateDesc.getReduceFunction());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalValueState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalValueState.java
@@ -16,27 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.mock;
 
-/** Test suite for per element methods of {@link TtlMapState}. */
-public class TtlMapStatePerElementTest extends TtlMapStateTestBase<String, String> {
-	private static final int TEST_KEY = 1;
-	private static final String TEST_VAL1 = "test value1";
-	private static final String TEST_VAL2 = "test value2";
-	private static final String TEST_VAL3 = "test value3";
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+/** In memory mock internal value state. */
+class MockInternalValueState<K, N, T>
+	extends MockInternalKvState<K, N, T> implements InternalValueState<K, N, T> {
 
 	@Override
-	void initTestValues() {
-		updater = v -> ttlState.put(TEST_KEY, v);
-		getter = () -> ttlState.get(TEST_KEY);
-		originalGetter = () -> ttlState.original.get(TEST_KEY);
+	public T value() {
+		return getInternal();
+	}
 
-		updateEmpty = TEST_VAL1;
-		updateUnexpired = TEST_VAL2;
-		updateExpired = TEST_VAL3;
+	@Override
+	public void update(T value) {
+		updateInternal(value);
+	}
 
-		getUpdateEmpty = TEST_VAL1;
-		getUnexpired = TEST_VAL2;
-		getUpdateExpired = TEST_VAL3;
+	@SuppressWarnings({"unchecked", "unused"})
+	static <N, T, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, T> stateDesc) {
+		return (IS) new MockInternalValueState<>();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyedStateFactory;
+import org.apache.flink.runtime.state.ttl.TtlStateFactory;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** State factory which produces in memory mock state objects. */
+public class MockKeyedStateFactory implements KeyedStateFactory {
+	@SuppressWarnings("deprecation")
+	private static final Map<Class<? extends StateDescriptor>, KeyedStateFactory> STATE_FACTORIES =
+		Stream.of(
+			Tuple2.of(ValueStateDescriptor.class, (KeyedStateFactory) MockInternalValueState::createState),
+			Tuple2.of(ListStateDescriptor.class, (KeyedStateFactory) MockInternalListState::createState),
+			Tuple2.of(MapStateDescriptor.class, (KeyedStateFactory) MockInternalMapState::createState),
+			Tuple2.of(ReducingStateDescriptor.class, (KeyedStateFactory) MockInternalReducingState::createState),
+			Tuple2.of(AggregatingStateDescriptor.class, (KeyedStateFactory) MockInternalAggregatingState::createState),
+			Tuple2.of(FoldingStateDescriptor.class, (KeyedStateFactory) MockInternalFoldingState::createState)
+		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+	@Override
+	public <N, SV, S extends State, IS extends S> IS createState(
+		TypeSerializer<N> namespaceSerializer,
+		StateDescriptor<S, SV> stateDesc) throws Exception {
+		KeyedStateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
+		if (stateFactory == null) {
+			String message = String.format("State %s is not supported by %s",
+				stateDesc.getClass(), TtlStateFactory.class);
+			throw new FlinkRuntimeException(message);
+		}
+		return stateFactory.createState(namespaceSerializer, stateDesc);
+	}
+}

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.scala
 
 import java.io._
 
+import org.apache.commons.cli.{CommandLine, Options}
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
 import org.apache.flink.client.deployment.ClusterDescriptor
 import org.apache.flink.client.program.ClusterClient
@@ -28,6 +29,7 @@ import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration, StandaloneMiniCluster}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConverters._
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter._
 
@@ -273,14 +275,14 @@ object FlinkShell {
     yarnConfig.queue.foreach((queue) => args ++= Seq("-yqu", queue.toString))
     yarnConfig.slots.foreach((slots) => args ++= Seq("-ys", slots.toString))
 
-    val commandLine = CliFrontendParser.parse(
-      CliFrontendParser.getRunCommandOptions,
-      args.toArray,
-      true)
-
-    val frontend = new CliFrontend(
-      configuration,
+    val frontend = new CliFrontend(configuration,
       CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
+
+    val commandOptions = CliFrontendParser.getRunCommandOptions
+    val commandLineOptions = CliFrontendParser.mergeOptions(commandOptions,
+      frontend.getCustomCommandLineOptions());
+    val commandLine = CliFrontendParser.parse(commandLineOptions, args.toArray, true)
+
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
 
     val clusterDescriptor = customCLI.createClusterDescriptor(commandLine)

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/InstantiationUtilTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/InstantiationUtilTest.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import java.io.ByteArrayOutputStream
+
+import org.apache.flink.util.{InstantiationUtil, TestLogger}
+import org.hamcrest.Matchers
+import org.junit.{Assert, Test}
+
+/**
+  * Serialization/Deserialization tests of Scala types using the
+  * [[org.apache.flink.util.InstantiationUtil]].
+  */
+class InstantiationUtilTest extends TestLogger {
+
+  @Test
+  def testNestedScalaTypeSerDe(): Unit = {
+    val instance = new Foo.Bar.Foobar(42)
+
+    val copy = serializeDeserializeInstance(instance)
+
+    Assert.assertThat(copy, Matchers.equalTo(instance))
+  }
+
+  @Test
+  def testAnonymousScalaTypeSerDe(): Unit = {
+    val instance = new Foo.FooTrait {
+      val value: Int = 41
+
+      override def hashCode(): Int = 37 * value
+
+      override def equals(obj: scala.Any): Boolean = {
+        obj match {
+          case x: Foo.FooTrait => value == x.value()
+          case _ => false
+        }
+      }
+    }
+
+    val copy = serializeDeserializeInstance(instance)
+
+    Assert.assertThat(copy, Matchers.equalTo(instance))
+  }
+
+  private def serializeDeserializeInstance[T](instance: T): T = {
+    val baos = new ByteArrayOutputStream()
+
+    InstantiationUtil.serializeObject(baos, instance)
+
+    InstantiationUtil.deserializeObject(
+      baos.toByteArray,
+      getClass.getClassLoader,
+      true)
+  }
+}
+
+object Foo extends Serializable {
+  trait FooTrait extends Serializable {
+    def value(): Int
+  }
+
+  object Bar extends Serializable {
+    class Foobar(val x: Int) extends Serializable {
+      override def hashCode(): Int = 37 * x
+
+      override def equals(obj: scala.Any): Boolean = {
+        obj match {
+          case other: Foobar =>
+            other.x == x
+          case _ =>
+            false
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Adding a PubSub connector with support for Checkpointing

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests*
 - *Manually verified the connector (without Checkpointing) on an actual PubSub topic and subscription.*
**Is there a need for integration tests? I did not see any for the other connectors. 
What is a good way of testing the checkpointing / exactly-once behavior?**

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, Google Cloud Sdk for PubSub (**Does this need to be shaded?**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know, don't think so
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes, checkpointing
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
