### PR TITLE
[FLINK-9377] [core] Implement restore serializer factory method for simple composite serializers

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -167,9 +167,9 @@ public final class WritableSerializer<T extends Writable> extends TypeSerializer
 	}
 
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof WritableSerializerConfigSnapshot
-				&& typeClass.equals(((WritableSerializerConfigSnapshot) configSnapshot).getTypeClass())) {
+				&& typeClass.equals(((WritableSerializerConfigSnapshot<?>) configSnapshot).getTypeClass())) {
 
 			return CompatibilityResult.compatible();
 		} else {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/BackwardsCompatibleConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/BackwardsCompatibleConfigSnapshot.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * A utility {@link TypeSerializerConfigSnapshot} that is used for backwards compatibility purposes.
+ *
+ * <p>If this placeholder config snapshot is provided to a new serializer for compatibility checks, the wrapped
+ * config snapshot will be "unwrapped" and be provided instead.
+ *
+ * @see TypeSerializer#internalEnsureCompatibility(TypeSerializerConfigSnapshot)
+ *
+ * @param <T> the data type that the wrapped serializer instance serializes.
+ */
+@Internal
+public class BackwardsCompatibleConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
+
+	private TypeSerializerConfigSnapshot<?> wrappedConfigSnapshot;
+
+	private TypeSerializer<T> serializerInstance;
+
+	public BackwardsCompatibleConfigSnapshot(
+			TypeSerializerConfigSnapshot<?> wrappedConfigSnapshot,
+			TypeSerializer<T> serializerInstance) {
+
+		this.wrappedConfigSnapshot = Preconditions.checkNotNull(wrappedConfigSnapshot);
+		this.serializerInstance = Preconditions.checkNotNull(serializerInstance);
+	}
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		throw new UnsupportedOperationException(
+			"This is a dummy config snapshot used only for backwards compatibility.");
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		throw new UnsupportedOperationException(
+			"This is a dummy config snapshot used only for backwards compatibility.");
+	}
+
+	@Override
+	public int getVersion() {
+		throw new UnsupportedOperationException(
+			"This is a dummy config snapshot used only for backwards compatibility.");
+	}
+
+	@Override
+	public TypeSerializer<T> restoreSerializer() {
+		return serializerInstance;
+	}
+
+	public TypeSerializerConfigSnapshot<?> getWrappedConfigSnapshot() {
+		return wrappedConfigSnapshot;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = wrappedConfigSnapshot.hashCode();
+		result = 31 * result + serializerInstance.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		BackwardsCompatibleConfigSnapshot<?> that = (BackwardsCompatibleConfigSnapshot<?>) o;
+
+		return that.wrappedConfigSnapshot.equals(wrappedConfigSnapshot)
+			&& that.serializerInstance.equals(serializerInstance);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityResult.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityResult.java
@@ -19,9 +19,6 @@
 package org.apache.flink.api.common.typeutils;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.util.Preconditions;
-
-import javax.annotation.Nonnull;
 
 /**
  * A {@code CompatibilityResult} contains information about whether or not data migration
@@ -36,78 +33,25 @@ public final class CompatibilityResult<T> {
 	private final boolean requiresMigration;
 
 	/**
-	 * The convert deserializer to use for reading previous data during migration,
-	 * in the case that the preceding serializer cannot be found.
-	 *
-	 * <p>This is only relevant if migration is required.
-	 */
-	private final TypeDeserializer<T> convertDeserializer;
-
-	/**
 	 * Returns a result that signals that the new serializer is compatible and no migration is required.
 	 *
-	 * @return a result that signals migration is not required for the new serializer
+	 * @return a result that signals migration is not required for the new serializer.
 	 */
 	public static <T> CompatibilityResult<T> compatible() {
-		return new CompatibilityResult<>(false, null);
+		return new CompatibilityResult<>(false);
 	}
 
 	/**
-	 * Returns a result that signals migration to be performed, and in the case that the preceding serializer
-	 * cannot be found or restored to read the previous data during migration, a provided convert deserializer
-	 * can be used.
+	 * Returns a result that signals migration to be performed.
 	 *
-	 * @param convertDeserializer the convert deserializer to use, in the case that the preceding serializer
-	 *                            cannot be found.
-	 *
-	 * @param <T> the type of the data being migrated.
-	 *
-	 * @return a result that signals migration is necessary, also providing a convert deserializer.
-	 */
-	public static <T> CompatibilityResult<T> requiresMigration(@Nonnull TypeDeserializer<T> convertDeserializer) {
-		Preconditions.checkNotNull(convertDeserializer, "Convert deserializer cannot be null.");
-
-		return new CompatibilityResult<>(true, convertDeserializer);
-	}
-
-	/**
-	 * Returns a result that signals migration to be performed, and in the case that the preceding serializer
-	 * cannot be found or restored to read the previous data during migration, a provided convert serializer
-	 * can be used. The provided serializer will only be used for deserialization.
-	 *
-	 * @param convertSerializer the convert serializer to use, in the case that the preceding serializer
-	 *                          cannot be found. The provided serializer will only be used for deserialization.
-	 *
-	 * @param <T> the type of the data being migrated.
-	 *
-	 * @return a result that signals migration is necessary, also providing a convert serializer.
-	 */
-	public static <T> CompatibilityResult<T> requiresMigration(@Nonnull TypeSerializer<T> convertSerializer) {
-		Preconditions.checkNotNull(convertSerializer, "Convert serializer cannot be null.");
-
-		return new CompatibilityResult<>(true, new TypeDeserializerAdapter<>(convertSerializer));
-	}
-
-	/**
-	 * Returns a result that signals migration to be performed. The migration will fail if the preceding
-	 * serializer for the previous data cannot be found.
-	 *
-	 * <p>You can also provide a convert deserializer using {@link #requiresMigration(TypeDeserializer)}
-	 * or {@link #requiresMigration(TypeSerializer)}, which will be used as a fallback resort in such cases.
-	 *
-	 * @return a result that signals migration is necessary, without providing a convert deserializer.
+	 * @return a result that signals migration is necessary.
 	 */
 	public static <T> CompatibilityResult<T> requiresMigration() {
-		return new CompatibilityResult<>(true, null);
+		return new CompatibilityResult<>(true);
 	}
 
-	private CompatibilityResult(boolean requiresMigration, TypeDeserializer<T> convertDeserializer) {
+	private CompatibilityResult(boolean requiresMigration) {
 		this.requiresMigration = requiresMigration;
-		this.convertDeserializer = convertDeserializer;
-	}
-
-	public TypeDeserializer<T> getConvertDeserializer() {
-		return convertDeserializer;
 	}
 
 	public boolean isRequiresMigration() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityUtil.java
@@ -19,8 +19,6 @@ package org.apache.flink.api.common.typeutils;
 
 import org.apache.flink.annotation.Internal;
 
-import javax.annotation.Nullable;
-
 /**
  * Utilities related to serializer compatibility.
  */
@@ -44,8 +42,6 @@ public class CompatibilityUtil {
 	 *      If yes, use that for state migration and simply return the result.
 	 *   6. If all of above fails, state migration is required but could not be performed; throw exception.
 	 *
-	 * @param precedingSerializer the preceding serializer used to write the data, null if none could be retrieved
-	 * @param dummySerializerClassTag any class tags that identifies the preceding serializer as a dummy placeholder
 	 * @param precedingSerializerConfigSnapshot configuration snapshot of the preceding serializer
 	 * @param newSerializer the new serializer to ensure compatibility with
 	 *
@@ -55,26 +51,11 @@ public class CompatibilityUtil {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> CompatibilityResult<T> resolveCompatibilityResult(
-			@Nullable TypeSerializer<?> precedingSerializer,
-			Class<?> dummySerializerClassTag,
 			TypeSerializerConfigSnapshot precedingSerializerConfigSnapshot,
 			TypeSerializer<T> newSerializer) {
 
 		if (precedingSerializerConfigSnapshot != null) {
-			CompatibilityResult<T> initialResult = newSerializer.ensureCompatibility(precedingSerializerConfigSnapshot);
-
-			if (!initialResult.isRequiresMigration()) {
-				return initialResult;
-			} else {
-				if (precedingSerializer != null && !(precedingSerializer.getClass().equals(dummySerializerClassTag))) {
-					// if the preceding serializer exists and is not a dummy, use
-					// that for converting instead of any provided convert deserializer
-					return CompatibilityResult.requiresMigration((TypeSerializer<T>) precedingSerializer);
-				} else {
-					// requires migration (may or may not have a convert deserializer)
-					return initialResult;
-				}
-			}
+			return newSerializer.ensureCompatibility(precedingSerializerConfigSnapshot);
 		} else {
 			// if the configuration snapshot of the preceding serializer cannot be provided,
 			// we can only simply assume that the new serializer is compatible

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityUtil.java
@@ -55,7 +55,7 @@ public class CompatibilityUtil {
 			TypeSerializer<T> newSerializer) {
 
 		if (precedingSerializerConfigSnapshot != null) {
-			return newSerializer.ensureCompatibility(precedingSerializerConfigSnapshot);
+			return newSerializer.internalEnsureCompatibility(precedingSerializerConfigSnapshot);
 		} else {
 			// if the configuration snapshot of the preceding serializer cannot be provided,
 			// we can only simply assume that the new serializer is compatible

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializer.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A base class for simple composite type serializers which consists of multiple nested
+ * type serializers. The constructor takes a pre-instantiated {@link CompositeTypeSerializerConfigSnapshot}
+ * instance, which is cached and returned on each {@link #snapshotConfiguration()} call.
+ * When compatibility is to be ensured with a restored configuration snapshot, that snapshot is checked whether or not
+ * it is of the same class as the cached one. The compatibility check is performed by simply ensuring that
+ * all nested serializers are compatible with the corresponding nested configuration snapshots.
+ */
+@Internal
+public abstract class CompositeTypeSerializer<T> extends TypeSerializer<T> {
+
+	private static final long serialVersionUID = -1460007327926564185L;
+
+	private final CompositeTypeSerializerConfigSnapshot<T> cachedConfigSnapshot;
+
+	private final TypeSerializer<?>[] nestedSerializers;
+
+	/**
+	 * Super constructor for composite type serializers.
+	 *
+	 * @param cachedConfigSnapshot the {@link CompositeTypeSerializerConfigSnapshot} to be cached.
+	 * @param nestedSerializers the nested serializers captured by the cached config snapshot, in the exact same order.
+	 */
+	public CompositeTypeSerializer(
+			CompositeTypeSerializerConfigSnapshot<T> cachedConfigSnapshot,
+			TypeSerializer<?>... nestedSerializers) {
+
+		this.cachedConfigSnapshot = Preconditions.checkNotNull(cachedConfigSnapshot);
+		this.nestedSerializers = Preconditions.checkNotNull(nestedSerializers);
+
+		Preconditions.checkArgument(
+			cachedConfigSnapshot.getNumNestedSerializers() == nestedSerializers.length,
+			"The cached composite type serializer configuration snapshot captures a different number of" +
+				" nested serializers than the length of the provided list of nested serializers.");
+	}
+
+	@Override
+	public final TypeSerializerConfigSnapshot<T> snapshotConfiguration() {
+		return cachedConfigSnapshot;
+	}
+
+	@Override
+	protected CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
+		if (isComparableSnapshot(configSnapshot)) {
+			@SuppressWarnings("unchecked")
+			CompositeTypeSerializerConfigSnapshot<T> snapshot = (CompositeTypeSerializerConfigSnapshot<T>) configSnapshot;
+
+			int i = 0;
+			for (TypeSerializer<?> nestedSerializer : nestedSerializers) {
+				CompatibilityResult<?> compatibilityResult = CompatibilityUtil.resolveCompatibilityResult(
+					snapshot.getNestedSerializerConfigSnapshot(i),
+					nestedSerializer);
+
+				if (compatibilityResult.isRequiresMigration()) {
+					return CompatibilityResult.requiresMigration();
+				}
+
+				i++;
+			}
+
+			return CompatibilityResult.compatible();
+		} else {
+			return CompatibilityResult.requiresMigration();
+		}
+	}
+
+	/**
+	 * Subclasses can override this if the serializer recognizes configuration snapshot
+	 * classes beyond the cached one. For example, composite type serializers which in previous versions
+	 * return a different configuration snapshot class than the one currently used could override this
+	 * method for backwards compatibility.
+	 *
+	 * @param configSnapshot the config snapshot to compare with.
+	 */
+	protected boolean isComparableSnapshot(TypeSerializerConfigSnapshot<?> configSnapshot) {
+		return configSnapshot.getClass().equals(cachedConfigSnapshot.getClass());
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerConfigSnapshot.java
@@ -38,7 +38,7 @@ import java.util.List;
  * is required.
  */
 @Internal
-public abstract class CompositeTypeSerializerConfigSnapshot extends TypeSerializerConfigSnapshot {
+public abstract class CompositeTypeSerializerConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
 
 	private List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> nestedSerializersAndConfigs;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerConfigSnapshot.java
@@ -40,7 +40,7 @@ import java.util.List;
 @Internal
 public abstract class CompositeTypeSerializerConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
 
-	private List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> nestedSerializersAndConfigs;
+	private List<TypeSerializerConfigSnapshot<?>> nestedSerializerConfigs;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	public CompositeTypeSerializerConfigSnapshot() {}
@@ -48,35 +48,56 @@ public abstract class CompositeTypeSerializerConfigSnapshot<T> extends TypeSeria
 	public CompositeTypeSerializerConfigSnapshot(TypeSerializer<?>... nestedSerializers) {
 		Preconditions.checkNotNull(nestedSerializers);
 
-		this.nestedSerializersAndConfigs = new ArrayList<>(nestedSerializers.length);
+		this.nestedSerializerConfigs = new ArrayList<>(nestedSerializers.length);
 		for (TypeSerializer<?> nestedSerializer : nestedSerializers) {
-			TypeSerializerConfigSnapshot configSnapshot = nestedSerializer.snapshotConfiguration();
-			this.nestedSerializersAndConfigs.add(
-				new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
-					nestedSerializer.duplicate(),
-					Preconditions.checkNotNull(configSnapshot)));
+			this.nestedSerializerConfigs.add(
+				Preconditions.checkNotNull(
+					nestedSerializer.snapshotConfiguration(),
+					"Configuration snapshots of nested serializers cannot be null."));
 		}
 	}
 
 	@Override
 	public void write(DataOutputView out) throws IOException {
 		super.write(out);
-		TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience(out, nestedSerializersAndConfigs);
+		TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshots(out, nestedSerializerConfigs);
 	}
 
 	@Override
 	public void read(DataInputView in) throws IOException {
 		super.read(in);
-		this.nestedSerializersAndConfigs =
-			TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(in, getUserCodeClassLoader());
+
+		if (!containsSerializers()) {
+			this.nestedSerializerConfigs = TypeSerializerConfigSnapshotSerializationUtil
+				.readSerializerConfigSnapshots(in, getUserCodeClassLoader());
+		} else {
+			// backwards compatible path
+			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> nestedSerializersAndConfigs =
+				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(in, getUserCodeClassLoader());
+
+			this.nestedSerializerConfigs = new ArrayList<>(nestedSerializersAndConfigs.size());
+			for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> entry : nestedSerializersAndConfigs) {
+				this.nestedSerializerConfigs.add(new BackwardsCompatibleConfigSnapshot<>(entry.f1, entry.f0));
+			}
+		}
 	}
 
-	public List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> getNestedSerializersAndConfigs() {
-		return nestedSerializersAndConfigs;
+	/**
+	 * Return whether or not this composite type serializer config snapshot still contains
+	 * serializers. Subclasses should uptick their version, and use that to compare against the read version
+	 * of the config snapshot to determine this. By default, it is assumed that all composite
+	 * type serializer config snapshots do not contain serializers.
+	 */
+	protected boolean containsSerializers() {
+		return false;
 	}
 
-	public Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> getSingleNestedSerializerAndConfig() {
-		return nestedSerializersAndConfigs.get(0);
+	public int getNumNestedSerializers() {
+		return nestedSerializerConfigs.size();
+	}
+
+	public TypeSerializerConfigSnapshot<?> getNestedSerializerConfigSnapshot(int index) {
+		return nestedSerializerConfigs.get(index);
 	}
 
 	@Override
@@ -90,11 +111,32 @@ public abstract class CompositeTypeSerializerConfigSnapshot<T> extends TypeSeria
 		}
 
 		return (obj.getClass().equals(getClass()))
-				&& nestedSerializersAndConfigs.equals(((CompositeTypeSerializerConfigSnapshot) obj).getNestedSerializersAndConfigs());
+				&& nestedSerializerConfigs.equals(((CompositeTypeSerializerConfigSnapshot) obj).nestedSerializerConfigs);
 	}
 
 	@Override
 	public int hashCode() {
-		return nestedSerializersAndConfigs.hashCode();
+		return nestedSerializerConfigs.hashCode();
 	}
+
+	@Override
+	public final TypeSerializer<T> restoreSerializer() {
+		TypeSerializer<?>[] restoredNestedSerializers = new TypeSerializer[nestedSerializerConfigs.size()];
+
+		int i = 0;
+		for (TypeSerializerConfigSnapshot<?> config : nestedSerializerConfigs) {
+			restoredNestedSerializers[i] = config.restoreSerializer();
+			i++;
+		}
+
+		return restoreSerializer(restoredNestedSerializers);
+	}
+
+	/**
+	 * Restore the composite type serializer with the restored nested serializers.
+	 *
+	 * @param restoredNestedSerializers the restored nested serializers.
+	 * @return the restored composite type serializer.
+	 */
+	protected abstract TypeSerializer<T> restoreSerializer(TypeSerializer<?>... restoredNestedSerializers);
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/GenericTypeSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/GenericTypeSerializerConfigSnapshot.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @param <T> The type to be instantiated.
  */
 @Internal
-public abstract class GenericTypeSerializerConfigSnapshot<T> extends TypeSerializerConfigSnapshot {
+public abstract class GenericTypeSerializerConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
 
 	private Class<T> typeClass;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/ParameterlessTypeSerializerConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/ParameterlessTypeSerializerConfig.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * A base class for {@link TypeSerializerConfigSnapshot}s that do not have any parameters.
  */
 @Internal
-public final class ParameterlessTypeSerializerConfig extends TypeSerializerConfigSnapshot {
+public final class ParameterlessTypeSerializerConfig<T> extends TypeSerializerConfigSnapshot<T> {
 
 	private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeDeserializerAdapter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeDeserializerAdapter.java
@@ -130,12 +130,12 @@ public final class TypeDeserializerAdapter<T> extends TypeSerializer<T> implemen
 			"This is a TypeDeserializerAdapter used only for deserialization; this method should not be used.");
 	}
 
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<T> snapshotConfiguration() {
 		throw new UnsupportedOperationException(
 			"This is a TypeDeserializerAdapter used only for deserialization; this method should not be used.");
 	}
 
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		throw new UnsupportedOperationException(
 			"This is a TypeDeserializerAdapter used only for deserialization; this method should not be used.");
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.typeutils;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -215,5 +216,28 @@ public abstract class TypeSerializer<T> implements Serializable {
 	 *
 	 * @return the determined compatibility result (cannot be {@code null}).
 	 */
-	public abstract CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot);
+	protected abstract CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot);
+
+	/**
+	 * Public-facing method for serializer compatibility checks. Restored configuration snapshots should
+	 * be provided via this method.
+	 *
+	 * <p>Before passing the configuration snapshot to the actual
+	 * {@link #ensureCompatibility(TypeSerializerConfigSnapshot)} method, the configuration snapshot is checked
+	 * to see if it is a dummy {@link BackwardsCompatibleConfigSnapshot}. If so, then the actual wrapped
+	 * configuration snapshot is extracted and used instead.
+	 *
+	 * @param configSnapshot configuration snapshot of a preceding serializer for the same managed state
+	 *
+	 * @return the determined compatibility result (cannot be {@code null}).
+	 */
+	@Internal
+	public final CompatibilityResult<T> internalEnsureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
+		if (configSnapshot instanceof BackwardsCompatibleConfigSnapshot) {
+			return ensureCompatibility(
+				((BackwardsCompatibleConfigSnapshot<?>) configSnapshot).getWrappedConfigSnapshot());
+		} else {
+			return ensureCompatibility(configSnapshot);
+		}
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -179,14 +179,14 @@ public abstract class TypeSerializer<T> implements Serializable {
 	 *
 	 * @return snapshot of the serializer's current configuration (cannot be {@code null}).
 	 */
-	public abstract TypeSerializerConfigSnapshot snapshotConfiguration();
+	public abstract TypeSerializerConfigSnapshot<T> snapshotConfiguration();
 
 	/**
 	 * Ensure compatibility of this serializer with a preceding serializer that was registered for serialization of
 	 * the same managed state (if any - this method is only relevant if this serializer is registered for
 	 * serialization of managed state).
 	 *
-	 * The compatibility check in this method should be performed by inspecting the preceding serializer's configuration
+	 * <p>The compatibility check in this method should be performed by inspecting the preceding serializer's configuration
 	 * snapshot. The method may reconfigure the serializer (if required and possible) so that it may be compatible,
 	 * or provide a signaling result that informs Flink that state migration is necessary before continuing to use
 	 * this serializer.
@@ -215,5 +215,5 @@ public abstract class TypeSerializer<T> implements Serializable {
 	 *
 	 * @return the determined compatibility result (cannot be {@code null}).
 	 */
-	public abstract CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot);
+	public abstract CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot);
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerConfigSnapshot.java
@@ -25,12 +25,33 @@ import org.apache.flink.util.Preconditions;
 
 /**
  * A {@code TypeSerializerConfigSnapshot} is a point-in-time view of a {@link TypeSerializer's} configuration.
- * The configuration snapshot of a serializer is persisted along with checkpoints of the managed state that the
- * serializer is registered to.
+ * The configuration snapshot of a serializer is persisted within checkpoints
+ * as a single source of meta information about the schema of serialized data in the checkpoint.
+ * This serves three purposes:
  *
- * <p>The persisted configuration may later on be used by new serializers to ensure serialization compatibility
- * for the same managed state. In order for new serializers to be able to ensure this, the configuration snapshot
- * should encode sufficient information about:
+ * <ul>
+ *   <li><strong>Capturing serializer parameters and schema:</strong> a serializer's configuration snapshot
+ *   represents information about the parameters, state, and schema of a serializer.
+ *   This is explained in more detail below.</li>
+ *
+ *   <li><strong>Compatibility checks for new serializers:</strong> when new serializers are available,
+ *   they need to be checked whether or not they are compatible to read the data written by the previous serializer.
+ *   This is performed by providing the serializer configuration snapshots in checkpoints to the corresponding
+ *   new serializers.</li>
+ *
+ *   <li><strong>Factory for a read serializer when schema conversion is required:<strong> in the case that new
+ *   serializers are not compatible to read previous data, a schema conversion process executed across all data
+ *   is required before the new serializer can be continued to be used. This conversion process requires a compatible
+ *   read serializer to restore serialized bytes as objects, and then written back again using the new serializer.
+ *   In this scenario, the serializer configuration snapshots in checkpoints doubles as a factory for the read
+ *   serializer of the conversion process.</li>
+ * </ul>
+ *
+ * <h2>Serializer Configuration and Schema</h2>
+ *
+ * <p>Since serializer configuration snapshots needs to be used to ensure serialization compatibility
+ * for the same managed state as well as serving as a factory for compatible read serializers, the configuration
+ * snapshot should encode sufficient information about:
  *
  * <ul>
  *   <li><strong>Parameter settings of the serializer:</strong> parameters of the serializer include settings
@@ -38,17 +59,33 @@ import org.apache.flink.util.Preconditions;
  *   has nested serializers, then the configuration snapshot should also contain the parameters of the nested
  *   serializers.</li>
  *
- *   <li><strong>Serialization schema of the serializer:</strong> the data format used by the serializer.</li>
+ *   <li><strong>Serialization schema of the serializer:</strong> the binary format used by the serializer, or
+ *   in other words, the schema of data written by the serializer.</li>
  * </ul>
  *
  * <p>NOTE: Implementations must contain the default empty nullary constructor. This is required to be able to
  * deserialize the configuration snapshot from its binary form.
+ *
+ * @param <T> The data type that the originating serializer of this configuration serializes.
  */
 @PublicEvolving
-public abstract class TypeSerializerConfigSnapshot extends VersionedIOReadableWritable {
+public abstract class TypeSerializerConfigSnapshot<T> extends VersionedIOReadableWritable {
 
 	/** The user code class loader; only relevant if this configuration instance was deserialized from binary form. */
 	private ClassLoader userCodeClassLoader;
+
+	/**
+	 * Creates a serializer using this configuration, that is capable of reading data
+	 * written by the serializer described by this configuration.
+	 *
+	 * @return the restored serializer.
+	 */
+	public TypeSerializer<T> restoreSerializer() {
+		// TODO this method actually should not have a default implementation;
+		// TODO this placeholder should be removed as soon as all subclasses have a proper implementation in place, and
+		// TODO the method is properly integrated in state backends' restore procedures
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Set the user code class loader.

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerConfigSnapshotSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerConfigSnapshotSerializationUtil.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.core.io.VersionedIOReadableWritable;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility methods for serialization of {@link TypeSerializerConfigSnapshot}.
+ */
+public class TypeSerializerConfigSnapshotSerializationUtil {
+
+	/**
+	 * Writes a {@link TypeSerializerConfigSnapshot} to the provided data output view.
+	 *
+	 * <p>It is written with a format that can be later read again using
+	 * {@link #readSerializerConfigSnapshot(DataInputView, ClassLoader)}.
+	 *
+	 * @param out the data output view
+	 * @param serializerConfigSnapshot the serializer configuration snapshot to write
+	 *
+	 * @throws IOException
+	 */
+	public static void writeSerializerConfigSnapshot(
+			DataOutputView out,
+			TypeSerializerConfigSnapshot serializerConfigSnapshot) throws IOException {
+
+		new TypeSerializerConfigSnapshotSerializationProxy(serializerConfigSnapshot).write(out);
+	}
+
+	/**
+	 * Reads from a data input view a {@link TypeSerializerConfigSnapshot} that was previously
+	 * written using {@link TypeSerializerConfigSnapshotSerializationUtil#writeSerializerConfigSnapshot(DataOutputView, TypeSerializerConfigSnapshot)}.
+	 *
+	 * @param in the data input view
+	 * @param userCodeClassLoader the user code class loader to use
+	 *
+	 * @return the read serializer configuration snapshot
+	 *
+	 * @throws IOException
+	 */
+	public static TypeSerializerConfigSnapshot readSerializerConfigSnapshot(
+			DataInputView in,
+			ClassLoader userCodeClassLoader) throws IOException {
+
+		final TypeSerializerConfigSnapshotSerializationProxy proxy = new TypeSerializerConfigSnapshotSerializationProxy(userCodeClassLoader);
+		proxy.read(in);
+
+		return proxy.getSerializerConfigSnapshot();
+	}
+
+	/**
+	 * Writes multiple {@link TypeSerializerConfigSnapshot}s to the provided data output view.
+	 *
+	 * <p>It is written with a format that can be later read again using
+	 * {@link #readSerializerConfigSnapshots(DataInputView, ClassLoader)}.
+	 *
+	 * @param out the data output view
+	 * @param serializerConfigSnapshots the serializer configuration snapshots to write
+	 *
+	 * @throws IOException
+	 */
+	public static void writeSerializerConfigSnapshots(
+			DataOutputView out,
+			List<TypeSerializerConfigSnapshot<?>> serializerConfigSnapshots) throws IOException {
+
+		out.writeInt(serializerConfigSnapshots.size());
+
+		for (TypeSerializerConfigSnapshot<?> snapshot : serializerConfigSnapshots) {
+			new TypeSerializerConfigSnapshotSerializationProxy(snapshot).write(out);
+		}
+	}
+
+	/**
+	 * Reads from a data input view multiple {@link TypeSerializerConfigSnapshot}s that was previously
+	 * written using {@link TypeSerializerConfigSnapshotSerializationUtil#writeSerializerConfigSnapshot(DataOutputView, TypeSerializerConfigSnapshot)}.
+	 *
+	 * @param in the data input view
+	 * @param userCodeClassLoader the user code class loader to use
+	 *
+	 * @return the read serializer configuration snapshots
+	 *
+	 * @throws IOException
+	 */
+	public static List<TypeSerializerConfigSnapshot<?>> readSerializerConfigSnapshots(
+			DataInputView in,
+			ClassLoader userCodeClassLoader) throws IOException {
+
+		int numFields = in.readInt();
+		final List<TypeSerializerConfigSnapshot<?>> serializerConfigSnapshots = new ArrayList<>(numFields);
+
+		TypeSerializerConfigSnapshotSerializationProxy proxy;
+		for (int i = 0; i < numFields; i++) {
+			proxy = new TypeSerializerConfigSnapshotSerializationProxy(userCodeClassLoader);
+			proxy.read(in);
+			serializerConfigSnapshots.add(proxy.getSerializerConfigSnapshot());
+		}
+
+		return serializerConfigSnapshots;
+	}
+
+	/**
+	 * Utility serialization proxy for a {@link TypeSerializerConfigSnapshot}.
+	 */
+	static final class TypeSerializerConfigSnapshotSerializationProxy extends VersionedIOReadableWritable {
+
+		private static final int VERSION = 1;
+
+		private ClassLoader userCodeClassLoader;
+		private TypeSerializerConfigSnapshot<?> serializerConfigSnapshot;
+
+		TypeSerializerConfigSnapshotSerializationProxy(ClassLoader userCodeClassLoader) {
+			this.userCodeClassLoader = Preconditions.checkNotNull(userCodeClassLoader);
+		}
+
+		TypeSerializerConfigSnapshotSerializationProxy(TypeSerializerConfigSnapshot<?> serializerConfigSnapshot) {
+			this.serializerConfigSnapshot = serializerConfigSnapshot;
+		}
+
+		@Override
+		public void write(DataOutputView out) throws IOException {
+			super.write(out);
+
+			// config snapshot class, so that we can re-instantiate the
+			// correct type of config snapshot instance when deserializing
+			out.writeUTF(serializerConfigSnapshot.getClass().getName());
+
+			// the actual configuration parameters
+			serializerConfigSnapshot.write(out);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void read(DataInputView in) throws IOException {
+			super.read(in);
+
+			String serializerConfigClassname = in.readUTF();
+			Class<? extends TypeSerializerConfigSnapshot> serializerConfigSnapshotClass;
+			try {
+				serializerConfigSnapshotClass = (Class<? extends TypeSerializerConfigSnapshot>)
+					Class.forName(serializerConfigClassname, true, userCodeClassLoader);
+			} catch (ClassNotFoundException e) {
+				throw new IOException(
+					"Could not find requested TypeSerializerConfigSnapshot class "
+						+ serializerConfigClassname +  " in classpath.", e);
+			}
+
+			serializerConfigSnapshot = InstantiationUtil.instantiate(serializerConfigSnapshotClass);
+			serializerConfigSnapshot.setUserCodeClassLoader(userCodeClassLoader);
+			serializerConfigSnapshot.read(in);
+		}
+
+		@Override
+		public int getVersion() {
+			return VERSION;
+		}
+
+		TypeSerializerConfigSnapshot<?> getSerializerConfigSnapshot() {
+			return serializerConfigSnapshot;
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -40,9 +40,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Utility methods for serialization of {@link TypeSerializer} and {@link TypeSerializerConfigSnapshot}.
+ * Utility methods for serialization of {@link TypeSerializer}.
+ *
+ * @deprecated This utility class was used to write serializers into checkpoints.
+ *             Starting from Flink 1.6.x, this should no longer happen, and therefore
+ *             this class is deprecated. It remains here for backwards compatibility paths.
  */
 @Internal
+@Deprecated
 public class TypeSerializerSerializationUtil {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TypeSerializerSerializationUtil.class);
@@ -154,7 +159,7 @@ public class TypeSerializerSerializationUtil {
 				writeSerializer(bufferWrapper, serAndConfSnapshot.f0);
 
 				out.writeInt(bufferWithPos.getPosition());
-				writeSerializerConfigSnapshot(bufferWrapper, serAndConfSnapshot.f1);
+				TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(bufferWrapper, serAndConfSnapshot.f1);
 			}
 
 			out.writeInt(bufferWithPos.getPosition());
@@ -208,7 +213,7 @@ public class TypeSerializerSerializationUtil {
 				serializer = tryReadSerializer(bufferWrapper, userCodeClassLoader, true);
 
 				bufferWithPos.setPosition(offsets[i * 2 + 1]);
-				configSnapshot = readSerializerConfigSnapshot(bufferWrapper, userCodeClassLoader);
+				configSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(bufferWrapper, userCodeClassLoader);
 
 				serializersAndConfigSnapshots.add(
 					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(serializer, configSnapshot));
@@ -216,95 +221,6 @@ public class TypeSerializerSerializationUtil {
 		}
 
 		return serializersAndConfigSnapshots;
-	}
-
-	/**
-	 * Writes a {@link TypeSerializerConfigSnapshot} to the provided data output view.
-	 *
-	 * <p>It is written with a format that can be later read again using
-	 * {@link #readSerializerConfigSnapshot(DataInputView, ClassLoader)}.
-	 *
-	 * @param out the data output view
-	 * @param serializerConfigSnapshot the serializer configuration snapshot to write
-	 *
-	 * @throws IOException
-	 */
-	public static void writeSerializerConfigSnapshot(
-			DataOutputView out,
-			TypeSerializerConfigSnapshot serializerConfigSnapshot) throws IOException {
-
-		new TypeSerializerConfigSnapshotSerializationProxy(serializerConfigSnapshot).write(out);
-	}
-
-	/**
-	 * Reads from a data input view a {@link TypeSerializerConfigSnapshot} that was previously
-	 * written using {@link #writeSerializerConfigSnapshot(DataOutputView, TypeSerializerConfigSnapshot)}.
-	 *
-	 * @param in the data input view
-	 * @param userCodeClassLoader the user code class loader to use
-	 *
-	 * @return the read serializer configuration snapshot
-	 *
-	 * @throws IOException
-	 */
-	public static TypeSerializerConfigSnapshot readSerializerConfigSnapshot(
-			DataInputView in,
-			ClassLoader userCodeClassLoader) throws IOException {
-
-		final TypeSerializerConfigSnapshotSerializationProxy proxy = new TypeSerializerConfigSnapshotSerializationProxy(userCodeClassLoader);
-		proxy.read(in);
-
-		return proxy.getSerializerConfigSnapshot();
-	}
-
-	/**
-	 * Writes multiple {@link TypeSerializerConfigSnapshot}s to the provided data output view.
-	 *
-	 * <p>It is written with a format that can be later read again using
-	 * {@link #readSerializerConfigSnapshots(DataInputView, ClassLoader)}.
-	 *
-	 * @param out the data output view
-	 * @param serializerConfigSnapshots the serializer configuration snapshots to write
-	 *
-	 * @throws IOException
-	 */
-	public static void writeSerializerConfigSnapshots(
-			DataOutputView out,
-			TypeSerializerConfigSnapshot... serializerConfigSnapshots) throws IOException {
-
-		out.writeInt(serializerConfigSnapshots.length);
-
-		for (TypeSerializerConfigSnapshot snapshot : serializerConfigSnapshots) {
-			new TypeSerializerConfigSnapshotSerializationProxy(snapshot).write(out);
-		}
-	}
-
-	/**
-	 * Reads from a data input view multiple {@link TypeSerializerConfigSnapshot}s that was previously
-	 * written using {@link #writeSerializerConfigSnapshot(DataOutputView, TypeSerializerConfigSnapshot)}.
-	 *
-	 * @param in the data input view
-	 * @param userCodeClassLoader the user code class loader to use
-	 *
-	 * @return the read serializer configuration snapshots
-	 *
-	 * @throws IOException
-	 */
-	public static TypeSerializerConfigSnapshot[] readSerializerConfigSnapshots(
-			DataInputView in,
-			ClassLoader userCodeClassLoader) throws IOException {
-
-		int numFields = in.readInt();
-		final TypeSerializerConfigSnapshot[] serializerConfigSnapshots = new TypeSerializerConfigSnapshot[numFields];
-
-		TypeSerializerConfigSnapshotSerializationProxy proxy;
-		for (int i = 0; i < numFields; i++) {
-			proxy = new TypeSerializerConfigSnapshotSerializationProxy(userCodeClassLoader);
-			proxy.read(in);
-			serializerConfigSnapshots[i] = proxy.getSerializerConfigSnapshot();
-		}
-
-		return serializerConfigSnapshots;
 	}
 
 	// -----------------------------------------------------------------------------------------------------
@@ -384,64 +300,4 @@ public class TypeSerializerSerializationUtil {
 		}
 	}
 
-	/**
-	 * Utility serialization proxy for a {@link TypeSerializerConfigSnapshot}.
-	 */
-	static final class TypeSerializerConfigSnapshotSerializationProxy extends VersionedIOReadableWritable {
-
-		private static final int VERSION = 1;
-
-		private ClassLoader userCodeClassLoader;
-		private TypeSerializerConfigSnapshot serializerConfigSnapshot;
-
-		TypeSerializerConfigSnapshotSerializationProxy(ClassLoader userCodeClassLoader) {
-			this.userCodeClassLoader = Preconditions.checkNotNull(userCodeClassLoader);
-		}
-
-		TypeSerializerConfigSnapshotSerializationProxy(TypeSerializerConfigSnapshot serializerConfigSnapshot) {
-			this.serializerConfigSnapshot = serializerConfigSnapshot;
-		}
-
-		@Override
-		public void write(DataOutputView out) throws IOException {
-			super.write(out);
-
-			// config snapshot class, so that we can re-instantiate the
-			// correct type of config snapshot instance when deserializing
-			out.writeUTF(serializerConfigSnapshot.getClass().getName());
-
-			// the actual configuration parameters
-			serializerConfigSnapshot.write(out);
-		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public void read(DataInputView in) throws IOException {
-			super.read(in);
-
-			String serializerConfigClassname = in.readUTF();
-			Class<? extends TypeSerializerConfigSnapshot> serializerConfigSnapshotClass;
-			try {
-				serializerConfigSnapshotClass = (Class<? extends TypeSerializerConfigSnapshot>)
-					Class.forName(serializerConfigClassname, true, userCodeClassLoader);
-			} catch (ClassNotFoundException e) {
-				throw new IOException(
-					"Could not find requested TypeSerializerConfigSnapshot class "
-						+ serializerConfigClassname +  " in classpath.", e);
-			}
-
-			serializerConfigSnapshot = InstantiationUtil.instantiate(serializerConfigSnapshotClass);
-			serializerConfigSnapshot.setUserCodeClassLoader(userCodeClassLoader);
-			serializerConfigSnapshot.read(in);
-		}
-
-		@Override
-		public int getVersion() {
-			return VERSION;
-		}
-
-		TypeSerializerConfigSnapshot getSerializerConfigSnapshot() {
-			return serializerConfigSnapshot;
-		}
-	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -202,7 +202,7 @@ public class TypeSerializerSerializationUtil {
 			new ArrayList<>(numSerializersAndConfigSnapshots);
 
 		TypeSerializer<?> serializer;
-		TypeSerializerConfigSnapshot configSnapshot;
+		TypeSerializerConfigSnapshot<?> configSnapshot;
 		try (
 			ByteArrayInputStreamWithPos bufferWithPos = new ByteArrayInputStreamWithPos(buffer);
 			DataInputViewStreamWrapper bufferWrapper = new DataInputViewStreamWrapper(bufferWithPos)) {
@@ -213,10 +213,17 @@ public class TypeSerializerSerializationUtil {
 				serializer = tryReadSerializer(bufferWrapper, userCodeClassLoader, true);
 
 				bufferWithPos.setPosition(offsets[i * 2 + 1]);
-				configSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(bufferWrapper, userCodeClassLoader);
 
-				serializersAndConfigSnapshots.add(
-					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(serializer, configSnapshot));
+				// the config snapshot is replaced with a dummy one, which wraps
+				// the actual config snapshot and the deserialized serializer.
+				// this is for backwards compatibility reasons, since before Flink 1.6, some serializers
+				// do not return config snapshots that can be used as a factory for themselves.
+				configSnapshot = new BackwardsCompatibleConfigSnapshot<>(
+					TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
+						bufferWrapper, userCodeClassLoader),
+					serializer);
+
+				serializersAndConfigSnapshots.add(new Tuple2<>(serializer, configSnapshot));
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/UnloadableDummyTypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/UnloadableDummyTypeSerializer.java
@@ -94,12 +94,12 @@ public class UnloadableDummyTypeSerializer<T> extends TypeSerializer<T> {
 	}
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<T> snapshotConfiguration() {
 		throw new UnsupportedOperationException("This object is a dummy TypeSerializer.");
 	}
 
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		throw new UnsupportedOperationException("This object is a dummy TypeSerializer.");
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CollectionSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CollectionSerializerConfigSnapshot.java
@@ -28,12 +28,17 @@ import java.util.Collection;
  * Configuration snapshot of a serializer for collection types.
  *
  * @param <T> Type of the element.
+ *
+ * @deprecated this configuration snapshot is not capable of being a factory for all serializers that
+ *             previously write this as their configuration snapshot, and therefore deprecated. It is no
+ *             longer written by any of Flink's serializers, but is still here for backwards compatibility.
  */
 @Internal
+@Deprecated
 public final class CollectionSerializerConfigSnapshot<C extends Collection<T>, T>
 		extends CompositeTypeSerializerConfigSnapshot<C> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	public CollectionSerializerConfigSnapshot() {}
@@ -43,7 +48,23 @@ public final class CollectionSerializerConfigSnapshot<C extends Collection<T>, T
 	}
 
 	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		// versions that still used this config snapshot always still wrote the serializers
+		return true;
+	}
+
+	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	protected TypeSerializer<C> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CollectionSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CollectionSerializerConfigSnapshot.java
@@ -22,13 +22,16 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import java.util.Collection;
+
 /**
  * Configuration snapshot of a serializer for collection types.
  *
  * @param <T> Type of the element.
  */
 @Internal
-public final class CollectionSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot {
+public final class CollectionSerializerConfigSnapshot<C extends Collection<T>, T>
+		extends CompositeTypeSerializerConfigSnapshot<C> {
 
 	private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
@@ -178,7 +178,7 @@ public final class EnumSerializer<T extends Enum<T>> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof EnumSerializerConfigSnapshot) {
 			final EnumSerializerConfigSnapshot<T> config = (EnumSerializerConfigSnapshot<T>) configSnapshot;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
@@ -198,12 +198,12 @@ public final class GenericArraySerializer<C> extends TypeSerializer<C[]> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public GenericArraySerializerConfigSnapshot snapshotConfiguration() {
+	public GenericArraySerializerConfigSnapshot<C> snapshotConfiguration() {
 		return new GenericArraySerializerConfigSnapshot<>(componentClass, componentSerializer);
 	}
 
 	@Override
-	public CompatibilityResult<C[]> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<C[]> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof GenericArraySerializerConfigSnapshot) {
 			final GenericArraySerializerConfigSnapshot config = (GenericArraySerializerConfigSnapshot) configSnapshot;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
@@ -24,10 +24,8 @@ import java.lang.reflect.Array;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -212,18 +210,11 @@ public final class GenericArraySerializer<C> extends TypeSerializer<C[]> {
 					config.getSingleNestedSerializerAndConfig();
 
 				CompatibilityResult<C> compatResult = CompatibilityUtil.resolveCompatibilityResult(
-						previousComponentSerializerAndConfig.f0,
-						UnloadableDummyTypeSerializer.class,
 						previousComponentSerializerAndConfig.f1,
 						componentSerializer);
 
 				if (!compatResult.isRequiresMigration()) {
 					return CompatibilityResult.compatible();
-				} else if (compatResult.getConvertDeserializer() != null) {
-					return CompatibilityResult.requiresMigration(
-						new GenericArraySerializer<>(
-							componentClass,
-							new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer())));
 				}
 			}
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerConfigSnapshot.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 @Internal
 public final class GenericArraySerializerConfigSnapshot<C> extends CompositeTypeSerializerConfigSnapshot<C[]> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	private Class<C> componentClass;
 
@@ -79,6 +79,11 @@ public final class GenericArraySerializerConfigSnapshot<C> extends CompositeType
 		return VERSION;
 	}
 
+	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
 	public Class<C> getComponentClass() {
 		return componentClass;
 	}
@@ -93,5 +98,18 @@ public final class GenericArraySerializerConfigSnapshot<C> extends CompositeType
 	@Override
 	public int hashCode() {
 		return super.hashCode() * 31 + componentClass.hashCode();
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		return getReadVersion() < 2;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<C[]> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new GenericArraySerializer<>(
+			componentClass,
+			(TypeSerializer<C>) restoredNestedSerializers[0]);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerConfigSnapshot.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  * @param <C> The component type.
  */
 @Internal
-public final class GenericArraySerializerConfigSnapshot<C> extends CompositeTypeSerializerConfigSnapshot {
+public final class GenericArraySerializerConfigSnapshot<C> extends CompositeTypeSerializerConfigSnapshot<C[]> {
 
 	private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
@@ -21,10 +21,8 @@ package org.apache.flink.api.common.typeutils.base;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -190,16 +188,11 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 				((CollectionSerializerConfigSnapshot<?, ?>) configSnapshot).getSingleNestedSerializerAndConfig();
 
 			CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousElemSerializerAndConfig.f0,
-					UnloadableDummyTypeSerializer.class,
 					previousElemSerializerAndConfig.f1,
 					elementSerializer);
 
 			if (!compatResult.isRequiresMigration()) {
 				return CompatibilityResult.compatible();
-			} else if (compatResult.getConvertDeserializer() != null) {
-				return CompatibilityResult.requiresMigration(
-					new ListSerializer<>(new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer())));
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
@@ -179,7 +179,7 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public CollectionSerializerConfigSnapshot snapshotConfiguration() {
+	public CollectionSerializerConfigSnapshot<List<T>, T> snapshotConfiguration() {
 		return new CollectionSerializerConfigSnapshot<>(elementSerializer);
 	}
 
@@ -187,7 +187,7 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 	public CompatibilityResult<List<T>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
 		if (configSnapshot instanceof CollectionSerializerConfigSnapshot) {
 			Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> previousElemSerializerAndConfig =
-				((CollectionSerializerConfigSnapshot) configSnapshot).getSingleNestedSerializerAndConfig();
+				((CollectionSerializerConfigSnapshot<?, ?>) configSnapshot).getSingleNestedSerializerAndConfig();
 
 			CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
 					previousElemSerializerAndConfig.f0,

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
@@ -19,11 +19,9 @@
 package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -43,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of element in the list.
  */
 @Internal
-public final class ListSerializer<T> extends TypeSerializer<List<T>> {
+public final class ListSerializer<T> extends CompositeTypeSerializer<List<T>> {
 
 	private static final long serialVersionUID = 1119562170939152304L;
 
@@ -56,7 +54,12 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 	 * @param elementSerializer The serializer for the elements of the list
 	 */
 	public ListSerializer(TypeSerializer<T> elementSerializer) {
-		this.elementSerializer = checkNotNull(elementSerializer);
+
+		super(
+			new ListSerializerConfigSnapshot<>(checkNotNull(elementSerializer)),
+			elementSerializer);
+
+		this.elementSerializer = elementSerializer;
 	}
 
 	// ------------------------------------------------------------------------
@@ -172,30 +175,11 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 		return elementSerializer.hashCode();
 	}
 
-	// --------------------------------------------------------------------------------------------
-	// Serializer configuration snapshotting & compatibility
-	// --------------------------------------------------------------------------------------------
-
 	@Override
-	public CollectionSerializerConfigSnapshot<List<T>, T> snapshotConfiguration() {
-		return new CollectionSerializerConfigSnapshot<>(elementSerializer);
-	}
-
-	@Override
-	public CompatibilityResult<List<T>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
-		if (configSnapshot instanceof CollectionSerializerConfigSnapshot) {
-			Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> previousElemSerializerAndConfig =
-				((CollectionSerializerConfigSnapshot<?, ?>) configSnapshot).getSingleNestedSerializerAndConfig();
-
-			CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousElemSerializerAndConfig.f1,
-					elementSerializer);
-
-			if (!compatResult.isRequiresMigration()) {
-				return CompatibilityResult.compatible();
-			}
-		}
-
-		return CompatibilityResult.requiresMigration();
+	protected boolean isComparableSnapshot(TypeSerializerConfigSnapshot<?> configSnapshot) {
+		// previous versions of the ListSerializer still wrote the deprecated
+		// CollectionSerializerConfigSnapshot as the configuration snapshot
+		return configSnapshot instanceof ListSerializerConfigSnapshot
+			|| configSnapshot instanceof CollectionSerializerConfigSnapshot;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerConfigSnapshot.java
@@ -16,27 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.scala.typeutils;
+package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
-import scala.util.Either;
+import java.util.List;
 
 /**
- * Configuration snapshot for serializers of Scala's {@link Either} type,
- * containing configuration snapshots of the Left and Right serializers.
+ * A {@link TypeSerializerConfigSnapshot} for the {@link ListSerializer}.
  */
-public class ScalaEitherSerializerConfigSnapshot<E extends Either<L, R>, L, R>
-		extends CompositeTypeSerializerConfigSnapshot<E> {
+public class ListSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<List<T>> {
 
-	private static final int VERSION = 1;
+	private final int VERSION = 1;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
-	public ScalaEitherSerializerConfigSnapshot() {}
+	public ListSerializerConfigSnapshot() {}
 
-	public ScalaEitherSerializerConfigSnapshot(TypeSerializer<L> leftSerializer, TypeSerializer<R> rightSerializer) {
-		super(leftSerializer, rightSerializer);
+	public ListSerializerConfigSnapshot(TypeSerializer<T> elementSerializer) {
+		super(elementSerializer);
 	}
 
 	@Override
@@ -46,9 +45,7 @@ public class ScalaEitherSerializerConfigSnapshot<E extends Either<L, R>, L, R>
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected TypeSerializer<E> restoreSerializer(TypeSerializer<?>... restoredNestedSerializers) {
-		return new EitherSerializer<>(
-			(TypeSerializer<L>) restoredNestedSerializers[0],
-			(TypeSerializer<R>) restoredNestedSerializers[1]);
+	protected TypeSerializer<List<T>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new ListSerializer<>((TypeSerializer<T>) restoredNestedSerializers[0]);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
@@ -21,10 +21,8 @@ package org.apache.flink.api.common.typeutils.base;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -218,24 +216,15 @@ public final class MapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
 				((MapSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 			CompatibilityResult<K> keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousKvSerializersAndConfigs.get(0).f0,
-					UnloadableDummyTypeSerializer.class,
 					previousKvSerializersAndConfigs.get(0).f1,
 					keySerializer);
 
 			CompatibilityResult<V> valueCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousKvSerializersAndConfigs.get(1).f0,
-					UnloadableDummyTypeSerializer.class,
 					previousKvSerializersAndConfigs.get(1).f1,
 					valueSerializer);
 
 			if (!keyCompatResult.isRequiresMigration() && !valueCompatResult.isRequiresMigration()) {
 				return CompatibilityResult.compatible();
-			} else if (keyCompatResult.getConvertDeserializer() != null && valueCompatResult.getConvertDeserializer() != null) {
-				return CompatibilityResult.requiresMigration(
-					new MapSerializer<>(
-						new TypeDeserializerAdapter<>(keyCompatResult.getConvertDeserializer()),
-						new TypeDeserializerAdapter<>(valueCompatResult.getConvertDeserializer())));
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
@@ -207,15 +207,15 @@ public final class MapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public MapSerializerConfigSnapshot snapshotConfiguration() {
+	public MapSerializerConfigSnapshot<K, V> snapshotConfiguration() {
 		return new MapSerializerConfigSnapshot<>(keySerializer, valueSerializer);
 	}
 
 	@Override
-	public CompatibilityResult<Map<K, V>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<Map<K, V>> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof MapSerializerConfigSnapshot) {
 			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousKvSerializersAndConfigs =
-				((MapSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+				((MapSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 			CompatibilityResult<K> keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
 					previousKvSerializersAndConfigs.get(0).f0,

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerConfigSnapshot.java
@@ -31,7 +31,7 @@ import java.util.Map;
 @Internal
 public final class MapSerializerConfigSnapshot<K, V> extends CompositeTypeSerializerConfigSnapshot<Map<K, V>> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	public MapSerializerConfigSnapshot() {}
@@ -41,7 +41,25 @@ public final class MapSerializerConfigSnapshot<K, V> extends CompositeTypeSerial
 	}
 
 	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
+	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		return getReadVersion() < 2;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<Map<K, V>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new MapSerializer<>(
+			(TypeSerializer<K>) restoredNestedSerializers[0],
+			(TypeSerializer<V>) restoredNestedSerializers[1]);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerConfigSnapshot.java
@@ -22,12 +22,14 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import java.util.Map;
+
 /**
  * Configuration snapshot for serializers of maps, containing the
  * configuration snapshot of its key serializer and value serializer.
  */
 @Internal
-public final class MapSerializerConfigSnapshot<K, V> extends CompositeTypeSerializerConfigSnapshot {
+public final class MapSerializerConfigSnapshot<K, V> extends CompositeTypeSerializerConfigSnapshot<Map<K, V>> {
 
 	private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
@@ -53,16 +53,16 @@ public abstract class TypeSerializerSingleton<T> extends TypeSerializer<T>{
 	}
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<T> snapshotConfiguration() {
 		// type serializer singletons should always be parameter-less
-		return new ParameterlessTypeSerializerConfig(getSerializationFormatIdentifier());
+		return new ParameterlessTypeSerializerConfig<>(getSerializationFormatIdentifier());
 	}
 
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof ParameterlessTypeSerializerConfig
 				&& isCompatibleSerializationFormatIdentifier(
-						((ParameterlessTypeSerializerConfig) configSnapshot).getSerializationFormatIdentifier())) {
+						((ParameterlessTypeSerializerConfig<?>) configSnapshot).getSerializationFormatIdentifier())) {
 
 			return CompatibilityResult.compatible();
 		} else {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
@@ -142,9 +142,9 @@ public final class CopyableValueSerializer<T extends CopyableValue<T>> extends T
 	}
 
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof CopyableValueSerializerConfigSnapshot
-				&& valueClass.equals(((CopyableValueSerializerConfigSnapshot) configSnapshot).getTypeClass())) {
+				&& valueClass.equals(((CopyableValueSerializerConfigSnapshot<?>) configSnapshot).getTypeClass())) {
 			return CompatibilityResult.compatible();
 		} else {
 			return CompatibilityResult.requiresMigration();

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
@@ -21,10 +21,8 @@ package org.apache.flink.api.java.typeutils.runtime;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -207,26 +205,15 @@ public class EitherSerializer<L, R> extends TypeSerializer<Either<L, R>> {
 				((EitherSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 			CompatibilityResult<L> leftCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousLeftRightSerializersAndConfigs.get(0).f0,
-					UnloadableDummyTypeSerializer.class,
 					previousLeftRightSerializersAndConfigs.get(0).f1,
 					leftSerializer);
 
 			CompatibilityResult<R> rightCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousLeftRightSerializersAndConfigs.get(1).f0,
-					UnloadableDummyTypeSerializer.class,
 					previousLeftRightSerializersAndConfigs.get(1).f1,
 					rightSerializer);
 
 			if (!leftCompatResult.isRequiresMigration() && !rightCompatResult.isRequiresMigration()) {
 				return CompatibilityResult.compatible();
-			} else {
-				if (leftCompatResult.getConvertDeserializer() != null && rightCompatResult.getConvertDeserializer() != null) {
-					return CompatibilityResult.requiresMigration(
-						new EitherSerializer<>(
-							new TypeDeserializerAdapter<>(leftCompatResult.getConvertDeserializer()),
-							new TypeDeserializerAdapter<>(rightCompatResult.getConvertDeserializer())));
-				}
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
@@ -196,15 +196,15 @@ public class EitherSerializer<L, R> extends TypeSerializer<Either<L, R>> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public EitherSerializerConfigSnapshot snapshotConfiguration() {
+	public EitherSerializerConfigSnapshot<L, R> snapshotConfiguration() {
 		return new EitherSerializerConfigSnapshot<>(leftSerializer, rightSerializer);
 	}
 
 	@Override
-	public CompatibilityResult<Either<L, R>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<Either<L, R>> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof EitherSerializerConfigSnapshot) {
 			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousLeftRightSerializersAndConfigs =
-				((EitherSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+				((EitherSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 			CompatibilityResult<L> leftCompatResult = CompatibilityUtil.resolveCompatibilityResult(
 					previousLeftRightSerializersAndConfigs.get(0).f0,

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerConfigSnapshot.java
@@ -28,7 +28,7 @@ import org.apache.flink.types.Either;
  * containing configuration snapshots of the Left and Right serializers.
  */
 @Internal
-public final class EitherSerializerConfigSnapshot<L, R> extends CompositeTypeSerializerConfigSnapshot {
+public final class EitherSerializerConfigSnapshot<L, R> extends CompositeTypeSerializerConfigSnapshot<Either<L, R>> {
 
 	private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerConfigSnapshot.java
@@ -30,7 +30,7 @@ import org.apache.flink.types.Either;
 @Internal
 public final class EitherSerializerConfigSnapshot<L, R> extends CompositeTypeSerializerConfigSnapshot<Either<L, R>> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	public EitherSerializerConfigSnapshot() {}
@@ -42,5 +42,23 @@ public final class EitherSerializerConfigSnapshot<L, R> extends CompositeTypeSer
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		return getReadVersion() < 2;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<Either<L, R>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new EitherSerializer<>(
+			(TypeSerializer<L>) restoredNestedSerializers[0],
+			(TypeSerializer<R>) restoredNestedSerializers[1]);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -38,6 +38,7 @@ import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.GenericTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshotSerializationUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -802,7 +803,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 					}
 
 					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+					TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
 				}
 
 				// --- write registered subclasses and their serializers, in registration order
@@ -819,7 +820,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 					}
 
 					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+					TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
 				}
 
 				// --- write snapshot of non-registered subclass serializer cache
@@ -836,7 +837,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 					}
 
 					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+					TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
 				}
 
 				out.writeInt(outWithPos.getPosition());
@@ -891,7 +892,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 					fieldSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader(), true);
 
 					inWithPos.setPosition(fieldSerializerOffsets[i * 2 + 1]);
-					fieldSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
+					fieldSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
 
 					fieldToSerializerConfigSnapshot.put(
 						fieldName,
@@ -917,7 +918,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 					registeredSubclassSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader(), true);
 
 					inWithPos.setPosition(registeredSerializerOffsets[i * 2 + 1]);
-					registeredSubclassSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
+					registeredSubclassSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
 
 					this.registeredSubclassesToSerializerConfigSnapshots.put(
 						registeredSubclass,
@@ -943,7 +944,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 					cachedSubclassSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader(), true);
 
 					inWithPos.setPosition(cachedSerializerOffsets[i * 2 + 1]);
-					cachedSubclassSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
+					cachedSubclassSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
 
 					this.nonRegisteredSubclassesToSerializerConfigSnapshots.put(
 						cachedSubclass,

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -594,7 +594,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof PojoSerializerConfigSnapshot) {
 			final PojoSerializerConfigSnapshot<T> config = (PojoSerializerConfigSnapshot<T>) configSnapshot;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -21,10 +21,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -274,38 +272,20 @@ public final class RowSerializer extends TypeSerializer<Row> {
 				((RowSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
 
 			if (previousFieldSerializersAndConfigs.size() == fieldSerializers.length) {
-				boolean requireMigration = false;
-				TypeSerializer<?>[] convertDeserializers = new TypeSerializer<?>[fieldSerializers.length];
 
 				CompatibilityResult<?> compatResult;
 				int i = 0;
 				for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> f : previousFieldSerializersAndConfigs) {
-					compatResult = CompatibilityUtil.resolveCompatibilityResult(
-							f.f0,
-							UnloadableDummyTypeSerializer.class,
-							f.f1,
-							fieldSerializers[i]);
+					compatResult = CompatibilityUtil.resolveCompatibilityResult(f.f1, fieldSerializers[i]);
 
 					if (compatResult.isRequiresMigration()) {
-						requireMigration = true;
-
-						if (compatResult.getConvertDeserializer() == null) {
-							// one of the field serializers cannot provide a fallback deserializer
-							return CompatibilityResult.requiresMigration();
-						} else {
-							convertDeserializers[i] =
-								new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer());
-						}
+						return CompatibilityResult.requiresMigration();
 					}
 
 					i++;
 				}
 
-				if (requireMigration) {
-					return CompatibilityResult.requiresMigration(new RowSerializer(convertDeserializers));
-				} else {
-					return CompatibilityResult.compatible();
-				}
+				return CompatibilityResult.compatible();
 			}
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -268,7 +268,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 	}
 
 	@Override
-	public CompatibilityResult<Row> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<Row> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof RowSerializerConfigSnapshot) {
 			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousFieldSerializersAndConfigs =
 				((RowSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
@@ -312,7 +312,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		return CompatibilityResult.requiresMigration();
 	}
 
-	public static final class RowSerializerConfigSnapshot extends CompositeTypeSerializerConfigSnapshot {
+	public static final class RowSerializerConfigSnapshot extends CompositeTypeSerializerConfigSnapshot<Row> {
 
 		private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -135,7 +135,7 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof TupleSerializerConfigSnapshot) {
 			final TupleSerializerConfigSnapshot<T> config = (TupleSerializerConfigSnapshot<T>) configSnapshot;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -145,37 +143,19 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 
 				if (previousFieldSerializersAndConfigs.size() == fieldSerializers.length) {
 
-					TypeSerializer<Object>[] convertFieldSerializers = new TypeSerializer[fieldSerializers.length];
-					boolean requiresMigration = false;
 					CompatibilityResult<Object> compatResult;
 					int i = 0;
 					for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> f : previousFieldSerializersAndConfigs) {
-						compatResult = CompatibilityUtil.resolveCompatibilityResult(
-								f.f0,
-								UnloadableDummyTypeSerializer.class,
-								f.f1,
-								fieldSerializers[i]);
+						compatResult = CompatibilityUtil.resolveCompatibilityResult(f.f1, fieldSerializers[i]);
 
 						if (compatResult.isRequiresMigration()) {
-							requiresMigration = true;
-
-							if (compatResult.getConvertDeserializer() != null) {
-								convertFieldSerializers[i] =
-									new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer());
-							} else {
-								return CompatibilityResult.requiresMigration();
-							}
+							return CompatibilityResult.requiresMigration();
 						}
 
 						i++;
 					}
 
-					if (!requiresMigration) {
-						return CompatibilityResult.compatible();
-					} else {
-						return CompatibilityResult.requiresMigration(
-							createSerializerInstance(tupleClass, convertFieldSerializers));
-					}
+					return CompatibilityResult.compatible();
 				}
 			}
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -20,23 +20,20 @@ package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializer;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @Internal
-public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
+public abstract class TupleSerializerBase<T> extends CompositeTypeSerializer<T> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -49,9 +46,15 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 	private int length = -2;
 
 	@SuppressWarnings("unchecked")
-	public TupleSerializerBase(Class<T> tupleClass, TypeSerializer<?>[] fieldSerializers) {
+	public TupleSerializerBase(
+			Class<T> tupleClass,
+			CompositeTypeSerializerConfigSnapshot<T> serializerConfigSnapshot,
+			TypeSerializer<?>[] fieldSerializers) {
+
+		super(serializerConfigSnapshot, fieldSerializers);
+
 		this.tupleClass = checkNotNull(tupleClass);
-		this.fieldSerializers = (TypeSerializer<Object>[]) checkNotNull(fieldSerializers);
+		this.fieldSerializers = (TypeSerializer<Object>[]) fieldSerializers;
 		this.arity = fieldSerializers.length;
 	}
 	
@@ -121,49 +124,6 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 	public boolean canEqual(Object obj) {
 		return obj instanceof TupleSerializerBase;
 	}
-
-	// --------------------------------------------------------------------------------------------
-	// Serializer configuration snapshotting & compatibility
-	// --------------------------------------------------------------------------------------------
-
-	@Override
-	public TupleSerializerConfigSnapshot<T> snapshotConfiguration() {
-		return new TupleSerializerConfigSnapshot<>(tupleClass, fieldSerializers);
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
-		if (configSnapshot instanceof TupleSerializerConfigSnapshot) {
-			final TupleSerializerConfigSnapshot<T> config = (TupleSerializerConfigSnapshot<T>) configSnapshot;
-
-			if (tupleClass.equals(config.getTupleClass())) {
-				List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousFieldSerializersAndConfigs =
-					((TupleSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
-
-				if (previousFieldSerializersAndConfigs.size() == fieldSerializers.length) {
-
-					CompatibilityResult<Object> compatResult;
-					int i = 0;
-					for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> f : previousFieldSerializersAndConfigs) {
-						compatResult = CompatibilityUtil.resolveCompatibilityResult(f.f1, fieldSerializers[i]);
-
-						if (compatResult.isRequiresMigration()) {
-							return CompatibilityResult.requiresMigration();
-						}
-
-						i++;
-					}
-
-					return CompatibilityResult.compatible();
-				}
-			}
-		}
-
-		return CompatibilityResult.requiresMigration();
-	}
-
-	protected abstract TupleSerializerBase<T> createSerializerInstance(Class<T> tupleClass, TypeSerializer<?>[] fieldSerializers);
 
 	@VisibleForTesting
 	public TypeSerializer<Object>[] getFieldSerializers() {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerConfigSnapshot.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * Snapshot of a tuple serializer's configuration.
  */
 @Internal
-public final class TupleSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot {
+public final class TupleSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<T> {
 
 	private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerConfigSnapshot.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
@@ -29,12 +30,12 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 
 /**
- * Snapshot of a tuple serializer's configuration.
+ * Snapshot of a {@link TupleSerializer}'s configuration.
  */
 @Internal
-public final class TupleSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<T> {
+public final class TupleSerializerConfigSnapshot<T extends Tuple> extends CompositeTypeSerializerConfigSnapshot<T> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	private Class<T> tupleClass;
 
@@ -70,6 +71,21 @@ public final class TupleSerializerConfigSnapshot<T> extends CompositeTypeSeriali
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		return getReadVersion() < 2;
+	}
+
+	@Override
+	protected TypeSerializer<T> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new TupleSerializer<>(tupleClass, restoredNestedSerializers);
 	}
 
 	public Class<T> getTupleClass() {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -182,7 +182,7 @@ public final class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof ValueSerializerConfigSnapshot) {
 			final ValueSerializerConfigSnapshot<T> config = (ValueSerializerConfigSnapshot<T>) configSnapshot;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -463,7 +463,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof KryoSerializerConfigSnapshot) {
 			final KryoSerializerConfigSnapshot<T> config = (KryoSerializerConfigSnapshot<T>) configSnapshot;
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -120,11 +120,11 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		CompatibilityResult strategy = getSerializer().ensureCompatibility(restoredConfig);
+		CompatibilityResult strategy = getSerializer().internalEnsureCompatibility(restoredConfig);
 		assertFalse(strategy.isRequiresMigration());
 
 		// also verify that the serializer's reconfigure implementation detects incompatibility
-		strategy = getSerializer().ensureCompatibility(new TestIncompatibleSerializerConfigSnapshot<>());
+		strategy = getSerializer().internalEnsureCompatibility(new TestIncompatibleSerializerConfigSnapshot<>());
 		assertTrue(strategy.isRequiresMigration());
 	}
 	

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -124,7 +124,7 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 		assertFalse(strategy.isRequiresMigration());
 
 		// also verify that the serializer's reconfigure implementation detects incompatibility
-		strategy = getSerializer().ensureCompatibility(new TestIncompatibleSerializerConfigSnapshot());
+		strategy = getSerializer().ensureCompatibility(new TestIncompatibleSerializerConfigSnapshot<>());
 		assertTrue(strategy.isRequiresMigration());
 	}
 	
@@ -526,7 +526,7 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 		}
 	}
 
-	public static final class TestIncompatibleSerializerConfigSnapshot extends TypeSerializerConfigSnapshot {
+	public static final class TestIncompatibleSerializerConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
 		@Override
 		public int getVersion() {
 			return 0;

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -109,14 +109,14 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(
 				new DataOutputViewStreamWrapper(out), configSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
 		TypeSerializerConfigSnapshot restoredConfig;
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			restoredConfig = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			restoredConfig = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -156,23 +156,22 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshots(
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshots(
 				new DataOutputViewStreamWrapper(out),
-				configSnapshot1,
-				configSnapshot2);
+				Arrays.asList(configSnapshot1, configSnapshot2));
 
 			serializedConfig = out.toByteArray();
 		}
 
-		TypeSerializerConfigSnapshot[] restoredConfigs;
+		List<TypeSerializerConfigSnapshot<?>> restoredConfigs;
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			restoredConfigs = TypeSerializerSerializationUtil.readSerializerConfigSnapshots(
+			restoredConfigs = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshots(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		assertEquals(2, restoredConfigs.length);
-		assertEquals(configSnapshot1, restoredConfigs[0]);
-		assertEquals(configSnapshot2, restoredConfigs[1]);
+		assertEquals(2, restoredConfigs.size());
+		assertEquals(configSnapshot1, restoredConfigs.get(0));
+		assertEquals(configSnapshot2, restoredConfigs.get(1));
 	}
 
 	/**
@@ -182,14 +181,14 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 	public void testFailsWhenConfigurationSnapshotClassNotFound() throws Exception {
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(
 				new DataOutputViewStreamWrapper(out), new TypeSerializerSerializationUtilTest.TestConfigSnapshot<>(123, "foobar"));
 			serializedConfig = out.toByteArray();
 		}
 
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
 			// read using a dummy classloader
-			TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), new URLClassLoader(new URL[0], null));
 			fail("Expected a ClassNotFoundException wrapped in IOException");
 		} catch (IOException expected) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -416,7 +416,7 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 
 		@Override
 		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
-			return IntSerializer.INSTANCE.ensureCompatibility(configSnapshot);
+			return IntSerializer.INSTANCE.internalEnsureCompatibility(configSnapshot);
 		}
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -148,11 +148,11 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 	 */
 	@Test
 	public void testSerializeConfigurationSnapshots() throws Exception {
-		TypeSerializerSerializationUtilTest.TestConfigSnapshot configSnapshot1 =
-			new TypeSerializerSerializationUtilTest.TestConfigSnapshot(1, "foo");
+		TypeSerializerSerializationUtilTest.TestConfigSnapshot<String> configSnapshot1 =
+			new TypeSerializerSerializationUtilTest.TestConfigSnapshot<>(1, "foo");
 
-		TypeSerializerSerializationUtilTest.TestConfigSnapshot configSnapshot2 =
-			new TypeSerializerSerializationUtilTest.TestConfigSnapshot(2, "bar");
+		TypeSerializerSerializationUtilTest.TestConfigSnapshot<String> configSnapshot2 =
+			new TypeSerializerSerializationUtilTest.TestConfigSnapshot<>(2, "bar");
 
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -183,7 +183,7 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(
-				new DataOutputViewStreamWrapper(out), new TypeSerializerSerializationUtilTest.TestConfigSnapshot(123, "foobar"));
+				new DataOutputViewStreamWrapper(out), new TypeSerializerSerializationUtilTest.TestConfigSnapshot<>(123, "foobar"));
 			serializedConfig = out.toByteArray();
 		}
 
@@ -266,7 +266,7 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 		Assert.assertTrue(anonymousClassSerializer.getClass().isAnonymousClass());
 	}
 
-	public static class TestConfigSnapshot extends TypeSerializerConfigSnapshot {
+	public static class TestConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
 
 		static final int VERSION = 1;
 
@@ -411,12 +411,12 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<Integer> snapshotConfiguration() {
 			return IntSerializer.INSTANCE.snapshotConfiguration();
 		}
 
 		@Override
-		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			return IntSerializer.INSTANCE.ensureCompatibility(configSnapshot);
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.api.common.typeutils.base;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshotSerializationUtil;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.InstantiationUtil;
@@ -95,14 +95,14 @@ public class EnumSerializerTest extends TestLogger {
 
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(
 				new DataOutputViewStreamWrapper(out), serializer.snapshotConfiguration());
 			serializedConfig = out.toByteArray();
 		}
 
 		TypeSerializerConfigSnapshot restoredConfig;
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			restoredConfig = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			restoredConfig = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
@@ -72,7 +72,7 @@ public class EnumSerializerTest extends TestLogger {
 		assertEquals(PublicEnum.PAULA.ordinal(), serializer.getValueToOrdinal().get(PublicEnum.PAULA).intValue());
 
 		// reconfigure and verify compatibility
-		CompatibilityResult<PublicEnum> compatResult = serializer.ensureCompatibility(
+		CompatibilityResult<PublicEnum> compatResult = serializer.internalEnsureCompatibility(
 			new EnumSerializer.EnumSerializerConfigSnapshot<>(PublicEnum.class, mockPreviousOrder));
 		assertFalse(compatResult.isRequiresMigration());
 
@@ -106,7 +106,7 @@ public class EnumSerializerTest extends TestLogger {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		CompatibilityResult<PublicEnum> compatResult = serializer.ensureCompatibility(restoredConfig);
+		CompatibilityResult<PublicEnum> compatResult = serializer.internalEnsureCompatibility(restoredConfig);
 		assertFalse(compatResult.isRequiresMigration());
 
 		assertEquals(PublicEnum.FOO.ordinal(), serializer.getValueToOrdinal().get(PublicEnum.FOO).intValue());
@@ -161,7 +161,7 @@ public class EnumSerializerTest extends TestLogger {
 		assertEquals(PublicEnum.PAULA.ordinal(), serializer.getValueToOrdinal().get(PublicEnum.PAULA).intValue());
 
 		// reconfigure and verify compatibility
-		CompatibilityResult<PublicEnum> compatResult = serializer.ensureCompatibility(
+		CompatibilityResult<PublicEnum> compatResult = serializer.internalEnsureCompatibility(
 			new EnumSerializer.EnumSerializerConfigSnapshot<>(PublicEnum.class, mockPreviousOrder));
 		assertFalse(compatResult.isRequiresMigration());
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
@@ -114,7 +114,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 		}
 
 		EnumSerializer enumSerializer2 = new EnumSerializer(classLoader2.loadClass(ENUM_NAME));
-		return enumSerializer2.ensureCompatibility(restoredSnapshot);
+		return enumSerializer2.internalEnsureCompatibility(restoredSnapshot);
 	}
 
 	private static ClassLoader compileAndLoadEnum(File root, String filename, String source) throws IOException {

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshotSerializationUtil;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.TestLogger;
@@ -98,7 +98,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 			ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
 			DataOutputViewStreamWrapper outputViewStreamWrapper = new DataOutputViewStreamWrapper(outBuffer)) {
 
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outputViewStreamWrapper, snapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(outputViewStreamWrapper, snapshot);
 			snapshotBytes = outBuffer.toByteArray();
 		}
 
@@ -110,7 +110,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 			ByteArrayInputStream inBuffer = new ByteArrayInputStream(snapshotBytes);
 			DataInputViewStreamWrapper inputViewStreamWrapper = new DataInputViewStreamWrapper(inBuffer)) {
 
-			restoredSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inputViewStreamWrapper, classLoader2);
+			restoredSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(inputViewStreamWrapper, classLoader2);
 		}
 
 		EnumSerializer enumSerializer2 = new EnumSerializer(classLoader2.loadClass(ENUM_NAME));

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -310,7 +310,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		CompatibilityResult<SubTestUserClassA> compatResult = pojoSerializer2.ensureCompatibility(pojoSerializerConfigSnapshot);
+		CompatibilityResult<SubTestUserClassA> compatResult = pojoSerializer2.internalEnsureCompatibility(pojoSerializerConfigSnapshot);
 		assertTrue(compatResult.isRequiresMigration());
 	}
 
@@ -350,7 +350,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(pojoSerializerConfigSnapshot);
+		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.internalEnsureCompatibility(pojoSerializerConfigSnapshot);
 		assertTrue(!compatResult.isRequiresMigration());
 
 		// reconfigure - check reconfiguration result and that registration ids remains the same
@@ -394,7 +394,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		}
 
 		// reconfigure - check reconfiguration result and that subclass serializer cache is repopulated
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(pojoSerializerConfigSnapshot);
+		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.internalEnsureCompatibility(pojoSerializerConfigSnapshot);
 		assertFalse(compatResult.isRequiresMigration());
 		assertEquals(2, pojoSerializer.getSubclassSerializerCache().size());
 		assertTrue(pojoSerializer.getSubclassSerializerCache().containsKey(SubTestUserClassA.class));
@@ -456,7 +456,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		// reconfigure - check reconfiguration result and that
 		// 1) subclass serializer cache is repopulated
 		// 2) registrations also contain the now registered subclasses
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(pojoSerializerConfigSnapshot);
+		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.internalEnsureCompatibility(pojoSerializerConfigSnapshot);
 		assertFalse(compatResult.isRequiresMigration());
 		assertEquals(2, pojoSerializer.getSubclassSerializerCache().size());
 		assertTrue(pojoSerializer.getSubclassSerializerCache().containsKey(SubTestUserClassA.class));
@@ -533,7 +533,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 				new HashMap<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>>()); // empty; irrelevant for this test
 
 		// reconfigure - check reconfiguration result and that fields are reordered to the previous order
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(mockPreviousConfigSnapshot);
+		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.internalEnsureCompatibility(mockPreviousConfigSnapshot);
 		assertFalse(compatResult.isRequiresMigration());
 		int i = 0;
 		for (Field field : mockOriginalFieldOrder) {
@@ -574,7 +574,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 						cnfThrowingClassnames));
 		}
 
-		Assert.assertFalse(pojoSerializer.ensureCompatibility(deserializedConfig).isRequiresMigration());
+		Assert.assertFalse(pojoSerializer.internalEnsureCompatibility(deserializedConfig).isRequiresMigration());
 		verifyPojoSerializerConfigSnapshotWithSerializerSerializationFailure(config, deserializedConfig);
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -42,7 +42,7 @@ import org.apache.flink.api.common.typeutils.CompositeType.FlatFieldDescriptor;
 import org.apache.flink.api.common.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.common.operators.Keys.IncompatibleKeysException;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshotSerializationUtil;
 import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.DateSerializer;
 import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
@@ -297,7 +297,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		TypeSerializerConfigSnapshot pojoSerializerConfigSnapshot = pojoSerializer1.snapshotConfiguration();
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -306,7 +306,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		// read configuration again from bytes
 		try(ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			pojoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			pojoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -333,7 +333,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		TypeSerializerConfigSnapshot pojoSerializerConfigSnapshot = pojoSerializer.snapshotConfiguration();
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -346,7 +346,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		// read configuration from bytes
 		try(ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			pojoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			pojoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -379,7 +379,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		TypeSerializerConfigSnapshot pojoSerializerConfigSnapshot = pojoSerializer.snapshotConfiguration();
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -389,7 +389,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		// read configuration from bytes
 		try(ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			pojoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			pojoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -437,7 +437,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		TypeSerializerConfigSnapshot pojoSerializerConfigSnapshot = pojoSerializer.snapshotConfiguration();
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), pojoSerializerConfigSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -449,7 +449,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		// read configuration from bytes
 		try(ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			pojoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			pojoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -552,7 +552,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		byte[] serializedConfig;
 		try (
 			ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), config);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), config);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -567,7 +567,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		PojoSerializer.PojoSerializerConfigSnapshot<TestUserClass> deserializedConfig;
 		try(ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
 			deserializedConfig = (PojoSerializer.PojoSerializerConfigSnapshot<TestUserClass>)
-				TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+				TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 					new DataInputViewStreamWrapper(in),
 					new ArtificialCNFExceptionThrowingClassLoader(
 						Thread.currentThread().getContextClassLoader(),

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshotSerializationUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -63,7 +64,7 @@ public class KryoSerializerCompatibilityTest {
 		// read configuration again from bytes
 		TypeSerializerConfigSnapshot kryoSerializerConfigSnapshot;
 		try (InputStream in = getClass().getResourceAsStream("/kryo-serializer-flink1.3-snapshot")) {
-			kryoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			kryoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 		CompatibilityResult<TestClass> compatResult = kryoSerializerForA.ensureCompatibility(kryoSerializerConfigSnapshot);
@@ -97,7 +98,7 @@ public class KryoSerializerCompatibilityTest {
 		TypeSerializerConfigSnapshot kryoSerializerConfigSnapshot = kryoSerializerForA.snapshotConfiguration();
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), kryoSerializerConfigSnapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), kryoSerializerConfigSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -105,7 +106,7 @@ public class KryoSerializerCompatibilityTest {
 
 		// read configuration again from bytes
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			kryoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			kryoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -251,7 +252,7 @@ public class KryoSerializerCompatibilityTest {
 		TypeSerializerConfigSnapshot kryoSerializerConfigSnapshot = kryoSerializer.snapshotConfiguration();
 		byte[] serializedConfig;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), kryoSerializerConfigSnapshot);
+			TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), kryoSerializerConfigSnapshot);
 			serializedConfig = out.toByteArray();
 		}
 
@@ -264,7 +265,7 @@ public class KryoSerializerCompatibilityTest {
 
 		// read configuration from bytes
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
-			kryoSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+			kryoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
@@ -67,7 +67,7 @@ public class KryoSerializerCompatibilityTest {
 			kryoSerializerConfigSnapshot = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
-		CompatibilityResult<TestClass> compatResult = kryoSerializerForA.ensureCompatibility(kryoSerializerConfigSnapshot);
+		CompatibilityResult<TestClass> compatResult = kryoSerializerForA.internalEnsureCompatibility(kryoSerializerConfigSnapshot);
 		assertFalse(compatResult.isRequiresMigration());
 	}
 
@@ -110,7 +110,7 @@ public class KryoSerializerCompatibilityTest {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		CompatibilityResult<TestClassB> compatResult = kryoSerializerForB.ensureCompatibility(kryoSerializerConfigSnapshot);
+		CompatibilityResult<TestClassB> compatResult = kryoSerializerForB.internalEnsureCompatibility(kryoSerializerConfigSnapshot);
 		assertTrue(compatResult.isRequiresMigration());
 	}
 
@@ -270,7 +270,7 @@ public class KryoSerializerCompatibilityTest {
 		}
 
 		// reconfigure - check reconfiguration result and that registration id remains the same
-		CompatibilityResult<TestClass> compatResult = kryoSerializer.ensureCompatibility(kryoSerializerConfigSnapshot);
+		CompatibilityResult<TestClass> compatResult = kryoSerializer.internalEnsureCompatibility(kryoSerializerConfigSnapshot);
 		assertFalse(compatResult.isRequiresMigration());
 		assertEquals(testClassId, kryoSerializer.getKryo().getRegistration(TestClass.class).getId());
 		assertEquals(testClassAId, kryoSerializer.getKryo().getRegistration(TestClassA.class).getId());

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/api/java/typeutils/runtime/AvroSerializer.java
@@ -225,7 +225,7 @@ public final class AvroSerializer<T> extends TypeSerializer<T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof AvroSerializerConfigSnapshot) {
 			final AvroSerializerConfigSnapshot<T> config = (AvroSerializerConfigSnapshot<T>) configSnapshot;
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializer.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializer.java
@@ -172,13 +172,13 @@ public class BackwardsCompatibleAvroSerializer<T> extends TypeSerializer<T> {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<T> snapshotConfiguration() {
 		// we return the configuration of the actually used serializer here
 		return serializer.snapshotConfiguration();
 	}
 
 	@Override
-	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof AvroSchemaSerializerConfigSnapshot ||
 				configSnapshot instanceof AvroSerializerConfigSnapshot) {
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializer.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializer.java
@@ -186,7 +186,7 @@ public class BackwardsCompatibleAvroSerializer<T> extends TypeSerializer<T> {
 			checkState(serializer instanceof AvroSerializer,
 					"Serializer was changed backwards to PojoSerializer and now encounters AvroSerializer snapshot.");
 
-			return serializer.ensureCompatibility(configSnapshot);
+			return serializer.internalEnsureCompatibility(configSnapshot);
 		}
 		else if (configSnapshot instanceof PojoSerializerConfigSnapshot) {
 			// common previous case
@@ -201,14 +201,14 @@ public class BackwardsCompatibleAvroSerializer<T> extends TypeSerializer<T> {
 			final TypeSerializer<T> pojoSerializer =
 					(TypeSerializer<T>) typeInfo.createPojoSerializer(new ExecutionConfig());
 			this.serializer = pojoSerializer;
-			return serializer.ensureCompatibility(configSnapshot);
+			return serializer.internalEnsureCompatibility(configSnapshot);
 		}
 		else if (configSnapshot instanceof KryoRegistrationSerializerConfigSnapshot) {
 			// force-kryo old case common previous case
 			// we create a new Kryo Serializer with a blank execution config.
 			// registrations are anyways picked up from the snapshot.
 			serializer = new KryoSerializer<>(type, new ExecutionConfig());
-			return serializer.ensureCompatibility(configSnapshot);
+			return serializer.internalEnsureCompatibility(configSnapshot);
 		}
 		else {
 			// completely incompatible type, needs migration

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializerTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializerTest.java
@@ -102,10 +102,10 @@ public class BackwardsCompatibleAvroSerializerTest {
 		validateDeserialization(serializer);
 
 		// sanity check for the test: check that a PoJoSerializer and the original serializer work together
-		assertFalse(serializer.ensureCompatibility(configSnapshot).isRequiresMigration());
+		assertFalse(serializer.internalEnsureCompatibility(configSnapshot).isRequiresMigration());
 
 		final TypeSerializer<User> newSerializer = new AvroTypeInfo<>(User.class, true).createSerializer(new ExecutionConfig());
-		assertFalse(newSerializer.ensureCompatibility(configSnapshot).isRequiresMigration());
+		assertFalse(newSerializer.internalEnsureCompatibility(configSnapshot).isRequiresMigration());
 
 		// deserialize the data and make sure this still works
 		validateDeserialization(newSerializer);
@@ -113,7 +113,7 @@ public class BackwardsCompatibleAvroSerializerTest {
 		TypeSerializerConfigSnapshot nextSnapshot = newSerializer.snapshotConfiguration();
 		final TypeSerializer<User> nextSerializer = new AvroTypeInfo<>(User.class, true).createSerializer(new ExecutionConfig());
 
-		assertFalse(nextSerializer.ensureCompatibility(nextSnapshot).isRequiresMigration());
+		assertFalse(nextSerializer.internalEnsureCompatibility(nextSnapshot).isRequiresMigration());
 
 		// deserialize the data and make sure this still works
 		validateDeserialization(nextSerializer);

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
@@ -395,12 +395,12 @@ public class CollectionInputFormatTest {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<ElementType> snapshotConfiguration() {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public CompatibilityResult<ElementType> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<ElementType> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -19,8 +19,7 @@
 package org.apache.flink.cep.nfa;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializer;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
@@ -863,7 +862,7 @@ public class NFA<T> {
 	@Deprecated
 	public static final class NFASerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<MigratedNFA<T>> {
 
-		private static final int VERSION = 1;
+		private static final int VERSION = 2;
 
 		/** This empty constructor is required for deserializing the configuration. */
 		public NFASerializerConfigSnapshot() {}
@@ -879,13 +878,31 @@ public class NFA<T> {
 		public int getVersion() {
 			return VERSION;
 		}
+
+		@Override
+		public int[] getCompatibleVersions() {
+			return new int[]{VERSION, 1};
+		}
+
+		@Override
+		protected boolean containsSerializers() {
+			return getReadVersion() < 2;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		protected TypeSerializer<MigratedNFA<T>> restoreSerializer(TypeSerializer<?>... restoredNestedSerializers) {
+			return new NFASerializer<>(
+				(TypeSerializer<T>) restoredNestedSerializers[0],
+				(TypeSerializer<org.apache.flink.cep.nfa.SharedBuffer<T>>) restoredNestedSerializers[1]);
+		}
 	}
 
 	/**
 	 * Only for backward compatibility with <=1.5.
 	 */
 	@Deprecated
-	public static class NFASerializer<T> extends TypeSerializer<MigratedNFA<T>> {
+	public static class NFASerializer<T> extends CompositeTypeSerializer<MigratedNFA<T>> {
 
 		private static final long serialVersionUID = 2098282423980597010L;
 
@@ -903,6 +920,14 @@ public class NFA<T> {
 		NFASerializer(
 				TypeSerializer<T> typeSerializer,
 				TypeSerializer<org.apache.flink.cep.nfa.SharedBuffer<T>> sharedBufferSerializer) {
+
+			super(
+				new NFASerializerConfigSnapshot<>(
+					Preconditions.checkNotNull(typeSerializer),
+					Preconditions.checkNotNull(sharedBufferSerializer)),
+				typeSerializer,
+				sharedBufferSerializer);
+
 			this.eventSerializer = typeSerializer;
 			this.sharedBufferSerializer = sharedBufferSerializer;
 		}
@@ -982,34 +1007,6 @@ public class NFA<T> {
 		@Override
 		public int hashCode() {
 			return 37 * sharedBufferSerializer.hashCode() + eventSerializer.hashCode();
-		}
-
-		@Override
-		public TypeSerializerConfigSnapshot<MigratedNFA<T>> snapshotConfiguration() {
-			return new NFASerializerConfigSnapshot<>(eventSerializer, sharedBufferSerializer);
-		}
-
-		@Override
-		public CompatibilityResult<MigratedNFA<T>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
-			if (configSnapshot instanceof NFASerializerConfigSnapshot) {
-				List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializersAndConfigs =
-					((NFASerializerConfigSnapshot<?>) configSnapshot).getNestedSerializersAndConfigs();
-
-				CompatibilityResult<T> eventCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-						serializersAndConfigs.get(0).f1,
-						eventSerializer);
-
-				CompatibilityResult<org.apache.flink.cep.nfa.SharedBuffer<T>> sharedBufCompatResult =
-						CompatibilityUtil.resolveCompatibilityResult(
-								serializersAndConfigs.get(1).f1,
-								sharedBufferSerializer);
-
-				if (!sharedBufCompatResult.isRequiresMigration() && !eventCompatResult.isRequiresMigration()) {
-					return CompatibilityResult.compatible();
-				}
-			}
-
-			return CompatibilityResult.requiresMigration();
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
@@ -998,28 +996,16 @@ public class NFA<T> {
 					((NFASerializerConfigSnapshot<?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<T> eventCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					serializersAndConfigs.get(0).f0,
-					UnloadableDummyTypeSerializer.class,
-					serializersAndConfigs.get(0).f1,
-					eventSerializer);
+						serializersAndConfigs.get(0).f1,
+						eventSerializer);
 
 				CompatibilityResult<org.apache.flink.cep.nfa.SharedBuffer<T>> sharedBufCompatResult =
-					CompatibilityUtil.resolveCompatibilityResult(
-						serializersAndConfigs.get(1).f0,
-						UnloadableDummyTypeSerializer.class,
-						serializersAndConfigs.get(1).f1,
-						sharedBufferSerializer);
+						CompatibilityUtil.resolveCompatibilityResult(
+								serializersAndConfigs.get(1).f1,
+								sharedBufferSerializer);
 
 				if (!sharedBufCompatResult.isRequiresMigration() && !eventCompatResult.isRequiresMigration()) {
 					return CompatibilityResult.compatible();
-				} else {
-					if (eventCompatResult.getConvertDeserializer() != null &&
-						sharedBufCompatResult.getConvertDeserializer() != null) {
-						return CompatibilityResult.requiresMigration(
-							new NFASerializer<>(
-								new TypeDeserializerAdapter<>(eventCompatResult.getConvertDeserializer()),
-								new TypeDeserializerAdapter<>(sharedBufCompatResult.getConvertDeserializer())));
-					}
 				}
 			}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -863,7 +863,7 @@ public class NFA<T> {
 	 * The {@link TypeSerializerConfigSnapshot} serializer configuration to be stored with the managed state.
 	 */
 	@Deprecated
-	public static final class NFASerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot {
+	public static final class NFASerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<MigratedNFA<T>> {
 
 		private static final int VERSION = 1;
 
@@ -987,7 +987,7 @@ public class NFA<T> {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<MigratedNFA<T>> snapshotConfiguration() {
 			return new NFASerializerConfigSnapshot<>(eventSerializer, sharedBufferSerializer);
 		}
 
@@ -995,7 +995,7 @@ public class NFA<T> {
 		public CompatibilityResult<MigratedNFA<T>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
 			if (configSnapshot instanceof NFASerializerConfigSnapshot) {
 				List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializersAndConfigs =
-					((NFASerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+					((NFASerializerConfigSnapshot<?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<T> eventCompatResult = CompatibilityUtil.resolveCompatibilityResult(
 					serializersAndConfigs.get(0).f0,

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
@@ -149,7 +149,8 @@ public class SharedBuffer<V> {
 	/**
 	 * The {@link TypeSerializerConfigSnapshot} serializer configuration to be stored with the managed state.
 	 */
-	public static final class SharedBufferSerializerConfigSnapshot<K, V> extends CompositeTypeSerializerConfigSnapshot {
+	public static final class SharedBufferSerializerConfigSnapshot<K, V>
+			extends CompositeTypeSerializerConfigSnapshot<SharedBuffer<V>> {
 
 		private static final int VERSION = 1;
 
@@ -342,7 +343,7 @@ public class SharedBuffer<V> {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<SharedBuffer<V>> snapshotConfiguration() {
 			return new SharedBufferSerializerConfigSnapshot<>(
 				keySerializer,
 				valueSerializer,
@@ -353,7 +354,7 @@ public class SharedBuffer<V> {
 		public CompatibilityResult<SharedBuffer<V>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
 			if (configSnapshot instanceof SharedBufferSerializerConfigSnapshot) {
 				List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializerConfigSnapshots =
-					((SharedBufferSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+					((SharedBufferSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<K> keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
 					serializerConfigSnapshots.get(0).f0,

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
@@ -21,10 +21,8 @@ package org.apache.flink.cep.nfa;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.nfa.compiler.NFAStateNameHandler;
 import org.apache.flink.cep.nfa.sharedbuffer.EventId;
@@ -357,37 +355,22 @@ public class SharedBuffer<V> {
 					((SharedBufferSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<K> keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					serializerConfigSnapshots.get(0).f0,
-					UnloadableDummyTypeSerializer.class,
-					serializerConfigSnapshots.get(0).f1,
-					keySerializer);
+						serializerConfigSnapshots.get(0).f1,
+						keySerializer);
 
 				CompatibilityResult<V> valueCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					serializerConfigSnapshots.get(1).f0,
-					UnloadableDummyTypeSerializer.class,
-					serializerConfigSnapshots.get(1).f1,
-					valueSerializer);
+						serializerConfigSnapshots.get(1).f1,
+						valueSerializer);
 
 				CompatibilityResult<DeweyNumber> versionCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					serializerConfigSnapshots.get(2).f0,
-					UnloadableDummyTypeSerializer.class,
-					serializerConfigSnapshots.get(2).f1,
-					versionSerializer);
+						serializerConfigSnapshots.get(2).f1,
+						versionSerializer);
 
 				if (!keyCompatResult.isRequiresMigration() && !valueCompatResult.isRequiresMigration() &&
 					!versionCompatResult.isRequiresMigration()) {
 					return CompatibilityResult.compatible();
 				} else {
-					if (keyCompatResult.getConvertDeserializer() != null
-						&& valueCompatResult.getConvertDeserializer() != null
-						&& versionCompatResult.getConvertDeserializer() != null) {
-						return CompatibilityResult.requiresMigration(
-							new SharedBufferSerializer<>(
-								new TypeDeserializerAdapter<>(keyCompatResult.getConvertDeserializer()),
-								new TypeDeserializerAdapter<>(valueCompatResult.getConvertDeserializer()),
-								new TypeDeserializerAdapter<>(versionCompatResult.getConvertDeserializer())
-							));
-					}
+					return CompatibilityResult.requiresMigration();
 				}
 			}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableSerializerConfigSnapshot.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableSerializerConfigSnapshot.java
@@ -40,4 +40,9 @@ public class LockableSerializerConfigSnapshot<E> extends CompositeTypeSerializer
 		return VERSION;
 	}
 
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<Lockable<E>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new Lockable.LockableTypeSerializer<>((TypeSerializer<E>) restoredNestedSerializers[0]);
+	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableSerializerConfigSnapshot.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableSerializerConfigSnapshot.java
@@ -16,29 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.scala.typeutils;
+package org.apache.flink.cep.nfa.sharedbuffer;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
-import scala.Option;
-
 /**
- * A {@link TypeSerializerConfigSnapshot} for the Scala {@link OptionSerializer}.
- *
- * <p>This configuration snapshot class is implemented in Java because Scala does not
- * allow calling different base class constructors from subclasses, while we need that
- * for the default empty constructor.
+ * A {@link TypeSerializerConfigSnapshot} for the {@link Lockable.LockableTypeSerializer}.
  */
-public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Option<E>> {
+@Internal
+public class LockableSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Lockable<E>> {
 
 	private static final int VERSION = 1;
 
-	/** This empty nullary constructor is required for deserializing the configuration. */
-	public ScalaOptionSerializerConfigSnapshot() {}
-
-	public ScalaOptionSerializerConfigSnapshot(TypeSerializer<E> elementSerializer) {
+	public LockableSerializerConfigSnapshot(TypeSerializer<E> elementSerializer) {
 		super(elementSerializer);
 	}
 
@@ -46,4 +39,5 @@ public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeS
 	public int getVersion() {
 		return VERSION;
 	}
+
 }

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/ListViewSerializerConfigSnapshot.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/ListViewSerializerConfigSnapshot.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.dataview;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.table.api.dataview.ListView;
@@ -39,5 +40,11 @@ public final class ListViewSerializerConfigSnapshot<T> extends CompositeTypeSeri
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<ListView<T>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new ListViewSerializer<>((ListSerializer<T>) restoredNestedSerializers[0]);
 	}
 }

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/ListViewSerializerConfigSnapshot.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/ListViewSerializerConfigSnapshot.java
@@ -16,30 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.scala.typeutils;
+package org.apache.flink.table.dataview;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-
-import scala.Option;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.table.api.dataview.ListView;
 
 /**
- * A {@link TypeSerializerConfigSnapshot} for the Scala {@link OptionSerializer}.
+ * A {@link TypeSerializerConfigSnapshot} for the {@link ListViewSerializer}.
  *
- * <p>This configuration snapshot class is implemented in Java because Scala does not
- * allow calling different base class constructors from subclasses, while we need that
- * for the default empty constructor.
+ * @param <T> the type of the list elements.
  */
-public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Option<E>> {
+public final class ListViewSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<ListView<T>> {
 
 	private static final int VERSION = 1;
 
-	/** This empty nullary constructor is required for deserializing the configuration. */
-	public ScalaOptionSerializerConfigSnapshot() {}
-
-	public ScalaOptionSerializerConfigSnapshot(TypeSerializer<E> elementSerializer) {
-		super(elementSerializer);
+	public ListViewSerializerConfigSnapshot(ListSerializer<T> listSerializer) {
+		super(listSerializer);
 	}
 
 	@Override

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/MapViewSerializerConfigSnapshot.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/MapViewSerializerConfigSnapshot.java
@@ -16,30 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.scala.typeutils;
+package org.apache.flink.table.dataview;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-
-import scala.Option;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.table.api.dataview.MapView;
 
 /**
- * A {@link TypeSerializerConfigSnapshot} for the Scala {@link OptionSerializer}.
+ * A {@link TypeSerializerConfigSnapshot} for the {@link MapViewSerializer}.
  *
- * <p>This configuration snapshot class is implemented in Java because Scala does not
- * allow calling different base class constructors from subclasses, while we need that
- * for the default empty constructor.
+ * @param <K> the key type of the map entries.
+ * @param <V> the value type of the map entries.
  */
-public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Option<E>> {
+public class MapViewSerializerConfigSnapshot<K, V> extends CompositeTypeSerializerConfigSnapshot<MapView<K, V>> {
 
 	private static final int VERSION = 1;
 
-	/** This empty nullary constructor is required for deserializing the configuration. */
-	public ScalaOptionSerializerConfigSnapshot() {}
-
-	public ScalaOptionSerializerConfigSnapshot(TypeSerializer<E> elementSerializer) {
-		super(elementSerializer);
+	public MapViewSerializerConfigSnapshot(MapSerializer<K, V> mapSerializer) {
+		super(mapSerializer);
 	}
 
 	@Override

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/MapViewSerializerConfigSnapshot.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/dataview/MapViewSerializerConfigSnapshot.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.dataview;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.table.api.dataview.MapView;
@@ -40,5 +41,11 @@ public class MapViewSerializerConfigSnapshot<K, V> extends CompositeTypeSerializ
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<MapView<K, V>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new MapViewSerializer<>((MapSerializer<K, V>) restoredNestedSerializers[0]);
 	}
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/ListViewSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/ListViewSerializer.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils._
 import org.apache.flink.api.common.typeutils.base.{CollectionSerializerConfigSnapshot, ListSerializer}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.table.api.dataview.ListView
+import org.apache.flink.util.Preconditions
 
 /**
   * A serializer for [[ListView]]. The serializer relies on an element
@@ -34,7 +35,9 @@ import org.apache.flink.table.api.dataview.ListView
   * @tparam T The type of element in the list.
   */
 class ListViewSerializer[T](val listSerializer: ListSerializer[T])
-  extends TypeSerializer[ListView[T]] {
+  extends CompositeTypeSerializer[ListView[T]](
+    new ListViewSerializerConfigSnapshot[T](Preconditions.checkNotNull(listSerializer)),
+    listSerializer) {
 
   override def isImmutableType: Boolean = false
 
@@ -75,40 +78,13 @@ class ListViewSerializer[T](val listSerializer: ListSerializer[T])
   override def equals(obj: Any): Boolean = canEqual(this) &&
     listSerializer.equals(obj.asInstanceOf[ListViewSerializer[_]].listSerializer)
 
-  override def snapshotConfiguration(): ListViewSerializerConfigSnapshot[T] =
-    new ListViewSerializerConfigSnapshot[T](listSerializer)
+  override def isComparableSnapshot(
+      configSnapshot: TypeSerializerConfigSnapshot[_]): Boolean = {
 
-  override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[ListView[T]] = {
-
-    configSnapshot match {
-      case snapshot: ListViewSerializerConfigSnapshot[T] =>
-        checkCompatibility(snapshot)
-
+    configSnapshot.isInstanceOf[ListViewSerializerConfigSnapshot[T]] ||
       // backwards compatibility path;
       // Flink versions older or equal to 1.5.x returns a
       // CollectionSerializerConfigSnapshot as the snapshot
-      case legacySnapshot: CollectionSerializerConfigSnapshot[java.util.List[T], T] =>
-        checkCompatibility(legacySnapshot)
-
-      case _ => CompatibilityResult.requiresMigration[ListView[T]]
-    }
-  }
-
-  private def checkCompatibility(
-      configSnapshot: CompositeTypeSerializerConfigSnapshot[_]
-    ): CompatibilityResult[ListView[T]] = {
-
-    val previousListSerializerAndConfig = configSnapshot.getSingleNestedSerializerAndConfig
-
-    val compatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousListSerializerAndConfig.f1,
-      listSerializer.getElementSerializer)
-
-    if (!compatResult.isRequiresMigration) {
-      CompatibilityResult.compatible[ListView[T]]
-    } else {
-      CompatibilityResult.requiresMigration[ListView[T]]
-    }
+      configSnapshot.isInstanceOf[CollectionSerializerConfigSnapshot[_, T]]
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/ListViewSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/ListViewSerializer.scala
@@ -102,8 +102,6 @@ class ListViewSerializer[T](val listSerializer: ListSerializer[T])
     val previousListSerializerAndConfig = configSnapshot.getSingleNestedSerializerAndConfig
 
     val compatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousListSerializerAndConfig.f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousListSerializerAndConfig.f1,
       listSerializer.getElementSerializer)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
@@ -105,14 +105,10 @@ class MapViewSerializer[K, V](val mapSerializer: MapSerializer[K, V])
     val previousKvSerializersAndConfigs = configSnapshot.getNestedSerializersAndConfigs
 
     val keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousKvSerializersAndConfigs.get(0).f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousKvSerializersAndConfigs.get(0).f1,
       mapSerializer.getKeySerializer)
 
     val valueCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousKvSerializersAndConfigs.get(1).f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousKvSerializersAndConfigs.get(1).f1,
       mapSerializer.getValueSerializer)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils._
 import org.apache.flink.api.common.typeutils.base.{MapSerializer, MapSerializerConfigSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.table.api.dataview.MapView
+import org.apache.flink.util.Preconditions
 
 /**
   * A serializer for [[MapView]]. The serializer relies on a key serializer and a value
@@ -36,7 +37,9 @@ import org.apache.flink.table.api.dataview.MapView
   * @tparam V The type of the values in the map.
   */
 class MapViewSerializer[K, V](val mapSerializer: MapSerializer[K, V])
-  extends TypeSerializer[MapView[K, V]] {
+  extends CompositeTypeSerializer[MapView[K, V]](
+    new MapViewSerializerConfigSnapshot[K, V](Preconditions.checkNotNull(mapSerializer)),
+    mapSerializer) {
 
   override def isImmutableType: Boolean = false
 
@@ -77,45 +80,13 @@ class MapViewSerializer[K, V](val mapSerializer: MapSerializer[K, V])
   override def equals(obj: Any): Boolean = canEqual(this) &&
     mapSerializer.equals(obj.asInstanceOf[MapViewSerializer[_, _]].mapSerializer)
 
-  override def snapshotConfiguration(): MapViewSerializerConfigSnapshot[K, V] =
-    new MapViewSerializerConfigSnapshot[K, V](mapSerializer)
+  override def isComparableSnapshot(
+      configSnapshot: TypeSerializerConfigSnapshot[_]): Boolean = {
 
-  // copy and modified from MapSerializer.ensureCompatibility
-  override def ensureCompatibility(configSnapshot: TypeSerializerConfigSnapshot[_])
-  : CompatibilityResult[MapView[K, V]] = {
-
-    configSnapshot match {
-      case snapshot: MapViewSerializerConfigSnapshot[K, V] =>
-        checkCompatibility(snapshot)
-
+    configSnapshot.isInstanceOf[MapViewSerializerConfigSnapshot[K, V]] ||
       // backwards compatibility path;
       // Flink versions older or equal to 1.5.x returns a
       // MapSerializerConfigSnapshot as the snapshot
-      case legacySnapshot: MapSerializerConfigSnapshot[K, V] =>
-        checkCompatibility(legacySnapshot)
-
-      case _ => CompatibilityResult.requiresMigration[MapView[K, V]]
-    }
-  }
-
-  private def checkCompatibility(
-      configSnapshot: CompositeTypeSerializerConfigSnapshot[_]
-    ): CompatibilityResult[MapView[K, V]] = {
-
-    val previousKvSerializersAndConfigs = configSnapshot.getNestedSerializersAndConfigs
-
-    val keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousKvSerializersAndConfigs.get(0).f1,
-      mapSerializer.getKeySerializer)
-
-    val valueCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousKvSerializersAndConfigs.get(1).f1,
-      mapSerializer.getValueSerializer)
-
-    if (!keyCompatResult.isRequiresMigration && !valueCompatResult.isRequiresMigration) {
-      CompatibilityResult.compatible[MapView[K, V]]
-    } else {
-      CompatibilityResult.requiresMigration[MapView[K, V]]
-    }
+      configSnapshot.isInstanceOf[MapSerializerConfigSnapshot[K, V]]
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
@@ -77,45 +77,49 @@ class MapViewSerializer[K, V](val mapSerializer: MapSerializer[K, V])
   override def equals(obj: Any): Boolean = canEqual(this) &&
     mapSerializer.equals(obj.asInstanceOf[MapViewSerializer[_, _]].mapSerializer)
 
-  override def snapshotConfiguration(): TypeSerializerConfigSnapshot =
-    mapSerializer.snapshotConfiguration()
+  override def snapshotConfiguration(): MapViewSerializerConfigSnapshot[K, V] =
+    new MapViewSerializerConfigSnapshot[K, V](mapSerializer)
 
   // copy and modified from MapSerializer.ensureCompatibility
-  override def ensureCompatibility(configSnapshot: TypeSerializerConfigSnapshot)
+  override def ensureCompatibility(configSnapshot: TypeSerializerConfigSnapshot[_])
   : CompatibilityResult[MapView[K, V]] = {
 
     configSnapshot match {
-      case snapshot: MapSerializerConfigSnapshot[_, _] =>
-        val previousKvSerializersAndConfigs = snapshot.getNestedSerializersAndConfigs
+      case snapshot: MapViewSerializerConfigSnapshot[K, V] =>
+        checkCompatibility(snapshot)
 
-        val keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-          previousKvSerializersAndConfigs.get(0).f0,
-          classOf[UnloadableDummyTypeSerializer[_]],
-          previousKvSerializersAndConfigs.get(0).f1,
-          mapSerializer.getKeySerializer)
-
-        val valueCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-          previousKvSerializersAndConfigs.get(1).f0,
-          classOf[UnloadableDummyTypeSerializer[_]],
-          previousKvSerializersAndConfigs.get(1).f1,
-          mapSerializer.getValueSerializer)
-
-        if (!keyCompatResult.isRequiresMigration && !valueCompatResult.isRequiresMigration) {
-          CompatibilityResult.compatible[MapView[K, V]]
-        } else if (keyCompatResult.getConvertDeserializer != null
-          && valueCompatResult.getConvertDeserializer != null) {
-          CompatibilityResult.requiresMigration(
-            new MapViewSerializer[K, V](
-              new MapSerializer[K, V](
-                new TypeDeserializerAdapter[K](keyCompatResult.getConvertDeserializer),
-                new TypeDeserializerAdapter[V](valueCompatResult.getConvertDeserializer))
-            )
-          )
-        } else {
-          CompatibilityResult.requiresMigration[MapView[K, V]]
-        }
+      // backwards compatibility path;
+      // Flink versions older or equal to 1.5.x returns a
+      // MapSerializerConfigSnapshot as the snapshot
+      case legacySnapshot: MapSerializerConfigSnapshot[K, V] =>
+        checkCompatibility(legacySnapshot)
 
       case _ => CompatibilityResult.requiresMigration[MapView[K, V]]
+    }
+  }
+
+  private def checkCompatibility(
+      configSnapshot: CompositeTypeSerializerConfigSnapshot[_]
+    ): CompatibilityResult[MapView[K, V]] = {
+
+    val previousKvSerializersAndConfigs = configSnapshot.getNestedSerializersAndConfigs
+
+    val keyCompatResult = CompatibilityUtil.resolveCompatibilityResult(
+      previousKvSerializersAndConfigs.get(0).f0,
+      classOf[UnloadableDummyTypeSerializer[_]],
+      previousKvSerializersAndConfigs.get(0).f1,
+      mapSerializer.getKeySerializer)
+
+    val valueCompatResult = CompatibilityUtil.resolveCompatibilityResult(
+      previousKvSerializersAndConfigs.get(1).f0,
+      classOf[UnloadableDummyTypeSerializer[_]],
+      previousKvSerializersAndConfigs.get(1).f1,
+      mapSerializer.getValueSerializer)
+
+    if (!keyCompatResult.isRequiresMigration && !valueCompatResult.isRequiresMigration) {
+      CompatibilityResult.compatible[MapView[K, V]]
+    } else {
+      CompatibilityResult.requiresMigration[MapView[K, V]]
     }
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
@@ -90,7 +90,7 @@ class CRowSerializer(val rowSerializer: TypeSerializer[Row]) extends TypeSeriali
     configSnapshot match {
       case crowSerializerConfigSnapshot: CRowSerializer.CRowSerializerConfigSnapshot =>
         val compatResult = CompatibilityUtil.resolveCompatibilityResult(
-          crowSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f1,
+          crowSerializerConfigSnapshot.getNestedSerializerConfigSnapshot(0),
           rowSerializer)
 
         if (compatResult.isRequiresMigration) {
@@ -114,10 +114,26 @@ object CRowSerializer {
     def this() = this(null)
 
     override def getVersion: Int = CRowSerializerConfigSnapshot.VERSION
+
+    override def restoreSerializer(
+        restoredNestedSerializers: TypeSerializer[_]*
+      ): TypeSerializer[CRow] = {
+
+      new CRowSerializer(
+        restoredNestedSerializers(0).asInstanceOf[TypeSerializer[Row]])
+    }
+
+    override def containsSerializers(): Boolean = {
+      getReadVersion < 2
+    }
+
+    override def getCompatibleVersions: Array[Int] = {
+      Array(CRowSerializerConfigSnapshot.VERSION, 1)
+    }
   }
 
   object CRowSerializerConfigSnapshot {
-    val VERSION = 1
+    val VERSION = 2
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
@@ -90,20 +90,11 @@ class CRowSerializer(val rowSerializer: TypeSerializer[Row]) extends TypeSeriali
     configSnapshot match {
       case crowSerializerConfigSnapshot: CRowSerializer.CRowSerializerConfigSnapshot =>
         val compatResult = CompatibilityUtil.resolveCompatibilityResult(
-          crowSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f0,
-          classOf[UnloadableDummyTypeSerializer[_]],
           crowSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f1,
           rowSerializer)
 
         if (compatResult.isRequiresMigration) {
-          if (compatResult.getConvertDeserializer != null) {
-            CompatibilityResult.requiresMigration(
-              new CRowSerializer(
-                new TypeDeserializerAdapter(compatResult.getConvertDeserializer))
-            )
-          } else {
-            CompatibilityResult.requiresMigration()
-          }
+          CompatibilityResult.requiresMigration()
         } else {
           CompatibilityResult.compatible()
         }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
@@ -80,12 +80,12 @@ class CRowSerializer(val rowSerializer: TypeSerializer[Row]) extends TypeSeriali
   // Serializer configuration snapshotting & compatibility
   // --------------------------------------------------------------------------------------------
 
-  override def snapshotConfiguration(): TypeSerializerConfigSnapshot = {
+  override def snapshotConfiguration(): TypeSerializerConfigSnapshot[CRow] = {
     new CRowSerializer.CRowSerializerConfigSnapshot(rowSerializer)
   }
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[CRow] = {
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[CRow] = {
 
     configSnapshot match {
       case crowSerializerConfigSnapshot: CRowSerializer.CRowSerializerConfigSnapshot =>
@@ -117,7 +117,7 @@ object CRowSerializer {
 
   class CRowSerializerConfigSnapshot(
       private val rowSerializer: TypeSerializer[Row])
-    extends CompositeTypeSerializerConfigSnapshot(rowSerializer) {
+    extends CompositeTypeSerializerConfigSnapshot[CRow](rowSerializer) {
 
     /** This empty nullary constructor is required for deserializing the configuration. */
     def this() = this(null)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializer.java
@@ -145,15 +145,15 @@ final public class ArrayListSerializer<T> extends TypeSerializer<ArrayList<T>> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<ArrayList<T>> snapshotConfiguration() {
 		return new CollectionSerializerConfigSnapshot<>(elementSerializer);
 	}
 
 	@Override
-	public CompatibilityResult<ArrayList<T>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<ArrayList<T>> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		if (configSnapshot instanceof CollectionSerializerConfigSnapshot) {
 			Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> previousElemSerializerAndConfig =
-				((CollectionSerializerConfigSnapshot) configSnapshot).getSingleNestedSerializerAndConfig();
+				((CollectionSerializerConfigSnapshot<?, ?>) configSnapshot).getSingleNestedSerializerAndConfig();
 
 			CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
 					previousElemSerializerAndConfig.f0,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializer.java
@@ -19,10 +19,8 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.CollectionSerializerConfigSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
@@ -156,16 +154,11 @@ final public class ArrayListSerializer<T> extends TypeSerializer<ArrayList<T>> {
 				((CollectionSerializerConfigSnapshot<?, ?>) configSnapshot).getSingleNestedSerializerAndConfig();
 
 			CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousElemSerializerAndConfig.f0,
-					UnloadableDummyTypeSerializer.class,
 					previousElemSerializerAndConfig.f1,
 					elementSerializer);
 
 			if (!compatResult.isRequiresMigration()) {
 				return CompatibilityResult.compatible();
-			} else if (compatResult.getConvertDeserializer() != null) {
-				return CompatibilityResult.requiresMigration(
-					new ArrayListSerializer<>(new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer())));
 			}
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializerConfigSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializerConfigSnapshot.java
@@ -16,27 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.scala.typeutils;
+package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
-import scala.util.Either;
+import java.util.ArrayList;
 
 /**
- * Configuration snapshot for serializers of Scala's {@link Either} type,
- * containing configuration snapshots of the Left and Right serializers.
+ * A {@link TypeSerializerConfigSnapshot} for the {@link ArrayListSerializer}.
  */
-public class ScalaEitherSerializerConfigSnapshot<E extends Either<L, R>, L, R>
-		extends CompositeTypeSerializerConfigSnapshot<E> {
+public class ArrayListSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<ArrayList<T>> {
 
-	private static final int VERSION = 1;
+	private final int VERSION = 1;
 
-	/** This empty nullary constructor is required for deserializing the configuration. */
-	public ScalaEitherSerializerConfigSnapshot() {}
-
-	public ScalaEitherSerializerConfigSnapshot(TypeSerializer<L> leftSerializer, TypeSerializer<R> rightSerializer) {
-		super(leftSerializer, rightSerializer);
+	public ArrayListSerializerConfigSnapshot(TypeSerializer<T> elementSerializer) {
+		super(elementSerializer);
 	}
 
 	@Override
@@ -46,9 +42,7 @@ public class ScalaEitherSerializerConfigSnapshot<E extends Either<L, R>, L, R>
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected TypeSerializer<E> restoreSerializer(TypeSerializer<?>... restoredNestedSerializers) {
-		return new EitherSerializer<>(
-			(TypeSerializer<L>) restoredNestedSerializers[0],
-			(TypeSerializer<R>) restoredNestedSerializers[1]);
+	protected TypeSerializer<ArrayList<T>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new ArrayListSerializer<>((TypeSerializer<T>) restoredNestedSerializers[0]);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -499,8 +499,10 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 				// Recreate all PartitionableListStates from the meta info
 				for (RegisteredOperatorBackendStateMetaInfo.Snapshot<?> restoredMetaInfo : restoredOperatorMetaInfoSnapshots) {
 
-					if (restoredMetaInfo.getPartitionStateSerializer() == null ||
-							restoredMetaInfo.getPartitionStateSerializer() instanceof UnloadableDummyTypeSerializer) {
+					TypeSerializer<?> restoredPartitionStateSerializer =
+						restoredMetaInfo.getPartitionStateSerializerConfigSnapshot().restoreSerializer();
+
+					if (restoredPartitionStateSerializer instanceof UnloadableDummyTypeSerializer) {
 
 						// must fail now if the previous serializer cannot be restored because there is no serializer
 						// capable of reading previous state
@@ -521,7 +523,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 						listState = new PartitionableListState<>(
 								new RegisteredOperatorBackendStateMetaInfo<>(
 										restoredMetaInfo.getName(),
-										restoredMetaInfo.getPartitionStateSerializer(),
+										restoredPartitionStateSerializer,
 										restoredMetaInfo.getAssignmentMode()));
 
 						registeredOperatorStates.put(listState.getStateMetaInfo().getName(), listState);
@@ -536,9 +538,14 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 				for (RegisteredBroadcastBackendStateMetaInfo.Snapshot<? ,?> restoredMetaInfo : restoredBroadcastMetaInfoSnapshots) {
 
-					if (restoredMetaInfo.getKeySerializer() == null || restoredMetaInfo.getValueSerializer() == null ||
-							restoredMetaInfo.getKeySerializer() instanceof UnloadableDummyTypeSerializer ||
-							restoredMetaInfo.getValueSerializer() instanceof UnloadableDummyTypeSerializer) {
+					TypeSerializer<?> restoredKeySerializer =
+						restoredMetaInfo.getKeySerializerConfigSnapshot().restoreSerializer();
+
+					TypeSerializer<?> restoredValueSerializer =
+						restoredMetaInfo.getValueSerializerConfigSnapshot().restoreSerializer();
+
+					if (restoredKeySerializer instanceof UnloadableDummyTypeSerializer ||
+							restoredValueSerializer instanceof UnloadableDummyTypeSerializer) {
 
 						// must fail now if the previous serializer cannot be restored because there is no serializer
 						// capable of reading previous state
@@ -560,8 +567,8 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 								new RegisteredBroadcastBackendStateMetaInfo<>(
 										restoredMetaInfo.getName(),
 										restoredMetaInfo.getAssignmentMode(),
-										restoredMetaInfo.getKeySerializer(),
-										restoredMetaInfo.getValueSerializer()));
+										restoredKeySerializer,
+										restoredValueSerializer));
 
 						registeredBroadcastStates.put(broadcastState.getStateMetaInfo().getName(), broadcastState);
 					} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -226,14 +226,10 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 			// check compatibility to determine if state migration is required
 			CompatibilityResult<K> keyCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					restoredMetaInfo.getKeySerializer(),
-					UnloadableDummyTypeSerializer.class,
 					restoredMetaInfo.getKeySerializerConfigSnapshot(),
 					broadcastStateKeySerializer);
 
 			CompatibilityResult<V> valueCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					restoredMetaInfo.getValueSerializer(),
-					UnloadableDummyTypeSerializer.class,
 					restoredMetaInfo.getValueSerializerConfigSnapshot(),
 					broadcastStateValueSerializer);
 
@@ -759,8 +755,6 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			// check compatibility to determine if state migration is required
 			TypeSerializer<S> newPartitionStateSerializer = partitionStateSerializer.duplicate();
 			CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					restoredMetaInfo.getPartitionStateSerializer(),
-					UnloadableDummyTypeSerializer.class,
 					restoredMetaInfo.getPartitionStateSerializerConfigSnapshot(),
 					newPartitionStateSerializer);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendSerializationProxy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendSerializationProxy.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class OperatorBackendSerializationProxy extends VersionedIOReadableWritable {
 
-	public static final int VERSION = 3;
+	public static final int VERSION = 4;
 
 	private List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> operatorStateMetaInfoSnapshots;
 	private List<RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> broadcastStateMetaInfoSnapshots;
@@ -62,8 +62,8 @@ public class OperatorBackendSerializationProxy extends VersionedIOReadableWritab
 
 	@Override
 	public int[] getCompatibleVersions() {
-		// we are compatible with version 3 (Flink 1.5.x), 2 (Flink 1.4.x, Flink 1.3.x) and version 1 (Flink 1.2.x)
-		return new int[] {VERSION, 2, 1};
+		// we are compatible with version 4 (Flink 1.6.x), 3 (Flink 1.5.x), 2 (Flink 1.4.x, Flink 1.3.x) and version 1 (Flink 1.2.x)
+		return new int[] {VERSION, 3, 2, 1};
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
@@ -140,8 +140,6 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
 
 		private String name;
 		private OperatorStateHandle.Mode assignmentMode;
-		private TypeSerializer<K> keySerializer;
-		private TypeSerializer<V> valueSerializer;
 		private TypeSerializerConfigSnapshot keySerializerConfigSnapshot;
 		private TypeSerializerConfigSnapshot valueSerializerConfigSnapshot;
 
@@ -158,8 +156,8 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
 
 			this.name = Preconditions.checkNotNull(name);
 			this.assignmentMode = Preconditions.checkNotNull(assignmentMode);
-			this.keySerializer = Preconditions.checkNotNull(keySerializer);
-			this.valueSerializer = Preconditions.checkNotNull(valueSerializer);
+			Preconditions.checkNotNull(keySerializer);
+			Preconditions.checkNotNull(valueSerializer);
 			this.keySerializerConfigSnapshot = Preconditions.checkNotNull(keySerializerConfigSnapshot);
 			this.valueSerializerConfigSnapshot = Preconditions.checkNotNull(valueSerializerConfigSnapshot);
 		}
@@ -178,22 +176,6 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
 
 		void setAssignmentMode(OperatorStateHandle.Mode mode) {
 			this.assignmentMode = mode;
-		}
-
-		public TypeSerializer<K> getKeySerializer() {
-			return keySerializer;
-		}
-
-		void setKeySerializer(TypeSerializer<K> serializer) {
-			this.keySerializer = serializer;
-		}
-
-		public TypeSerializer<V> getValueSerializer() {
-			return valueSerializer;
-		}
-
-		void setValueSerializer(TypeSerializer<V> serializer) {
-			this.valueSerializer = serializer;
 		}
 
 		public TypeSerializerConfigSnapshot getKeySerializerConfigSnapshot() {
@@ -227,8 +209,6 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
 
 			return name.equals(snapshot.getName())
 					&& assignmentMode.ordinal() == snapshot.getAssignmentMode().ordinal()
-					&& Objects.equals(keySerializer, snapshot.getKeySerializer())
-					&& Objects.equals(valueSerializer, snapshot.getValueSerializer())
 					&& keySerializerConfigSnapshot.equals(snapshot.getKeySerializerConfigSnapshot())
 					&& valueSerializerConfigSnapshot.equals(snapshot.getValueSerializerConfigSnapshot());
 		}
@@ -237,8 +217,6 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
 		public int hashCode() {
 			int result = name.hashCode();
 			result = 31 * result + assignmentMode.hashCode();
-			result = 31 * result + ((keySerializer != null) ? keySerializer.hashCode() : 0);
-			result = 31 * result + ((valueSerializer != null) ? valueSerializer.hashCode() : 0);
 			result = 31 * result + keySerializerConfigSnapshot.hashCode();
 			result = 31 * result + valueSerializerConfigSnapshot.hashCode();
 			return result;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyedBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyedBackendStateMetaInfo.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
@@ -273,15 +272,11 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 
 		// check compatibility results to determine if state migration is required
 		CompatibilityResult<N> namespaceCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-			restoredStateMetaInfoSnapshot.getNamespaceSerializer(),
-			null,
 			restoredStateMetaInfoSnapshot.getNamespaceSerializerConfigSnapshot(),
 			newNamespaceSerializer);
 
 		TypeSerializer<S> newStateSerializer = newStateDescriptor.getSerializer();
 		CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-			restoredStateMetaInfoSnapshot.getStateSerializer(),
-			UnloadableDummyTypeSerializer.class,
 			restoredStateMetaInfoSnapshot.getStateSerializerConfigSnapshot(),
 			newStateSerializer);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyedBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyedBackendStateMetaInfo.java
@@ -77,9 +77,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 			stateType,
 			name,
 			namespaceSerializer.duplicate(),
-			stateSerializer.duplicate(),
-			namespaceSerializer.snapshotConfiguration(),
-			stateSerializer.snapshotConfiguration());
+			stateSerializer.duplicate());
 	}
 
 	@Override
@@ -132,10 +130,8 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 
 		private StateDescriptor.Type stateType;
 		private String name;
-		private TypeSerializer<N> namespaceSerializer;
-		private TypeSerializer<S> stateSerializer;
-		private TypeSerializerConfigSnapshot namespaceSerializerConfigSnapshot;
-		private TypeSerializerConfigSnapshot stateSerializerConfigSnapshot;
+		private TypeSerializerConfigSnapshot<N> namespaceSerializerConfigSnapshot;
+		private TypeSerializerConfigSnapshot<S> stateSerializerConfigSnapshot;
 
 		/** Empty constructor used when restoring the state meta info snapshot. */
 		Snapshot() {}
@@ -144,16 +140,15 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 				StateDescriptor.Type stateType,
 				String name,
 				TypeSerializer<N> namespaceSerializer,
-				TypeSerializer<S> stateSerializer,
-				TypeSerializerConfigSnapshot namespaceSerializerConfigSnapshot,
-				TypeSerializerConfigSnapshot stateSerializerConfigSnapshot) {
+				TypeSerializer<S> stateSerializer) {
 
 			this.stateType = Preconditions.checkNotNull(stateType);
 			this.name = Preconditions.checkNotNull(name);
-			this.namespaceSerializer = Preconditions.checkNotNull(namespaceSerializer);
-			this.stateSerializer = Preconditions.checkNotNull(stateSerializer);
-			this.namespaceSerializerConfigSnapshot = Preconditions.checkNotNull(namespaceSerializerConfigSnapshot);
-			this.stateSerializerConfigSnapshot = Preconditions.checkNotNull(stateSerializerConfigSnapshot);
+
+			Preconditions.checkNotNull(namespaceSerializer);
+			Preconditions.checkNotNull(stateSerializer);
+			this.namespaceSerializerConfigSnapshot = Preconditions.checkNotNull(namespaceSerializer.snapshotConfiguration());
+			this.stateSerializerConfigSnapshot = Preconditions.checkNotNull(stateSerializer.snapshotConfiguration());
 		}
 
 		public StateDescriptor.Type getStateType() {
@@ -172,35 +167,19 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 			this.name = name;
 		}
 
-		public TypeSerializer<N> getNamespaceSerializer() {
-			return namespaceSerializer;
-		}
-
-		void setNamespaceSerializer(TypeSerializer<N> namespaceSerializer) {
-			this.namespaceSerializer = namespaceSerializer;
-		}
-
-		public TypeSerializer<S> getStateSerializer() {
-			return stateSerializer;
-		}
-
-		void setStateSerializer(TypeSerializer<S> stateSerializer) {
-			this.stateSerializer = stateSerializer;
-		}
-
-		public TypeSerializerConfigSnapshot getNamespaceSerializerConfigSnapshot() {
+		public TypeSerializerConfigSnapshot<N> getNamespaceSerializerConfigSnapshot() {
 			return namespaceSerializerConfigSnapshot;
 		}
 
-		void setNamespaceSerializerConfigSnapshot(TypeSerializerConfigSnapshot namespaceSerializerConfigSnapshot) {
+		void setNamespaceSerializerConfigSnapshot(TypeSerializerConfigSnapshot<N> namespaceSerializerConfigSnapshot) {
 			this.namespaceSerializerConfigSnapshot = namespaceSerializerConfigSnapshot;
 		}
 
-		public TypeSerializerConfigSnapshot getStateSerializerConfigSnapshot() {
+		public TypeSerializerConfigSnapshot<S> getStateSerializerConfigSnapshot() {
 			return stateSerializerConfigSnapshot;
 		}
 
-		void setStateSerializerConfigSnapshot(TypeSerializerConfigSnapshot stateSerializerConfigSnapshot) {
+		void setStateSerializerConfigSnapshot(TypeSerializerConfigSnapshot<S> stateSerializerConfigSnapshot) {
 			this.stateSerializerConfigSnapshot = stateSerializerConfigSnapshot;
 		}
 
@@ -225,9 +204,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 			}
 
 			// need to check for nulls because serializer and config snapshots may be null on restore
-			return Objects.equals(getStateSerializer(), that.getStateSerializer())
-				&& Objects.equals(getNamespaceSerializer(), that.getNamespaceSerializer())
-				&& Objects.equals(getNamespaceSerializerConfigSnapshot(), that.getNamespaceSerializerConfigSnapshot())
+			return Objects.equals(getNamespaceSerializerConfigSnapshot(), that.getNamespaceSerializerConfigSnapshot())
 				&& Objects.equals(getStateSerializerConfigSnapshot(), that.getStateSerializerConfigSnapshot());
 		}
 
@@ -236,8 +213,6 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 			// need to check for nulls because serializer and config snapshots may be null on restore
 			int result = getName().hashCode();
 			result = 31 * result + getStateType().hashCode();
-			result = 31 * result + (getNamespaceSerializer() != null ? getNamespaceSerializer().hashCode() : 0);
-			result = 31 * result + (getStateSerializer() != null ? getStateSerializer().hashCode() : 0);
 			result = 31 * result + (getNamespaceSerializerConfigSnapshot() != null ? getNamespaceSerializerConfigSnapshot().hashCode() : 0);
 			result = 31 * result + (getStateSerializerConfigSnapshot() != null ? getStateSerializerConfigSnapshot().hashCode() : 0);
 			return result;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorBackendStateMetaInfo.java
@@ -133,7 +133,6 @@ public class RegisteredOperatorBackendStateMetaInfo<S> {
 
 		private String name;
 		private OperatorStateHandle.Mode assignmentMode;
-		private TypeSerializer<S> partitionStateSerializer;
 		private TypeSerializerConfigSnapshot partitionStateSerializerConfigSnapshot;
 
 		/** Empty constructor used when restoring the state meta info snapshot. */
@@ -147,7 +146,7 @@ public class RegisteredOperatorBackendStateMetaInfo<S> {
 
 			this.name = Preconditions.checkNotNull(name);
 			this.assignmentMode = Preconditions.checkNotNull(assignmentMode);
-			this.partitionStateSerializer = Preconditions.checkNotNull(partitionStateSerializer);
+			Preconditions.checkNotNull(partitionStateSerializer);
 			this.partitionStateSerializerConfigSnapshot = Preconditions.checkNotNull(partitionStateSerializerConfigSnapshot);
 		}
 
@@ -165,14 +164,6 @@ public class RegisteredOperatorBackendStateMetaInfo<S> {
 
 		void setAssignmentMode(OperatorStateHandle.Mode assignmentMode) {
 			this.assignmentMode = assignmentMode;
-		}
-
-		public TypeSerializer<S> getPartitionStateSerializer() {
-			return partitionStateSerializer;
-		}
-
-		void setPartitionStateSerializer(TypeSerializer<S> partitionStateSerializer) {
-			this.partitionStateSerializer = partitionStateSerializer;
 		}
 
 		public TypeSerializerConfigSnapshot getPartitionStateSerializerConfigSnapshot() {
@@ -202,7 +193,6 @@ public class RegisteredOperatorBackendStateMetaInfo<S> {
 			// need to check for nulls because serializer and config snapshots may be null on restore
 			return name.equals(snapshot.getName())
 				&& assignmentMode.equals(snapshot.getAssignmentMode())
-				&& Objects.equals(partitionStateSerializer, snapshot.getPartitionStateSerializer())
 				&& Objects.equals(partitionStateSerializerConfigSnapshot, snapshot.getPartitionStateSerializerConfigSnapshot());
 		}
 
@@ -211,7 +201,6 @@ public class RegisteredOperatorBackendStateMetaInfo<S> {
 			// need to check for nulls because serializer and config snapshots may be null on restore
 			int result = getName().hashCode();
 			result = 31 * result + getAssignmentMode().hashCode();
-			result = 31 * result + (getPartitionStateSerializer() != null ? getPartitionStateSerializer().hashCode() : 0);
 			result = 31 * result + (getPartitionStateSerializerConfigSnapshot() != null ? getPartitionStateSerializerConfigSnapshot().hashCode() : 0);
 			return result;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -318,8 +318,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 								new RegisteredKeyedBackendStateMetaInfo<>(
 									restoredMetaInfo.getStateType(),
 									restoredMetaInfo.getName(),
-									restoredMetaInfo.getNamespaceSerializer(),
-									restoredMetaInfo.getStateSerializer());
+									restoredMetaInfo.getNamespaceSerializerConfigSnapshot().restoreSerializer(),
+									restoredMetaInfo.getStateSerializerConfigSnapshot().restoreSerializer());
 
 						stateTable = snapshotStrategy.newStateTable(registeredKeyedBackendStateMetaInfo);
 						stateTables.put(restoredMetaInfo.getName(), stateTable);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -30,7 +30,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -292,8 +291,6 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					// check for key serializer compatibility; this also reconfigures the
 					// key serializer to be compatible, if it is required and is possible
 					if (CompatibilityUtil.resolveCompatibilityResult(
-							serializationProxy.getKeySerializer(),
-							UnloadableDummyTypeSerializer.class,
 							serializationProxy.getKeySerializerConfigSnapshot(),
 							keySerializer)
 						.isRequiresMigration()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
@@ -131,12 +131,12 @@ public class IntListSerializer extends TypeSerializer<IntList> {
 	}
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<IntList> snapshotConfiguration() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public CompatibilityResult<IntList> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<IntList> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
@@ -140,12 +140,12 @@ public class IntPairSerializer extends TypeSerializer<IntPair> {
 	}
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<IntPair> snapshotConfiguration() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public CompatibilityResult<IntPair> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<IntPair> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
@@ -108,12 +108,12 @@ public class StringPairSerializer extends TypeSerializer<StringPair> {
 	}
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<StringPair> snapshotConfiguration() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public CompatibilityResult<StringPair> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<StringPair> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateRegistryTest.java
@@ -401,12 +401,12 @@ public class KvStateRegistryTest extends TestLogger {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<String> snapshotConfiguration() {
 			return null;
 		}
 
 		@Override
-		public CompatibilityResult<String> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<String> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			return null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -351,12 +351,12 @@ public class OperatorStateBackendTest {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<Integer> snapshotConfiguration() {
 			return IntSerializer.INSTANCE.snapshotConfiguration();
 		}
 
 		@Override
-		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			return IntSerializer.INSTANCE.ensureCompatibility(configSnapshot);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -357,7 +357,7 @@ public class OperatorStateBackendTest {
 
 		@Override
 		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
-			return IntSerializer.INSTANCE.ensureCompatibility(configSnapshot);
+			return IntSerializer.INSTANCE.internalEnsureCompatibility(configSnapshot);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
@@ -74,7 +73,6 @@ public class SerializationProxiesTest {
 		}
 
 		Assert.assertEquals(true, serializationProxy.isUsingKeyGroupCompression());
-		Assert.assertEquals(keySerializer, serializationProxy.getKeySerializer());
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 		Assert.assertEquals(stateMetaInfoList, serializationProxy.getStateMetaInfoSnapshots());
 	}
@@ -123,12 +121,9 @@ public class SerializationProxiesTest {
 		}
 
 		Assert.assertEquals(true, serializationProxy.isUsingKeyGroupCompression());
-		Assert.assertTrue(serializationProxy.getKeySerializer() instanceof UnloadableDummyTypeSerializer);
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 
 		for (RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> meta : serializationProxy.getStateMetaInfoSnapshots()) {
-			Assert.assertTrue(meta.getNamespaceSerializer() instanceof UnloadableDummyTypeSerializer);
-			Assert.assertTrue(meta.getStateSerializer() instanceof UnloadableDummyTypeSerializer);
 			Assert.assertEquals(namespaceSerializer.snapshotConfiguration(), meta.getNamespaceSerializerConfigSnapshot());
 			Assert.assertEquals(stateSerializer.snapshotConfiguration(), meta.getStateSerializerConfigSnapshot());
 		}
@@ -195,8 +190,6 @@ public class SerializationProxiesTest {
 		}
 
 		Assert.assertEquals(name, metaInfo.getName());
-		Assert.assertTrue(metaInfo.getNamespaceSerializer() instanceof UnloadableDummyTypeSerializer);
-		Assert.assertTrue(metaInfo.getStateSerializer() instanceof UnloadableDummyTypeSerializer);
 		Assert.assertEquals(namespaceSerializer.snapshotConfiguration(), metaInfo.getNamespaceSerializerConfigSnapshot());
 		Assert.assertEquals(stateSerializer.snapshotConfiguration(), metaInfo.getStateSerializerConfigSnapshot());
 	}
@@ -271,7 +264,6 @@ public class SerializationProxiesTest {
 
 		Assert.assertEquals(name, metaInfo.getName());
 		Assert.assertEquals(OperatorStateHandle.Mode.UNION, metaInfo.getAssignmentMode());
-		Assert.assertEquals(stateSerializer, metaInfo.getPartitionStateSerializer());
 	}
 
 	@Test
@@ -302,8 +294,6 @@ public class SerializationProxiesTest {
 
 		Assert.assertEquals(name, metaInfo.getName());
 		Assert.assertEquals(OperatorStateHandle.Mode.BROADCAST, metaInfo.getAssignmentMode());
-		Assert.assertEquals(keySerializer, metaInfo.getKeySerializer());
-		Assert.assertEquals(valueSerializer, metaInfo.getValueSerializer());
 	}
 
 	@Test
@@ -339,7 +329,6 @@ public class SerializationProxiesTest {
 		}
 
 		Assert.assertEquals(name, metaInfo.getName());
-		Assert.assertTrue(metaInfo.getPartitionStateSerializer() instanceof UnloadableDummyTypeSerializer);
 		Assert.assertEquals(stateSerializer.snapshotConfiguration(), metaInfo.getPartitionStateSerializerConfigSnapshot());
 	}
 
@@ -377,9 +366,7 @@ public class SerializationProxiesTest {
 		}
 
 		Assert.assertEquals(broadcastName, broadcastMetaInfo.getName());
-		Assert.assertTrue(broadcastMetaInfo.getKeySerializer() instanceof UnloadableDummyTypeSerializer);
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), broadcastMetaInfo.getKeySerializerConfigSnapshot());
-		Assert.assertTrue(broadcastMetaInfo.getValueSerializer() instanceof UnloadableDummyTypeSerializer);
 		Assert.assertEquals(valueSerializer.snapshotConfiguration(), broadcastMetaInfo.getValueSerializerConfigSnapshot());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -4242,14 +4242,14 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
-			return new ParameterlessTypeSerializerConfig(getClass().getName());
+		public TypeSerializerConfigSnapshot<TestCustomStateClass> snapshotConfiguration() {
+			return new ParameterlessTypeSerializerConfig<>(getClass().getName());
 		}
 
 		@Override
-		public CompatibilityResult<TestCustomStateClass> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<TestCustomStateClass> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			if (configSnapshot instanceof ParameterlessTypeSerializerConfig &&
-					((ParameterlessTypeSerializerConfig) configSnapshot).getSerializationFormatIdentifier().equals(getClass().getName())) {
+					((ParameterlessTypeSerializerConfig<?>) configSnapshot).getSerializationFormatIdentifier().equals(getClass().getName())) {
 
 				this.reconfigured = true;
 				return CompatibilityResult.compatible();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -654,12 +654,12 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<Integer> snapshotConfiguration() {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<Integer> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/RecordSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/RecordSerializer.java
@@ -145,12 +145,12 @@ public final class RecordSerializer extends TypeSerializer<Record> {
 	}
 
 	@Override
-	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+	public TypeSerializerConfigSnapshot<Record> snapshotConfiguration() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public CompatibilityResult<Record> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<Record> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerConfigSnapshot.java
@@ -20,26 +20,23 @@ package org.apache.flink.api.scala.typeutils;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
-import scala.Option;
+import scala.util.Either;
 
 /**
- * A {@link TypeSerializerConfigSnapshot} for the Scala {@link OptionSerializer}.
- *
- * <p>This configuration snapshot class is implemented in Java because Scala does not
- * allow calling different base class constructors from subclasses, while we need that
- * for the default empty constructor.
+ * Configuration snapshot for serializers of Scala's {@link Either} type,
+ * containing configuration snapshots of the Left and Right serializers.
  */
-public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Option<E>> {
+public class ScalaEitherSerializerConfigSnapshot<E extends Either<L, R>, L, R>
+		extends CompositeTypeSerializerConfigSnapshot<E> {
 
 	private static final int VERSION = 1;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
-	public ScalaOptionSerializerConfigSnapshot() {}
+	public ScalaEitherSerializerConfigSnapshot() {}
 
-	public ScalaOptionSerializerConfigSnapshot(TypeSerializer<E> elementSerializer) {
-		super(elementSerializer);
+	public ScalaEitherSerializerConfigSnapshot(TypeSerializer<L> leftSerializer, TypeSerializer<R> rightSerializer) {
+		super(leftSerializer, rightSerializer);
 	}
 
 	@Override

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaOptionSerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaOptionSerializerConfigSnapshot.java
@@ -33,7 +33,7 @@ import scala.Option;
  */
 public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Option<E>> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	public ScalaOptionSerializerConfigSnapshot() {}
@@ -45,5 +45,21 @@ public final class ScalaOptionSerializerConfigSnapshot<E> extends CompositeTypeS
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		return getReadVersion() < 2;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<Option<E>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new OptionSerializer<>((TypeSerializer<E>) restoredNestedSerializers[0]);
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerConfigSnapshot.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapsh
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
+import scala.util.Try;
+
 /**
  * A {@link TypeSerializerConfigSnapshot} for the Scala {@link TrySerializer}.
  *
@@ -29,7 +31,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
  * allow calling different base class constructors from subclasses, while we need that
  * for the default empty constructor.
  */
-public class ScalaTrySerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot {
+public class ScalaTrySerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Try<E>> {
 
 	private static final int VERSION = 1;
 

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerConfigSnapshot.java
@@ -33,7 +33,7 @@ import scala.util.Try;
  */
 public class ScalaTrySerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot<Try<E>> {
 
-	private static final int VERSION = 1;
+	private static final int VERSION = 2;
 
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	public ScalaTrySerializerConfigSnapshot() {}
@@ -48,5 +48,23 @@ public class ScalaTrySerializerConfigSnapshot<E> extends CompositeTypeSerializer
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
+	}
+
+	@Override
+	protected boolean containsSerializers() {
+		return getReadVersion() < 2;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected TypeSerializer<Try<E>> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		return new TrySerializer<>(
+			(TypeSerializer<E>) restoredNestedSerializers[0],
+			(TypeSerializer<Throwable>) restoredNestedSerializers[1]);
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerConfigSnapshot.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapsh
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
+import scala.collection.TraversableOnce;
+
 /**
  * A {@link TypeSerializerConfigSnapshot} for the Scala {@link TraversableSerializer}.
  *
@@ -29,7 +31,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
  * allow calling different base class constructors from subclasses, while we need that
  * for the default empty constructor.
  */
-public class TraversableSerializerConfigSnapshot<E> extends CompositeTypeSerializerConfigSnapshot {
+public class TraversableSerializerConfigSnapshot<T extends TraversableOnce<E>, E>
+		extends CompositeTypeSerializerConfigSnapshot<T> {
 
 	private static final int VERSION = 1;
 

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerConfigSnapshot.java
@@ -47,4 +47,10 @@ public class TraversableSerializerConfigSnapshot<T extends TraversableOnce<E>, E
 	public int getVersion() {
 		return VERSION;
 	}
+
+	@Override
+	protected TypeSerializer<T> restoreSerializer(TypeSerializer<?>[] restoredNestedSerializers) {
+		// TODO to be implemented in follow-up commits
+		return null;
+	}
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -149,15 +149,6 @@ private[flink] trait TypeInformationGen[C <: Context] {
             override def createInstance(fields: Array[AnyRef]): T = {
               instance.splice
             }
-
-            override def createSerializerInstance(
-                tupleClass: Class[T],
-                fieldSerializers: Array[TypeSerializer[_]]) = {
-              this.getClass
-                .getConstructors()(0)
-                .newInstance(tupleClass, fieldSerializers)
-                .asInstanceOf[CaseClassSerializer[T]]
-            }
           }
         }
       }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
@@ -118,11 +118,5 @@ package object scala {
     override def createInstance(fields: Array[AnyRef]) = {
       (fields(0).asInstanceOf[T1], fields(1).asInstanceOf[T2])
     }
-
-    override def createSerializerInstance(
-        tupleClass: Class[(T1, T2)],
-        fieldSerializers: Array[TypeSerializer[_]]) = {
-      new Tuple2CaseClassSerializer[T1, T2](tupleClass, fieldSerializers)
-    }
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassSerializer.scala
@@ -32,7 +32,9 @@ import org.apache.flink.types.NullFieldException
 abstract class CaseClassSerializer[T <: Product](
     clazz: Class[T],
     scalaFieldSerializers: Array[TypeSerializer[_]])
-  extends TupleSerializerBase[T](clazz, scalaFieldSerializers)
+  // TODO configuration snapshot of case class serializers is to
+  // TODO be implemented in follow-up commits
+  extends TupleSerializerBase[T](clazz, null, scalaFieldSerializers)
   with Cloneable {
 
   @transient var fields : Array[AnyRef] = _
@@ -79,15 +81,6 @@ abstract class CaseClassSerializer[T <: Product](
 
   override def createOrReuseInstance(fields: Array[Object], reuse: T) : T = {
     createInstance(fields)
-  }
-
-  override def createSerializerInstance(
-      tupleClass: Class[T],
-      fieldSerializers: Array[TypeSerializer[_]]): TupleSerializerBase[T] = {
-    this.getClass
-      .getConstructors()(0)
-      .newInstance(tupleClass, fieldSerializers)
-      .asInstanceOf[CaseClassSerializer[T]]
   }
 
   def copy(from: T, reuse: T): T = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
@@ -111,51 +111,51 @@ class EitherSerializer[A, B, T <: Either[A, B]](
   // Serializer configuration snapshotting & compatibility
   // --------------------------------------------------------------------------------------------
 
-  override def snapshotConfiguration(): EitherSerializerConfigSnapshot[A, B] = {
-    new EitherSerializerConfigSnapshot[A, B](leftSerializer, rightSerializer)
+  override def snapshotConfiguration(): ScalaEitherSerializerConfigSnapshot[T, A, B] = {
+    new ScalaEitherSerializerConfigSnapshot[T, A, B](leftSerializer, rightSerializer)
   }
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[T] = {
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[T] = {
 
     configSnapshot match {
-      case eitherSerializerConfig: EitherSerializerConfigSnapshot[A, B] =>
-        val previousLeftRightSerWithConfigs =
-          eitherSerializerConfig.getNestedSerializersAndConfigs
+      case eitherSerializerConfig: ScalaEitherSerializerConfigSnapshot[T, A, B] =>
+        checkCompatibility(eitherSerializerConfig)
 
-        val leftCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-          previousLeftRightSerWithConfigs.get(0).f0,
-          classOf[UnloadableDummyTypeSerializer[_]],
-          previousLeftRightSerWithConfigs.get(0).f1,
-          leftSerializer)
-
-        val rightCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-          previousLeftRightSerWithConfigs.get(1).f0,
-          classOf[UnloadableDummyTypeSerializer[_]],
-          previousLeftRightSerWithConfigs.get(1).f1,
-          rightSerializer)
-
-        if (leftCompatResult.isRequiresMigration
-            || rightCompatResult.isRequiresMigration) {
-
-          if (leftCompatResult.getConvertDeserializer != null
-              && rightCompatResult.getConvertDeserializer != null) {
-
-            CompatibilityResult.requiresMigration(
-              new EitherSerializer[A, B, T](
-                new TypeDeserializerAdapter(leftCompatResult.getConvertDeserializer),
-                new TypeDeserializerAdapter(rightCompatResult.getConvertDeserializer)
-              )
-            )
-
-          } else {
-            CompatibilityResult.requiresMigration()
-          }
-        } else {
-          CompatibilityResult.compatible()
-        }
+      // backwards compatibility path;
+      // Flink versions older or equal to 1.5.x uses a
+      // EitherSerializerConfigSnapshot as the snapshot
+      case legacyConfig: EitherSerializerConfigSnapshot[A, B] =>
+        checkCompatibility(legacyConfig)
 
       case _ => CompatibilityResult.requiresMigration()
+    }
+  }
+
+  private def checkCompatibility(
+      configSnapshot: CompositeTypeSerializerConfigSnapshot[_]
+    ): CompatibilityResult[T] = {
+
+    val previousLeftRightSerWithConfigs =
+      configSnapshot.getNestedSerializersAndConfigs
+
+    val leftCompatResult = CompatibilityUtil.resolveCompatibilityResult(
+      previousLeftRightSerWithConfigs.get(0).f0,
+      classOf[UnloadableDummyTypeSerializer[_]],
+      previousLeftRightSerWithConfigs.get(0).f1,
+      leftSerializer)
+
+    val rightCompatResult = CompatibilityUtil.resolveCompatibilityResult(
+      previousLeftRightSerWithConfigs.get(1).f0,
+      classOf[UnloadableDummyTypeSerializer[_]],
+      previousLeftRightSerWithConfigs.get(1).f1,
+      rightSerializer)
+
+    if (leftCompatResult.isRequiresMigration
+      || rightCompatResult.isRequiresMigration) {
+      CompatibilityResult.requiresMigration()
+    } else {
+      CompatibilityResult.compatible()
     }
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
@@ -140,14 +140,10 @@ class EitherSerializer[A, B, T <: Either[A, B]](
       configSnapshot.getNestedSerializersAndConfigs
 
     val leftCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousLeftRightSerWithConfigs.get(0).f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousLeftRightSerWithConfigs.get(0).f1,
       leftSerializer)
 
     val rightCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-      previousLeftRightSerWithConfigs.get(1).f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousLeftRightSerWithConfigs.get(1).f1,
       rightSerializer)
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
@@ -84,7 +84,7 @@ class EnumValueSerializer[E <: Enumeration](val enum: E) extends TypeSerializer[
   }
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[E#Value] = {
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[E#Value] = {
 
     configSnapshot match {
       case enumSerializerConfigSnapshot: EnumValueSerializer.ScalaEnumSerializerConfigSnapshot[_] =>
@@ -122,7 +122,7 @@ class EnumValueSerializer[E <: Enumeration](val enum: E) extends TypeSerializer[
 object EnumValueSerializer {
 
   class ScalaEnumSerializerConfigSnapshot[E <: Enumeration]
-      extends TypeSerializerConfigSnapshot {
+      extends TypeSerializerConfigSnapshot[E#Value] {
 
     var enumClass: Class[E] = _
     var enumConstants: List[(String, Int)] = _

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/NothingSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/NothingSerializer.scala
@@ -56,11 +56,11 @@ class NothingSerializer extends TypeSerializer[Any] {
   override def deserialize(reuse: Any, source: DataInputView): Any =
     throw new RuntimeException("This must not be used. You encountered a bug.")
 
-  override def snapshotConfiguration(): TypeSerializerConfigSnapshot =
+  override def snapshotConfiguration(): TypeSerializerConfigSnapshot[Any] =
     throw new RuntimeException("This must not be used. You encountered a bug.")
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[Any] =
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[Any] =
     throw new RuntimeException("This must not be used. You encountered a bug.")
 
   override def equals(obj: Any): Boolean = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
@@ -124,19 +124,11 @@ class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
       : CompatibilityResult[Option[A]] = {
 
     val compatResult = CompatibilityUtil.resolveCompatibilityResult(
-      compositeConfigSnapshot.getSingleNestedSerializerAndConfig.f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       compositeConfigSnapshot.getSingleNestedSerializerAndConfig.f1,
       elemSerializer)
 
     if (compatResult.isRequiresMigration) {
-      if (compatResult.getConvertDeserializer != null) {
-        CompatibilityResult.requiresMigration(
-          new OptionSerializer[A](
-            new TypeDeserializerAdapter(compatResult.getConvertDeserializer)))
-      } else {
-        CompatibilityResult.requiresMigration()
-      }
+      CompatibilityResult.requiresMigration()
     } else {
       CompatibilityResult.compatible()
     }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
@@ -106,7 +106,7 @@ class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
   }
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[Option[A]] = {
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[Option[A]] = {
 
     configSnapshot match {
       case optionSerializerConfigSnapshot
@@ -120,7 +120,7 @@ class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
   }
 
   private def ensureCompatibility(
-      compositeConfigSnapshot: CompositeTypeSerializerConfigSnapshot)
+      compositeConfigSnapshot: CompositeTypeSerializerConfigSnapshot[Option[A]])
       : CompatibilityResult[Option[A]] = {
 
     val compatResult = CompatibilityUtil.resolveCompatibilityResult(
@@ -150,7 +150,7 @@ object OptionSerializer {
     * Once Flink 1.3.x is no longer supported, this can be removed.
     */
   class OptionSerializerConfigSnapshot[A]()
-      extends CompositeTypeSerializerConfigSnapshot {
+      extends CompositeTypeSerializerConfigSnapshot[Option[A]] {
 
     override def getVersion: Int = OptionSerializerConfigSnapshot.VERSION
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
@@ -152,16 +152,16 @@ abstract class TraversableSerializer[T <: TraversableOnce[E], E](
     obj.isInstanceOf[TraversableSerializer[_, _]]
   }
 
-  override def snapshotConfiguration(): TraversableSerializerConfigSnapshot[E] = {
-    new TraversableSerializerConfigSnapshot[E](elementSerializer)
+  override def snapshotConfiguration(): TraversableSerializerConfigSnapshot[T, E] = {
+    new TraversableSerializerConfigSnapshot[T, E](elementSerializer)
   }
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[T] = {
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[T] = {
 
     configSnapshot match {
       case traversableSerializerConfigSnapshot
-          : TraversableSerializerConfigSnapshot[E] =>
+          : TraversableSerializerConfigSnapshot[T, E] =>
 
         val elemCompatRes = CompatibilityUtil.resolveCompatibilityResult(
           traversableSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f0,

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
@@ -164,8 +164,6 @@ abstract class TraversableSerializer[T <: TraversableOnce[E], E](
           : TraversableSerializerConfigSnapshot[T, E] =>
 
         val elemCompatRes = CompatibilityUtil.resolveCompatibilityResult(
-          traversableSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f0,
-          classOf[UnloadableDummyTypeSerializer[_]],
           traversableSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f1,
           elementSerializer)
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
@@ -164,7 +164,7 @@ abstract class TraversableSerializer[T <: TraversableOnce[E], E](
           : TraversableSerializerConfigSnapshot[T, E] =>
 
         val elemCompatRes = CompatibilityUtil.resolveCompatibilityResult(
-          traversableSerializerConfigSnapshot.getSingleNestedSerializerAndConfig.f1,
+          traversableSerializerConfigSnapshot.getNestedSerializerConfigSnapshot(0),
           elementSerializer)
 
         if (elemCompatRes.isRequiresMigration) {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
@@ -130,14 +130,10 @@ class TrySerializer[A](
       compositeConfigSnapshot.getNestedSerializersAndConfigs
 
     val elemCompatRes = CompatibilityUtil.resolveCompatibilityResult(
-      previousSerializersAndConfigs.get(0).f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousSerializersAndConfigs.get(0).f1,
       elemSerializer)
 
     val throwableCompatRes = CompatibilityUtil.resolveCompatibilityResult(
-      previousSerializersAndConfigs.get(1).f0,
-      classOf[UnloadableDummyTypeSerializer[_]],
       previousSerializersAndConfigs.get(1).f1,
       throwableSerializer)
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
@@ -109,7 +109,7 @@ class TrySerializer[A](
   }
 
   override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot): CompatibilityResult[Try[A]] = {
+      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[Try[A]] = {
 
     configSnapshot match {
       case trySerializerConfigSnapshot
@@ -123,7 +123,7 @@ class TrySerializer[A](
   }
 
   private def ensureCompatibility(
-      compositeConfigSnapshot: CompositeTypeSerializerConfigSnapshot)
+      compositeConfigSnapshot: CompositeTypeSerializerConfigSnapshot[Try[A]])
         : CompatibilityResult[Try[A]] = {
 
     val previousSerializersAndConfigs =
@@ -156,7 +156,7 @@ object TrySerializer {
     * Once Flink 1.3.x is no longer supported, this can be removed.
     */
   class TrySerializerConfigSnapshot[A]()
-      extends CompositeTypeSerializerConfigSnapshot() {
+      extends CompositeTypeSerializerConfigSnapshot[Try[A]]() {
 
     override def getVersion: Int = TrySerializerConfigSnapshot.VERSION
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
@@ -18,10 +18,9 @@
 package org.apache.flink.api.scala.typeutils
 
 import org.apache.flink.annotation.Internal
-import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeutils._
-import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+import org.apache.flink.util.Preconditions
 
 import scala.util.{Failure, Success, Try}
 
@@ -32,12 +31,15 @@ import scala.util.{Failure, Success, Try}
 @SerialVersionUID(-3052182891252564491L)
 class TrySerializer[A](
     private val elemSerializer: TypeSerializer[A],
-    private val executionConfig: ExecutionConfig)
-  extends TypeSerializer[Try[A]] {
+    private val throwableSerializer: TypeSerializer[Throwable])
+  extends CompositeTypeSerializer[Try[A]](
+    new ScalaTrySerializerConfigSnapshot[A](
+      Preconditions.checkNotNull(elemSerializer),
+      Preconditions.checkNotNull(throwableSerializer)),
+    elemSerializer,
+    throwableSerializer) {
 
   override def duplicate: TrySerializer[A] = this
-
-  val throwableSerializer = new KryoSerializer[Throwable](classOf[Throwable], executionConfig)
 
   override def createInstance: Try[A] = {
     Failure(new RuntimeException("Empty Failure"))
@@ -97,51 +99,20 @@ class TrySerializer[A](
   }
 
   override def hashCode(): Int = {
-    31 * elemSerializer.hashCode() + executionConfig.hashCode()
+    31 * elemSerializer.hashCode() + throwableSerializer.hashCode()
   }
 
   // --------------------------------------------------------------------------------------------
   // Serializer configuration snapshotting & compatibility
   // --------------------------------------------------------------------------------------------
 
-  override def snapshotConfiguration(): ScalaTrySerializerConfigSnapshot[A] = {
-    new ScalaTrySerializerConfigSnapshot[A](elemSerializer, throwableSerializer)
-  }
-
-  override def ensureCompatibility(
-      configSnapshot: TypeSerializerConfigSnapshot[_]): CompatibilityResult[Try[A]] = {
-
-    configSnapshot match {
-      case trySerializerConfigSnapshot
-          : ScalaTrySerializerConfigSnapshot[A] =>
-        ensureCompatibility(trySerializerConfigSnapshot)
-      case legacyTrySerializerConfigSnapshot
-          : TrySerializer.TrySerializerConfigSnapshot[A] =>
-        ensureCompatibility(legacyTrySerializerConfigSnapshot)
-      case _ => CompatibilityResult.requiresMigration()
-    }
-  }
-
-  private def ensureCompatibility(
-      compositeConfigSnapshot: CompositeTypeSerializerConfigSnapshot[Try[A]])
-        : CompatibilityResult[Try[A]] = {
-
-    val previousSerializersAndConfigs =
-      compositeConfigSnapshot.getNestedSerializersAndConfigs
-
-    val elemCompatRes = CompatibilityUtil.resolveCompatibilityResult(
-      previousSerializersAndConfigs.get(0).f1,
-      elemSerializer)
-
-    val throwableCompatRes = CompatibilityUtil.resolveCompatibilityResult(
-      previousSerializersAndConfigs.get(1).f1,
-      throwableSerializer)
-
-    if (elemCompatRes.isRequiresMigration || throwableCompatRes.isRequiresMigration) {
-      CompatibilityResult.requiresMigration()
-    } else {
-      CompatibilityResult.compatible()
-    }
+  override def isComparableSnapshot(
+      configSnapshot: TypeSerializerConfigSnapshot[_]): Boolean = {
+    configSnapshot.isInstanceOf[ScalaTrySerializerConfigSnapshot[A]] ||
+      // backwards compatibility path;
+      // Flink versions older or equal to 1.5.x returns a
+      // TrySerializer.TrySerializerConfigSnapshot as the snapshot
+      configSnapshot.isInstanceOf[TrySerializer.TrySerializerConfigSnapshot[A]]
   }
 }
 
@@ -155,10 +126,23 @@ object TrySerializer {
       extends CompositeTypeSerializerConfigSnapshot[Try[A]]() {
 
     override def getVersion: Int = TrySerializerConfigSnapshot.VERSION
+
+    override def restoreSerializer(
+        restoredNestedSerializers: TypeSerializer[_]*
+      ): TypeSerializer[Try[A]] = {
+
+      new TrySerializer[A](
+        restoredNestedSerializers(0).asInstanceOf[TypeSerializer[A]],
+        restoredNestedSerializers(1).asInstanceOf[TypeSerializer[Throwable]])
+    }
+
+    override def containsSerializers(): Boolean = {
+      getReadVersion < 2
+    }
   }
 
   object TrySerializerConfigSnapshot {
-    val VERSION = 1
+    val VERSION = 2
   }
 
 }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerCompatibilityTest.scala
@@ -59,7 +59,8 @@ class TupleSerializerCompatibilityTest {
 
       val currentSerializer = createTypeInformation[TestCaseClass]
         .createSerializer(new ExecutionConfig())
-      assertFalse(currentSerializer.ensureCompatibility(oldConfigSnapshot).isRequiresMigration)
+      assertFalse(currentSerializer
+        .internalEnsureCompatibility(oldConfigSnapshot).isRequiresMigration)
 
       // test old data serialization
       is.close()

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerTest.scala
@@ -35,7 +35,7 @@ class EnumValueSerializerTest extends TestLogger with JUnitSuiteLike {
 
     val snapshot = enumSerializer.snapshotConfiguration()
 
-    assertFalse(enumSerializer.ensureCompatibility(snapshot).isRequiresMigration)
+    assertFalse(enumSerializer.internalEnsureCompatibility(snapshot).isRequiresMigration)
   }
 }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -150,7 +150,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
     val enum2 = instantiateEnum[Enumeration](classLoader2, enumName)
 
     val enumValueSerializer2 = new EnumValueSerializer(enum2)
-    enumValueSerializer2.ensureCompatibility(snapshot2)
+    enumValueSerializer2.internalEnsureCompatibility(snapshot2)
   }
 }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.api.scala.typeutils
 import java.io._
 import java.net.{URL, URLClassLoader}
 
-import org.apache.flink.api.common.typeutils.{CompatibilityResult, TypeSerializerSerializationUtil}
+import org.apache.flink.api.common.typeutils.{CompatibilityResult, TypeSerializerConfigSnapshotSerializationUtil}
 import org.apache.flink.core.memory.{DataInputViewStreamWrapper, DataOutputViewStreamWrapper}
 import org.apache.flink.util.TestLogger
 import org.junit.rules.TemporaryFolder
@@ -134,7 +134,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
 
     val baos = new ByteArrayOutputStream()
     val output = new DataOutputViewStreamWrapper(baos)
-    TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(output, snapshot)
+    TypeSerializerConfigSnapshotSerializationUtil.writeSerializerConfigSnapshot(output, snapshot)
 
     output.close()
     baos.close()
@@ -144,7 +144,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
 
     val classLoader2 = compileAndLoadEnum(tempFolder.newFolder(), s"$enumName.scala", enumSourceB)
 
-    val snapshot2 = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+    val snapshot2 = TypeSerializerConfigSnapshotSerializationUtil.readSerializerConfigSnapshot(
       input,
       classLoader2)
     val enum2 = instantiateEnum[Enumeration](classLoader2, enumName)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
@@ -612,8 +611,6 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			// check for key serializer compatibility; this also reconfigures the
 			// key serializer to be compatible, if it is required and is possible
 			if (CompatibilityUtil.resolveCompatibilityResult(
-				serializationProxy.getKeySerializer(),
-				UnloadableDummyTypeSerializer.class,
 				serializationProxy.getKeySerializerConfigSnapshot(),
 				rocksDBKeyedStateBackend.keySerializer)
 				.isRequiresMigration()) {
@@ -1156,8 +1153,6 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				// check for key serializer compatibility; this also reconfigures the
 				// key serializer to be compatible, if it is required and is possible
 				if (CompatibilityUtil.resolveCompatibilityResult(
-					serializationProxy.getKeySerializer(),
-					UnloadableDummyTypeSerializer.class,
 					serializationProxy.getKeySerializerConfigSnapshot(),
 					stateBackend.keySerializer)
 					.isRequiresMigration()) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -643,8 +643,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 						new RegisteredKeyedBackendStateMetaInfo<>(
 							restoredMetaInfo.getStateType(),
 							restoredMetaInfo.getName(),
-							restoredMetaInfo.getNamespaceSerializer(),
-							restoredMetaInfo.getStateSerializer());
+							restoredMetaInfo.getNamespaceSerializerConfigSnapshot().restoreSerializer(),
+							restoredMetaInfo.getStateSerializerConfigSnapshot().restoreSerializer());
 
 					rocksDBKeyedStateBackend.restoredKvStateMetaInfos.put(restoredMetaInfo.getName(), restoredMetaInfo);
 
@@ -949,8 +949,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					new RegisteredKeyedBackendStateMetaInfo<>(
 						stateMetaInfoSnapshot.getStateType(),
 						stateMetaInfoSnapshot.getName(),
-						stateMetaInfoSnapshot.getNamespaceSerializer(),
-						stateMetaInfoSnapshot.getStateSerializer());
+						stateMetaInfoSnapshot.getNamespaceSerializerConfigSnapshot().restoreSerializer(),
+						stateMetaInfoSnapshot.getStateSerializerConfigSnapshot().restoreSerializer());
 
 				registeredStateMetaInfoEntry =
 					new Tuple2<>(
@@ -1082,8 +1082,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					new RegisteredKeyedBackendStateMetaInfo<>(
 						stateMetaInfoSnapshot.getStateType(),
 						stateMetaInfoSnapshot.getName(),
-						stateMetaInfoSnapshot.getNamespaceSerializer(),
-						stateMetaInfoSnapshot.getStateSerializer());
+						stateMetaInfoSnapshot.getNamespaceSerializerConfigSnapshot().restoreSerializer(),
+						stateMetaInfoSnapshot.getStateSerializerConfigSnapshot().restoreSerializer());
 
 				stateBackend.kvStateInformation.put(
 					stateMetaInfoSnapshot.getName(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -553,15 +553,15 @@ public class CoGroupedStreams<T1, T2> {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<TaggedUnion<T1, T2>> snapshotConfiguration() {
 			return new UnionSerializerConfigSnapshot<>(oneSerializer, twoSerializer);
 		}
 
 		@Override
-		public CompatibilityResult<TaggedUnion<T1, T2>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<TaggedUnion<T1, T2>> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			if (configSnapshot instanceof UnionSerializerConfigSnapshot) {
 				List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousSerializersAndConfigs =
-					((UnionSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+					((UnionSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<T1> oneSerializerCompatResult = CompatibilityUtil.resolveCompatibilityResult(
 					previousSerializersAndConfigs.get(0).f0,
@@ -592,7 +592,8 @@ public class CoGroupedStreams<T1, T2> {
 	/**
 	 * The {@link TypeSerializerConfigSnapshot} for the {@link UnionSerializer}.
 	 */
-	public static class UnionSerializerConfigSnapshot<T1, T2> extends CompositeTypeSerializerConfigSnapshot {
+	public static class UnionSerializerConfigSnapshot<T1, T2>
+			extends CompositeTypeSerializerConfigSnapshot<TaggedUnion<T1, T2>> {
 
 		private static final int VERSION = 1;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -27,10 +27,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.operators.translation.WrappingFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -564,24 +562,15 @@ public class CoGroupedStreams<T1, T2> {
 					((UnionSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<T1> oneSerializerCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousSerializersAndConfigs.get(0).f0,
-					UnloadableDummyTypeSerializer.class,
 					previousSerializersAndConfigs.get(0).f1,
 					oneSerializer);
 
 				CompatibilityResult<T2> twoSerializerCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-					previousSerializersAndConfigs.get(1).f0,
-					UnloadableDummyTypeSerializer.class,
 					previousSerializersAndConfigs.get(1).f1,
 					twoSerializer);
 
 				if (!oneSerializerCompatResult.isRequiresMigration() && !twoSerializerCompatResult.isRequiresMigration()) {
 					return CompatibilityResult.compatible();
-				} else if (oneSerializerCompatResult.getConvertDeserializer() != null && twoSerializerCompatResult.getConvertDeserializer() != null) {
-					return CompatibilityResult.requiresMigration(
-						new UnionSerializer<>(
-							new TypeDeserializerAdapter<>(oneSerializerCompatResult.getConvertDeserializer()),
-							new TypeDeserializerAdapter<>(twoSerializerCompatResult.getConvertDeserializer())));
 				}
 			}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -763,16 +763,16 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<State<TXN, CONTEXT>> snapshotConfiguration() {
 			return new StateSerializerConfigSnapshot<>(transactionSerializer, contextSerializer);
 		}
 
 		@Override
 		public CompatibilityResult<State<TXN, CONTEXT>> ensureCompatibility(
-				TypeSerializerConfigSnapshot configSnapshot) {
+				TypeSerializerConfigSnapshot<?> configSnapshot) {
 			if (configSnapshot instanceof StateSerializerConfigSnapshot) {
 				List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousSerializersAndConfigs =
-						((StateSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+						((StateSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<TXN> txnCompatResult = CompatibilityUtil.resolveCompatibilityResult(
 						previousSerializersAndConfigs.get(0).f0,
@@ -809,7 +809,7 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 	 */
 	@Internal
 	public static final class StateSerializerConfigSnapshot<TXN, CONTEXT>
-			extends CompositeTypeSerializerConfigSnapshot {
+			extends CompositeTypeSerializerConfigSnapshot<State<TXN, CONTEXT>> {
 
 		private static final int VERSION = 1;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -27,10 +27,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -775,26 +773,15 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 						((StateSerializerConfigSnapshot<?, ?>) configSnapshot).getNestedSerializersAndConfigs();
 
 				CompatibilityResult<TXN> txnCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-						previousSerializersAndConfigs.get(0).f0,
-						UnloadableDummyTypeSerializer.class,
 						previousSerializersAndConfigs.get(0).f1,
 						transactionSerializer);
 
 				CompatibilityResult<CONTEXT> contextCompatResult = CompatibilityUtil.resolveCompatibilityResult(
-						previousSerializersAndConfigs.get(1).f0,
-						UnloadableDummyTypeSerializer.class,
 						previousSerializersAndConfigs.get(1).f1,
 						contextSerializer);
 
 				if (!txnCompatResult.isRequiresMigration() && !contextCompatResult.isRequiresMigration()) {
 					return CompatibilityResult.compatible();
-				} else {
-					if (txnCompatResult.getConvertDeserializer() != null && contextCompatResult.getConvertDeserializer() != null) {
-						return CompatibilityResult.requiresMigration(
-								new StateSerializer<>(
-										new TypeDeserializerAdapter<>(txnCompatResult.getConvertDeserializer()),
-										new TypeDeserializerAdapter<>(contextCompatResult.getConvertDeserializer())));
-					}
 				}
 			}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -253,9 +253,7 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	public InternalTimersSnapshot<K, N> snapshotTimersForKeyGroup(int keyGroupIdx) {
 		return new InternalTimersSnapshot<>(
 				keySerializer,
-				keySerializer.snapshotConfiguration(),
 				namespaceSerializer,
-				namespaceSerializer.snapshotConfiguration(),
 				eventTimeTimersQueue.getTimersForKeyGroup(keyGroupIdx),
 				processingTimeTimersQueue.getTimersForKeyGroup(keyGroupIdx));
 	}
@@ -271,13 +269,18 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	public void restoreTimersForKeyGroup(InternalTimersSnapshot<?, ?> restoredSnapshot, int keyGroupIdx) {
 		this.restoredTimersSnapshot = (InternalTimersSnapshot<K, N>) restoredSnapshot;
 
-		if (areSnapshotSerializersIncompatible(restoredSnapshot)) {
+		TypeSerializer<K> restoredKeyDeserializer =
+			restoredTimersSnapshot.getKeySerializerConfigSnapshot().restoreSerializer();
+		TypeSerializer<N> restoredNamespaceDeserializer =
+			restoredTimersSnapshot.getNamespaceSerializerConfigSnapshot().restoreSerializer();
+
+		if (areSnapshotSerializersIncompatible(restoredKeyDeserializer, restoredNamespaceDeserializer)) {
 			throw new IllegalArgumentException("Tried to restore timers " +
 				"for the same service with different serializers.");
 		}
 
-		this.keyDeserializer = restoredTimersSnapshot.getKeySerializer();
-		this.namespaceDeserializer = restoredTimersSnapshot.getNamespaceSerializer();
+		this.keyDeserializer = restoredKeyDeserializer;
+		this.namespaceDeserializer = restoredNamespaceDeserializer;
 
 		checkArgument(localKeyGroupRange.contains(keyGroupIdx),
 			"Key Group " + keyGroupIdx + " does not belong to the local range.");
@@ -332,8 +335,11 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		return processingTimeTimersQueue.getTimersByKeyGroup();
 	}
 
-	private boolean areSnapshotSerializersIncompatible(InternalTimersSnapshot<?, ?> restoredSnapshot) {
-		return (this.keyDeserializer != null && !this.keyDeserializer.equals(restoredSnapshot.getKeySerializer())) ||
-			(this.namespaceDeserializer != null && !this.namespaceDeserializer.equals(restoredSnapshot.getNamespaceSerializer()));
+	private boolean areSnapshotSerializersIncompatible(
+			TypeSerializer<K> restoredKeySerializer,
+			TypeSerializer<N> restoredNamespaceSerializer) {
+
+		return (this.keyDeserializer != null && !this.keyDeserializer.equals(restoredKeySerializer)) ||
+			(this.namespaceDeserializer != null && !this.namespaceDeserializer.equals(restoredNamespaceSerializer));
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -137,14 +137,10 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 			// the following is the case where we restore
 			if (restoredTimersSnapshot != null) {
 				CompatibilityResult<K> keySerializerCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					this.keyDeserializer,
-					null,
 					restoredTimersSnapshot.getKeySerializerConfigSnapshot(),
 					keySerializer);
 
 				CompatibilityResult<N> namespaceSerializerCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					this.namespaceDeserializer,
-					null,
 					restoredTimersSnapshot.getNamespaceSerializerConfigSnapshot(),
 					namespaceSerializer);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
@@ -36,7 +36,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIOReadableWritable {
 
-	public static final int VERSION = 1;
+	public static final int VERSION = 2;
 
 	/** The key-group timer services to write / read. */
 	private Map<String, HeapInternalTimerService<K, ?>> timerServices;
@@ -86,6 +86,11 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	@Override
 	public int getVersion() {
 		return VERSION;
+	}
+
+	@Override
+	public int[] getCompatibleVersions() {
+		return new int[]{VERSION, 1};
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
@@ -242,12 +242,12 @@ public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N> {
 		}
 
 		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		public TypeSerializerConfigSnapshot<InternalTimer<K, N>> snapshotConfiguration() {
 			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
 		}
 
 		@Override
-		public CompatibilityResult<InternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		public CompatibilityResult<InternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
@@ -281,18 +281,18 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public StreamElementSerializerConfigSnapshot snapshotConfiguration() {
+	public StreamElementSerializerConfigSnapshot<T> snapshotConfiguration() {
 		return new StreamElementSerializerConfigSnapshot<>(typeSerializer);
 	}
 
 	@Override
-	public CompatibilityResult<StreamElement> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+	public CompatibilityResult<StreamElement> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
 		Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> previousTypeSerializerAndConfig;
 
 		// we are compatible for data written by ourselves or the legacy MultiplexingStreamRecordSerializer
 		if (configSnapshot instanceof StreamElementSerializerConfigSnapshot) {
 			previousTypeSerializerAndConfig =
-				((StreamElementSerializerConfigSnapshot) configSnapshot).getSingleNestedSerializerAndConfig();
+				((StreamElementSerializerConfigSnapshot<?>) configSnapshot).getSingleNestedSerializerAndConfig();
 		} else {
 			return CompatibilityResult.requiresMigration();
 		}
@@ -317,7 +317,7 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 	/**
 	 * Configuration snapshot specific to the {@link StreamElementSerializer}.
 	 */
-	public static final class StreamElementSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot {
+	public static final class StreamElementSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot<StreamElement> {
 
 		private static final int VERSION = 1;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -298,17 +296,11 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 		}
 
 		CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
-				previousTypeSerializerAndConfig.f0,
-				UnloadableDummyTypeSerializer.class,
 				previousTypeSerializerAndConfig.f1,
 				typeSerializer);
 
 		if (!compatResult.isRequiresMigration()) {
 			return CompatibilityResult.compatible();
-		} else if (compatResult.getConvertDeserializer() != null) {
-			return CompatibilityResult.requiresMigration(
-				new StreamElementSerializer<>(
-					new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer())));
 		} else {
 			return CompatibilityResult.requiresMigration();
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR is built on top of #6235. It is a WIP PR.

This PR implements the restore serializer factory method for all simple composite serializers (i.e., Flink serializers with nested serializers). More complex serializers such as the Scala serializers, POJO serializers, KryoSerializer, AvroSerializer, etc. will come as a follow-up PR.

## Brief change log

- Introduce the `CompositeTypeSerializer` base class, which wraps the configuration snapshotting logic and compatibility checks.
- Let all simple composite type serializers extend the `CompositeTypeSerializer`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
