### PR TITLE
[MINOR] Add generated avro java codes to RAT exclusion list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1129,6 +1129,8 @@ under the License.
 						<exclude>apache-maven-3.2.5/**</exclude>
 						<!-- PyCharm -->
 						<exclude>**/.idea/**</exclude>
+						<!-- Generated code via Avro -->
+						<exclude>flink-end-to-end-tests/flink-confluent-schema-registry/src/main/java/example/avro/**</exclude>
 					</excludes>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## What is the purpose of the change

This patch adds generated avro java codes to the RAT plugin exclusion list to avoid RAT error when running `mvn clean verify` in flink root directory.

## Brief change log

* Add generated avro java code to the RAT plugin exclusion list to avoid RAT error

## Verifying this change

This change is already covered by existing tests, such as *mvn clean verify in flink root directory*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
