### PR TITLE
[FLINK-9769][rest] Clear FileUpload attribute after access

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -188,7 +188,7 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 	}
 
 	public static FileUploads getMultipartFileUploads(ChannelHandlerContext ctx) {
-		return Optional.ofNullable(ctx.channel().attr(UPLOADED_FILES).get())
+		return Optional.ofNullable(ctx.channel().attr(UPLOADED_FILES).getAndRemove())
 			.orElse(FileUploads.EMPTY);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Prevents a resource leakage by clearing the `UPLOADED_FILES` attribute after accessing it.
Previously it could happen that a handler might see the result of a file upload operation if it happened to be sharing the same channel. In this case said files were already cleaned up, leading to `FileNotFoundExceptions`.

## Verifying this change

Manually verified. Submit a job via the Web UI, no exception should be logged.