### PR TITLE
[FLINK-9681] [table] Make sure difference between minRetentionTime and maxRetentionTime at least 5 minutes

### DIFF
--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -579,7 +579,7 @@ The parameters are specified as follows:
 
 StreamQueryConfig qConfig = ...
 
-// set idle state retention time: min = 12 hour, max = 24 hours
+// set idle state retention time: min = 12 hours, max = 24 hours
 qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24));
 
 {% endhighlight %}
@@ -589,14 +589,14 @@ qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24));
 
 val qConfig: StreamQueryConfig = ???
 
-// set idle state retention time: min = 12 hour, max = 24 hours
+// set idle state retention time: min = 12 hours, max = 24 hours
 qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24))
 
 {% endhighlight %}
 </div>
 </div>
 
-Configuring different minimum and maximum idle state retention times is more efficient because it reduces the internal book-keeping of a query for when to remove state. Difference between minTime and maxTime shoud be at least 5 minutes.
+Cleaning up state requires additional bookkeeping which becomes less expensive for larger differences of `minTime` and `maxTime`. The difference between `minTime` and `maxTime` must be at least 5 minutes.
 
 {% top %}
 

--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -507,7 +507,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 // obtain query configuration from TableEnvironment
 StreamQueryConfig qConfig = tableEnv.queryConfig();
 // set query parameters
-qConfig.withIdleStateRetentionTime(Time.hours(12));
+qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24));
 
 // define query
 Table result = ...
@@ -531,7 +531,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // obtain query configuration from TableEnvironment
 val qConfig: StreamQueryConfig = tableEnv.queryConfig
 // set query parameters
-qConfig.withIdleStateRetentionTime(Time.hours(12))
+qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24))
 
 // define query
 val result: Table = ???
@@ -579,10 +579,8 @@ The parameters are specified as follows:
 
 StreamQueryConfig qConfig = ...
 
-// set idle state retention time: min = 12 hour, max = 16 hours
-qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(16));
-// set idle state retention time. min = max = 12 hours
-qConfig.withIdleStateRetentionTime(Time.hours(12);
+// set idle state retention time: min = 12 hour, max = 24 hours
+qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24));
 
 {% endhighlight %}
 </div>
@@ -591,16 +589,14 @@ qConfig.withIdleStateRetentionTime(Time.hours(12);
 
 val qConfig: StreamQueryConfig = ???
 
-// set idle state retention time: min = 12 hour, max = 16 hours
-qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(16))
-// set idle state retention time. min = max = 12 hours
-qConfig.withIdleStateRetentionTime(Time.hours(12)
+// set idle state retention time: min = 12 hour, max = 24 hours
+qConfig.withIdleStateRetentionTime(Time.hours(12), Time.hours(24))
 
 {% endhighlight %}
 </div>
 </div>
 
-Configuring different minimum and maximum idle state retention times is more efficient because it reduces the internal book-keeping of a query for when to remove state.
+Configuring different minimum and maximum idle state retention times is more efficient because it reduces the internal book-keeping of a query for when to remove state. Difference between minTime and maxTime shoud be at least 5 minutes.
 
 {% top %}
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -75,11 +75,11 @@ public class Execution {
 	}
 
 	public long getMinStateRetention() {
-		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_MIN_STATE_RETENTION, Long.toString(Long.MIN_VALUE)));
+		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_MIN_STATE_RETENTION, Long.toString(0)));
 	}
 
 	public long getMaxStateRetention() {
-		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_STATE_RETENTION, Long.toString(Long.MIN_VALUE)));
+		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_STATE_RETENTION, Long.toString(0)));
 	}
 
 	public int getParallelism() {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/queryConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/queryConfig.scala
@@ -41,33 +41,13 @@ class StreamQueryConfig private[table] extends QueryConfig {
     * The minimum time until state which was not updated will be retained.
     * State might be cleared and removed if it was not updated for the defined period of time.
     */
-  private var minIdleStateRetentionTime: Long = Long.MinValue
+  private var minIdleStateRetentionTime: Long = 0L
 
   /**
     * The maximum time until state which was not updated will be retained.
     * State will be cleared and removed if it was not updated for the defined period of time.
     */
-  private var maxIdleStateRetentionTime: Long = Long.MinValue
-
-  /**
-    * Specifies the time interval for how long idle state, i.e., state which was not updated, will
-    * be retained. When state was not updated for the specified interval of time, it will be cleared
-    * and removed.
-    *
-    * When new data arrives for previously cleaned-up state, the new data will be handled as if it
-    * was the first data. This can result in previous results being overwritten.
-    *
-    * Note: [[withIdleStateRetentionTime(minTime: Time, maxTime: Time)]] allows to set a minimum and
-    * maximum time for state to be retained. This method is more efficient, because the system has
-    * to do less bookkeeping to identify the time at which state must be cleared.
-    *
-    * @param time The time interval for how long idle state is retained. Set to 0 (zero) to never
-    *             clean-up the state.
-    */
-  def withIdleStateRetentionTime(time: Time): StreamQueryConfig = {
-    withIdleStateRetentionTime(time, time)
-  }
-
+  private var maxIdleStateRetentionTime: Long = 0L
   /**
     * Specifies a minimum and a maximum time interval for how long idle state, i.e., state which
     * was not updated, will be retained.
@@ -79,14 +59,22 @@ class StreamQueryConfig private[table] extends QueryConfig {
     *
     * Set to 0 (zero) to never clean-up the state.
     *
+    * NOTE: Configuring different minimum and maximum idle state retention times is more efficient
+    * because it reduces the internal book-keeping of a query for when to remove state.
+    * Difference between minTime and maxTime shoud be at least 5 minute.
+    *
     * @param minTime The minimum time interval for which idle state is retained. Set to 0 (zero) to
     *                never clean-up the state.
     * @param maxTime The maximum time interval for which idle state is retained. May not be smaller
     *                than than minTime. Set to 0 (zero) to never clean-up the state.
     */
   def withIdleStateRetentionTime(minTime: Time, maxTime: Time): StreamQueryConfig = {
-    if (maxTime.toMilliseconds < minTime.toMilliseconds) {
-      throw new IllegalArgumentException("maxTime may not be smaller than minTime.")
+
+    if (maxTime.toMilliseconds - minTime.toMilliseconds < 300000 &&
+      !(maxTime.toMilliseconds == 0 && minTime.toMilliseconds == 0)) {
+      throw new IllegalArgumentException(
+        s"Difference between minTime: ${minTime.toString} and maxTime: ${maxTime.toString} " +
+          s"shoud be at least 5 minutes.")
     }
     minIdleStateRetentionTime = minTime.toMilliseconds
     maxIdleStateRetentionTime = maxTime.toMilliseconds

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/QueryConfigTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/QueryConfigTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api
+
+import org.apache.flink.api.common.time.Time
+import org.junit.Test
+
+class QueryConfigTest {
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMinBiggerThanMax(): Unit = {
+    new StreamQueryConfig().withIdleStateRetentionTime(Time.hours(2), Time.hours(1))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMinEqualMax(): Unit = {
+    new StreamQueryConfig().withIdleStateRetentionTime(Time.hours(1), Time.hours(1))
+  }
+
+  @Test
+  def testMinMaxZero(): Unit = {
+    new StreamQueryConfig().withIdleStateRetentionTime(Time.hours(0), Time.hours(0))
+  }
+
+  @Test
+  def testPass(): Unit = {
+    new StreamQueryConfig().withIdleStateRetentionTime(Time.minutes(1), Time.minutes(6))
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.runtime.harness
 
 import java.util.{Comparator, Queue => JQueue}
 
+import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.functions.KeySelector
@@ -27,6 +28,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.{KeyedOneInputStreamOperatorTestHarness, TestHarnessUtil}
+import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.GeneratedAggregationsFunction
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
@@ -383,5 +385,13 @@ object HarnessTestBase {
     override def getKey(value: CRow): T = {
       value.row.getField(selectorField).asInstanceOf[T]
     }
+  }
+
+  /**
+    * Test class used to test min and max retention time.
+    */
+  class StreamQueryConfigTest(min: Time, max: Time) extends StreamQueryConfig {
+    override def getMinIdleStateRetentionTime: Long = min.toMilliseconds
+    override def getMaxIdleStateRetentionTime: Long = max.toMilliseconds
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -390,7 +390,7 @@ object HarnessTestBase {
   /**
     * Test class used to test min and max retention time.
     */
-  class StreamQueryConfigTest(min: Time, max: Time) extends StreamQueryConfig {
+  class TestStreamQueryConfig(min: Time, max: Time) extends StreamQueryConfig {
     override def getMinIdleStateRetentionTime: Long = min.toMilliseconds
     override def getMaxIdleStateRetentionTime: Long = max.toMilliseconds
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
 import org.apache.flink.table.api.{StreamQueryConfig, Types}
-import org.apache.flink.table.runtime.harness.HarnessTestBase.{RowResultSortComparator, RowResultSortComparatorWithWatermarks, TupleRowKeySelector}
+import org.apache.flink.table.runtime.harness.HarnessTestBase.{RowResultSortComparator, RowResultSortComparatorWithWatermarks, StreamQueryConfigTest, TupleRowKeySelector}
 import org.apache.flink.table.runtime.join._
 import org.apache.flink.table.runtime.operators.KeyedCoProcessOperatorWithWatermarkDelay
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -44,7 +44,7 @@ import org.junit.Test
 class JoinHarnessTest extends HarnessTestBase {
 
   private val queryConfig =
-    new StreamQueryConfig().withIdleStateRetentionTime(Time.milliseconds(2), Time.milliseconds(4))
+    new StreamQueryConfigTest(Time.milliseconds(2), Time.milliseconds(4))
 
   private val rowType = Types.ROW(
     Types.LONG,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
 import org.apache.flink.table.api.{StreamQueryConfig, Types}
-import org.apache.flink.table.runtime.harness.HarnessTestBase.{RowResultSortComparator, RowResultSortComparatorWithWatermarks, StreamQueryConfigTest, TupleRowKeySelector}
+import org.apache.flink.table.runtime.harness.HarnessTestBase.{RowResultSortComparator, RowResultSortComparatorWithWatermarks, TestStreamQueryConfig, TupleRowKeySelector}
 import org.apache.flink.table.runtime.join._
 import org.apache.flink.table.runtime.operators.KeyedCoProcessOperatorWithWatermarkDelay
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -44,7 +44,7 @@ import org.junit.Test
 class JoinHarnessTest extends HarnessTestBase {
 
   private val queryConfig =
-    new StreamQueryConfigTest(Time.milliseconds(2), Time.milliseconds(4))
+    new TestStreamQueryConfig(Time.milliseconds(2), Time.milliseconds(4))
 
   private val rowType = Types.ROW(
     Types.LONG,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
@@ -34,7 +34,7 @@ import org.junit.Test
 class NonWindowHarnessTest extends HarnessTestBase {
 
   protected var queryConfig =
-    new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(2), Time.seconds(3))
+    new StreamQueryConfigTest(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testNonWindow(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
@@ -34,7 +34,7 @@ import org.junit.Test
 class NonWindowHarnessTest extends HarnessTestBase {
 
   protected var queryConfig =
-    new StreamQueryConfigTest(Time.seconds(2), Time.seconds(3))
+    new TestStreamQueryConfig(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testNonWindow(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -35,7 +35,7 @@ import org.junit.Test
 class OverWindowHarnessTest extends HarnessTestBase{
 
   protected var queryConfig: StreamQueryConfig =
-    new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(2), Time.seconds(3))
+    new StreamQueryConfigTest(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testProcTimeBoundedRowsOver(): Unit = {
@@ -368,7 +368,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxCRowType,
         4000,
         0,
-        new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
+        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
@@ -518,7 +518,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxCRowType,
         3,
         0,
-        new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
+        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
@@ -665,7 +665,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxAggregationStateType,
         minMaxCRowType,
         0,
-        new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
+        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
@@ -801,7 +801,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxAggregationStateType,
         minMaxCRowType,
         0,
-        new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
+        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -35,7 +35,7 @@ import org.junit.Test
 class OverWindowHarnessTest extends HarnessTestBase{
 
   protected var queryConfig: StreamQueryConfig =
-    new StreamQueryConfigTest(Time.seconds(2), Time.seconds(3))
+    new TestStreamQueryConfig(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testProcTimeBoundedRowsOver(): Unit = {
@@ -368,7 +368,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxCRowType,
         4000,
         0,
-        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
+        new TestStreamQueryConfig(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
@@ -518,7 +518,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxCRowType,
         3,
         0,
-        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
+        new TestStreamQueryConfig(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
@@ -665,7 +665,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxAggregationStateType,
         minMaxCRowType,
         0,
-        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
+        new TestStreamQueryConfig(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
@@ -801,7 +801,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxAggregationStateType,
         minMaxCRowType,
         0,
-        new StreamQueryConfigTest(Time.seconds(1), Time.seconds(2))))
+        new TestStreamQueryConfig(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/StateCleaningCountTriggerHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/StateCleaningCountTriggerHarnessTest.scala
@@ -22,14 +22,14 @@ import org.apache.flink.streaming.api.windowing.triggers.TriggerResult
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow
 import org.apache.flink.streaming.runtime.operators.windowing.TriggerTestHarness
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
-import org.apache.flink.table.runtime.harness.HarnessTestBase.StreamQueryConfigTest
+import org.apache.flink.table.runtime.harness.HarnessTestBase.TestStreamQueryConfig
 import org.apache.flink.table.runtime.triggers.StateCleaningCountTrigger
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class StateCleaningCountTriggerHarnessTest {
   protected var queryConfig =
-    new StreamQueryConfigTest(Time.seconds(2), Time.seconds(3))
+    new TestStreamQueryConfig(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testFiringAndFiringWithPurging(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/StateCleaningCountTriggerHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/StateCleaningCountTriggerHarnessTest.scala
@@ -22,14 +22,14 @@ import org.apache.flink.streaming.api.windowing.triggers.TriggerResult
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow
 import org.apache.flink.streaming.runtime.operators.windowing.TriggerTestHarness
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
-import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.runtime.harness.HarnessTestBase.StreamQueryConfigTest
 import org.apache.flink.table.runtime.triggers.StateCleaningCountTrigger
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class StateCleaningCountTriggerHarnessTest {
   protected var queryConfig =
-    new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(2), Time.seconds(3))
+    new StreamQueryConfigTest(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testFiringAndFiringWithPurging(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessFunctionWithCleanupStateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessFunctionWithCleanupStateTest.scala
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.runtime.aggregate.KeyedProcessFunctionWithCleanupState
 import org.apache.flink.table.runtime.harness.HarnessTestBase
-import org.apache.flink.table.runtime.harness.HarnessTestBase.StreamQueryConfigTest
+import org.apache.flink.table.runtime.harness.HarnessTestBase.TestStreamQueryConfig
 import org.apache.flink.util.Collector
 
 import org.junit.Test
@@ -37,7 +37,7 @@ class KeyedProcessFunctionWithCleanupStateTest extends HarnessTestBase {
 
   @Test
   def testStateCleaning(): Unit = {
-    val queryConfig = new StreamQueryConfigTest(Time.milliseconds(5), Time.milliseconds(10))
+    val queryConfig = new TestStreamQueryConfig(Time.milliseconds(5), Time.milliseconds(10))
 
     val func = new MockedKeyedProcessFunction(queryConfig)
     val operator = new KeyedProcessOperator(func)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessFunctionWithCleanupStateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessFunctionWithCleanupStateTest.scala
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.runtime.aggregate.KeyedProcessFunctionWithCleanupState
 import org.apache.flink.table.runtime.harness.HarnessTestBase
+import org.apache.flink.table.runtime.harness.HarnessTestBase.StreamQueryConfigTest
 import org.apache.flink.util.Collector
 
 import org.junit.Test
@@ -36,8 +37,7 @@ class KeyedProcessFunctionWithCleanupStateTest extends HarnessTestBase {
 
   @Test
   def testStateCleaning(): Unit = {
-    val queryConfig = new StreamQueryConfig()
-      .withIdleStateRetentionTime(Time.milliseconds(5), Time.milliseconds(10))
+    val queryConfig = new StreamQueryConfigTest(Time.milliseconds(5), Time.milliseconds(10))
 
     val func = new MockedKeyedProcessFunction(queryConfig)
     val operator = new KeyedProcessOperator(func)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/ProcessFunctionWithCleanupStateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/ProcessFunctionWithCleanupStateTest.scala
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.runtime.aggregate.ProcessFunctionWithCleanupState
 import org.apache.flink.table.runtime.harness.HarnessTestBase
+import org.apache.flink.table.runtime.harness.HarnessTestBase.StreamQueryConfigTest
 import org.apache.flink.util.Collector
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -36,8 +37,7 @@ class ProcessFunctionWithCleanupStateTest extends HarnessTestBase {
 
   @Test
   def testStateCleaning(): Unit = {
-    val queryConfig = new StreamQueryConfig()
-      .withIdleStateRetentionTime(Time.milliseconds(5), Time.milliseconds(10))
+    val queryConfig = new StreamQueryConfigTest(Time.milliseconds(5), Time.milliseconds(10))
 
     val func = new MockedProcessFunction(queryConfig)
     val operator = new LegacyKeyedProcessOperator(func)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/ProcessFunctionWithCleanupStateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/ProcessFunctionWithCleanupStateTest.scala
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.runtime.aggregate.ProcessFunctionWithCleanupState
 import org.apache.flink.table.runtime.harness.HarnessTestBase
-import org.apache.flink.table.runtime.harness.HarnessTestBase.StreamQueryConfigTest
+import org.apache.flink.table.runtime.harness.HarnessTestBase.TestStreamQueryConfig
 import org.apache.flink.util.Collector
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -37,7 +37,7 @@ class ProcessFunctionWithCleanupStateTest extends HarnessTestBase {
 
   @Test
   def testStateCleaning(): Unit = {
-    val queryConfig = new StreamQueryConfigTest(Time.milliseconds(5), Time.milliseconds(10))
+    val queryConfig = new TestStreamQueryConfig(Time.milliseconds(5), Time.milliseconds(10))
 
     val func = new MockedProcessFunction(queryConfig)
     val operator = new LegacyKeyedProcessOperator(func)


### PR DESCRIPTION

## What is the purpose of the change

This PR aims to make sure difference between minRetentionTime and maxRetentionTime at least 5 minutes. Currently, for a group by(or other operators), if minRetentionTime equals to maxRetentionTime, the group by operator will register a timer for each record coming at different time which cause performance problem. The reasoning for having two parameters is that we can avoid to register many timers if we have more freedom when to discard state. As min equals to max cause performance problem it is better to make sure these two parameters are not same.


## Brief change log

  - Throw exception when difference between minRetentionTime and maxRetentionTime smaller than  5 minutes
  - Add a `QueryConfigTest` class extends from StreamQueryConfig. `QueryConfigTest` don't have the 5min limitation which makes test more convenient.
  - Adapt tests.


## Verifying this change

This change added tests and can be verified as follows:
  - Added test that validates that min and max retention time are set correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
