### PR TITLE
[hotfix][filesystem] Remove incorrect equals methods in StreamWriters

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/AvroKeyValueSinkWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/AvroKeyValueSinkWriter.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 
 /**
 * Implementation of AvroKeyValue writer that can be used in Sink.
@@ -204,7 +203,7 @@ public class AvroKeyValueSinkWriter<K, V> extends StreamWriterBase<Tuple2<K, V>>
 	}
 
 	@Override
-	public Writer<Tuple2<K, V>> duplicate() {
+	public AvroKeyValueSinkWriter<K, V> duplicate() {
 		return new AvroKeyValueSinkWriter<>(this);
 	}
 
@@ -335,25 +334,7 @@ public class AvroKeyValueSinkWriter<K, V> extends StreamWriterBase<Tuple2<K, V>>
 		}
 	}
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), properties);
-	}
-
-	@Override
-	public boolean equals(Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (other == null) {
-			return false;
-		}
-		if (getClass() != other.getClass()) {
-			return false;
-		}
-		AvroKeyValueSinkWriter<K, V> writer = (AvroKeyValueSinkWriter<K, V>) other;
-		// field comparison
-		return Objects.equals(properties, writer.properties)
-			&& super.equals(other);
+	Map<String, String> getProperties() {
+		return properties;
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriter.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * A {@link Writer} that writes the bucket files as Hadoop {@link SequenceFile SequenceFiles}.
@@ -152,32 +151,23 @@ public class SequenceFileWriter<K extends Writable, V extends Writable> extends 
 	}
 
 	@Override
-	public Writer<Tuple2<K, V>> duplicate() {
+	public SequenceFileWriter<K, V> duplicate() {
 		return new SequenceFileWriter<>(this);
 	}
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), compressionCodecName, compressionType, keyClass, valueClass);
+	String getCompressionCodecName() {
+		return compressionCodecName;
 	}
 
-	@Override
-	public boolean equals(Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (other == null) {
-			return false;
-		}
-		if (getClass() != other.getClass()) {
-			return false;
-		}
-		SequenceFileWriter<K, V> writer = (SequenceFileWriter<K, V>) other;
-		// field comparison
-		return Objects.equals(compressionCodecName, writer.compressionCodecName)
-			&& Objects.equals(compressionType, writer.compressionType)
-			&& Objects.equals(keyClass, writer.keyClass)
-			&& Objects.equals(valueClass, writer.valueClass)
-			&& super.equals(other);
+	SequenceFile.CompressionType getCompressionType() {
+		return compressionType;
+	}
+
+	Class<K> getKeyClass() {
+		return keyClass;
+	}
+
+	Class<V> getValueClass() {
+		return valueClass;
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StreamWriterBase.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StreamWriterBase.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * Base class for {@link Writer Writers} that write to a {@link FSDataOutputStream}.
@@ -102,24 +101,7 @@ public abstract class StreamWriterBase<T> implements Writer<T> {
 		}
 	}
 
-	@Override
-	public int hashCode() {
-		return Boolean.hashCode(syncOnFlush);
-	}
-
-	@Override
-	public boolean equals(Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (other == null) {
-			return false;
-		}
-		if (getClass() != other.getClass()) {
-			return false;
-		}
-		StreamWriterBase<T> writer = (StreamWriterBase<T>) other;
-		// field comparison
-		return Objects.equals(syncOnFlush, writer.syncOnFlush);
+	public boolean isSyncOnFlush() {
+		return syncOnFlush;
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/StringWriter.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.Objects;
 
 /**
  * A {@link Writer} that uses {@code toString()} on the input elements and writes them to
@@ -87,29 +86,11 @@ public class StringWriter<T> extends StreamWriterBase<T> {
 	}
 
 	@Override
-	public Writer<T> duplicate() {
+	public StringWriter<T> duplicate() {
 		return new StringWriter<>(this);
 	}
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), charsetName);
-	}
-
-	@Override
-	public boolean equals(Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (other == null) {
-			return false;
-		}
-		if (getClass() != other.getClass()) {
-			return false;
-		}
-		StringWriter<T> writer = (StringWriter<T>) other;
-		// field comparison
-		return Objects.equals(charsetName, writer.charsetName)
-			&& super.equals(other);
+	String getCharsetName() {
+		return charsetName;
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/AvroKeyValueSinkWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/AvroKeyValueSinkWriterTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.streaming.connectors.fs;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileConstants;
 import org.junit.Test;
@@ -47,11 +45,11 @@ public class AvroKeyValueSinkWriterTest {
 
 		AvroKeyValueSinkWriter<String, String> writer = new AvroKeyValueSinkWriter(properties);
 		writer.setSyncOnFlush(true);
-		Writer<Tuple2<String, String>> other = writer.duplicate();
+		AvroKeyValueSinkWriter<String, String> other = writer.duplicate();
 
-		assertTrue(writer.equals(other));
+		assertTrue(StreamWriterBaseComparator.equals(writer, other));
 
 		writer.setSyncOnFlush(false);
-		assertFalse(writer.equals(other));
+		assertFalse(StreamWriterBaseComparator.equals(writer, other));
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
@@ -930,7 +930,7 @@ public class RollingSinkITCase extends TestLogger {
 		}
 
 		@Override
-		public Writer<T> duplicate() {
+		public StreamWriterWithConfigCheck<T> duplicate() {
 			return new StreamWriterWithConfigCheck<>(key, expect);
 		}
 	}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/SequenceFileWriterTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.streaming.connectors.fs;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
@@ -36,11 +34,11 @@ public class SequenceFileWriterTest {
 	public void testDuplicate() {
 		SequenceFileWriter<Text, Text> writer = new SequenceFileWriter("BZ", SequenceFile.CompressionType.BLOCK);
 		writer.setSyncOnFlush(true);
-		Writer<Tuple2<Text, Text>> other = writer.duplicate();
+		SequenceFileWriter<Text, Text> other = writer.duplicate();
 
-		assertTrue(writer.equals(other));
+		assertTrue(StreamWriterBaseComparator.equals(writer, other));
 
 		writer.setSyncOnFlush(false);
-		assertFalse(writer.equals(other));
+		assertFalse(StreamWriterBaseComparator.equals(writer, other));
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/StreamWriterBaseComparator.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/StreamWriterBaseComparator.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.fs;
+
+import org.apache.hadoop.io.Writable;
+
+import java.util.Objects;
+
+/**
+ * Helper class to perform partial comparisons of {@link StreamWriterBase} instances. During comparisons
+ * it ignores changes in underlying output streams.
+ */
+public class StreamWriterBaseComparator {
+
+	public static <T> boolean equals(
+			StreamWriterBase<T> writer1,
+			StreamWriterBase<T> writer2) {
+		return Objects.equals(writer1.isSyncOnFlush(), writer2.isSyncOnFlush());
+	}
+
+	public static <K, V> boolean equals(
+			AvroKeyValueSinkWriter<K, V> writer1,
+			AvroKeyValueSinkWriter<K, V> writer2) {
+		return equals((StreamWriterBase) writer1, (StreamWriterBase) writer2) &&
+			Objects.equals(writer1.getProperties(), writer2.getProperties());
+	}
+
+	public static <K extends Writable, V extends Writable> boolean equals(
+			SequenceFileWriter<K, V> writer1,
+			SequenceFileWriter<K, V> writer2) {
+		return equals((StreamWriterBase) writer1, (StreamWriterBase) writer2) &&
+			Objects.equals(writer1.getCompressionCodecName(), writer2.getCompressionCodecName()) &&
+			Objects.equals(writer1.getCompressionType(), writer2.getCompressionType()) &&
+			Objects.equals(writer1.getKeyClass(), writer2.getKeyClass()) &&
+			Objects.equals(writer1.getValueClass(), writer2.getValueClass());
+	}
+
+	public static <T> boolean equals(
+		StringWriter<T> writer1,
+		StringWriter<T> writer2) {
+		return equals((StreamWriterBase) writer1, (StreamWriterBase) writer2) &&
+			Objects.equals(writer1.getCharsetName(), writer2.getCharsetName());
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/StringWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/StringWriterTest.java
@@ -34,12 +34,12 @@ public class StringWriterTest {
 	public void testDuplicate() {
 		StringWriter<String> writer = new StringWriter(StandardCharsets.UTF_16.name());
 		writer.setSyncOnFlush(true);
-		Writer<String> other = writer.duplicate();
+		StringWriter<String> other = writer.duplicate();
 
-		assertTrue(writer.equals(other));
+		assertTrue(StreamWriterBaseComparator.equals(writer, other));
 
 		writer.setSyncOnFlush(false);
-		assertFalse(writer.equals(other));
-		assertFalse(writer.equals(new StringWriter<>()));
+		assertFalse(StreamWriterBaseComparator.equals(writer, other));
+		assertFalse(StreamWriterBaseComparator.equals(writer, new StringWriter<>()));
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.streaming.connectors.fs.AvroKeyValueSinkWriter;
 import org.apache.flink.streaming.connectors.fs.Clock;
 import org.apache.flink.streaming.connectors.fs.SequenceFileWriter;
 import org.apache.flink.streaming.connectors.fs.StringWriter;
-import org.apache.flink.streaming.connectors.fs.Writer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -918,7 +917,7 @@ public class BucketingSinkTest extends TestLogger {
 		}
 
 		@Override
-		public Writer<Tuple2<K, V>> duplicate() {
+		public StreamWriterWithConfigCheck<K, V> duplicate() {
 			return new StreamWriterWithConfigCheck<>(properties, key, expect);
 		}
 	}


### PR DESCRIPTION
This pull request removes incorrect equals methods in `StreamWriterBase` (and in classes that inherit from it) that were used for tests and moves their logic to test class.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
