### PR TITLE
[FLINK-9676][network] clarify contracts of BufferListener#notifyBufferAvailable() and fix a deadlock

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
@@ -27,6 +27,11 @@ public interface BufferListener {
 	/**
 	 * Notification callback if a buffer is recycled and becomes available in buffer pool.
 	 *
+	 * <p><strong>BEWARE:</strong> This happens under synchronization in {@link LocalBufferPool}.
+	 * Therefore, if the implementation requires another lock (for whatever reason), make sure that
+	 * no other use of this lock recycles buffers (to the same buffer pool) or you may deadlock
+	 * because of the locks being acquired in different order (for an example, see FLINK-9676).
+	 *
 	 * @param buffer buffer that becomes available in buffer pool.
 	 * @return true if the listener wants to be notified next time.
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -405,13 +406,13 @@ public class LocalBufferPoolTest {
 
 	private BufferListener createBufferListener(int notificationTimes) {
 		return spy(new BufferListener() {
-			int times = 0;
+			AtomicInteger times = new AtomicInteger(0);
 
 			@Override
 			public boolean notifyBufferAvailable(Buffer buffer) {
-				times++;
+				int newCount = times.incrementAndGet();
 				buffer.recycleBuffer();
-				return times < notificationTimes;
+				return newCount < notificationTimes;
 			}
 
 			@Override


### PR DESCRIPTION
## What is the purpose of the change

When recycling exclusive buffers of a `RemoteInputChannel` and recycling (other/floating) buffers to the buffer pool concurrently while the `RemoteInputChannel` is registered as a listener to the buffer pool and adding the exclusive buffer triggers a floating buffer to be recycled back to the same
buffer pool, a deadlock would occur holding locks on `LocalBufferPool#availableMemorySegments` and `RemoteInputChannel#bufferQueue` but acquiring them in reverse order.

One such instance would be (thanks @zhijiangW for finding this):

```
Task canceler thread -> RemoteInputChannel1#releaseAllResources -> recycle floating buffers
 -> lock(LocalBufferPool#availableMemorySegments) -> RemoteInputChannel2#notifyBufferAvailable
 -> try to lock(RemoteInputChannel2#bufferQueue)
```
```
Task thread -> RemoteInputChannel2#recycle
 -> lock(RemoteInputChannel2#bufferQueue) -> bufferQueue#addExclusiveBuffer -> floatingBuffer#recycleBuffer
 -> try to lock(LocalBufferPool#availableMemorySegments)
```

@pnowojski and @tillrohrmann can you also have a quick look so that this can get into 1.5.1?

## Brief change log

- clarify the contract of `BufferListener#notifyBufferAvailable()` (see in the code)
- make sure that none of the places in `RemoteInputChannel` break this contract, i.e. wherever a lock on `bufferQueue` is taken, we may not recycle any buffer under this lock

## Verifying this change

This change added tests and can be verified as follows:

- added `RemoteInputChannelTest#testConcurrentRecycleAndRelease2` which catches this deadlock quite quickly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** (per buffer, but we're only moving recycling out of the synchronized block so if there's any effect, it should be positive)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
