### PR TITLE
[hotfix] [docs] [FLINK-9734] Fix 'deleimiter' typo

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -461,7 +461,7 @@ format:
       type: VARCHAR
     - name: field2
       type: TIMESTAMP
-  field-deleimiter: ","      # optional: string delimiter "," by default 
+  field-delimiter: ","      # optional: string delimiter "," by default 
   line-delimiter: "\n"       # optional: string delimiter "\n" by default 
   quote-character: '"'       # optional: single character for string values, empty by default
   comment-prefix: '#'        # optional: string to indicate comments, empty by default


### PR DESCRIPTION
## What is the purpose of the change

*This PR fixes typo in 

> deleimeter

 word at https://ci.apache.org/projects/flink/flink-docs-master/dev/table/sqlClient.html#csv-format*


## Brief change log
  - *type fix at docs/dev/table/sqlClient.md*

