### PR TITLE
[FLINK-8094][Table API & SQL] Support other types for ExistingField rowtime extractor

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -460,7 +460,8 @@ val source: KafkaTableSource = Kafka010JsonTableSource.builder()
 Flink provides `TimestampExtractor` implementations for common use cases.
 The following `TimestampExtractor` implementations are currently available:
 
-* `ExistingField(fieldName)`: Extracts the value of a rowtime attribute from an existing `LONG` or `SQL_TIMESTAMP` field.
+* `ExistingField(fieldName)`: Extracts the value of a rowtime attribute from an existing `LONG` or `SQL_TIMESTAMP`, or ISO date formatted `STRING` field.
+  * One example of ISO date format would be '2018-05-28 12:34:56.000'.
 * `StreamRecordTimestamp()`: Extracts the value of a rowtime attribute from the timestamp of the `DataStream` `StreamRecord`. Note, this `TimestampExtractor` is not available for batch table sources.
 
 A custom `TimestampExtractor` can be defined by implementing the corresponding interface.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -18,12 +18,13 @@
 
 package org.apache.flink.table.sources.tsextractors
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.expressions.{Cast, Expression, ResolvedFieldReference}
 
 /**
-  * Converts an existing [[Long]] or [[java.sql.Timestamp]] field into a rowtime attribute.
+  * Converts an existing [[Long]] or [[java.sql.Timestamp]], or
+  * ISO date formatted [[java.lang.String]] field into a rowtime attribute.
   *
   * @param field The field to convert into a rowtime attribute.
   */
@@ -32,27 +33,24 @@ final class ExistingField(val field: String) extends TimestampExtractor {
   override def getArgumentFields: Array[String] = Array(field)
 
   @throws[ValidationException]
-  override def validateArgumentFields(physicalFieldTypes: Array[TypeInformation[_]]): Unit = {
+  override def validateArgumentFields(argumentFieldTypes: Array[TypeInformation[_]]): Unit = {
+    val fieldType = argumentFieldTypes(0)
 
-    // get type of field to convert
-    val fieldType = physicalFieldTypes(0)
-
-    // check that the field to convert is of type Long or Timestamp
     fieldType match {
       case Types.LONG => // OK
       case Types.SQL_TIMESTAMP => // OK
+      case Types.STRING => // OK
       case _: TypeInformation[_] =>
         throw ValidationException(
-          s"Field '$field' must be of type Long or Timestamp but is of type $fieldType.")
+          s"Field '$field' must be of type Long or Timestamp or String but is of type $fieldType.")
     }
   }
 
   /**
-    * Returns an [[Expression]] that casts a [[Long]] or [[java.sql.Timestamp]] field into a
-    * rowtime attribute.
+    * Returns an [[Expression]] that casts a [[Long]] or [[java.sql.Timestamp]], or
+    * ISO date formatted [[java.lang.String]] field into a rowtime attribute.
     */
-  def getExpression(fieldAccesses: Array[ResolvedFieldReference]): Expression = {
-
+  override def getExpression(fieldAccesses: Array[ResolvedFieldReference]): Expression = {
     val fieldAccess: Expression = fieldAccesses(0)
 
     fieldAccess.resultType match {
@@ -62,6 +60,8 @@ final class ExistingField(val field: String) extends TimestampExtractor {
       case Types.SQL_TIMESTAMP =>
         // cast timestamp to long
         Cast(fieldAccess, Types.LONG)
+      case Types.STRING =>
+        Cast(Cast(fieldAccess, SqlTimeTypeInfo.TIMESTAMP), Types.LONG)
     }
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -741,4 +741,41 @@ class TableSourceITCase extends AbstractTestBase {
     val expected = Seq("(1,A,1)", "(6,C,10)", "(6,D,20)")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
+
+  @Test
+  def testRowtimeStringTableSource(): Unit = {
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = Seq(
+      "1970-01-01 00:00:00",
+      "1970-01-01 00:00:01",
+      "1970-01-01 00:00:01",
+      "1970-01-01 00:00:02",
+      "1970-01-01 00:00:04")
+
+    val schema = new TableSchema(Array("rtime"), Array(Types.SQL_TIMESTAMP))
+    val returnType = Types.STRING
+
+    val tableSource = new TestTableSourceWithTime(schema, returnType, data, "rtime", null)
+    tEnv.registerTableSource(tableName, tableSource)
+
+    tEnv.scan(tableName)
+      .window(Tumble over 1.second on 'rtime as 'w)
+      .groupBy('w)
+      .select('w.start, 1.count)
+      .addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = Seq(
+      "1970-01-01 00:00:00.0,1",
+      "1970-01-01 00:00:01.0,2",
+      "1970-01-01 00:00:02.0,1",
+      "1970-01-01 00:00:04.0,1")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
 }


### PR DESCRIPTION
## What is the purpose of the change

This patch proposes new rowtime extractor which is improved version of ExistingField,
handles ISO dateformatted String type as well as Long and Timestamp types.

## Brief change log

* introduce IsoDateStringAwareExistingField class to provide improved version of ExistingField
  * handles ISO dateformatted String type as well as Long and Timestamp types.

## Verifying this change

This change added tests and can be verified as follows:

- Manually verified the change by applying to TableSource which has ISO dateformatted STRING as rowtime field's type and confirmed watermark working correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
