### PR TITLE
[FLINK-9743][Client] Use correct zip/jar path separator

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -696,7 +696,9 @@ public class PackagedProgram {
 					for (int i = 0; i < containedJarFileEntries.size(); i++) {
 						final JarEntry entry = containedJarFileEntries.get(i);
 						String name = entry.getName();
-						name = name.replace(File.separatorChar, '_');
+						// '/' as in case of zip, jar
+						// java.util.zip.ZipEntry#isDirectory always looks only for '/' not for File.separator
+						name = name.replace('/', '_');
 
 						File tempFile;
 						try {

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -21,15 +21,23 @@ package org.apache.flink.client.program;
 import org.apache.flink.client.cli.CliFrontendTestUtils;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Tests for the {@link PackagedProgramTest}.
  */
 public class PackagedProgramTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Test
 	public void testGetPreviewPlan() {
@@ -54,6 +62,26 @@ public class PackagedProgramTest {
 			e.printStackTrace();
 			Assert.fail("Test is erroneous: " + e.getMessage());
 		}
+	}
+
+	/**
+	 * The test for {@link PackagedProgram#extractContainedLibraries}.
+	 * As a prerequisite the test generates a jar file with the following structure
+	 * test.jar
+	 * |- lib
+	 * |--|- internalTest.jar
+	 */
+	@Test
+	public void testExtractContainedLibraries() throws Exception {
+		String s = "testExtractContainedLibraries";
+		File fakeJar = temporaryFolder.newFile("test.jar");
+		try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(fakeJar))) {
+			ZipEntry entry = new ZipEntry("lib/internalTest.jar");
+			zos.putNextEntry(entry);
+			zos.write(s.getBytes());
+			zos.closeEntry();
+		}
+		PackagedProgram.extractContainedLibraries(fakeJar.toURI().toURL());
 	}
 
 	private static final class NullOutputStream extends java.io.OutputStream {


### PR DESCRIPTION
## What is the purpose of the change

*This PR resolves libraries extraction issue from jars*

## Brief change log

  - *Always in case of zip/jar use '/' path separator*
  - *Test with generated jar emulating the real case*

## Verifying this change
  - Added test generates fake jar with a structure
        test.jar
	 |- lib
	 |--|- internalTest.jar 
    and then calls for `PackagedProgram#extractContainedLibraries` to check if it extracts internalTest.jar correctly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
