### PR TITLE
[FLINK-9742][Table API & SQL] Expose Expression.resultType to public

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionUtils.scala
@@ -29,7 +29,13 @@ import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.typeutils.{RowIntervalTypeInfo, TimeIntervalTypeInfo}
 
 object ExpressionUtils {
-  def getReturnType(expr: Expression): TypeInformation[_] = {
+  /**
+    * Retrieve result type of given Expression.
+    *
+    * @param expr The expression which caller is interested about result type
+    * @return     The result type of Expression
+    */
+  def getResultType(expr: Expression): TypeInformation[_] = {
     expr.resultType
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionUtils.scala
@@ -22,13 +22,16 @@ import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float =
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.{Date, Time, Timestamp}
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.streaming.api.windowing.time.{Time => FlinkTime}
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.typeutils.{RowIntervalTypeInfo, TimeIntervalTypeInfo}
 
 object ExpressionUtils {
+  def getReturnType(expr: Expression): TypeInformation[_] = {
+    expr.resultType
+  }
 
   private[flink] def isTimeIntervalLiteral(expr: Expression): Boolean = expr match {
     case Literal(_, TimeIntervalTypeInfo.INTERVAL_MILLIS) => true


### PR DESCRIPTION
## What is the purpose of the change

This patch proposes exposing Expression.resultType to public, to enable custom TimestampExtractor outside of Flink acessing Expression.resultType.

There is some use cases of TableSource which requires custom implementation of TimestampExtractor, and to ensure new TimestampExtractor to cover more general use cases, accessing Expression.resultType is necessary, but its scope is now defined as package private for "org.apache.flink". It would be better to just make Expression.resultType public to cover other cases as well.

In order to avoid changing public API side, this patch adds new method to ExpressionUtils to let it access resultType and return it instead.

Please refer https://issues.apache.org/jira/browse/FLINK-9742 for more details. 

## Brief change log

* adds ExpressionUtils.getReturnType to let it access resultType and return it instead

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
