### PR TITLE
[FLINK-9765] [sql-client] Improve CLI responsiveness when cluster is not reachable

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
@@ -217,15 +217,7 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
 
 	@Override
 	protected void cleanUp() {
-		// stop retrieval
 		stopRetrieval();
-
-		// cancel table program
-		try {
-			client.getExecutor().cancelQuery(client.getContext(), resultDescriptor.getResultId());
-		} catch (SqlExecutionException e) {
-			// ignore further exceptions
-		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -284,6 +276,15 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
 				if (CliResultView.this.isRunning()) {
 					display();
 				}
+			}
+
+			// cancel table program
+			try {
+				// the cancellation happens in the refresh thread in order to keep the main thread
+				// responsive at all times; esp. if the cluster is not available
+				client.getExecutor().cancelQuery(client.getContext(), resultDescriptor.getResultId());
+			} catch (SqlExecutionException e) {
+				// ignore further exceptions
 			}
 		}
 	}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -57,7 +57,7 @@ public interface Executor {
 	String explainStatement(SessionContext session, String statement) throws SqlExecutionException;
 
 	/**
-	 * Submits a Flink job (detached) and returns the result descriptor.
+	 * Submits a Flink job (detached/non-blocking) and returns the result descriptor.
 	 */
 	ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException;
 
@@ -78,7 +78,8 @@ public interface Executor {
 	List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException;
 
 	/**
-	 * Cancels a table program and stops the result retrieval.
+	 * Cancels a table program and stops the result retrieval. Blocking until cancellation command has
+	 * been sent to cluster.
 	 */
 	void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException;
 


### PR DESCRIPTION
## What is the purpose of the change

Moves the job cancellation into the final phase of the refresh thread in order to keep the CLI responsive. The result of the cancellation is not used anyway.

## Brief change log

Moves the job cancellation into the phase of the refresh thread

## Verifying this change

Manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
