### PR TITLE
[FLINK-9682] Add setDescription to execution environment and provide description field for the rest api

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -55,8 +55,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan p = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
+		Plan p = createProgramPlan(jobName, jobDescription);
 		JobWithJars toRun = new JobWithJars(p, this.jarFilesToAttach, this.classpathsToAttach,
 				this.userCodeClassLoader);
 		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointSettings).getJobExecutionResult();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
@@ -53,8 +53,8 @@ public class DetachedEnvironment extends ContextEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan p = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
+		Plan p = createProgramPlan(jobName, jobDescription);
 		setDetachedPlan(ClusterClient.getOptimizedPlan(client.compiler, p, getParallelism()));
 		LOG.warn("Job was executed in detached mode, the results will be available on completion.");
 		this.lastJobExecutionResult = DetachedJobExecutionResult.INSTANCE;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -46,7 +46,7 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		Plan plan = createProgramPlan(jobName);
 		this.optimizerPlan = compiler.compile(plan);
 
@@ -56,7 +56,7 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan plan = createProgramPlan(null, false);
+		Plan plan = createProgramPlan(null, null, false);
 		this.optimizerPlan = compiler.compile(plan);
 
 		// do not go on with anything now!

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
@@ -39,8 +39,8 @@ public final class PreviewPlanEnvironment extends ExecutionEnvironment {
 	Plan plan;
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		this.plan = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
+		this.plan = createProgramPlan(jobName, jobDescription);
 		this.previewPlan = Optimizer.createPreOptimizedPlan(plan);
 
 		// do not go on with anything now!

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -322,8 +322,8 @@ public class ClusterClientTest extends TestLogger {
 
 		@Override
 		public MultipleJobsDetails process(RequestJobDetails message) {
-			JobDetails running = new JobDetails(new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[9], 0);
-			JobDetails finished = new JobDetails(new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0);
+			JobDetails running = new JobDetails(new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[9], 0, "job1 description");
+			JobDetails finished = new JobDetails(new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0, "job2 description");
 			return new MultipleJobsDetails(Arrays.asList(running, finished));
 		}
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -842,8 +842,8 @@ public class RestClusterClientTest extends TestLogger {
 
 		@Override
 		protected CompletableFuture<MultipleJobsDetails> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
-			JobDetails running = new JobDetails(new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[9], 0);
-			JobDetails finished = new JobDetails(new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0);
+			JobDetails running = new JobDetails(new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[9], 0, "job1 description");
+			JobDetails finished = new JobDetails(new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0, "job2 description");
 			return CompletableFuture.completedFuture(new MultipleJobsDetails(Arrays.asList(running, finished)));
 		}
 	}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
@@ -184,7 +184,7 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 	private static class StreamExecutionEnvironmentMock extends StreamExecutionEnvironment {
 
 		@Override
-		public JobExecutionResult execute(String jobName) {
+		public JobExecutionResult execute(String jobName, String jobDescription) {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -239,7 +239,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		}
 
 		@Override
-		public JobExecutionResult execute(String jobName) {
+		public JobExecutionResult execute(String jobName, String jobDescription) {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
@@ -220,7 +220,7 @@ public class DataGenerators {
 		private static class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
 
 			@Override
-			public JobExecutionResult execute(String jobName) throws Exception {
+			public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 				return null;
 			}
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -105,8 +105,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 */
 	private int maxParallelism = -1;
 
-	private String description;
-
 	/**
 	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
 	 */

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -105,6 +105,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 */
 	private int maxParallelism = -1;
 
+	private String description;
+
 	/**
 	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
 	 */

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -55,6 +55,9 @@ public class Plan implements Visitable<Operator<?>> {
 	/** The name of the job. */
 	protected String jobName;
 
+	/** The description of the job. */
+	protected String jobDescription;
+
 	/** The default parallelism to use for nodes that have no explicitly specified parallelism. */
 	protected int defaultParallelism = ExecutionConfig.PARALLELISM_DEFAULT;
 	
@@ -77,12 +80,13 @@ public class Plan implements Visitable<Operator<?>> {
 	 * 
 	 * <p>If not all of the sinks of a data flow are given to the plan, the flow might
 	 * not be translated entirely.</p>
-	 *  
+	 *
 	 * @param sinks The collection will the sinks of the job's data flow.
 	 * @param jobName The name to display for the job.
+	 * @param jobDescription The description to display for the job.
 	 */
-	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks, String jobName) {
-		this(sinks, jobName, ExecutionConfig.PARALLELISM_DEFAULT);
+	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks, String jobName, String jobDescription) {
+		this(sinks, jobName, ExecutionConfig.PARALLELISM_DEFAULT, jobDescription);
 	}
 
 	/**
@@ -95,10 +99,12 @@ public class Plan implements Visitable<Operator<?>> {
 	 * @param sinks The collection will the sinks of the job's data flow.
 	 * @param jobName The name to display for the job.
 	 * @param defaultParallelism The default parallelism for the job.
+	 * @param jobDescription The description to display for the job.
 	 */
-	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks, String jobName, int defaultParallelism) {
+	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks, String jobName, int defaultParallelism, String jobDescription) {
 		this.sinks.addAll(sinks);
 		this.jobName = jobName;
+		this.jobDescription = jobDescription;
 		this.defaultParallelism = defaultParallelism;
 	}
 
@@ -108,12 +114,13 @@ public class Plan implements Visitable<Operator<?>> {
 	 * If not all of the sinks of a data flow are given, the flow might
 	 * not be translated entirely, but only the parts of the flow reachable by traversing backwards
 	 * from the given data sinks.
-	 * 
+	 *
 	 * @param sink The data sink of the data flow.
 	 * @param jobName The name to display for the job.
+	 * @param jobDescription The description to display for the job.
 	 */
-	public Plan(GenericDataSinkBase<?> sink, String jobName) {
-		this(sink, jobName, ExecutionConfig.PARALLELISM_DEFAULT);
+	public Plan(GenericDataSinkBase<?> sink, String jobName, String jobDescription) {
+		this(sink, jobName, ExecutionConfig.PARALLELISM_DEFAULT, jobDescription);
 	}
 
 	/**
@@ -127,9 +134,10 @@ public class Plan implements Visitable<Operator<?>> {
 	 * @param sink The data sink of the data flow.
 	 * @param jobName The name to display for the job.
 	 * @param defaultParallelism The default parallelism for the job.
+	 * @param jobDescription The description for the job.
 	 */
-	public Plan(GenericDataSinkBase<?> sink, String jobName, int defaultParallelism) {
-		this(Collections.<GenericDataSinkBase<?>>singletonList(sink), jobName, defaultParallelism);
+	public Plan(GenericDataSinkBase<?> sink, String jobName, int defaultParallelism, String jobDescription) {
+		this(Collections.<GenericDataSinkBase<?>>singletonList(sink), jobName, defaultParallelism, jobDescription);
 	}
 
 	/**
@@ -158,7 +166,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 * @param defaultParallelism The default parallelism for the job.
 	 */
 	public Plan(Collection<? extends GenericDataSinkBase<?>> sinks, int defaultParallelism) {
-		this(sinks, "Flink Job at " + Calendar.getInstance().getTime(), defaultParallelism);
+		this(sinks, "Flink Job at " + Calendar.getInstance().getTime(), defaultParallelism, "");
 	}
 
 	/**
@@ -185,7 +193,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 * @param defaultParallelism The default parallelism for the job.
 	 */
 	public Plan(GenericDataSinkBase<?> sink, int defaultParallelism) {
-		this(sink, "Flink Job at " + Calendar.getInstance().getTime(), defaultParallelism);
+		this(sink, "Flink Job at " + Calendar.getInstance().getTime(), defaultParallelism, "");
 	}
 
 	// ------------------------------------------------------------------------
@@ -229,6 +237,24 @@ public class Plan implements Visitable<Operator<?>> {
 	public void setJobName(String jobName) {
 		checkNotNull(jobName, "The job name must not be null.");
 		this.jobName = jobName;
+	}
+
+	/**
+	 * Gets the description of this plan.
+	 *
+	 * @return The description of the plan.
+	 */
+	public String getJobDescription() {
+		return jobDescription;
+	}
+
+	/**
+	 * Sets the jobDescription for this Plan.
+	 *
+	 * @param jobDescription The jobDescription to set.
+	 */
+	public void setJobDescription(String jobDescription) {
+		this.jobDescription = jobDescription;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -254,7 +254,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 * @param jobDescription The jobDescription to set.
 	 */
 	public void setJobDescription(String jobDescription) {
-		this.jobDescription = jobDescription;
+		this.jobDescription = checkNotNull(jobDescription);
 	}
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -31,7 +31,7 @@ public class CollectionEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
-		Plan p = createProgramPlan(jobName);
+		Plan p = createProgramPlan(jobName, jobDescription);
 
 		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
 		CollectionExecutor exec = new CollectionExecutor(getConfig());

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -30,7 +30,7 @@ import org.apache.flink.api.common.operators.CollectionExecutor;
 public class CollectionEnvironment extends ExecutionEnvironment {
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		Plan p = createProgramPlan(jobName);
 
 		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -77,6 +77,11 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		return super.execute(jobName);
+	}
+
+	@Override
 	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		if (executor == null) {
 			startNewSession();

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -77,12 +77,12 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		if (executor == null) {
 			startNewSession();
 		}
 
-		Plan p = createProgramPlan(jobName);
+		Plan p = createProgramPlan(jobName, jobDescription);
 
 		// Session management is disabled, revert this commit to enable
 		//p.setJobId(jobID);
@@ -96,7 +96,7 @@ public class LocalEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan(null, false);
+		Plan p = createProgramPlan(null, null, false);
 
 		// make sure that we do not start an executor in any case here.
 		// if one runs, fine, of not, we only create the class but disregard immediately afterwards

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -161,10 +161,10 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		PlanExecutor executor = getExecutor();
 
-		Plan p = createProgramPlan(jobName);
+		Plan p = createProgramPlan(jobName, jobDescription);
 
 		// Session management is disabled, revert this commit to enable
 		//p.setJobId(jobID);
@@ -178,7 +178,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan("plan", false);
+		Plan p = createProgramPlan("plan", "", false);
 
 		// make sure that we do not start an new executor here
 		// if one runs, fine, of not, we create a local executor (lightweight) and let it

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -161,6 +161,11 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	// ------------------------------------------------------------------------
 
 	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		return super.execute(jobName);
+	}
+
+	@Override
 	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		PlanExecutor executor = getExecutor();
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/OperatorTranslation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/OperatorTranslation.java
@@ -45,7 +45,7 @@ public class OperatorTranslation {
 	/** The already translated operations. */
 	private Map<DataSet<?>, Operator<?>> translated = new HashMap<>();
 
-	public Plan translateToPlan(List<DataSink<?>> sinks, String jobName) {
+	public Plan translateToPlan(List<DataSink<?>> sinks, String jobName, String jobDescription) {
 		List<GenericDataSinkBase<?>> planSinks = new ArrayList<>();
 
 		for (DataSink<?> sink : sinks) {
@@ -54,6 +54,7 @@ public class OperatorTranslation {
 
 		Plan p = new Plan(planSinks);
 		p.setJobName(jobName);
+		p.setJobDescription(jobDescription);
 		return p;
 	}
 

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -89,7 +89,7 @@ public class JMXJobManagerMetricTest extends TestLogger {
 			JobVertex sourceJobVertex = new JobVertex("Source");
 			sourceJobVertex.setInvokableClass(BlockingInvokable.class);
 
-			JobGraph jobGraph = new JobGraph("TestingJob", sourceJobVertex);
+			JobGraph jobGraph = new JobGraph("TestingJob", "", sourceJobVertex);
 			jobGraph.setSnapshotSettings(new JobCheckpointingSettings(
 				Collections.<JobVertexID>emptyList(),
 				Collections.<JobVertexID>emptyList(),

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
@@ -517,7 +517,7 @@ public class Optimizer {
 		}
 
 		// finalize the plan
-		OptimizedPlan plan = new PlanFinalizer().createFinalPlan(bestPlanSinks, program.getJobName(), program);
+		OptimizedPlan plan = new PlanFinalizer().createFinalPlan(bestPlanSinks, program.getJobName(), program, program.getJobDescription());
 		
 		plan.accept(new BinaryUnionReplacer());
 

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
@@ -517,7 +517,7 @@ public class Optimizer {
 		}
 
 		// finalize the plan
-		OptimizedPlan plan = new PlanFinalizer().createFinalPlan(bestPlanSinks, program.getJobName(), program, program.getJobDescription());
+		OptimizedPlan plan = new PlanFinalizer().createFinalPlan(bestPlanSinks, program);
 		
 		plan.accept(new BinaryUnionReplacer());
 

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/OptimizedPlan.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/OptimizedPlan.java
@@ -46,25 +46,20 @@ public class OptimizedPlan implements FlinkPlan, Visitable<PlanNode>  {
 	/** The original program (as a dataflow plan). */
 	private final Plan originalProgram;
 
-	/** Name of the job */
-	private final String jobName;
-
 	/**
 	 * Creates a new instance of this optimizer plan container. The plan is given and fully
 	 * described by the data sources, sinks and the collection of all nodes.
-	 * 
+	 *
 	 * @param sources The data sources.
 	 * @param sinks The data sinks.
 	 * @param allNodes A collection containing all nodes in the plan.
-	 * @param jobName The name of the program
 	 */
 	public OptimizedPlan(Collection<SourcePlanNode> sources, Collection<SinkPlanNode> sinks,
-			Collection<PlanNode> allNodes, String jobName, Plan programPlan)
+						 Collection<PlanNode> allNodes, Plan programPlan)
 	{
 		this.dataSources = sources;
 		this.dataSinks = sinks;
 		this.allNodes = allNodes;
-		this.jobName = jobName;
 		this.originalProgram = programPlan;
 	}
 
@@ -101,9 +96,18 @@ public class OptimizedPlan implements FlinkPlan, Visitable<PlanNode>  {
 	 * @return The name of the program.
 	 */
 	public String getJobName() {
-		return this.jobName;
+		return getOriginalPlan().getJobName();
 	}
-	
+
+	/**
+	 * Returns the description of the program.
+	 *
+	 * @return The description of the program.
+	 */
+	public String getJobDescription() {
+		return getOriginalPlan().getJobDescription();
+	}
+
 	/**
 	 * Gets the original program's dataflow plan from which this optimized plan was created.
 	 * 

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/OptimizedPlan.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/OptimizedPlan.java
@@ -55,7 +55,7 @@ public class OptimizedPlan implements FlinkPlan, Visitable<PlanNode>  {
 	 * @param allNodes A collection containing all nodes in the plan.
 	 */
 	public OptimizedPlan(Collection<SourcePlanNode> sources, Collection<SinkPlanNode> sinks,
-						 Collection<PlanNode> allNodes, Plan programPlan)
+			Collection<PlanNode> allNodes, Plan programPlan)
 	{
 		this.dataSources = sources;
 		this.dataSinks = sinks;

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -232,7 +232,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		// ----------- finalize the job graph -----------
 
 		// create the job graph object
-		JobGraph graph = new JobGraph(jobId, program.getJobName());
+		JobGraph graph = new JobGraph(jobId, program.getJobName(), program.getJobDescription());
 		try {
 			graph.setExecutionConfig(program.getOriginalPlan().getExecutionConfig());
 		}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/PlanFinalizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/PlanFinalizer.java
@@ -76,7 +76,7 @@ public class PlanFinalizer implements Visitor<PlanNode> {
 		this.stackOfIterationNodes = new ArrayDeque<IterationPlanNode>();
 	}
 
-	public OptimizedPlan createFinalPlan(List<SinkPlanNode> sinks, String jobName, Plan originalPlan) {
+	public OptimizedPlan createFinalPlan(List<SinkPlanNode> sinks, String jobName, Plan originalPlan, String jobDescription) {
 		this.memoryConsumerWeights = 0;
 
 		// traverse the graph
@@ -119,7 +119,7 @@ public class PlanFinalizer implements Visitor<PlanNode> {
 				}
 			}
 		}
-		return new OptimizedPlan(this.sources, this.sinks, this.allNodes, jobName, originalPlan);
+		return new OptimizedPlan(this.sources, this.sinks, this.allNodes, originalPlan);
 	}
 
 	@Override

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/PlanFinalizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/PlanFinalizer.java
@@ -76,7 +76,7 @@ public class PlanFinalizer implements Visitor<PlanNode> {
 		this.stackOfIterationNodes = new ArrayDeque<IterationPlanNode>();
 	}
 
-	public OptimizedPlan createFinalPlan(List<SinkPlanNode> sinks, String jobName, Plan originalPlan, String jobDescription) {
+	public OptimizedPlan createFinalPlan(List<SinkPlanNode> sinks, Plan originalPlan) {
 		this.memoryConsumerWeights = 0;
 
 		// traverse the graph

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -240,6 +240,10 @@ class HistoryServerArchiveFetcher {
 
 		JobID jobId = JobID.fromHexString(job.get("jid").asText());
 		String name = job.get("name").asText();
+		String description = "";
+		if (job.get("description") != null) {
+			description = job.get("description").asText();
+		}
 		JobStatus state = JobStatus.valueOf(job.get("state").asText());
 
 		long startTime = job.get("start-time").asLong();
@@ -266,7 +270,7 @@ class HistoryServerArchiveFetcher {
 		tasksPerState[ExecutionState.CANCELED.ordinal()] = canceled;
 		tasksPerState[ExecutionState.FAILED.ordinal()] = failed;
 
-		JobDetails jobDetails = new JobDetails(jobId, name, startTime, endTime, duration, state, lastMod, tasksPerState, numTasks);
+		JobDetails jobDetails = new JobDetails(jobId, name, startTime, endTime, duration, state, lastMod, tasksPerState, numTasks, description);
 		MultipleJobsDetails multipleJobsDetails = new MultipleJobsDetails(Collections.singleton(jobDetails));
 
 		StringWriter sw = new StringWriter();

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -257,7 +257,7 @@ public class WebFrontendITCase extends TestLogger {
 		sender.setParallelism(2);
 		sender.setInvokableClass(BlockingInvokable.class);
 
-		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", sender);
+		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", "", sender);
 		final JobID jid = jobGraph.getJobID();
 
 		ClusterClient<?> clusterClient = CLUSTER.getClusterClient();
@@ -316,7 +316,7 @@ public class WebFrontendITCase extends TestLogger {
 		sender.setParallelism(2);
 		sender.setInvokableClass(BlockingInvokable.class);
 
-		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", sender);
+		final JobGraph jobGraph = new JobGraph("Stoppable streaming test job", "", sender);
 		final JobID jid = jobGraph.getJobID();
 
 		ClusterClient<?> clusterClient = CLUSTER.getClusterClient();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -58,6 +58,13 @@ public interface AccessExecutionGraph {
 	String getJobName();
 
 	/**
+	 * Returns the job description for the execution graph.
+	 *
+	 * @return job description for the execution graph
+	 */
+	String getJobDescription();
+
+	/**
 	 * Returns the current {@link JobStatus} for this execution graph.
 	 *
 	 * @return job status for this execution graph

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -54,6 +54,10 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 	/** The name of the original job graph. */
 	private final String jobName;
 
+	/** The description of the original job graph */
+	@Nullable
+	private final String jobDescription;
+
 	/** All job vertices that are part of this graph. */
 	private final Map<JobVertexID, ArchivedExecutionJobVertex> tasks;
 
@@ -109,7 +113,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 			ArchivedExecutionConfig executionConfig,
 			boolean isStoppable,
 			@Nullable CheckpointCoordinatorConfiguration jobCheckpointingConfiguration,
-			@Nullable CheckpointStatsSnapshot checkpointStatsSnapshot) {
+			@Nullable CheckpointStatsSnapshot checkpointStatsSnapshot,
+			@Nullable String jobDescription) {
 
 		this.jobID = Preconditions.checkNotNull(jobID);
 		this.jobName = Preconditions.checkNotNull(jobName);
@@ -125,6 +130,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 		this.isStoppable = isStoppable;
 		this.jobCheckpointingConfiguration = jobCheckpointingConfiguration;
 		this.checkpointStatsSnapshot = checkpointStatsSnapshot;
+		this.jobDescription = jobDescription;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -142,6 +148,12 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 	@Override
 	public String getJobName() {
 		return jobName;
+	}
+
+	@Override
+	@Nullable
+	public String getJobDescription() {
+		return jobDescription;
 	}
 
 	@Override
@@ -337,6 +349,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 			executionGraph.getArchivedExecutionConfig(),
 			executionGraph.isStoppable(),
 			executionGraph.getCheckpointCoordinatorConfiguration(),
-			executionGraph.getCheckpointStatsSnapshot());
+			executionGraph.getCheckpointStatsSnapshot(),
+			executionGraph.getJobDescription());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -310,7 +310,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			SerializedValue<ExecutionConfig> serializedConfig,
 			Time timeout,
 			RestartStrategy restartStrategy,
-			SlotProvider slotProvider) throws IOException {
+			SlotProvider slotProvider,
+			String jobDescription) throws IOException {
 
 		this(
 			new JobInformation(
@@ -319,7 +320,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				serializedConfig,
 				jobConfig,
 				Collections.emptyList(),
-				Collections.emptyList()),
+				Collections.emptyList(),
+				jobDescription),
 			futureExecutor,
 			ioExecutor,
 			timeout,
@@ -625,6 +627,11 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	@Override
 	public String getJobName() {
 		return jobInformation.getJobName();
+	}
+
+	@Override
+	public String getJobDescription() {
+		return jobInformation.getJobDescription();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -143,6 +143,7 @@ public class ExecutionGraphBuilder {
 
 		final String jobName = jobGraph.getName();
 		final JobID jobId = jobGraph.getJobID();
+		final String jobDescription = jobGraph.getDescription();
 
 		final FailoverStrategy.Factory failoverStrategy =
 				FailoverStrategyLoader.loadFailoverStrategy(jobManagerConfig, log);
@@ -153,7 +154,8 @@ public class ExecutionGraphBuilder {
 			jobGraph.getSerializedExecutionConfig(),
 			jobGraph.getJobConfiguration(),
 			jobGraph.getUserJarBlobKeys(),
-			jobGraph.getClasspaths());
+			jobGraph.getClasspaths(),
+			jobDescription);
 
 		// create a new execution graph, if none exists so far
 		final ExecutionGraph executionGraph;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
@@ -42,6 +42,9 @@ public class JobInformation implements Serializable {
 	/** Job name */
 	private final String jobName;
 
+	/** Job description */
+	private final String jobDescription;
+
 	/** Serialized execution config because it can contain user code classes */
 	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
 
@@ -61,13 +64,15 @@ public class JobInformation implements Serializable {
 			SerializedValue<ExecutionConfig> serializedExecutionConfig,
 			Configuration jobConfiguration,
 			Collection<PermanentBlobKey> requiredJarFileBlobKeys,
-			Collection<URL> requiredClasspathURLs) {
+			Collection<URL> requiredClasspathURLs,
+			String jobDescription) {
 		this.jobId = Preconditions.checkNotNull(jobId);
 		this.jobName = Preconditions.checkNotNull(jobName);
 		this.serializedExecutionConfig = Preconditions.checkNotNull(serializedExecutionConfig);
 		this.jobConfiguration = Preconditions.checkNotNull(jobConfiguration);
 		this.requiredJarFileBlobKeys = Preconditions.checkNotNull(requiredJarFileBlobKeys);
 		this.requiredClasspathURLs = Preconditions.checkNotNull(requiredClasspathURLs);
+		this.jobDescription = Preconditions.checkNotNull(jobDescription);
 	}
 
 	public JobID getJobId() {
@@ -92,6 +97,10 @@ public class JobInformation implements Serializable {
 
 	public Collection<URL> getRequiredClasspathURLs() {
 		return requiredClasspathURLs;
+	}
+
+	public String getJobDescription() {
+		return jobDescription;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -73,6 +73,9 @@ public class JobGraph implements Serializable {
 	/** Name of this job. */
 	private final String jobName;
 
+	/** Description of this job */
+	private String jobDescription;
+
 	/** The number of seconds after which the corresponding ExecutionGraph is removed at the
 	 * job manager after it has been executed. */
 	private long sessionTimeout = 0;
@@ -117,7 +120,18 @@ public class JobGraph implements Serializable {
 	 * @param jobName The name of the job.
 	 */
 	public JobGraph(String jobName) {
-		this(null, jobName);
+		this(null, jobName, "");
+	}
+
+	/**
+	 * Constructs a new job graph with the given name, the given {@link ExecutionConfig},
+	 * and a random job ID. The ExecutionConfig will be serialized and can't be modified afterwards.
+	 *
+	 * @param jobName The name of the job.
+	 * @param jobDescription The name of the job.
+	 */
+	public JobGraph(String jobName, String jobDescription) {
+		this(null, jobName, jobDescription);
 	}
 
 	/**
@@ -127,10 +141,12 @@ public class JobGraph implements Serializable {
 	 *
 	 * @param jobId The id of the job. A random ID is generated, if {@code null} is passed.
 	 * @param jobName The name of the job.
+	 * @param jobDescription The description of the job.
 	 */
-	public JobGraph(JobID jobId, String jobName) {
+	public JobGraph(JobID jobId, String jobName, String jobDescription) {
 		this.jobID = jobId == null ? new JobID() : jobId;
 		this.jobName = jobName == null ? "(unnamed job)" : jobName;
+		this.jobDescription = jobDescription == null ? "" : jobDescription;
 
 		try {
 			setExecutionConfig(new ExecutionConfig());
@@ -147,7 +163,7 @@ public class JobGraph implements Serializable {
 	 * @param vertices The vertices to add to the graph.
 	 */
 	public JobGraph(JobVertex... vertices) {
-		this(null, vertices);
+		this(null, null, vertices);
 	}
 
 	/**
@@ -155,10 +171,11 @@ public class JobGraph implements Serializable {
 	 * and the given job vertices. The ExecutionConfig will be serialized and can't be modified afterwards.
 	 *
 	 * @param jobName The name of the job.
+	 * @param jobDescription The description of the job.
 	 * @param vertices The vertices to add to the graph.
 	 */
-	public JobGraph(String jobName, JobVertex... vertices) {
-		this(null, jobName, vertices);
+	public JobGraph(String jobName, String jobDescription, JobVertex... vertices) {
+		this(null, jobName, jobDescription, vertices);
 	}
 
 	/**
@@ -168,10 +185,11 @@ public class JobGraph implements Serializable {
 	 *
 	 * @param jobId The id of the job. A random ID is generated, if {@code null} is passed.
 	 * @param jobName The name of the job.
+	 * @param jobDescription the description of the job.
 	 * @param vertices The vertices to add to the graph.
 	 */
-	public JobGraph(JobID jobId, String jobName, JobVertex... vertices) {
-		this(jobId, jobName);
+	public JobGraph(JobID jobId, String jobName, String jobDescription, JobVertex... vertices) {
+		this(jobId, jobName, jobDescription);
 
 		for (JobVertex vertex : vertices) {
 			addVertex(vertex);
@@ -196,6 +214,15 @@ public class JobGraph implements Serializable {
 	 */
 	public String getName() {
 		return this.jobName;
+	}
+
+	/**
+	 * Returns the description assigned to the job graph.
+	 *
+	 * @return the description assigned to the job graph
+	 */
+	public String getDescription() {
+		return jobDescription;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
@@ -50,6 +50,7 @@ public class JobDetails implements Serializable {
 
 	private static final String FIELD_NAME_JOB_ID = "jid";
 	private static final String FIELD_NAME_JOB_NAME = "name";
+	private static final String FIELD_NAME_JOB_DESCRIPTION = "description";
 	private static final String FIELD_NAME_START_TIME = "start-time";
 	private static final String FIELD_NAME_END_TIME = "end-time";
 	private static final String FIELD_NAME_DURATION = "duration";
@@ -60,6 +61,8 @@ public class JobDetails implements Serializable {
 	private final JobID jobId;
 
 	private final String jobName;
+
+	private final String jobDescription;
 
 	private final long startTime;
 
@@ -84,7 +87,8 @@ public class JobDetails implements Serializable {
 			JobStatus status,
 			long lastUpdateTime,
 			int[] tasksPerState,
-			int numTasks) {
+			int numTasks,
+			String jobDescription) {
 
 		this.jobId = checkNotNull(jobId);
 		this.jobName = checkNotNull(jobName);
@@ -97,6 +101,7 @@ public class JobDetails implements Serializable {
 			"tasksPerState argument must be of size {}.", ExecutionState.values().length);
 		this.tasksPerState = checkNotNull(tasksPerState);
 		this.numTasks = numTasks;
+		this.jobDescription = checkNotNull(jobDescription);
 	}
 	
 	// ------------------------------------------------------------------------
@@ -135,6 +140,10 @@ public class JobDetails implements Serializable {
 
 	public int[] getTasksPerState() {
 		return tasksPerState;
+	}
+
+	public String getJobDescription() {
+		return jobDescription;
 	}
 
 	// ------------------------------------------------------------------------
@@ -185,6 +194,7 @@ public class JobDetails implements Serializable {
 				", lastUpdateTime=" + lastUpdateTime +
 				", numVerticesPerExecutionState=" + Arrays.toString(tasksPerState) +
 				", numTasks=" + numTasks +
+				", jobDescription=" + jobDescription +
 				'}';
 	}
 
@@ -204,6 +214,7 @@ public class JobDetails implements Serializable {
 
 			jsonGenerator.writeStringField(FIELD_NAME_JOB_ID, jobDetails.getJobId().toString());
 			jsonGenerator.writeStringField(FIELD_NAME_JOB_NAME, jobDetails.getJobName());
+			jsonGenerator.writeStringField(FIELD_NAME_JOB_DESCRIPTION, jobDetails.getJobDescription());
 			jsonGenerator.writeStringField(FIELD_NAME_STATUS, jobDetails.getStatus().name());
 
 			jsonGenerator.writeNumberField(FIELD_NAME_START_TIME, jobDetails.getStartTime());
@@ -241,6 +252,7 @@ public class JobDetails implements Serializable {
 
 			JobID jobId = JobID.fromHexString(rootNode.get(FIELD_NAME_JOB_ID).textValue());
 			String jobName = rootNode.get(FIELD_NAME_JOB_NAME).textValue();
+			String jobDescription = rootNode.get(FIELD_NAME_JOB_DESCRIPTION).textValue();
 			long startTime = rootNode.get(FIELD_NAME_START_TIME).longValue();
 			long endTime = rootNode.get(FIELD_NAME_END_TIME).longValue();
 			long duration = rootNode.get(FIELD_NAME_DURATION).longValue();
@@ -265,7 +277,8 @@ public class JobDetails implements Serializable {
 				jobStatus,
 				lastUpdateTime,
 				numVerticesPerExecutionState,
-				numTasks);
+				numTasks,
+				jobDescription);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
@@ -328,7 +328,8 @@ public final class WebMonitorUtils {
 			status,
 			lastChanged,
 			countsPerStatus,
-			numTotalTasks);
+			numTotalTasks,
+			job.getJobDescription());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -88,7 +88,7 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 				new SerializedValue<StateBackend>(new CustomStateBackend(outOfClassPath)),
 				serHooks);
 
-		final JobGraph jobGraph = new JobGraph(new JobID(), "test job");
+		final JobGraph jobGraph = new JobGraph(new JobID(), "test job", "");
 		jobGraph.setSnapshotSettings(checkpointingSettings);
 
 		// to serialize/deserialize the job graph to see if the behavior is correct under

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
@@ -74,7 +74,7 @@ public class CoordinatorShutdownTest extends TestLogger {
 			final ExecutionConfig executionConfig = new ExecutionConfig();
 			executionConfig.setRestartStrategy(RestartStrategies.noRestart());
 
-			JobGraph testGraph = new JobGraph("test job", vertex);
+			JobGraph testGraph = new JobGraph("test job", "", vertex);
 			testGraph.setSnapshotSettings(
 				new JobCheckpointingSettings(
 					vertexIdList,
@@ -145,7 +145,7 @@ public class CoordinatorShutdownTest extends TestLogger {
 			vertex.setInvokableClass(BlockingInvokable.class);
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 
-			JobGraph testGraph = new JobGraph("test job", vertex);
+			JobGraph testGraph = new JobGraph("test job", "", vertex);
 			testGraph.setSnapshotSettings(
 				new JobCheckpointingSettings(
 					vertexIdList,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
@@ -95,7 +95,7 @@ public class JobClientActorRecoveryITCase extends TestLogger {
 		JobVertex blockingVertex = new JobVertex("Blocking Vertex");
 		blockingVertex.setInvokableClass(BlockingTask.class);
 		blockingVertex.setParallelism(1);
-		final JobGraph jobGraph = new JobGraph("Blocking Test Job", blockingVertex);
+		final JobGraph jobGraph = new JobGraph("Blocking Test Job", "", blockingVertex);
 		final Promise<JobExecutionResult> promise = new scala.concurrent.impl.Promise.DefaultPromise<>();
 
 		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -56,6 +56,7 @@ public class TaskDeploymentDescriptorTest {
 			final ExecutionAttemptID execId = new ExecutionAttemptID();
 			final AllocationID allocationId = new AllocationID();
 			final String jobName = "job name";
+			final String jobDescription = "job description";
 			final String taskName = "task name";
 			final int numberOfKeyGroups = 1;
 			final int indexInSubtaskGroup = 0;
@@ -70,7 +71,7 @@ public class TaskDeploymentDescriptorTest {
 			final List<URL> requiredClasspaths = new ArrayList<>(0);
 			final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
 			final SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(new JobInformation(
-				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths));
+				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths, jobDescription));
 			final SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(new TaskInformation(
 				vertexID, taskName, currentNumberOfSubtasks, numberOfKeyGroups, invokableClass.getName(), taskConfiguration));
 			final int targetSlotNumber = 47;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -131,7 +131,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 		final JobVertex testVertex = new JobVertex("testVertex");
 		testVertex.setInvokableClass(NoOpInvokable.class);
 		jobId = new JobID();
-		jobGraph = new JobGraph(jobId, "testJob", testVertex);
+		jobGraph = new JobGraph(jobId, "testJob", "", testVertex);
 		jobGraph.setAllowQueuedScheduling(true);
 
 		configuration = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -170,7 +170,7 @@ public class DispatcherTest extends TestLogger {
 	public void setUp() throws Exception {
 		final JobVertex testVertex = new JobVertex("testVertex");
 		testVertex.setInvokableClass(NoOpInvokable.class);
-		jobGraph = new JobGraph(TEST_JOB_ID, "testJob", testVertex);
+		jobGraph = new JobGraph(TEST_JOB_ID, "testJob", "", testVertex);
 		jobGraph.setAllowQueuedScheduling(true);
 
 		fatalErrorHandler = new TestingFatalErrorHandler();
@@ -691,7 +691,7 @@ public class DispatcherTest extends TestLogger {
 	private JobGraph createFailingJobGraph(Exception failureCause) {
 		final FailingJobVertex jobVertex = new FailingJobVertex("Failing JobVertex", failureCause);
 		jobVertex.setInvokableClass(NoOpInvokable.class);
-		return new JobGraph(jobGraph.getJobID(), "Failing JobGraph", jobVertex);
+		return new JobGraph(jobGraph.getJobID(), "Failing JobGraph", "", jobVertex);
 	}
 
 	private static class FailingJobVertex extends JobVertex {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -108,7 +108,8 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 			new SerializedValue<>(config),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			mock(SlotProvider.class));
+			mock(SlotProvider.class),
+			"test job description");
 
 		runtimeGraph.attachJobGraph(vertices);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DummyJobInformation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DummyJobInformation.java
@@ -41,7 +41,8 @@ public class DummyJobInformation extends JobInformation {
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
 			Collections.emptyList(),
-			Collections.emptyList());
+			Collections.emptyList(),
+			"");
 	}
 
 	public DummyJobInformation() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -82,6 +82,7 @@ public class ExecutionGraphConstructionTest {
 		
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
+		final String jobDescription = "Test Job Sample Description";
 		final Configuration cfg = new Configuration();
 		
 		JobVertex v1 = new JobVertex("vertex1");
@@ -119,7 +120,8 @@ public class ExecutionGraphConstructionTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -135,6 +137,7 @@ public class ExecutionGraphConstructionTest {
 	public void testAttachViaDataSets() throws Exception {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
+		final String jobDescription = "Test Job Sample description";
 		final Configuration cfg = new Configuration();
 		
 		// construct part one of the execution graph
@@ -170,7 +173,8 @@ public class ExecutionGraphConstructionTest {
 				new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -212,6 +216,7 @@ public class ExecutionGraphConstructionTest {
 	public void testAttachViaIds() throws Exception {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
+		final String jobDescription = "Test Job Sample Description";
 		final Configuration cfg = new Configuration();
 		
 		// construct part one of the execution graph
@@ -246,7 +251,8 @@ public class ExecutionGraphConstructionTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -299,6 +305,7 @@ public class ExecutionGraphConstructionTest {
 	public void testCannotConnectMissingId() throws Exception {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
+		final String jobDescription = "Test Job Sample Description";
 		final Configuration cfg = new Configuration();
 		
 		// construct part one of the execution graph
@@ -317,7 +324,8 @@ public class ExecutionGraphConstructionTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -346,6 +354,7 @@ public class ExecutionGraphConstructionTest {
 	public void testCannotConnectWrongOrder() throws Exception {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
+		final String jobDescription = "Test Job Sample Description";
 		final Configuration cfg = new Configuration();
 		
 		JobVertex v1 = new JobVertex("vertex1");
@@ -383,7 +392,8 @@ public class ExecutionGraphConstructionTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 			fail("Attached wrong jobgraph");
@@ -413,6 +423,7 @@ public class ExecutionGraphConstructionTest {
 			
 			final JobID jobId = new JobID();
 			final String jobName = "Test Job Sample Name";
+			final String jobDescription = "Test Job Sample Description";
 			final Configuration cfg = new Configuration();
 			
 			JobVertex v1 = new JobVertex("vertex1");
@@ -453,7 +464,8 @@ public class ExecutionGraphConstructionTest {
 				new SerializedValue<>(new ExecutionConfig()),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy(),
-				new Scheduler(TestingUtils.defaultExecutionContext()));
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				jobDescription);
 			try {
 				eg.attachJobGraph(ordered);
 			}
@@ -476,6 +488,7 @@ public class ExecutionGraphConstructionTest {
 		try {
 			final JobID jobId = new JobID();
 			final String jobName = "Test Job Sample Name";
+			final String jobDescription = "Test Job Sample Description";
 			final Configuration cfg = new Configuration();
 			
 			JobVertex v1 = new JobVertex("vertex1");
@@ -501,7 +514,8 @@ public class ExecutionGraphConstructionTest {
 				new SerializedValue<>(new ExecutionConfig()),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy(),
-				new Scheduler(TestingUtils.defaultExecutionContext()));
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				jobDescription);
 
 			try {
 				eg.attachJobGraph(ordered);
@@ -522,6 +536,7 @@ public class ExecutionGraphConstructionTest {
 		try {
 			final JobID jobId = new JobID();
 			final String jobName = "Co-Location Constraint Sample Job";
+			final String jobDescrption = "Co-Location Constraint Sample Job";
 			final Configuration cfg = new Configuration();
 			
 			// simple group of two, cyclic
@@ -573,7 +588,7 @@ public class ExecutionGraphConstructionTest {
 			v8.setParallelism(2);
 			v8.setInvokableClass(AbstractInvokable.class);
 
-			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
+			JobGraph jg = new JobGraph(jobId, jobName, "", v1, v2, v3, v4, v5, v6, v7, v8);
 			
 			ExecutionGraph eg = new ExecutionGraph(
 				TestingUtils.defaultExecutor(),
@@ -584,7 +599,8 @@ public class ExecutionGraphConstructionTest {
 				new SerializedValue<>(new ExecutionConfig()),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy(),
-				new Scheduler(TestingUtils.defaultExecutionContext()));
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				jobDescrption);
 			
 			eg.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -682,7 +682,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		final ScheduledExecutorService executor = TestingUtils.defaultExecutor();
 
 		final JobID jobId = new JobID();
-		final JobGraph jobGraph = new JobGraph(jobId, "test");
+		final JobGraph jobGraph = new JobGraph(jobId, "test", "");
 		jobGraph.setSnapshotSettings(
 			new JobCheckpointingSettings(
 				Collections.<JobVertexID>emptyList(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -72,7 +72,7 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 			JobVertex jobVertex = new JobVertex("TestVertex");
 			jobVertex.setParallelism(parallelism);
 			jobVertex.setInvokableClass(NoOpInvokable.class);
-			JobGraph jobGraph = new JobGraph("Test Job", jobVertex);
+			JobGraph jobGraph = new JobGraph("Test Job", "", jobVertex);
 
 			Configuration jobConfig = new Configuration();
 			Time timeout = Time.seconds(10L);
@@ -93,7 +93,8 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 				new SerializedValue<>(null),
 				timeout,
 				testingRestartStrategy,
-				scheduler);
+				scheduler,
+				jobGraph.getDescription());
 
 			RestartTimeGauge restartingTime = new RestartTimeGauge(executionGraph);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -205,13 +205,14 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			AkkaUtils.getDefaultTimeout(),
 			// We want to manually control the restart and delay
 			new InfiniteDelayRestartStrategy(),
-			scheduler);
+			scheduler,
+			"TestJobDescription");
 
 		JobVertex jobVertex = new JobVertex("NoOpInvokable");
 		jobVertex.setInvokableClass(NoOpInvokable.class);
 		jobVertex.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("TestJob", jobVertex);
+		JobGraph jobGraph = new JobGraph("TestJob", "", jobVertex);
 
 		executionGraph.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -338,7 +339,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		JobVertex sender = ExecutionGraphTestUtils.createJobVertex("Task1", 1, NoOpInvokable.class);
 		JobVertex receiver = ExecutionGraphTestUtils.createJobVertex("Task2", 1, NoOpInvokable.class);
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender, receiver);
+		JobGraph jobGraph = new JobGraph("Pointwise job", "", sender, receiver);
 		ExecutionGraph eg = newExecutionGraph(new FixedDelayRestartStrategy(1, 0L), scheduler);
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -405,7 +406,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		ExecutionConfig executionConfig = new ExecutionConfig();
 		executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(
 			Integer.MAX_VALUE, Integer.MAX_VALUE));
-		JobGraph jobGraph = new JobGraph("Test Job", vertex);
+		JobGraph jobGraph = new JobGraph("Test Job", "", vertex);
 		jobGraph.setExecutionConfig(executionConfig);
 
 		ExecutionGraph eg = newExecutionGraph(new InfiniteDelayRestartStrategy(), scheduler);
@@ -451,7 +452,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		ExecutionConfig executionConfig = new ExecutionConfig();
 		executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(
 			Integer.MAX_VALUE, Integer.MAX_VALUE));
-		JobGraph jobGraph = new JobGraph("Test Job", vertex);
+		JobGraph jobGraph = new JobGraph("Test Job", "", vertex);
 		jobGraph.setExecutionConfig(executionConfig);
 
 		ExecutionGraph eg = newExecutionGraph(new InfiniteDelayRestartStrategy(), scheduler);
@@ -497,7 +498,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		sender.setInvokableClass(NoOpInvokable.class);
 		sender.setParallelism(NUM_TASKS);
 
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender);
+		JobGraph jobGraph = new JobGraph("Pointwise job", "", sender);
 
 		ControllableRestartStrategy controllableRestartStrategy = new ControllableRestartStrategy(timeout);
 
@@ -510,7 +511,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			controllableRestartStrategy,
-			scheduler);
+			scheduler,
+			"Test job description");
 
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -947,7 +949,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	private static JobGraph createJobGraph(int parallelism) {
 		JobVertex sender = ExecutionGraphTestUtils.createJobVertex("Task", parallelism, NoOpInvokable.class);
 
-		return new JobGraph("Pointwise job", sender);
+		return new JobGraph("Pointwise job", "", sender);
 	}
 
 	private static ExecutionGraph newExecutionGraph(RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException {
@@ -960,7 +962,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			restartStrategy,
-			slotProvider);
+			slotProvider,
+			"Test job description");
 	}
 
 	private static void restartAfterFailure(ExecutionGraph eg, FiniteDuration timeout, boolean haltAfterRestart) throws InterruptedException, TimeoutException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -131,7 +131,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		targetVertex.connectNewDataSetAsInput(sourceVertex, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
 		final JobID jobId = new JobID();
-		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
+		final JobGraph jobGraph = new JobGraph(jobId, "test", "", sourceVertex, targetVertex);
 
 		final CompletableFuture<LogicalSlot> sourceFuture = new CompletableFuture<>();
 		final CompletableFuture<LogicalSlot> targetFuture = new CompletableFuture<>();
@@ -198,7 +198,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		targetVertex.connectNewDataSetAsInput(sourceVertex, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
 		final JobID jobId = new JobID();
-		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
+		final JobGraph jobGraph = new JobGraph(jobId, "test", "", sourceVertex, targetVertex);
 
 		@SuppressWarnings({"unchecked", "rawtypes"})
 		final CompletableFuture<LogicalSlot>[] sourceFutures = new CompletableFuture[parallelism];
@@ -295,7 +295,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		targetVertex.connectNewDataSetAsInput(sourceVertex, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
 		final JobID jobId = new JobID();
-		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
+		final JobGraph jobGraph = new JobGraph(jobId, "test", "", sourceVertex, targetVertex);
 
 		//
 		//  Create the slots, futures, and the slot provider
@@ -380,7 +380,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		vertex.setInvokableClass(NoOpInvokable.class);
 
 		final JobID jobId = new JobID();
-		final JobGraph jobGraph = new JobGraph(jobId, "test", vertex);
+		final JobGraph jobGraph = new JobGraph(jobId, "test", "", vertex);
 
 		final BlockingQueue<AllocationID> returnedSlots = new ArrayBlockingQueue<>(2);
 		final TestingSlotOwner slotOwner = new TestingSlotOwner();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -445,7 +445,7 @@ public class ExecutionGraphTestUtils {
 
 		return ExecutionGraphBuilder.buildGraph(
 			null,
-			new JobGraph(jid, "test job", vertices),
+			new JobGraph(jid, "test job", "", vertices),
 			new Configuration(),
 			executor,
 			executor,
@@ -583,7 +583,8 @@ public class ExecutionGraphTestUtils {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(ExecutionContext$.MODULE$.fromExecutor(executor)));
+			new Scheduler(ExecutionContext$.MODULE$.fromExecutor(executor)),
+			"test job description");
 
 		return spy(new ExecutionJobVertex(graph, ajv, 1, AkkaUtils.getDefaultTimeout()));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
@@ -207,7 +207,7 @@ public class ExecutionVertexLocalityTest extends TestLogger {
 		DistributionPattern connectionPattern = allToAll ? DistributionPattern.ALL_TO_ALL : DistributionPattern.POINTWISE;
 		target.connectNewDataSetAsInput(source, connectionPattern, ResultPartitionType.PIPELINED);
 
-		JobGraph testJob = new JobGraph(jobId, "test job", source, target);
+		JobGraph testJob = new JobGraph(jobId, "test job", "", source, target);
 
 		final Time timeout = Time.seconds(10L);
 		return ExecutionGraphBuilder.buildGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -175,7 +175,7 @@ public class GlobalModVersionTest extends TestLogger {
 		jv.setInvokableClass(NoOpInvokable.class);
 		jv.setParallelism(parallelism);
 
-		JobGraph jg = new JobGraph(jid, "testjob", jv);
+		JobGraph jg = new JobGraph(jid, "testjob", "", jv);
 		graph.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 
 		return graph;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndividualRestartsConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndividualRestartsConcurrencyTest.java
@@ -440,7 +440,7 @@ public class IndividualRestartsConcurrencyTest extends TestLogger {
 		jv.setInvokableClass(NoOpInvokable.class);
 		jv.setParallelism(parallelism);
 
-		JobGraph jg = new JobGraph(jid, "testjob", jv);
+		JobGraph jg = new JobGraph(jid, "testjob", "", jv);
 		graph.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 
 		return graph;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LegacyJobVertexIdTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/LegacyJobVertexIdTest.java
@@ -60,7 +60,8 @@ public class LegacyJobVertexIdTest {
 			mock(SerializedValue.class),
 			Time.seconds(1),
 			mock(RestartStrategy.class),
-			mock(SlotProvider.class));
+			mock(SlotProvider.class),
+			"test description");
 
 		ExecutionJobVertex executionJobVertex =
 				new ExecutionJobVertex(executionGraph, jobVertex, 1, Time.seconds(1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PipelinedRegionFailoverConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PipelinedRegionFailoverConcurrencyTest.java
@@ -327,7 +327,7 @@ public class PipelinedRegionFailoverConcurrencyTest extends TestLogger {
 		jv.setInvokableClass(NoOpInvokable.class);
 		jv.setParallelism(parallelism);
 
-		JobGraph jg = new JobGraph(jid, "testjob", jv);
+		JobGraph jg = new JobGraph(jid, "testjob", "", jv);
 		graph.attachJobGraph(jg.getVerticesSortedTopologicallyFromSources());
 
 		return graph;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -48,6 +48,7 @@ public class PointwisePatternTest {
 
 	private final JobID jobId = new JobID();
 	private final String jobName = "Test Job Sample Name";
+	private final String jobDescription = "Test Job Sample Description";
 	private final Configuration cfg = new Configuration();
 	
 	@Test
@@ -76,7 +77,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -123,7 +125,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -171,7 +174,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -220,7 +224,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -267,7 +272,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -334,7 +340,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}
@@ -392,7 +399,8 @@ public class PointwisePatternTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
-			new Scheduler(TestingUtils.defaultExecutionContext()));
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			jobDescription);
 		try {
 			eg.attachJobGraph(ordered);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -90,7 +90,8 @@ public class VertexSlotSharingTest {
 				new SerializedValue<>(new ExecutionConfig()),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy(),
-				new Scheduler(TestingUtils.defaultExecutionContext()));
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				"test job description");
 			eg.attachJobGraph(vertices);
 			
 			// verify that the vertices are all in the same slot sharing group

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
@@ -76,7 +76,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		source2.setInvokableClass(NoOpInvokable.class);
 		source2.setParallelism(2);
 
-		final JobGraph jobGraph = new JobGraph("test job", source1, source2);
+		final JobGraph jobGraph = new JobGraph("test job", "", source1, source2);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -121,7 +121,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex2.connectNewDataSetAsInput(vertex1, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 		vertex3.connectNewDataSetAsInput(vertex2, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -175,7 +175,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex2.connectNewDataSetAsInput(vertex1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		vertex3.connectNewDataSetAsInput(vertex2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -242,7 +242,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex7.connectNewDataSetAsInput(vertex5, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		vertex7.connectNewDataSetAsInput(vertex6, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -312,7 +312,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex5.connectNewDataSetAsInput(vertex7, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		vertex6.connectNewDataSetAsInput(vertex7, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex7, vertex5, vertex6, vertex1, vertex2, vertex3, vertex4);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex7, vertex5, vertex6, vertex1, vertex2, vertex3, vertex4);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -358,7 +358,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex2.connectNewDataSetAsInput(vertex1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		vertex3.connectNewDataSetAsInput(vertex2, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -402,7 +402,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex2.connectNewDataSetAsInput(vertex1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		vertex3.connectNewDataSetAsInput(vertex2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -474,7 +474,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex7.connectNewDataSetAsInput(vertex5, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
 		vertex7.connectNewDataSetAsInput(vertex6, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -527,7 +527,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 		vertex4.connectNewDataSetAsInput(vertex2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		vertex4.connectNewDataSetAsInput(vertex3, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
-		final JobGraph jobGraph = new JobGraph("test job", vertex1, vertex2, vertex3, vertex4);
+		final JobGraph jobGraph = new JobGraph("test job", "", vertex1, vertex2, vertex3, vertex4);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -565,7 +565,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 
 		source.setStrictlyCoLocatedWith(target);
 
-		final JobGraph jobGraph = new JobGraph("test job", source, target);
+		final JobGraph jobGraph = new JobGraph("test job", "", source, target);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
@@ -600,7 +600,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 
 		source.setStrictlyCoLocatedWith(target);
 
-		final JobGraph jobGraph = new JobGraph("test job", source, target);
+		final JobGraph jobGraph = new JobGraph("test job", "", source, target);
 		final ExecutionGraph eg = createExecutionGraph(jobGraph);
 
 		RestartPipelinedRegionStrategy failoverStrategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -103,7 +103,7 @@ public class PartialConsumePipelinedResultTest extends TestLogger {
 		receiver.connectNewDataSetAsInput(
 			sender, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-		final JobGraph jobGraph = new JobGraph("Partial Consume of Pipelined Result", sender, receiver);
+		final JobGraph jobGraph = new JobGraph("Partial Consume of Pipelined Result", "", sender, receiver);
 
 		final SlotSharingGroup slotSharingGroup = new SlotSharingGroup(
 			sender.getID(), receiver.getID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTest.java
@@ -99,7 +99,7 @@ public class JobGraphTest extends TestLogger {
 			intermediate2.connectNewDataSetAsInput(intermediate1, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 			intermediate1.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-			JobGraph graph = new JobGraph("TestGraph",
+			JobGraph graph = new JobGraph("TestGraph", "",
 				source1, source2, intermediate1, intermediate2, target1, target2);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
@@ -144,7 +144,7 @@ public class JobGraphTest extends TestLogger {
 			
 			l13.connectNewDataSetAsInput(source2, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-			JobGraph graph = new JobGraph("TestGraph",
+			JobGraph graph = new JobGraph("TestGraph", "",
 				source1, source2, root, l11, l13, l12, l2);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
@@ -191,7 +191,7 @@ public class JobGraphTest extends TestLogger {
 			op2.connectNewDataSetAsInput(source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 			op3.connectNewDataSetAsInput(op2, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-			JobGraph graph = new JobGraph("TestGraph", source, op1, op2, op3);
+			JobGraph graph = new JobGraph("TestGraph", "", source, op1, op2, op3);
 			List<JobVertex> sorted = graph.getVerticesSortedTopologicallyFromSources();
 			
 			assertEquals(4,  sorted.size());
@@ -220,7 +220,7 @@ public class JobGraphTest extends TestLogger {
 			v3.connectNewDataSetAsInput(v2, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 			v4.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-			JobGraph jg = new JobGraph("Cyclic Graph", v1, v2, v3, v4);
+			JobGraph jg = new JobGraph("Cyclic Graph", "", v1, v2, v3, v4);
 			try {
 				jg.getVerticesSortedTopologicallyFromSources();
 				fail("Failed to raise error on topologically sorting cyclic graph.");
@@ -252,7 +252,7 @@ public class JobGraphTest extends TestLogger {
 			v4.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 			target.connectNewDataSetAsInput(v3, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-			JobGraph jg = new JobGraph("Cyclic Graph", v1, v2, v3, v4, source, target);
+			JobGraph jg = new JobGraph("Cyclic Graph", "", v1, v2, v3, v4, source, target);
 			try {
 				jg.getVerticesSortedTopologicallyFromSources();
 				fail("Failed to raise error on topologically sorting cyclic graph.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
@@ -71,7 +71,7 @@ public class JsonGeneratorTest {
 			sink1.connectNewDataSetAsInput(join2, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 			sink2.connectNewDataSetAsInput(join1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
-			JobGraph jg = new JobGraph("my job", source1, source2, source3,
+			JobGraph jg = new JobGraph("my job", "", source1, source2, source3,
 					intermediate1, intermediate2, join1, join2, sink1, sink2);
 			
 			String plan = JsonPlanGenerator.generatePlan(jg);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
@@ -179,7 +179,7 @@ public class JobManagerCleanupITCase extends TestLogger {
 						}
 						source.setParallelism(num_tasks);
 
-						JobGraph jobGraph = new JobGraph("BlobCleanupTest", source);
+						JobGraph jobGraph = new JobGraph("BlobCleanupTest", "", source);
 						final JobID jid = jobGraph.getJobID();
 
 						// request the blob port from the job manager

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -245,7 +245,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 			sourceJobVertex.setInvokableClass(BlockingStatefulInvokable.class);
 			sourceJobVertex.setParallelism(slots);
 
-			JobGraph jobGraph = new JobGraph("TestingJob", sourceJobVertex);
+			JobGraph jobGraph = new JobGraph("TestingJob", "", sourceJobVertex);
 
 			List<JobVertexID> vertexId = Collections.singletonList(sourceJobVertex.getID());
 			jobGraph.setSnapshotSettings(new JobCheckpointingSettings(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -130,7 +130,7 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 				DistributionPattern.ALL_TO_ALL,
 				ResultPartitionType.BLOCKING);
 
-		final JobGraph jobGraph = new JobGraph(jobName, sender, receiver);
+		final JobGraph jobGraph = new JobGraph(jobName, "", sender, receiver);
 
 		// We need to allow queued scheduling, because there are not enough slots available
 		// to run all tasks at once. We queue tasks and then let them finish/consume the blocking

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
@@ -273,7 +273,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 	// ---------------------------------------------------------------------------------------------
 
 	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId, long start) {
-		final JobGraph jobGraph = new JobGraph(jobId, "Test JobGraph");
+		final JobGraph jobGraph = new JobGraph(jobId, "Test JobGraph", "");
 
 		final JobVertex jobVertex = new JobVertex("Test JobVertex");
 		jobVertex.setParallelism(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -133,6 +133,7 @@ public class ScheduleOrUpdateConsumersTest extends TestLogger {
 
 		final JobGraph jobGraph = new JobGraph(
 				"Mixed pipelined and blocking result",
+				"",
 				sender,
 				pipelinedReceiver,
 				blockingReceiver);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeJobRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeJobRecoveryTest.java
@@ -154,6 +154,6 @@ public class LeaderChangeJobRecoveryTest extends TestLogger {
 		sender.setSlotSharingGroup(slotSharingGroup);
 		receiver.setSlotSharingGroup(slotSharingGroup);
 
-		return new JobGraph("Blocking test job", sender, receiver);
+		return new JobGraph("Blocking test job", "", sender, receiver);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeStateCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeStateCleanupTest.java
@@ -294,6 +294,6 @@ public class LeaderChangeStateCleanupTest extends TestLogger {
 		sender.setSlotSharingGroup(slotSharingGroup);
 		receiver.setSlotSharingGroup(slotSharingGroup);
 
-		return new JobGraph("Blocking test job", sender, receiver);
+		return new JobGraph("Blocking test job", "", sender, receiver);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/WebMonitorMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/WebMonitorMessagesTest.java
@@ -89,11 +89,12 @@ public class WebMonitorMessagesTest {
 			long lastModified = endTime == -1 ? time + rnd.nextInt() : endTime;
 
 			String name = GenericMessageTester.randomString(rnd);
+			String description = GenericMessageTester.randomString(rnd);
 			JobID jid = GenericMessageTester.randomJobId(rnd);
 			JobStatus status = GenericMessageTester.randomJobStatus(rnd);
 			
-			JobDetails msg1 = new JobDetails(jid, name, time, endTime, endTime - time, status, lastModified, numVerticesPerState, numTotal);
-			JobDetails msg2 = new JobDetails(jid, name, time, endTime, endTime - time, status, lastModified, numVerticesPerState, numTotal);
+			JobDetails msg1 = new JobDetails(jid, name, time, endTime, endTime - time, status, lastModified, numVerticesPerState, numTotal, description);
+			JobDetails msg2 = new JobDetails(jid, name, time, endTime, endTime - time, status, lastModified, numVerticesPerState, numTotal, description);
 			
 			GenericMessageTester.testMessageInstances(msg1, msg2);
 		}
@@ -144,10 +145,11 @@ public class WebMonitorMessagesTest {
 			long lastModified = endTime == -1 ? time + rnd.nextInt() : endTime;
 
 			String name = new GenericMessageTester.StringInstantiator().instantiate(rnd);
+			String description = new GenericMessageTester.StringInstantiator().instantiate(rnd);
 			JobID jid = new JobID();
 			JobStatus status = JobStatus.values()[rnd.nextInt(JobStatus.values().length)];
 
-			details[k] = new JobDetails(jid, name, time, endTime, endTime - time, status, lastModified, numVerticesPerState, numTotal);
+			details[k] = new JobDetails(jid, name, time, endTime, endTime - time, status, lastModified, numVerticesPerState, numTotal, description);
 		}
 		return Arrays.asList(details);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/JobDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/JobDetailsTest.java
@@ -50,7 +50,8 @@ public class JobDetailsTest extends TestLogger {
 			JobStatus.RUNNING,
 			8L,
 			new int[]{1, 3, 3, 7, 4, 2, 7, 3, 3},
-			42);
+			42,
+			"foobar description");
 
 		final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/MultipleJobsDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/MultipleJobsDetailsTest.java
@@ -59,7 +59,8 @@ public class MultipleJobsDetailsTest extends TestLogger {
 			JobStatus.RUNNING,
 			9L,
 			verticesPerState,
-			9);
+			9,
+			"test description");
 
 		final JobDetails finished = new JobDetails(
 			new JobID(),
@@ -70,7 +71,8 @@ public class MultipleJobsDetailsTest extends TestLogger {
 			JobStatus.FINISHED,
 			8L,
 			verticesPerState,
-			4);
+			4,
+			"test description");
 
 		final MultipleJobsDetails expected = new MultipleJobsDetails(
 			Arrays.asList(running, finished));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -54,9 +54,9 @@ public class JobManagerGroupTest extends TestLogger {
 		final String jobName1 = "testjob";
 		final String jobName2 = "anotherJob";
 
-		JobManagerJobMetricGroup jmJobGroup11 = group.addJob(new JobGraph(jid1, jobName1));
-		JobManagerJobMetricGroup jmJobGroup12 = group.addJob(new JobGraph(jid1, jobName1));
-		JobManagerJobMetricGroup jmJobGroup21 = group.addJob(new JobGraph(jid2, jobName2));
+		JobManagerJobMetricGroup jmJobGroup11 = group.addJob(new JobGraph(jid1, jobName1, ""));
+		JobManagerJobMetricGroup jmJobGroup12 = group.addJob(new JobGraph(jid1, jobName1, ""));
+		JobManagerJobMetricGroup jmJobGroup21 = group.addJob(new JobGraph(jid2, jobName2, ""));
 
 		assertEquals(jmJobGroup11, jmJobGroup12);
 
@@ -86,8 +86,8 @@ public class JobManagerGroupTest extends TestLogger {
 		final String jobName1 = "testjob";
 		final String jobName2 = "anotherJob";
 
-		JobManagerJobMetricGroup jmJobGroup11 = group.addJob(new JobGraph(jid1, jobName1));
-		JobManagerJobMetricGroup jmJobGroup21 = group.addJob(new JobGraph(jid2, jobName2));
+		JobManagerJobMetricGroup jmJobGroup11 = group.addJob(new JobGraph(jid1, jobName1, ""));
+		JobManagerJobMetricGroup jmJobGroup21 = group.addJob(new JobGraph(jid2, jobName2, ""));
 
 		group.close();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -100,7 +100,7 @@ public class MiniClusterITCase extends TestLogger {
 		task.setMaxParallelism(1);
 		task.setInvokableClass(NoOpInvokable.class);
 
-		JobGraph jg = new JobGraph(new JobID(), "Test Job", task);
+		JobGraph jg = new JobGraph(new JobID(), "Test Job", "", task);
 		jg.setAllowQueuedScheduling(true);
 		jg.setScheduleMode(ScheduleMode.EAGER);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
@@ -395,7 +395,8 @@ public class ExecutionGraphCacheTest extends TestLogger {
 				new ArchivedExecutionConfig(new ExecutionConfig()),
 				false,
 				null,
-				null);
+				null,
+				"ExecutionGraphCacheTest description");
 
 			jobStatus = super.getState();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -45,6 +45,7 @@ public class ArchivedExecutionGraphBuilder {
 
 	private JobID jobID;
 	private String jobName;
+	private String jobDescription;
 	private Map<JobVertexID, ArchivedExecutionJobVertex> tasks;
 	private List<ArchivedExecutionJobVertex> verticesInCreationOrder;
 	private long[] stateTimestamps;
@@ -117,9 +118,14 @@ public class ArchivedExecutionGraphBuilder {
 		return this;
 	}
 
+	public void setJobDescription(String jobDescription) {
+		this.jobDescription = jobDescription;
+	}
+
 	public ArchivedExecutionGraph build() {
 		JobID jobID = this.jobID != null ? this.jobID : new JobID();
 		String jobName = this.jobName != null ? this.jobName : "job_" + RANDOM.nextInt();
+		String jobDescription = this.jobDescription != null ? this.jobDescription : jobName + "'s description";
 
 		if (tasks == null) {
 			tasks = Collections.emptyMap();
@@ -139,7 +145,8 @@ public class ArchivedExecutionGraphBuilder {
 			archivedExecutionConfig != null ? archivedExecutionConfig : new ArchivedExecutionConfigBuilder().build(),
 			isStoppable,
 			null,
-			null
+			null,
+			jobDescription
 		);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -701,7 +701,8 @@ public class TaskExecutorTest extends TestLogger {
 				new SerializedValue<>(new ExecutionConfig()),
 				new Configuration(),
 				Collections.emptyList(),
-				Collections.emptyList());
+				Collections.emptyList(),
+				"");
 
 		TaskInformation taskInformation = new TaskInformation(
 				jobVertexId,
@@ -1132,7 +1133,8 @@ public class TaskExecutorTest extends TestLogger {
 				new SerializedValue<>(new ExecutionConfig()),
 				new Configuration(),
 				Collections.emptyList(),
-				Collections.emptyList());
+				Collections.emptyList(),
+				"");
 
 			TaskInformation taskInformation = new TaskInformation(
 				jobVertexId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -236,7 +236,8 @@ public class TaskAsyncCallTest extends TestLogger {
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
 			Collections.emptyList(),
-			Collections.emptyList());
+			Collections.emptyList(),
+			"Job Description");
 
 		TaskInformation taskInformation = new TaskInformation(
 			new JobVertexID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -216,7 +216,7 @@ public class TaskManagerTest extends TestLogger {
 					TestInvokableCorrect.class.getName(),
 					Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 					Collections.<InputGateDeploymentDescriptor>emptyList(),
-					new ArrayList<PermanentBlobKey>(), Collections.emptyList(), 0);
+					new ArrayList<PermanentBlobKey>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				new Within(d) {
 
@@ -316,7 +316,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.<URL>emptyList(), 0, "TestJobDescription");
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid2, "TestJob2", vid2, eid2,
@@ -325,7 +325,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				final ActorGateway tm = taskManager;
 
@@ -456,13 +456,13 @@ public class TaskManagerTest extends TestLogger {
 						"TestTask1", 5, 1, 5, 0, new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(jid2, "TestJob", vid2, eid2, executionConfig,
 						"TestTask2", 7, 2, 7, 0, new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				final ActorGateway tm = taskManager;
 
@@ -588,7 +588,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
@@ -597,7 +597,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				new Within(d){
 
@@ -696,7 +696,7 @@ public class TaskManagerTest extends TestLogger {
 						"Sender", 1, 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<>(),
-						Collections.emptyList(), 0);
+						Collections.emptyList(), 0, "TestJobDescription");
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
@@ -705,7 +705,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				new Within(d) {
 
@@ -845,7 +845,7 @@ public class TaskManagerTest extends TestLogger {
 						"Sender", 1, 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
@@ -854,7 +854,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.BlockingReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
-						new ArrayList<>(), Collections.emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 				new Within(d){
 
@@ -1002,7 +1002,7 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(igdd),
 						Collections.emptyList(),
-						Collections.emptyList(), 0);
+						Collections.emptyList(), 0, "TestJobDescription");
 
 				new Within(d) {
 					@Override
@@ -1120,7 +1120,7 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(igdd),
 						Collections.emptyList(),
-						Collections.emptyList(), 0);
+						Collections.emptyList(), 0, "TestJobDescription");
 
 				new Within(new FiniteDuration(120, TimeUnit.SECONDS)) {
 					@Override
@@ -1272,7 +1272,8 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						Collections.emptyList(),
 						Collections.emptyList(),
-						0);
+						0,
+						"Task Description");
 
 				// Submit the task
 				new Within(d) {
@@ -1591,7 +1592,7 @@ public class TaskManagerTest extends TestLogger {
 				TestInvokableRecordCancel.class.getName(),
 				Collections.singletonList(resultPartitionDeploymentDescriptor),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				new ArrayList<>(), Collections.emptyList(), 0);
+				new ArrayList<>(), Collections.emptyList(), 0, "TestJobDescription");
 
 			ActorRef jmActorRef = system.actorOf(Props.create(FailingScheduleOrUpdateConsumersJobManager.class, LEADER_SESSION_ID), "jobmanager");
 			ActorGateway jobManager = new AkkaActorGateway(jmActorRef, LEADER_SESSION_ID);
@@ -1667,7 +1668,8 @@ public class TaskManagerTest extends TestLogger {
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
 				Collections.emptyList(),
 				Collections.emptyList(),
-				0);
+				0,
+				"test task description");
 
 			Future<Object> submitResponse = taskManager.ask(new SubmitTask(tdd), timeout);
 
@@ -1728,7 +1730,8 @@ public class TaskManagerTest extends TestLogger {
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
 				Collections.emptyList(),
 				Collections.emptyList(),
-				0);
+				0,
+				"test Job Description");
 
 			Future<Object> submitResponse = taskManager.ask(new SubmitTask(tdd), timeout);
 
@@ -1845,7 +1848,8 @@ public class TaskManagerTest extends TestLogger {
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
 				Collections.emptyList(),
 				Collections.emptyList(),
-				0);
+				0,
+				"test job description");
 
 			Future<Object> submitResponse = taskManager.ask(new SubmitTask(tdd), timeout);
 
@@ -2146,7 +2150,8 @@ public class TaskManagerTest extends TestLogger {
 		Collection<InputGateDeploymentDescriptor> inputGates,
 		Collection<PermanentBlobKey> requiredJarFiles,
 		Collection<URL> requiredClasspaths,
-		int targetSlotNumber) throws IOException {
+		int targetSlotNumber,
+		String jobDescription) throws IOException {
 
 		JobInformation jobInformation = new JobInformation(
 			jobId,
@@ -2154,7 +2159,8 @@ public class TaskManagerTest extends TestLogger {
 			serializedExecutionConfig,
 			jobConfiguration,
 			requiredJarFiles,
-			requiredClasspaths);
+			requiredClasspaths,
+			jobDescription);
 
 		TaskInformation taskInformation = new TaskInformation(
 			jobVertexId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -1024,7 +1024,8 @@ public class TaskTest extends TestLogger {
 				serializedExecutionConfig,
 				new Configuration(),
 				requiredJarFileBlobKeys,
-				Collections.emptyList());
+				Collections.emptyList(),
+				"");
 
 			final TaskInformation taskInformation = new TaskInformation(
 				jobVertexId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -160,7 +160,7 @@ public class JvmExitOnFatalErrorTest {
 
 				final JobInformation jobInformation = new JobInformation(
 						jid, "Test Job", execConfig, new Configuration(),
-						Collections.emptyList(), Collections.emptyList());
+						Collections.emptyList(), Collections.emptyList(), "Test Job Description");
 
 				final TaskInformation taskInformation = new TaskInformation(
 						jobVertexId, "Test Task", 1, 1, OomInvokable.class.getName(), new Configuration());

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
@@ -60,7 +60,7 @@ class TaskManagerLossFailsTasksTest extends WordSpecLike with Matchers {
         sender.setInvokableClass(classOf[NoOpInvokable])
         sender.setParallelism(20)
 
-        val jobGraph = new JobGraph("Pointwise job", sender)
+        val jobGraph = new JobGraph("Pointwise job", "", sender)
 
         val eg = new ExecutionGraph(
           executor,
@@ -71,7 +71,8 @@ class TaskManagerLossFailsTasksTest extends WordSpecLike with Matchers {
           new SerializedValue(new ExecutionConfig()),
           AkkaUtils.getDefaultTimeout,
           new NoRestartStrategy(),
-          scheduler)
+          scheduler,
+          "test job description")
 
         eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/CoLocationConstraintITCase.scala
@@ -69,7 +69,7 @@ class CoLocationConstraintITCase(_system: ActorSystem)
 
       receiver.setStrictlyCoLocatedWith(sender)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -71,7 +71,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(2)
       vertex.setInvokableClass(classOf[BlockingNoOpInvokable])
 
-      val jobGraph = new JobGraph("Test Job", vertex)
+      val jobGraph = new JobGraph("Test Job", "", vertex)
 
       val cluster = TestingUtils.startTestingCluster(1)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -113,7 +113,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(num_tasks)
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph = new JobGraph("Test Job", vertex)
+      val jobGraph = new JobGraph("Test Job", "", vertex)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -148,7 +148,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(num_tasks)
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph = new JobGraph("Test job", vertex)
+      val jobGraph = new JobGraph("Test job", "", vertex)
       jobGraph.setAllowQueuedScheduling(true)
 
       val cluster = TestingUtils.startTestingCluster(10)
@@ -185,7 +185,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(2 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -221,7 +221,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Bipartite Job", sender, receiver)
+      val jobGraph = new JobGraph("Bipartite Job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(2 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -260,7 +260,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Bipartite Job", sender1, receiver, sender2)
+      val jobGraph = new JobGraph("Bipartite Job", "", sender1, receiver, sender2)
 
       val cluster = TestingUtils.startTestingCluster(6 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -307,7 +307,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Bipartite Job", sender1, receiver, sender2)
+      val jobGraph = new JobGraph("Bipartite Job", "", sender1, receiver, sender2)
 
       val cluster = TestingUtils.startTestingCluster(6 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -351,7 +351,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(forwarder, DistributionPattern.ALL_TO_ALL,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Forwarding Job", sender, forwarder, receiver)
+      val jobGraph = new JobGraph("Forwarding Job", "", sender, forwarder, receiver)
 
       jobGraph.setScheduleMode(ScheduleMode.EAGER)
 
@@ -388,7 +388,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -437,7 +437,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -483,7 +483,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(2 * num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -524,7 +524,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -573,7 +573,7 @@ class JobManagerITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -616,7 +616,7 @@ class JobManagerITCase(_system: ActorSystem)
       source.setParallelism(num_tasks)
       sink.setParallelism(num_tasks)
 
-      val jobGraph = new JobGraph("SubtaskInFinalStateRaceCondition", source, sink)
+      val jobGraph = new JobGraph("SubtaskInFinalStateRaceCondition", "", source, sink)
 
       val cluster = TestingUtils.startTestingCluster(2*num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -642,12 +642,12 @@ class JobManagerITCase(_system: ActorSystem)
       val vertex = new JobVertex("Test Vertex")
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph1 = new JobGraph("Test Job", vertex)
+      val jobGraph1 = new JobGraph("Test Job", "", vertex)
 
       val slowVertex = new WaitingOnFinalizeJobVertex("Long running Vertex", 2000)
       slowVertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph2 = new JobGraph("Long running Job", slowVertex)
+      val jobGraph2 = new JobGraph("Long running Job", "", slowVertex)
 
       val cluster = TestingUtils.startTestingCluster(1)
       val jm = cluster.getLeaderGateway(1 seconds)
@@ -696,7 +696,7 @@ class JobManagerITCase(_system: ActorSystem)
       vertex.setParallelism(1)
       vertex.setInvokableClass(classOf[NoOpInvokable])
 
-      val jobGraph = new JobGraph("Test Job", vertex)
+      val jobGraph = new JobGraph("Test Job", "", vertex)
 
       val cluster = TestingUtils.startTestingCluster(1)
       val jm = cluster.getLeaderGateway(1 seconds)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/RecoveryITCase.scala
@@ -86,7 +86,7 @@ class RecoveryITCase(_system: ActorSystem)
       val executionConfig = new ExecutionConfig()
       executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0))
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
       jobGraph.setExecutionConfig(executionConfig)
 
       val cluster = createTestClusterWithHeartbeatTimeout(2 * NUM_TASKS, 1, "100 ms")
@@ -135,7 +135,7 @@ class RecoveryITCase(_system: ActorSystem)
       val executionConfig = new ExecutionConfig()
       executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0))
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
       jobGraph.setExecutionConfig(executionConfig)
 
       val cluster = createTestClusterWithHeartbeatTimeout(NUM_TASKS, 1, "100 ms")
@@ -184,7 +184,7 @@ class RecoveryITCase(_system: ActorSystem)
       val executionConfig = new ExecutionConfig()
       executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0))
 
-      val jobGraph = new JobGraph("Pointwise job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise job", "", sender, receiver)
       jobGraph.setExecutionConfig(executionConfig)
 
       val cluster = createTestClusterWithHeartbeatTimeout(NUM_TASKS, 2, "100 ms")

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/SlotSharingITCase.scala
@@ -67,7 +67,7 @@ class SlotSharingITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)
@@ -113,7 +113,7 @@ class SlotSharingITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender2, DistributionPattern.ALL_TO_ALL,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Bipartite job", sender1, sender2, receiver)
+      val jobGraph = new JobGraph("Bipartite job", "", sender1, sender2, receiver)
 
       val cluster = TestingUtils.startTestingCluster(num_tasks)
       val jmGateway = cluster.getLeaderGateway(1 seconds)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/TaskManagerFailsWithSlotSharingITCase.scala
@@ -69,7 +69,7 @@ class TaskManagerFailsWithSlotSharingITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks/2, 2)
@@ -119,7 +119,7 @@ class TaskManagerFailsWithSlotSharingITCase(_system: ActorSystem)
       sender.setSlotSharingGroup(sharingGroup)
       receiver.setSlotSharingGroup(sharingGroup)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks/2, 2)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -517,7 +517,8 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * [[DataSet.print]], writing results (e.g. [[DataSet.writeAsText]], [[DataSet.write]], or other
    * generic data sinks created with [[DataSet.output]].
    *
-   * The program execution will be logged and displayed with a generated default name.
+   * The program execution will be logged and displayed with a generated default name
+   * and description.
    *
    * @return The result of the job execution, containing elapsed time and accumulators.
    */
@@ -531,12 +532,27 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * [[DataSet.print]], writing results (e.g. [[DataSet.writeAsText]], [[DataSet.write]], or other
    * generic data sinks created with [[DataSet.output]].
    *
-   * The program execution will be logged and displayed with the given name.
+   * The program execution will be logged and displayed with the given name and a generated
+   * description.
    *
    * @return The result of the job execution, containing elapsed time and accumulators.
    */
   def execute(jobName: String): JobExecutionResult = {
     javaEnv.execute(jobName)
+  }
+
+  /**
+    * Triggers the program execution. The environment will execute all parts of the program that
+    * have resulted in a "sink" operation. Sink operations are for example printing results
+    * [[DataSet.print]], writing results (e.g. [[DataSet.writeAsText]], [[DataSet.write]], or other
+    * generic data sinks created with [[DataSet.output]].
+    *
+    * The program execution will be logged and displayed with the given name and description.
+    *
+    * @return The result of the job execution, containing elapsed time and accumulators.
+    */
+  def execute(jobName: String, jobDescription: String): JobExecutionResult = {
+    javaEnv.execute(jobName, jobDescription)
   }
 
   /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -63,15 +64,17 @@ public class LegacyLocalStreamEnvironment extends LocalStreamEnvironment {
 	 * Executes the JobGraph of the on a mini cluster of CLusterUtil with a user
 	 * specified name.
 	 *
-	 * @param jobName
-	 *            name of the job
+	 * @param jobName name of the job
+	 * @param jobDescription description of the job
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 */
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	@PublicEvolving
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		// transform the streaming program into a JobGraph
 		StreamGraph streamGraph = getStreamGraph();
 		streamGraph.setJobName(jobName);
+		streamGraph.setJobDescription(jobDescription);
 
 		JobGraph jobGraph = streamGraph.getJobGraph();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
@@ -59,6 +59,11 @@ public class LegacyLocalStreamEnvironment extends LocalStreamEnvironment {
 		super(config);
 	}
 
+	@Override
+	public JobExecutionResult execute(String jobName) throws Exception {
+		return super.execute(jobName);
+	}
+
 	/**
 	 * Executes the JobGraph of the on a mini cluster of CLusterUtil with a user
 	 * specified name.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -69,7 +68,6 @@ public class LegacyLocalStreamEnvironment extends LocalStreamEnvironment {
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 */
 	@Override
-	@PublicEvolving
 	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		// transform the streaming program into a JobGraph
 		StreamGraph streamGraph = getStreamGraph();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -79,15 +80,17 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 	 * Executes the JobGraph of the on a mini cluster of CLusterUtil with a user
 	 * specified name.
 	 *
-	 * @param jobName
-	 *            name of the job
+	 * @param jobName name of the job
+	 * @param jobDescription description of the job
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 */
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	@PublicEvolving
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		// transform the streaming program into a JobGraph
 		StreamGraph streamGraph = getStreamGraph();
 		streamGraph.setJobName(jobName);
+		streamGraph.setJobDescription(jobDescription);
 
 		JobGraph jobGraph = streamGraph.getJobGraph();
 		jobGraph.setAllowQueuedScheduling(true);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -170,9 +171,11 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws ProgramInvocationException {
+	@PublicEvolving
+	public JobExecutionResult execute(String jobName, String jobDescription) throws ProgramInvocationException {
 		StreamGraph streamGraph = getStreamGraph();
 		streamGraph.setJobName(jobName);
+		streamGraph.setJobDescription(jobDescription);
 		transformations.clear();
 		return executeRemotely(streamGraph, jarFiles);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -47,11 +47,12 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		Preconditions.checkNotNull(jobName, "Streaming Job name should not be null.");
 
 		StreamGraph streamGraph = this.getStreamGraph();
 		streamGraph.setJobName(jobName);
+		streamGraph.setJobDescription(jobDescription);
 
 		transformations.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -107,6 +107,9 @@ public abstract class StreamExecutionEnvironment {
 	/** The default name to use for a streaming job if no other name has been specified. */
 	public static final String DEFAULT_JOB_NAME = "Flink Streaming Job";
 
+	/** The default descrption to use for a streaming job if no other description name has been specified. */
+	public static final String DEFAULT_JOB_DESCRIPTION = "";
+
 	/** The time characteristic that is used if none other is set. */
 	private static final TimeCharacteristic DEFAULT_TIME_CHARACTERISTIC = TimeCharacteristic.ProcessingTime;
 
@@ -142,7 +145,6 @@ public abstract class StreamExecutionEnvironment {
 	private TimeCharacteristic timeCharacteristic = DEFAULT_TIME_CHARACTERISTIC;
 
 	protected final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile = new ArrayList<>();
-
 
 	// --------------------------------------------------------------------------------------------
 	// Constructor and Properties
@@ -1515,14 +1517,31 @@ public abstract class StreamExecutionEnvironment {
 	 * the program that have resulted in a "sink" operation. Sink operations are
 	 * for example printing results or forwarding them to a message queue.
 	 *
-	 * <p>The program execution will be logged and displayed with the provided name
+	 * <p>The program execution will be logged and displayed with a generated
+	 * default description.
 	 *
-	 * @param jobName
-	 * 		Desired name of the job
+	 * @param jobName Desired name of the job
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 * @throws Exception which occurs during job execution.
 	 */
-	public abstract JobExecutionResult execute(String jobName) throws Exception;
+	public JobExecutionResult execute(String jobName) throws Exception {
+		return execute(jobName, DEFAULT_JOB_DESCRIPTION);
+	}
+
+	/**
+	 * Triggers the program execution. The environment will execute all parts of
+	 * the program that have resulted in a "sink" operation. Sink operations are
+	 * for example printing results or forwarding them to a message queue.
+	 *
+	 * <p>The program execution will be logged and displayed with the provided name
+	 *
+	 * @param jobName Desired name of the job
+	 * @param jobDescription Desired description of the job
+	 * @return The result of the job execution, containing elapsed time and accumulators.
+	 * @throws Exception which occurs during job execution.
+	 */
+	@PublicEvolving
+	public abstract JobExecutionResult execute(String jobName, String jobDescription) throws Exception;
 
 	/**
 	 * Getter of the {@link org.apache.flink.streaming.api.graph.StreamGraph} of the streaming job.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -50,14 +50,15 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute() throws Exception {
-		return execute("");
+		return execute("", "");
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 
 		StreamGraph streamGraph = getStreamGraph();
 		streamGraph.setJobName(jobName);
+		streamGraph.setJobDescription(jobDescription);
 
 		transformations.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -79,6 +79,7 @@ public class StreamGraph extends StreamingPlan {
 	private static final Logger LOG = LoggerFactory.getLogger(StreamGraph.class);
 
 	private String jobName = StreamExecutionEnvironment.DEFAULT_JOB_NAME;
+	private String jobDescription = StreamExecutionEnvironment.DEFAULT_JOB_DESCRIPTION;
 
 	private final StreamExecutionEnvironment environment;
 	private final ExecutionConfig executionConfig;
@@ -140,6 +141,14 @@ public class StreamGraph extends StreamingPlan {
 
 	public void setJobName(String jobName) {
 		this.jobName = jobName;
+	}
+
+	public String getJobDescription() {
+		return jobDescription;
+	}
+
+	public void setJobDescription(String jobDescription) {
+		this.jobDescription = jobDescription;
 	}
 
 	public void setChaining(boolean chaining) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -132,7 +132,7 @@ public class StreamingJobGraphGenerator {
 		this.chainedPreferredResources = new HashMap<>();
 		this.physicalEdgesInOrder = new ArrayList<>();
 
-		jobGraph = new JobGraph(jobID, streamGraph.getJobName());
+		jobGraph = new JobGraph(jobID, streamGraph.getJobName(), streamGraph.getJobDescription());
 	}
 
 	private JobGraph createJobGraph() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -241,7 +241,8 @@ public class InterruptSensitiveRestoreTest {
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
 			Collections.emptyList(),
-			Collections.emptyList());
+			Collections.emptyList(),
+			"test job description");
 
 		TaskInformation taskInformation = new TaskInformation(
 			jobVertexID,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -128,7 +128,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
 			Collections.emptyList(),
-			Collections.emptyList());
+			Collections.emptyList(),
+			"Test Job Description");
 
 		final TaskInformation taskInformation = new TaskInformation(
 			new JobVertexID(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -910,7 +910,8 @@ public class StreamTaskTest extends TestLogger {
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
 			Collections.emptyList(),
-			Collections.emptyList());
+			Collections.emptyList(),
+			"Job Description");
 
 		TaskInformation taskInformation = new TaskInformation(
 			new JobVertexID(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -208,7 +208,8 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 				new SerializedValue<>(executionConfig),
 				new Configuration(),
 				Collections.emptyList(),
-				Collections.emptyList());
+				Collections.emptyList(),
+				"test job description");
 
 		TaskInformation taskInformation = new TaskInformation(
 				new JobVertexID(),

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -640,7 +640,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * for example printing results or forwarding them to a message queue.
    * 
    * The program execution will be logged and displayed with a generated
-   * default name.
+   * default name and description.
    */
   def execute() = javaEnv.execute()
 
@@ -649,9 +649,20 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * the program that have resulted in a "sink" operation. Sink operations are
    * for example printing results or forwarding them to a message queue.
    * 
-   * The program execution will be logged and displayed with the provided name.
+   * The program execution will be logged and displayed with the provided name
+    * and a generated description.
    */
   def execute(jobName: String) = javaEnv.execute(jobName)
+
+  /**
+    * Triggers the program execution. The environment will execute all parts of
+    * the program that have resulted in a "sink" operation. Sink operations are
+    * for example printing results or forwarding them to a message queue.
+    *
+    * The program execution will be logged and displayed with the provided name
+    * and description.
+    */
+  def execute(jobName: String, jobDescription: String) = javaEnv.execute(jobName, jobDescription)
 
   /**
    * Creates the plan with which the system will execute the program, and

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -65,9 +65,10 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
 		final StreamGraph streamGraph = getStreamGraph();
 		streamGraph.setJobName(jobName);
+		streamGraph.setJobDescription(jobDescription);
 		final JobGraph jobGraph = streamGraph.getJobGraph();
 
 		for (Path jarFile : jarFiles) {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -48,8 +48,8 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		JobExecutionResult result = super.execute(jobName);
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
+		JobExecutionResult result = super.execute(jobName, jobDescription);
 		this.lastJobExecutionResult = result;
 		return result;
 	}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -105,8 +105,8 @@ public class TestEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		OptimizedPlan op = compileProgram(jobName);
+	public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
+		OptimizedPlan op = compileProgram(jobName, jobDescription);
 
 		JobGraphGenerator jgg = new JobGraphGenerator();
 		JobGraph jobGraph = jgg.compileJobGraph(op);
@@ -123,14 +123,14 @@ public class TestEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		OptimizedPlan op = compileProgram("unused");
+		OptimizedPlan op = compileProgram("unused", "");
 
 		PlanJSONDumpGenerator jsonGen = new PlanJSONDumpGenerator();
 		return jsonGen.getOptimizerPlanAsJSON(op);
 	}
 
-	private OptimizedPlan compileProgram(String jobName) {
-		Plan p = createProgramPlan(jobName);
+	private OptimizedPlan compileProgram(String jobName, String jobDescription) {
+		Plan p = createProgramPlan(jobName, jobDescription);
 
 		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
 		return pc.compile(p);

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -88,7 +88,7 @@ public class JobRetrievalITCase extends TestLogger {
 		final JobVertex imalock = new JobVertex("imalock");
 		imalock.setInvokableClass(SemaphoreInvokable.class);
 
-		final JobGraph jobGraph = new JobGraph(jobID, "testjob", imalock);
+		final JobGraph jobGraph = new JobGraph(jobID, "testjob", "", imalock);
 
 		// acquire the lock to make sure that the job cannot complete until the job client
 		// has been attached in resumingThread

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
@@ -71,7 +71,7 @@ public class JobSubmissionFailsITCase extends TestLogger {
 	private static JobGraph getWorkingJobGraph() {
 		final JobVertex jobVertex = new JobVertex("Working job vertex.");
 		jobVertex.setInvokableClass(NoOpInvokable.class);
-		return new JobGraph("Working testing job", jobVertex);
+		return new JobGraph("Working testing job", "", jobVertex);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ public class JobSubmissionFailsITCase extends TestLogger {
 		final JobVertex failingJobVertex = new FailingJobVertex("Failing job vertex");
 		failingJobVertex.setInvokableClass(NoOpInvokable.class);
 
-		final JobGraph failingJobGraph = new JobGraph("Failing testing job", failingJobVertex);
+		final JobGraph failingJobGraph = new JobGraph("Failing testing job", "", failingJobVertex);
 		runJobSubmissionTest(failingJobGraph, e ->
 			ExceptionUtils.findThrowable(
 				e,

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -338,8 +338,8 @@ public class JsonJobGraphGenerationTest {
 		}
 
 		@Override
-		public JobExecutionResult execute(String jobName) throws Exception {
-			Plan plan = createProgramPlan(jobName);
+		public JobExecutionResult execute(String jobName, String jobDescription) throws Exception {
+			Plan plan = createProgramPlan(jobName, jobDescription);
 
 			Optimizer pc = new Optimizer(new Configuration());
 			OptimizedPlan op = pc.compile(plan);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -182,7 +182,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 		sender.setSlotSharingGroup(slotSharingGroup);
 		receiver.setSlotSharingGroup(slotSharingGroup);
 
-		final JobGraph graph = new JobGraph("Blocking test job", sender, receiver);
+		final JobGraph graph = new JobGraph("Blocking test job", "", sender, receiver);
 
 		final TestingCluster cluster = new TestingCluster(configuration);
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -88,12 +88,12 @@ class JobManagerFailsITCase(_system: ActorSystem)
       val sender = new JobVertex("BlockingSender")
       sender.setParallelism(num_slots)
       sender.setInvokableClass(classOf[BlockingNoOpInvokable])
-      val jobGraph = new JobGraph("Blocking Testjob", sender)
+      val jobGraph = new JobGraph("Blocking Testjob", "", sender)
 
       val noOp = new JobVertex("NoOpInvokable")
       noOp.setParallelism(num_slots)
       noOp.setInvokableClass(classOf[NoOpInvokable])
-      val jobGraph2 = new JobGraph("NoOp Testjob", noOp)
+      val jobGraph2 = new JobGraph("NoOp Testjob", "", noOp)
 
       val cluster = startDeathwatchCluster(num_slots / 2, 2)
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/taskmanager/TaskManagerFailsITCase.scala
@@ -97,7 +97,7 @@ class TaskManagerFailsITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks, 2)
@@ -150,7 +150,7 @@ class TaskManagerFailsITCase(_system: ActorSystem)
       receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE,
         ResultPartitionType.PIPELINED)
 
-      val jobGraph = new JobGraph("Pointwise Job", sender, receiver)
+      val jobGraph = new JobGraph("Pointwise Job", "", sender, receiver)
       val jobID = jobGraph.getJobID
 
       val cluster = TestingUtils.startTestingCluster(num_tasks, 2)
@@ -189,12 +189,12 @@ class TaskManagerFailsITCase(_system: ActorSystem)
       val sender = new JobVertex("BlockingSender")
       sender.setParallelism(num_slots)
       sender.setInvokableClass(classOf[BlockingNoOpInvokable])
-      val jobGraph = new JobGraph("Blocking Testjob", sender)
+      val jobGraph = new JobGraph("Blocking Testjob", "", sender)
 
       val noOp = new JobVertex("NoOpInvokable")
       noOp.setParallelism(num_slots)
       noOp.setInvokableClass(classOf[NoOpInvokable])
-      val jobGraph2 = new JobGraph("NoOp Testjob", noOp)
+      val jobGraph2 = new JobGraph("NoOp Testjob", "", noOp)
 
       val cluster = createDeathwatchCluster(num_slots/2, 2)
 

--- a/pom.xml
+++ b/pom.xml
@@ -1633,6 +1633,9 @@ under the License.
 								<exclude>org.apache.flink.api.scala.hadoop.mapred.HadoopOutputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopInputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopOutputFormat</exclude>
+								<exclude>org.apache.flink.api.java.ExecutionEnvironment</exclude>
+								<exclude>org.apache.flink.api.java.LocalEnvironment</exclude>
+								<exclude>org.apache.flink.api.java.RemoteEnvironment</exclude>
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>

--- a/pom.xml
+++ b/pom.xml
@@ -1636,6 +1636,7 @@ under the License.
 								<exclude>org.apache.flink.api.java.ExecutionEnvironment</exclude>
 								<exclude>org.apache.flink.api.java.LocalEnvironment</exclude>
 								<exclude>org.apache.flink.api.java.RemoteEnvironment</exclude>
+								<exclude>org.apache.flink.streaming.api.environment.LegacyLocalStreamEnvironment</exclude>
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>

--- a/pom.xml
+++ b/pom.xml
@@ -1633,10 +1633,7 @@ under the License.
 								<exclude>org.apache.flink.api.scala.hadoop.mapred.HadoopOutputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopInputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopOutputFormat</exclude>
-								<exclude>org.apache.flink.api.java.ExecutionEnvironment</exclude>
-								<exclude>org.apache.flink.api.java.LocalEnvironment</exclude>
-								<exclude>org.apache.flink.api.java.RemoteEnvironment</exclude>
-								<exclude>org.apache.flink.streaming.api.environment.LegacyLocalStreamEnvironment</exclude>
+								<exclude>org.apache.flink.api.java.ExecutionEnvironment#execute(java.lang.String,java.lang.String)</exclude>
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add setDescription to execution environment and provide description field for the rest api*

## Brief change log

  - *add setDescription API to execution environment and provide description field for the rest api*

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
