### PR TITLE
[FLINK-9679] Implement AvroSerializationSchema

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -29,6 +29,10 @@ under the License.
 
 	<artifactId>flink-avro-confluent-registry</artifactId>
 
+	<properties>
+		<confluent.schema.rigestry.version>4.1.0</confluent.schema.rigestry.version>
+	</properties>
+
 	<repositories>
 		<repository>
 			<id>confluent</id>
@@ -40,7 +44,7 @@ under the License.
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-schema-registry-client</artifactId>
-			<version>3.3.1</version>
+			<version>${confluent.schema.rigestry.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.avro</groupId>

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
@@ -132,10 +132,5 @@ public class ConfluentRegistryAvroDeserializationSchema<T> extends RegistryAvroD
 				url,
 				identityMapCapacity));
 		}
-
-		@Override
-		public Object getSchemaId() {
-			return null;
-		}
 	}
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
@@ -132,5 +132,10 @@ public class ConfluentRegistryAvroDeserializationSchema<T> extends RegistryAvroD
 				url,
 				identityMapCapacity));
 		}
+
+		@Override
+		public Object getSchemaId() {
+			return null;
+		}
 	}
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroSerializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroSerializationSchema.java
@@ -57,21 +57,21 @@ public class ConfluentRegistryAvroSerializationSchema<T> extends RegistryAvroSer
 	 *
 	 * @param tClass              class of record to be produced
 	 * @param schemaRegistryUrl   url of schema registry to connect
-	 * @param topic topic of schema registry to produce
+	 * @param subject subject of schema registry to produce
 	 * @return Serialized record
 	 */
-	public static <T extends SpecificRecord> ConfluentRegistryAvroSerializationSchema<T> forSpecific(Class<T> tClass, String topic, String schemaRegistryUrl) {
+	public static <T extends SpecificRecord> ConfluentRegistryAvroSerializationSchema<T> forSpecific(Class<T> tClass, String subject, String schemaRegistryUrl) {
 		return new ConfluentRegistryAvroSerializationSchema<>(
 			tClass,
-			getSchemaId(tClass, topic, schemaRegistryUrl)
+			getSchemaId(tClass, subject, schemaRegistryUrl)
 		);
 	}
 
-	private static int getSchemaId(Class tClass, String topic, String schemaRegistryUrl){
+	private static int getSchemaId(Class tClass, String subject, String schemaRegistryUrl){
 		CachedSchemaRegistryClient cachedSchemaRegistryClient = new CachedSchemaRegistryClient(schemaRegistryUrl, DEFAULT_IDENTITY_MAP_CAPACITY);
 		int schemaId;
 		try {
-			schemaId = cachedSchemaRegistryClient.register(topic + "-value", SpecificData.get().getSchema(tClass));
+			schemaId = cachedSchemaRegistryClient.register(subject, SpecificData.get().getSchema(tClass));
 		} catch (IOException | RestClientException e) {
 			throw new RuntimeException("Failed to serialize schema registry.", e);
 		}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroSerializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroSerializationSchema.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.formats.avro.AvroSerializationSchema;
+import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificRecord;
+
+import java.io.IOException;
+
+/**
+ * Serialization schema that serializes from Avro binary format that uses
+ * Confluent Schema Registry.
+ *
+ * @param <T> type of record it produces
+ */
+public class ConfluentRegistryAvroSerializationSchema<T> extends RegistryAvroSerializationSchema<T> {
+
+	private static final int DEFAULT_IDENTITY_MAP_CAPACITY = 1000;
+
+	private static final long serialVersionUID = -1771641202177852775L;
+
+	/**
+	 * Creates a Avro Serialization schema.
+	 *
+	 * @param recordClazz         class to which Serialize which is
+	 *                            {@link SpecificRecord}.
+	 * @param schemaId   id of schema registry
+	 */
+	private ConfluentRegistryAvroSerializationSchema(Class<T> recordClazz, int schemaId) {
+		super(recordClazz, schemaId);
+	}
+
+	/**
+	 * Creates {@link AvroSerializationSchema} that produces classes that were generated from avro
+	 * schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param tClass              class of record to be produced
+	 * @param schemaRegistryUrl   url of schema registry to connect
+	 * @param topic topic of schema registry to produce
+	 * @return Serialized record
+	 */
+	public static <T extends SpecificRecord> ConfluentRegistryAvroSerializationSchema<T> forSpecific(Class<T> tClass, String topic, String schemaRegistryUrl) {
+		return new ConfluentRegistryAvroSerializationSchema<>(
+			tClass,
+			getSchemaId(tClass, topic, schemaRegistryUrl)
+		);
+	}
+
+	private static int getSchemaId(Class tClass, String topic, String schemaRegistryUrl){
+		CachedSchemaRegistryClient cachedSchemaRegistryClient = new CachedSchemaRegistryClient(schemaRegistryUrl, DEFAULT_IDENTITY_MAP_CAPACITY);
+		int schemaId;
+		try {
+			schemaId = cachedSchemaRegistryClient.register(topic + "-value", SpecificData.get().getSchema(tClass));
+		} catch (IOException | RestClientException e) {
+			throw new RuntimeException("Failed to serialize schema registry.", e);
+		}
+		return schemaId;
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
@@ -42,6 +42,7 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 	/**
 	 * Creates {@link AvroSerializationSchema} that produces {@link SpecificRecord} using provided schema.
 	 *
+	 * @param tClass class of record to be produced
 	 * @return topic record in form of {@link SpecificRecord}
 	 */
 	public static <T extends SpecificRecord> AvroSerializationSchema<T> forSpecific(Class<T> tClass) {
@@ -66,15 +67,14 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 	private transient ByteArrayOutputStream arrayOutputStream;
 
 	/**
-	 * Avro decoder that decodes binary data.
+	 * Avro encoder that encodes binary data.
 	 */
 	private transient BinaryEncoder encoder;
-
 
 	/**
 	 * Creates Avro Serialization schema.
 	 *
-	 * @param recordClazz         class to which deserialize which is
+	 * @param recordClazz         class to which serialize which is
 	 *                            {@link SpecificRecord}.
 	 */
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
@@ -31,7 +31,6 @@ import org.apache.avro.specific.SpecificRecord;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * Serialization schema that serializes from Avro binary format.
@@ -43,12 +42,10 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 	/**
 	 * Creates {@link AvroSerializationSchema} that produces {@link SpecificRecord} using provided schema.
 	 *
-	 * @param schemaId   id of schema registry
 	 * @return topic record in form of {@link SpecificRecord}
 	 */
-	public static <T extends SpecificRecord> AvroSerializationSchema<T> forSpecific(Class<T> tClass,
-																					int schemaId) {
-		return new AvroSerializationSchema<>(tClass, schemaId);
+	public static <T extends SpecificRecord> AvroSerializationSchema<T> forSpecific(Class<T> tClass) {
+		return new AvroSerializationSchema<>(tClass);
 	}
 
 	private static final long serialVersionUID = -8766681879020862312L;
@@ -73,23 +70,17 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 	 */
 	private transient BinaryEncoder encoder;
 
-	/**
-	 * schema id.
-	 */
-	private int schemaId;
 
 	/**
 	 * Creates Avro Serialization schema.
 	 *
 	 * @param recordClazz         class to which deserialize which is
 	 *                            {@link SpecificRecord}.
-	 * @param schemaId   id of schema registry to connect
 	 */
 
-	AvroSerializationSchema(Class<T> recordClazz, int schemaId) {
+	AvroSerializationSchema(Class<T> recordClazz) {
 		Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
 		this.recordClazz = recordClazz;
-		this.schemaId = schemaId;
 
 	}
 
@@ -105,10 +96,6 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 		return arrayOutputStream;
 	}
 
-	int getSchemaId(){
-		return schemaId;
-	}
-
 	@Override
 	public byte[] serialize(T object) {
 		checkAvroInitialized();
@@ -118,7 +105,6 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 		} else {
 			try {
 				arrayOutputStream.write(0);
-				arrayOutputStream.write(ByteBuffer.allocate(4).putInt(schemaId).array());
 				datumWriter.write(object, encoder);
 				encoder.flush();
 				byte[] bytes = arrayOutputStream.toByteArray();

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Serialization schema that serializes from Avro binary format.
+ *
+ * @param <T> type of record it produces
+ */
+public class AvroSerializationSchema<T> implements SerializationSchema<T> {
+
+	/**
+	 * Creates {@link AvroSerializationSchema} that produces {@link SpecificRecord} using provided schema.
+	 *
+	 * @param schemaId   id of schema registry
+	 * @return topic record in form of {@link SpecificRecord}
+	 */
+	public static <T extends SpecificRecord> AvroSerializationSchema<T> forSpecific(Class<T> tClass,
+																					int schemaId) {
+		return new AvroSerializationSchema<>(tClass, schemaId);
+	}
+
+	private static final long serialVersionUID = -8766681879020862312L;
+
+	/**
+	 * Class to serialize from.
+	 */
+	private Class<T> recordClazz;
+
+	/**
+	 * Write the serializes byte array into a record.
+	 */
+	private transient GenericDatumWriter<T> datumWriter;
+
+	/**
+	 * Output stream to write message to.
+	 */
+	private transient ByteArrayOutputStream arrayOutputStream;
+
+	/**
+	 * Avro decoder that decodes binary data.
+	 */
+	private transient BinaryEncoder encoder;
+
+	/**
+	 * schema id.
+	 */
+	private int schemaId;
+
+	/**
+	 * Creates Avro Serialization schema.
+	 *
+	 * @param recordClazz         class to which deserialize which is
+	 *                            {@link SpecificRecord}.
+	 * @param schemaId   id of schema registry to connect
+	 */
+
+	AvroSerializationSchema(Class<T> recordClazz, int schemaId) {
+		Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
+		this.recordClazz = recordClazz;
+		this.schemaId = schemaId;
+
+	}
+
+	BinaryEncoder getEncoder() {
+		return encoder;
+	}
+
+	GenericDatumWriter<T> getDatumWriter() {
+		return datumWriter;
+	}
+
+	ByteArrayOutputStream getOutputStream() {
+		return arrayOutputStream;
+	}
+
+	int getSchemaId(){
+		return schemaId;
+	}
+
+	@Override
+	public byte[] serialize(T object) {
+		checkAvroInitialized();
+
+		if (object == null) {
+			return null;
+		} else {
+			try {
+				arrayOutputStream.write(0);
+				arrayOutputStream.write(ByteBuffer.allocate(4).putInt(schemaId).array());
+				datumWriter.write(object, encoder);
+				encoder.flush();
+				byte[] bytes = arrayOutputStream.toByteArray();
+				arrayOutputStream.close();
+				return bytes;
+			} catch (RuntimeException | IOException e) {
+				throw new RuntimeException("Failed to serialize schema registry.", e);
+			}
+
+		}
+	}
+
+	void checkAvroInitialized() {
+		if (datumWriter != null) {
+			return;
+		}
+		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
+			Schema schema = SpecificData.get().getSchema(recordClazz);
+			this.datumWriter = new SpecificDatumWriter<>(schema);
+
+		} else {
+			this.datumWriter = new GenericDatumWriter<>();
+		}
+		this.arrayOutputStream = new ByteArrayOutputStream();
+		this.encoder = EncoderFactory.get().directBinaryEncoder(arrayOutputStream, null);
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroSerializationSchema.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.avro.io.Encoder;
+import org.apache.avro.specific.SpecificRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Serialization schema that serializes from Avro binary format.
+ *
+ * @param <T> type of record it produces
+ */
+public class RegistryAvroSerializationSchema<T> extends AvroSerializationSchema<T> {
+
+	private static final long serialVersionUID = -6766681879020862312L;
+
+	/**
+	 * Creates Avro Serialization schema.
+	 *
+	 * @param recordClazz         class to which deserialize which is
+	 *                            {@link SpecificRecord}.
+	 * @param schemaId   id of schema registry to connect
+	 */
+	public RegistryAvroSerializationSchema(Class<T> recordClazz, int schemaId) {
+		super(recordClazz, schemaId);
+	}
+
+	@Override
+	public byte[] serialize(T object) {
+		checkAvroInitialized();
+
+		if (object == null) {
+			return null;
+		} else {
+			try {
+				Encoder encoder = getEncoder();
+				ByteArrayOutputStream arrayOutputStream = getOutputStream();
+				arrayOutputStream.write(0);
+				arrayOutputStream.write(ByteBuffer.allocate(4).putInt(getSchemaId()).array());
+
+				getDatumWriter().write(object, encoder);
+				encoder.flush();
+
+				byte[] bytes = arrayOutputStream.toByteArray();
+				arrayOutputStream.close();
+				return bytes;
+			} catch (RuntimeException | IOException e) {
+				throw new RuntimeException("Failed to serialize schema registry.", e);
+			}
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/SchemaCoder.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/SchemaCoder.java
@@ -26,7 +26,8 @@ import java.io.Serializable;
 
 /**
  * Schema coder that allows reading schema that is somehow embedded into serialized record.
- * Used by {@link RegistryAvroDeserializationSchema}.
+ * Used by {@link RegistryAvroDeserializationSchema} and {@link RegistryAvroSerializationSchema}.
+ *
  */
 public interface SchemaCoder {
 	Schema readSchema(InputStream in) throws IOException;
@@ -44,5 +45,14 @@ public interface SchemaCoder {
 		 * @return new instance {@link SchemaCoder}
 		 */
 		SchemaCoder get();
+
+		/**
+		 * Creates a new instance of {@link Object}. Each time it should create a new
+		 * instance, as it will be called on multiple nodes.
+		 *
+		 * @return new instance {@link Object}
+		 */
+		Object getSchemaId();
+
 	}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/SchemaCoder.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/SchemaCoder.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro;
 
 import org.apache.avro.Schema;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -31,6 +32,8 @@ import java.io.Serializable;
  */
 public interface SchemaCoder {
 	Schema readSchema(InputStream in) throws IOException;
+
+	byte[] writeSchema(Class recordClazz, ByteArrayOutputStream out) throws IOException;
 
 	/**
 	 * Provider for {@link SchemaCoder}. It allows creating multiple instances of client in
@@ -45,14 +48,5 @@ public interface SchemaCoder {
 		 * @return new instance {@link SchemaCoder}
 		 */
 		SchemaCoder get();
-
-		/**
-		 * Creates a new instance of {@link Object}. Each time it should create a new
-		 * instance, as it will be called on multiple nodes.
-		 *
-		 * @return new instance {@link Object}
-		 */
-		Object getSchemaId();
-
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
@@ -29,6 +29,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
@@ -59,6 +60,11 @@ public class RegistryAvroDeserializationSchemaTest {
 				public Schema readSchema(InputStream in) {
 					return Address.getClassSchema();
 				}
+
+				@Override
+				public byte[] writeSchema(Class recordClazz, ByteArrayOutputStream out) {
+					return new byte[0];
+				}
 			}
 		);
 
@@ -86,7 +92,17 @@ public class RegistryAvroDeserializationSchemaTest {
 		RegistryAvroDeserializationSchema<SimpleRecord> deserializer = new RegistryAvroDeserializationSchema<>(
 			SimpleRecord.class,
 			null,
-			() -> in -> smallerUserSchema
+			() -> new SchemaCoder() {
+				@Override
+				public Schema readSchema(InputStream in) {
+					return smallerUserSchema;
+				}
+
+				@Override
+				public byte[] writeSchema(Class recordClazz, ByteArrayOutputStream out) {
+					return new byte[0];
+				}
+			}
 		);
 
 		GenericData.Record smallUser = new GenericRecordBuilder(smallerUserSchema)


### PR DESCRIPTION
## What is the purpose of the change

Provides implementation of AvroSerializationSchema that write records serialized as avro and also provides version that uses Confluent Schema Registry to write the record.

This is following AvroDESerializationSchema implementation patterns to have a consistent code base for Ser/Des.

## Brief change log

- Implemented AvroSerializationSchema / RegistryAvroSerializationSchema / ConfluentRegistryAvroSerializationSchema

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
