### PR TITLE
[FLINK-9770][rest] Fix jar listing

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandler.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -82,7 +83,7 @@ public class JarUploadHandler extends
 					"Only Jar files are allowed.",
 					HttpResponseStatus.BAD_REQUEST));
 			} else {
-				final Path destination = jarDir.resolve(fileUpload.getFileName());
+				final Path destination = jarDir.resolve(UUID.randomUUID() + "_" + fileUpload.getFileName());
 				try {
 					Files.move(fileUpload, destination);
 				} catch (IOException e) {
@@ -93,7 +94,7 @@ public class JarUploadHandler extends
 						HttpResponseStatus.INTERNAL_SERVER_ERROR,
 						e));
 				}
-				return new JarUploadResponseBody(fileUpload
+				return new JarUploadResponseBody(destination
 					.normalize()
 					.toString());
 			}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
@@ -104,7 +104,10 @@ public class JarUploadHandlerTest extends TestLogger {
 
 		final JarUploadResponseBody jarUploadResponseBody = jarUploadHandler.handleRequest(request, mockDispatcherGateway).get();
 		assertThat(jarUploadResponseBody.getStatus(), equalTo(JarUploadResponseBody.UploadStatus.success));
-		assertThat(jarUploadResponseBody.getFilename(), equalTo(uploadedFile.normalize().toString()));
+		final String returnedFileNameWithUUID = jarUploadResponseBody.getFilename();
+		assertThat(returnedFileNameWithUUID, containsString("_"));
+		final String returnedFileName = returnedFileNameWithUUID.substring(returnedFileNameWithUUID.indexOf("_") + 1);
+		assertThat(returnedFileName, equalTo(uploadedFile.getFileName().toString()));
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Ensures that uploaded jars adhere to the naming scheme that the `JarListHandler` expects.

## Verifying this change

Manually verified.

* upload any jar
* refresh page
* jar should show up