### PR TITLE
[FLINK-9776] [runtime] Stop sending periodic interrupts once executing thread leaves user function / operator code.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -59,6 +59,9 @@ public abstract class AbstractInvokable {
 	/** The environment assigned to this invokable. */
 	private final Environment environment;
 
+	/** Flag whether cancellation should interrupt the executing thread. */
+	private volatile boolean shouldInterruptOnCancel = true;
+
 	/**
 	 * Create an Invokable task and set its environment.
 	 *
@@ -67,6 +70,10 @@ public abstract class AbstractInvokable {
 	public AbstractInvokable(Environment environment) {
 		this.environment = checkNotNull(environment);
 	}
+
+	// ------------------------------------------------------------------------
+	//  Core methods
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Starts the execution.
@@ -95,8 +102,34 @@ public abstract class AbstractInvokable {
 	}
 
 	/**
+	 * Sets whether the thread that executes the {@link #invoke()} method should be
+	 * interrupted during cancellation. This method sets the flag for both the initial
+	 * interrupt, as well as for the repeated interrupt. Setting the interruption to
+	 * false at some point during the cancellation procedure is a way to stop further
+	 * interrupts from happening.
+	 */
+	public void setShouldInterruptOnCancel(boolean shouldInterruptOnCancel) {
+		this.shouldInterruptOnCancel = shouldInterruptOnCancel;
+	}
+
+	/**
+	 * Checks whether the task should be interrupted during cancellation.
+	 * This method is check both for the initial interrupt, as well as for the
+	 * repeated interrupt. Setting the interruption to false via
+	 * {@link #setShouldInterruptOnCancel(boolean)} is a way to stop further interrupts
+	 * from happening.
+	 */
+	public boolean shouldInterruptOnCancel() {
+		return shouldInterruptOnCancel;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Access to Environment and Configuration
+	// ------------------------------------------------------------------------
+
+	/**
 	 * Returns the environment of this task.
-	 * 
+	 *
 	 * @return The environment of this task.
 	 */
 	public Environment getEnvironment() {
@@ -114,7 +147,7 @@ public abstract class AbstractInvokable {
 
 	/**
 	 * Returns the current number of subtasks the respective task is split into.
-	 * 
+	 *
 	 * @return the current number of subtasks the respective task is split into
 	 */
 	public int getCurrentNumberOfSubtasks() {
@@ -123,7 +156,7 @@ public abstract class AbstractInvokable {
 
 	/**
 	 * Returns the index of this subtask in the subtask group.
-	 * 
+	 *
 	 * @return the index of this subtask in the subtask group
 	 */
 	public int getIndexInSubtaskGroup() {
@@ -132,7 +165,7 @@ public abstract class AbstractInvokable {
 
 	/**
 	 * Returns the task configuration object which was attached to the original {@link org.apache.flink.runtime.jobgraph.JobVertex}.
-	 * 
+	 *
 	 * @return the task configuration object which was attached to the original {@link org.apache.flink.runtime.jobgraph.JobVertex}
 	 */
 	public Configuration getTaskConfiguration() {
@@ -141,7 +174,7 @@ public abstract class AbstractInvokable {
 
 	/**
 	 * Returns the job configuration object which was attached to the original {@link org.apache.flink.runtime.jobgraph.JobGraph}.
-	 * 
+	 *
 	 * @return the job configuration object which was attached to the original {@link org.apache.flink.runtime.jobgraph.JobGraph}
 	 */
 	public Configuration getJobConfiguration() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -341,6 +341,16 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// clean up everything we initialized
 			isRunning = false;
 
+			// Now that we are outside the user code, we do not want to be interrupted further
+			// upon cancellation. The shutdown logic below needs to make sure it does not issue calls
+			// that block and stall shutdown.
+			// Additionally, the cancellation watch dog will issue a hard-cancel (kill the TaskManager
+			// process) as a backup in case some shutdown procedure blocks outside our control.
+			setShouldInterruptOnCancel(false);
+
+			// clear any previously issued interrupt for a more graceful shutdown
+			Thread.interrupted();
+
 			// stop all timers and threads
 			tryShutdownTimerService();
 


### PR DESCRIPTION
## What is the purpose of the change

Upon cancellation, the task thread is periodically interrupted. This helps to pull the thread out of blocking operations in the user code.

However, once the thread leaves the user code, the repeated interrupts may interfere with the shutdown cleanup logic, causing confusing exceptions.

This PR changes the behavior to stop sending the periodic interrupts once the thread leaves the user code.

## Brief change log

  - `AbstractInvokable` maintains a flag whether interrupts should be sent.
  - `StreamTask` sets to not receive interrupts after coming out of the user code

## Verifying this change

This change is a trivial rework that currently only avoids  throwing and catching of InterruptedExceptions that may cause noise in the logs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
