### PR TITLE
[FLINK-9755][network] forward exceptions in RemoteInputChannel#notifyBufferAvailable() to the responsible thread

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
@@ -27,6 +27,15 @@ public interface BufferListener {
 	/**
 	 * Notification callback if a buffer is recycled and becomes available in buffer pool.
 	 *
+	 * <p>Note: responsibility on recycling the given buffer is transferred to this implementation,
+	 * including any errors that lead to exceptions being thrown!
+	 *
+	 * <p><strong>BEWARE:</strong> since this may be called from outside the thread that relies on
+	 * the listener's logic, any exception that occurs with this handler should be forwarded to the
+	 * responsible thread for handling and otherwise ignored in the processing of this method. The
+	 * buffer pool forwards any {@link Throwable} from here upwards to a potentially unrelated call
+	 * stack!
+	 *
 	 * @param buffer buffer that becomes available in buffer pool.
 	 * @return true if the listener wants to be notified next time.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -360,32 +360,44 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 			return false;
 		}
 
-		boolean needMoreBuffers = false;
-		synchronized (bufferQueue) {
-			checkState(isWaitingForFloatingBuffers, "This channel should be waiting for floating buffers.");
+		boolean recycleBuffer = true;
+		try {
+			boolean needMoreBuffers = false;
+			synchronized (bufferQueue) {
+				checkState(isWaitingForFloatingBuffers,
+					"This channel should be waiting for floating buffers.");
 
-			// Important: double check the isReleased state inside synchronized block, so there is no
-			// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
-			if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
-				isWaitingForFloatingBuffers = false;
+				// Important: double check the isReleased state inside synchronized block, so there is no
+				// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
+				if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
+					isWaitingForFloatingBuffers = false;
+					recycleBuffer = false; // just in case
+					buffer.recycleBuffer();
+					return false;
+				}
+
+				recycleBuffer = false;
+				bufferQueue.addFloatingBuffer(buffer);
+
+				if (bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
+					isWaitingForFloatingBuffers = false;
+				} else {
+					needMoreBuffers = true;
+				}
+
+				if (unannouncedCredit.getAndAdd(1) == 0) {
+					notifyCreditAvailable();
+				}
+			}
+
+			return needMoreBuffers;
+		} catch (Throwable t) {
+			if (recycleBuffer) {
 				buffer.recycleBuffer();
-				return false;
 			}
-
-			bufferQueue.addFloatingBuffer(buffer);
-
-			if (bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
-				isWaitingForFloatingBuffers = false;
-			} else {
-				needMoreBuffers =  true;
-			}
+			setError(t);
+			return false;
 		}
-
-		if (unannouncedCredit.getAndAdd(1) == 0) {
-			notifyCreditAvailable();
-		}
-
-		return needMoreBuffers;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Exceptions in `RemoteInputChannel#notifyBufferAvailable()`, e.g. state checks, were swallowed inside `LocalBufferPool#recycle()` and neither logged nor otherwise processed and may have lead to stalling processes waiting for a notification that never comes.

Please note that this PR builds upon #6271 which also touched the unit tests which we change here. @tillrohrmann, @zhijiangW can you have a look at this cleanup of `LocalBufferPool#recycle()`?

## Brief change log

- cleanup of `LocalBufferPool#recycle()` also clarifying the contract of `BufferListener#notifyBufferAvailable()` which should recycle the given buffer (one implementation already did that; `RemoteInputChannel` did not)
- forward exceptions in `RemoteInputChannel#notifyBufferAvailable()` to the responsible channel and recycle the given buffer in that case

## Verifying this change

This change added tests and can be verified as follows:

- added `RemoteInputChannelTest#testFailureInNotifyBufferAvailable()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
