### PR TITLE
[FLINK-9486] Introduce TimerState in keyed state backend

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.contrib.streaming.state.PredefinedOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -74,9 +75,12 @@ public final class KVStateRequestSerializerRocksDBTest {
 				columnFamilyOptions,
 				mock(TaskKvStateRegistry.class),
 				LongSerializer.INSTANCE,
-				1, new KeyGroupRange(0, 0),
-				new ExecutionConfig(), false,
-				TestLocalRecoveryConfig.disabled()
+				1,
+				new KeyGroupRange(0, 0),
+				new ExecutionConfig(),
+				false,
+				TestLocalRecoveryConfig.disabled(),
+				RocksDBStateBackend.PriorityQueueStateType.HEAP
 			);
 		longHeapKeyedStateBackend.restore(null);
 		longHeapKeyedStateBackend.setCurrentKey(key);
@@ -112,10 +116,12 @@ public final class KVStateRequestSerializerRocksDBTest {
 				columnFamilyOptions,
 				mock(TaskKvStateRegistry.class),
 				LongSerializer.INSTANCE,
-				1, new KeyGroupRange(0, 0),
+				1,
+				new KeyGroupRange(0, 0),
 				new ExecutionConfig(),
 				false,
-				TestLocalRecoveryConfig.disabled());
+				TestLocalRecoveryConfig.disabled(),
+				RocksDBStateBackend.PriorityQueueStateType.HEAP);
 		longHeapKeyedStateBackend.restore(null);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
@@ -185,18 +186,19 @@ public class KvStateRequestSerializerTest {
 	@Test
 	public void testListSerialization() throws Exception {
 		final long key = 0L;
-
+		final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
 		// objects for heap state list serialisation
 		final HeapKeyedStateBackend<Long> longHeapKeyedStateBackend =
 			new HeapKeyedStateBackend<>(
 				mock(TaskKvStateRegistry.class),
 				LongSerializer.INSTANCE,
 				ClassLoader.getSystemClassLoader(),
-				1,
-				new KeyGroupRange(0, 0),
+				keyGroupRange.getNumberOfKeyGroups(),
+				keyGroupRange,
 				async,
 				new ExecutionConfig(),
-				TestLocalRecoveryConfig.disabled()
+				TestLocalRecoveryConfig.disabled(),
+				new HeapPriorityQueueSetFactory(keyGroupRange, keyGroupRange.getNumberOfKeyGroups(), 128)
 			);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 
@@ -292,18 +294,19 @@ public class KvStateRequestSerializerTest {
 	@Test
 	public void testMapSerialization() throws Exception {
 		final long key = 0L;
-
+		final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
 		// objects for heap state list serialisation
 		final HeapKeyedStateBackend<Long> longHeapKeyedStateBackend =
 			new HeapKeyedStateBackend<>(
 				mock(TaskKvStateRegistry.class),
 				LongSerializer.INSTANCE,
 				ClassLoader.getSystemClassLoader(),
-				1,
-				new KeyGroupRange(0, 0),
+				keyGroupRange.getNumberOfKeyGroups(),
+				keyGroupRange,
 				async,
 				new ExecutionConfig(),
-				TestLocalRecoveryConfig.disabled()
+				TestLocalRecoveryConfig.disabled(),
+				new HeapPriorityQueueSetFactory(keyGroupRange, keyGroupRange.getNumberOfKeyGroups(), 128)
 			);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/InternalPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/InternalPriorityQueue.java
@@ -26,6 +26,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * Interface for collection that gives in order access to elements w.r.t their priority.
@@ -34,6 +36,16 @@ import java.util.Collection;
  */
 @Internal
 public interface InternalPriorityQueue<T> {
+
+	/**
+	 * Polls from the top of the queue as long as the the queue is not empty and passes the elements to
+	 * {@link Consumer} until a {@link Predicate} rejects an offered element. The rejected element is not
+	 * removed from the queue and becomes the new head.
+	 *
+	 * @param canConsume bulk polling ends once this returns false. The rejected element is nor removed and not consumed.
+	 * @param consumer consumer function for elements accepted by canConsume.
+	 */
+	void bulkPoll(@Nonnull Predicate<T> canConsume, @Nonnull Consumer<T> consumer);
 
 	/**
 	 * Retrieves and removes the first element (w.r.t. the order) of this set,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupedInternalPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupedInternalPriorityQueue.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import javax.annotation.Nonnull;
+
+import java.util.Set;
+
+/**
+ *
+ */
+@Nonnull
+public interface KeyGroupedInternalPriorityQueue<T> extends InternalPriorityQueue<T> {
+	Set<T> getSubsetForKeyGroup(int keyGroupId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupedInternalPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupedInternalPriorityQueue.java
@@ -23,9 +23,16 @@ import javax.annotation.Nonnull;
 import java.util.Set;
 
 /**
- *
+ * This interface exists as (temporary) adapter between the new {@link InternalPriorityQueue} and the old way in which
+ * timers are written in a snapshot. This interface can probably go away once timer state becomes part of the
+ * keyed state backend snapshot.
  */
-@Nonnull
 public interface KeyGroupedInternalPriorityQueue<T> extends InternalPriorityQueue<T> {
+
+	/**
+	 * Returns the subset of elements in the priority queue that belongs to the given key-group, within the operator's
+	 * key-group range.
+	 */
+	@Nonnull
 	Set<T> getSubsetForKeyGroup(int keyGroupId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -31,7 +31,8 @@ import java.util.stream.Stream;
  *
  * @param <K> The key by which state is keyed.
  */
-public interface KeyedStateBackend<K> extends InternalKeyContext<K>, KeyedStateFactory, Disposable {
+public interface KeyedStateBackend<K>
+	extends InternalKeyContext<K>, KeyedStateFactory, PriorityQueueSetFactory, Disposable {
 
 	/**
 	 * Sets the current key that is used for partitioned state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+/**
+ * This interface works similar to {@link Comparable} and is used to prioritize between two objects. The main difference
+ * between this interface and {@link Comparable} is it is not require to follow the usual contract between that
+ * {@link Comparable#compareTo(Object)} and {@link Object#equals(Object)}. The contract of this interface is:
+ * When two objects are equal, they indicate the same priority, but indicating the same priority does not require that
+ * both objects are equal.
+ *
+ * @param <T> type of the compared objects.
+ */
+@FunctionalInterface
+public interface PriorityComparator<T> {
+
+	/**
+	 * Compares two objects for priority. Returns a negative integer, zero, or a positive integer as the first
+	 * argument has lower, equal to, or higher priority than the second.
+	 * @param left left operand in the comparison by priority.
+	 * @param right left operand in the comparison by priority.
+	 * @return a negative integer, zero, or a positive integer as the first argument has lower, equal to, or higher
+	 * priority than the second.
+	 */
+	int comparePriority(T left, T right);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityQueueSetFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityQueueSetFactory.java
@@ -23,23 +23,24 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 
 import javax.annotation.Nonnull;
 
-import java.util.Comparator;
-
 /**
- *
+ * Factory for {@link KeyGroupedInternalPriorityQueue} instances.
  */
 public interface PriorityQueueSetFactory {
 
 	/**
+	 * Creates a {@link KeyGroupedInternalPriorityQueue}.
 	 *
-	 * @param stateName
-	 * @param byteOrderedElementSerializer
-	 * @param <T>
-	 * @return
+	 * @param stateName                    unique name for associated with this queue.
+	 * @param byteOrderedElementSerializer a serializer that with a format that is lexicographically ordered in
+	 *                                     alignment with elementPriorityComparator.
+	 * @param <T>                          type of the stored elements.
+	 * @return the queue with the specified unique name.
 	 */
+	@Nonnull
 	<T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
 		@Nonnull String stateName,
 		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
-		@Nonnull Comparator<T> elementComparator,
+		@Nonnull PriorityComparator<T> elementPriorityComparator,
 		@Nonnull KeyExtractorFunction<T> keyExtractor);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityQueueSetFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityQueueSetFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+
+import javax.annotation.Nonnull;
+
+import java.util.Comparator;
+
+/**
+ *
+ */
+public interface PriorityQueueSetFactory {
+
+	/**
+	 *
+	 * @param stateName
+	 * @param byteOrderedElementSerializer
+	 * @param <T>
+	 * @return
+	 */
+	<T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
+		@Nonnull String stateName,
+		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
+		@Nonnull Comparator<T> elementComparator,
+		@Nonnull KeyExtractorFunction<T> keyExtractor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TieBreakingPriorityComparator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TieBreakingPriorityComparator.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * This class is an adapter between {@link PriorityComparator} and a full {@link Comparator} that respects the
+ * contract between {@link Comparator#compare(Object, Object)} and {@link Object#equals(Object)}. This is currently
+ * needed for implementations of
+ * {@link org.apache.flink.runtime.state.heap.CachingInternalPriorityQueueSet.OrderedSetCache} that are implemented
+ * on top of a data structure that relies on the this contract, e.g. a tree set. We should replace this in the near
+ * future.
+ *
+ * @param <T> type of the compared elements.
+ */
+public class TieBreakingPriorityComparator<T> implements Comparator<T>, PriorityComparator<T> {
+
+	/** The {@link PriorityComparator} to which we delegate in a first step. */
+	@Nonnull
+	private final PriorityComparator<T> priorityComparator;
+
+	/** Serializer for instances of the compared objects. */
+	@Nonnull
+	private final TypeSerializer<T> serializer;
+
+	/** Stream that we use in serialization. */
+	@Nonnull
+	private final ByteArrayOutputStreamWithPos outStream;
+
+	/** {@link org.apache.flink.core.memory.DataOutputView} around outStream. */
+	@Nonnull
+	private final DataOutputViewStreamWrapper outView;
+
+	public TieBreakingPriorityComparator(
+		@Nonnull PriorityComparator<T> priorityComparator,
+		@Nonnull TypeSerializer<T> serializer,
+		@Nonnull ByteArrayOutputStreamWithPos outStream,
+		@Nonnull DataOutputViewStreamWrapper outView) {
+
+		this.priorityComparator = priorityComparator;
+		this.serializer = serializer;
+		this.outStream = outStream;
+		this.outView = outView;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public int compare(T o1, T o2) {
+
+		// first we compare priority, this should be the most commonly hit case
+		int cmp = priorityComparator.comparePriority(o1, o2);
+
+		if (cmp != 0) {
+			return cmp;
+		}
+
+		// here we start tie breaking and do our best to comply with the compareTo/equals contract, first we try
+		// to simply find an existing way to fully compare.
+		if (o1 instanceof Comparable && o1.getClass().equals(o2.getClass())) {
+			return ((Comparable<T>) o1).compareTo(o2);
+		}
+
+		// we catch this case before moving to more expensive tie breaks.
+		if (o1.equals(o2)) {
+			return 0;
+		}
+
+		// if objects are not equal, their serialized form should somehow differ as well. this can be costly, and...
+		// TODO we should have an alternative approach in the future, e.g. a cache that does not rely on compare to check equality.
+		try {
+			outStream.reset();
+			serializer.serialize(o1, outView);
+			int leftLen = outStream.getPosition();
+			serializer.serialize(o2, outView);
+			int rightLen = outStream.getPosition() - leftLen;
+			return compareBytes(outStream.getBuf(), 0, leftLen, leftLen, rightLen);
+		} catch (IOException ex) {
+			throw new FlinkRuntimeException("Serializer problem in comparator.", ex);
+		}
+	}
+
+	@Override
+	public int comparePriority(T left, T right) {
+		return priorityComparator.comparePriority(left, right);
+	}
+
+	public static int compareBytes(byte[] bytes, int offLeft, int leftLen, int offRight, int rightLen) {
+		int maxLen = Math.min(leftLen, rightLen);
+		for (int i = 0; i < maxLen; ++i) {
+			int cmp = bytes[offLeft + i] - bytes[offRight + i];
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		return leftLen - rightLen;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.LoggerFactory;
@@ -457,6 +458,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 
 		TaskStateManager taskStateManager = env.getTaskStateManager();
 		LocalRecoveryConfig localRecoveryConfig = taskStateManager.createLocalRecoveryConfig();
+		HeapPriorityQueueSetFactory priorityQueueSetFactory =
+			new HeapPriorityQueueSetFactory(keyGroupRange, numberOfKeyGroups, 128);
 
 		return new HeapKeyedStateBackend<>(
 				kvStateRegistry,
@@ -466,7 +469,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 				keyGroupRange,
 				isUsingAsynchronousSnapshots(),
 				env.getExecutionConfig(),
-				localRecoveryConfig);
+				localRecoveryConfig,
+				priorityQueueSetFactory);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
@@ -27,6 +27,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * This class is an implementation of a {@link InternalPriorityQueue} with set semantics that internally consists of
@@ -74,6 +76,15 @@ public class CachingInternalPriorityQueueSet<E> implements InternalPriorityQueue
 		checkRefillCacheFromStore();
 
 		return orderedCache.peekFirst();
+	}
+
+	@Override
+	public void bulkPoll(@Nonnull Predicate<E> canConsume, @Nonnull Consumer<E> consumer) {
+		E element;
+		while ((element = peek()) != null && canConsume.test(element)) {
+			poll();
+			consumer.accept(element);
+		}
 	}
 
 	@Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
@@ -184,7 +184,7 @@ public class CachingInternalPriorityQueueSet<E> implements InternalPriorityQueue
 				}
 				storeOnlyElements = iterator.hasNext();
 			} catch (Exception e) {
-				throw new FlinkRuntimeException("Exception while closing RocksDB iterator.", e);
+				throw new FlinkRuntimeException("Exception while refilling store from iterator.", e);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
@@ -158,7 +158,11 @@ public class CachingInternalPriorityQueueSet<E> implements InternalPriorityQueue
 	@Nonnull
 	@Override
 	public CloseableIterator<E> iterator() {
-		return orderedStore.orderedIterator();
+		if (storeOnlyElements) {
+			return orderedStore.orderedIterator();
+		} else {
+			return orderedCache.orderedIterator();
+		}
 	}
 
 	@Override
@@ -249,6 +253,13 @@ public class CachingInternalPriorityQueueSet<E> implements InternalPriorityQueue
 		 */
 		@Nullable
 		E peekLast();
+
+		/**
+		 * Returns an iterator over the store that returns element in order. The iterator must be closed by the client
+		 * after usage.
+		 */
+		@Nonnull
+		CloseableIterator<E> orderedIterator();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -158,7 +158,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private final HeapSnapshotStrategy snapshotStrategy;
 
 	/**
-	 *
+	 * Factory for state that is organized as priority queue.
 	 */
 	private final PriorityQueueSetFactory priorityQueueSetFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
 import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.PriorityComparator;
 import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
 import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
 import org.apache.flink.runtime.state.SnapshotResult;
@@ -76,7 +77,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,15 +105,16 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			Tuple2.of(FoldingStateDescriptor.class, (StateFactory) HeapFoldingState::create)
 		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
 
+	@Nonnull
 	@Override
 	public <T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
 		@Nonnull String stateName,
 		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
-		@Nonnull Comparator<T> elementComparator,
+		@Nonnull PriorityComparator<T> elementPriorityComparator,
 		@Nonnull KeyExtractorFunction<T> keyExtractor) {
 
 		return new HeapPriorityQueueSet<>(
-			elementComparator,
+			elementPriorityComparator,
 			keyExtractor,
 			128,
 			keyGroupRange,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -114,12 +114,11 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		@Nonnull PriorityComparator<T> elementPriorityComparator,
 		@Nonnull KeyExtractorFunction<T> keyExtractor) {
 
-		return new HeapPriorityQueueSet<>(
+		return priorityQueueSetFactory.create(
+			stateName,
+			byteOrderedElementSerializer,
 			elementPriorityComparator,
-			keyExtractor,
-			128,
-			keyGroupRange,
-			numberOfKeyGroups);
+			keyExtractor);
 	}
 
 	private interface StateFactory {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
 import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
 import org.apache.flink.runtime.state.SnapshotResult;
@@ -156,6 +157,11 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	 */
 	private final HeapSnapshotStrategy snapshotStrategy;
 
+	/**
+	 *
+	 */
+	private final PriorityQueueSetFactory priorityQueueSetFactory;
+
 	public HeapKeyedStateBackend(
 			TaskKvStateRegistry kvStateRegistry,
 			TypeSerializer<K> keySerializer,
@@ -164,7 +170,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			KeyGroupRange keyGroupRange,
 			boolean asynchronousSnapshots,
 			ExecutionConfig executionConfig,
-			LocalRecoveryConfig localRecoveryConfig) {
+			LocalRecoveryConfig localRecoveryConfig,
+			PriorityQueueSetFactory priorityQueueSetFactory) {
 
 		super(kvStateRegistry, keySerializer, userCodeClassLoader, numberOfKeyGroups, keyGroupRange, executionConfig);
 		this.localRecoveryConfig = Preconditions.checkNotNull(localRecoveryConfig);
@@ -176,6 +183,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.snapshotStrategy = new HeapSnapshotStrategy(synchronicityTrait);
 		LOG.info("Initializing heap keyed state backend with stream factory.");
 		this.restoredKvStateMetaInfos = new HashMap<>();
+		this.priorityQueueSetFactory = priorityQueueSetFactory;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueue.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static org.apache.flink.util.CollectionUtil.MAX_ARRAY_SIZE;
 
@@ -83,6 +85,15 @@ public class HeapPriorityQueue<T extends HeapPriorityQueueElement> implements In
 
 		this.elementPriorityComparator = elementPriorityComparator;
 		this.queue = (T[]) new HeapPriorityQueueElement[QUEUE_HEAD_INDEX + minimumCapacity];
+	}
+
+	@Override
+	public void bulkPoll(@Nonnull Predicate<T> canConsume, @Nonnull Consumer<T> consumer) {
+		T element;
+		while ((element = peek()) != null && canConsume.test(element)) {
+			poll();
+			consumer.accept(element);
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSet.java
@@ -22,12 +22,12 @@ import org.apache.flink.runtime.state.KeyExtractorFunction;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.PriorityComparator;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -73,7 +73,7 @@ public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement>
 	/**
 	 * Creates an empty {@link HeapPriorityQueueSet} with the requested initial capacity.
 	 *
-	 * @param elementComparator comparator for the contained elements.
+	 * @param elementPriorityComparator comparator for the priority of contained elements.
 	 * @param keyExtractor function to extract a key from the contained elements.
 	 * @param minimumCapacity the minimum and initial capacity of this priority queue.
 	 * @param keyGroupRange the key-group range of the elements in this set.
@@ -81,13 +81,13 @@ public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement>
 	 */
 	@SuppressWarnings("unchecked")
 	public HeapPriorityQueueSet(
-		@Nonnull Comparator<T> elementComparator,
+		@Nonnull PriorityComparator<T> elementPriorityComparator,
 		@Nonnull KeyExtractorFunction<T> keyExtractor,
 		@Nonnegative int minimumCapacity,
 		@Nonnull KeyGroupRange keyGroupRange,
 		@Nonnegative int totalNumberOfKeyGroups) {
 
-		super(elementComparator, minimumCapacity);
+		super(elementPriorityComparator, minimumCapacity);
 
 		this.keyExtractor = keyExtractor;
 
@@ -163,6 +163,7 @@ public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement>
 		return keyGroup - keyGroupRange.getStartKeyGroup();
 	}
 
+	@Nonnull
 	@Override
 	public Set<T> getSubsetForKeyGroup(int keyGroupId) {
 		return getDedupMapForKeyGroup(keyGroupId).keySet();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSet.java
@@ -18,20 +18,17 @@
 
 package org.apache.flink.runtime.state.heap;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.state.KeyExtractorFunction;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -49,7 +46,9 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  *
  * @param <T> type of the contained elements.
  */
-public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement> extends HeapPriorityQueue<T> {
+public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement>
+	extends HeapPriorityQueue<T>
+	implements KeyGroupedInternalPriorityQueue<T> {
 
 	/**
 	 * Function to extract the key from contained elements.
@@ -147,28 +146,9 @@ public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement> extends He
 		}
 	}
 
-	/**
-	 * Returns an unmodifiable set of all elements in the given key-group.
-	 */
-	@Nonnull
-	public Set<T> getElementsForKeyGroup(@Nonnegative int keyGroupIdx) {
-		return Collections.unmodifiableSet(getDedupMapForKeyGroup(keyGroupIdx).keySet());
-	}
-
-	@VisibleForTesting
-	@SuppressWarnings("unchecked")
-	@Nonnull
-	public List<Set<T>> getElementsByKeyGroup() {
-		List<Set<T>> result = new ArrayList<>(deduplicationMapsByKeyGroup.length);
-		for (int i = 0; i < deduplicationMapsByKeyGroup.length; ++i) {
-			result.add(i, Collections.unmodifiableSet(deduplicationMapsByKeyGroup[i].keySet()));
-		}
-		return result;
-	}
-
 	private HashMap<T, T> getDedupMapForKeyGroup(
-		@Nonnegative int keyGroupIdx) {
-		return deduplicationMapsByKeyGroup[globalKeyGroupToLocalIndex(keyGroupIdx)];
+		@Nonnegative int keyGroupId) {
+		return deduplicationMapsByKeyGroup[globalKeyGroupToLocalIndex(keyGroupId)];
 	}
 
 	private HashMap<T, T> getDedupMapForElement(T element) {
@@ -181,5 +161,10 @@ public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement> extends He
 	private int globalKeyGroupToLocalIndex(int keyGroup) {
 		checkArgument(keyGroupRange.contains(keyGroup));
 		return keyGroup - keyGroupRange.getStartKeyGroup();
+	}
+
+	@Override
+	public Set<T> getSubsetForKeyGroup(int keyGroupId) {
+		return getDedupMapForKeyGroup(keyGroupId).keySet();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetFactory.java
@@ -15,25 +15,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.runtime.state;
+
+package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
+import org.apache.flink.runtime.state.KeyExtractorFunction;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 /**
- * Test implementation of a {@link PriorityQueueSetFactory}.
+ *
  */
-public class TestPriorityQueueSetFactory implements PriorityQueueSetFactory {
+public class HeapPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
+	@Nonnull
 	private final KeyGroupRange keyGroupRange;
-	private final int totalkeyGroups;
 
-	public TestPriorityQueueSetFactory(KeyGroupRange keyGroupRange, int totalKeyGroups) {
+	@Nonnegative
+	private final int totalKeyGroups;
+
+	@Nonnegative
+	private final int minimumCapacity;
+
+	public HeapPriorityQueueSetFactory(
+		@Nonnull KeyGroupRange keyGroupRange,
+		@Nonnegative int totalKeyGroups,
+		@Nonnegative int minimumCapacity) {
+
 		this.keyGroupRange = keyGroupRange;
-		this.totalkeyGroups = totalKeyGroups;
+		this.totalKeyGroups = totalKeyGroups;
+		this.minimumCapacity = minimumCapacity;
 	}
 
 	@Nonnull
@@ -46,8 +62,8 @@ public class TestPriorityQueueSetFactory implements PriorityQueueSetFactory {
 		return new HeapPriorityQueueSet<>(
 			elementPriorityComparator,
 			keyExtractor,
-			128,
+			minimumCapacity,
 			keyGroupRange,
-			totalkeyGroups);
+			totalKeyGroups);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.state.KeyExtractorFunction;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.PriorityComparator;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -32,7 +33,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -70,7 +70,7 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 	@SuppressWarnings("unchecked")
 	public KeyGroupPartitionedPriorityQueue(
 		@Nonnull KeyExtractorFunction<T> keyExtractor,
-		@Nonnull Comparator<T> elementComparator,
+		@Nonnull PriorityComparator<T> elementPriorityComparator,
 		@Nonnull PartitionQueueSetFactory<T, PQ> orderedCacheFactory,
 		@Nonnull KeyGroupRange keyGroupRange,
 		@Nonnegative int totalKeyGroups) {
@@ -80,11 +80,11 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 		this.firstKeyGroup = keyGroupRange.getStartKeyGroup();
 		this.keyGroupedHeaps = (PQ[]) new InternalPriorityQueue[keyGroupRange.getNumberOfKeyGroups()];
 		this.heapOfkeyGroupedHeaps = new HeapPriorityQueue<>(
-			new InternalPriorityQueueComparator<>(elementComparator),
+			new InternalPriorityQueueComparator<>(elementPriorityComparator),
 			keyGroupRange.getNumberOfKeyGroups());
 		for (int i = 0; i < keyGroupedHeaps.length; i++) {
 			final PQ keyGroupSubHeap =
-				orderedCacheFactory.create(firstKeyGroup + i, totalKeyGroups, elementComparator);
+				orderedCacheFactory.create(firstKeyGroup + i, totalKeyGroups, elementPriorityComparator);
 			keyGroupedHeaps[i] = keyGroupSubHeap;
 			heapOfkeyGroupedHeaps.add(keyGroupSubHeap);
 		}
@@ -184,6 +184,7 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 		return keyGroupId - firstKeyGroup;
 	}
 
+	@Nonnull
 	@Override
 	public Set<T> getSubsetForKeyGroup(int keyGroupId) {
 		HashSet<T> result = new HashSet<>();
@@ -258,24 +259,24 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 	 * @param <Q> type of queue.
 	 */
 	private static final class InternalPriorityQueueComparator<T, Q extends InternalPriorityQueue<T>>
-		implements Comparator<Q> {
+		implements PriorityComparator<Q> {
 
 		/** Comparator for the queue elements, so we can compare their heads. */
 		@Nonnull
-		private final Comparator<T> elementComparator;
+		private final PriorityComparator<T> elementPriorityComparator;
 
-		InternalPriorityQueueComparator(@Nonnull Comparator<T> elementComparator) {
-			this.elementComparator = elementComparator;
+		InternalPriorityQueueComparator(@Nonnull PriorityComparator<T> elementPriorityComparator) {
+			this.elementPriorityComparator = elementPriorityComparator;
 		}
 
 		@Override
-		public int compare(Q o1, Q o2) {
+		public int comparePriority(Q o1, Q o2) {
 			final T left = o1.peek();
 			final T right = o2.peek();
 			if (left == null) {
 				return (right == null ? 0 : 1);
 			} else {
-				return (right == null ? -1 : elementComparator.compare(left, right));
+				return (right == null ? -1 : elementPriorityComparator.comparePriority(left, right));
 			}
 		}
 	}
@@ -293,10 +294,13 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 		 *
 		 * @param keyGroupId the key-group of the elements managed by the produced queue.
 		 * @param numKeyGroups the total number of key-groups in the job.
-		 * @param elementComparator the comparator that determines the order of the managed elements.
+		 * @param elementPriorityComparator the comparator that determines the order of managed elements by priority.
 		 * @return a new queue for the given key-group.
 		 */
 		@Nonnull
-		PQS create(@Nonnegative int keyGroupId, @Nonnegative int numKeyGroups, @Nonnull Comparator<T> elementComparator);
+		PQS create(
+			@Nonnegative int keyGroupId,
+			@Nonnegative int numKeyGroups,
+			@Nonnull PriorityComparator<T> elementPriorityComparator);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -35,6 +35,8 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * This implementation of {@link InternalPriorityQueue} is internally partitioned into sub-queues per key-group and
@@ -87,6 +89,15 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 				orderedCacheFactory.create(firstKeyGroup + i, totalKeyGroups, elementPriorityComparator);
 			keyGroupedHeaps[i] = keyGroupSubHeap;
 			heapOfkeyGroupedHeaps.add(keyGroupSubHeap);
+		}
+	}
+
+	@Override
+	public void bulkPoll(@Nonnull Predicate<T> canConsume, @Nonnull Consumer<T> consumer) {
+		T element;
+		while ((element = peek()) != null && canConsume.test(element)) {
+			poll();
+			consumer.accept(element);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/TreeOrderedSetCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/TreeOrderedSetCache.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
 
 import it.unimi.dsi.fastutil.objects.ObjectAVLTreeSet;
@@ -124,5 +125,11 @@ public class TreeOrderedSetCache<E> implements CachingInternalPriorityQueueSet.O
 	@Override
 	public E peekLast() {
 		return !avlTree.isEmpty() ? avlTree.last() : null;
+	}
+
+	@Nonnull
+	@Override
+	public CloseableIterator<E> orderedIterator() {
+		return CloseableIterator.adapterForIterator(avlTree.iterator());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.filesystem.AbstractFileStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.util.TernaryBoolean;
 
 import javax.annotation.Nullable;
@@ -309,7 +310,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 			TaskKvStateRegistry kvStateRegistry) {
 
 		TaskStateManager taskStateManager = env.getTaskStateManager();
-
+		HeapPriorityQueueSetFactory priorityQueueSetFactory =
+			new HeapPriorityQueueSetFactory(keyGroupRange, numberOfKeyGroups, 128);
 		return new HeapKeyedStateBackend<>(
 				kvStateRegistry,
 				keySerializer,
@@ -318,7 +320,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 				keyGroupRange,
 				isUsingAsynchronousSnapshots(),
 				env.getExecutionConfig(),
-				taskStateManager.createLocalRecoveryConfig());
+				taskStateManager.createLocalRecoveryConfig(),
+				priorityQueueSetFactory);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
@@ -51,8 +51,16 @@ public abstract class InternalPriorityQueueTestBase extends TestLogger {
 
 	protected static final KeyGroupRange KEY_GROUP_RANGE = new KeyGroupRange(0, 2);
 	protected static final KeyExtractorFunction<TestElement> KEY_EXTRACTOR_FUNCTION = TestElement::getKey;
-	protected static final Comparator<TestElement> TEST_ELEMENT_COMPARATOR =
-		Comparator.comparingLong(TestElement::getPriority).thenComparingLong(TestElement::getKey);
+	protected static final PriorityComparator<TestElement> TEST_ELEMENT_PRIORITY_COMPARATOR =
+		(left, right) -> Long.compare(left.getPriority(), right.getPriority());
+	protected static final Comparator<TestElement> TEST_ELEMENT_COMPARATOR = (o1, o2) -> {
+		int priorityCmp = TEST_ELEMENT_PRIORITY_COMPARATOR.comparePriority(o1, o2);
+		if (priorityCmp != 0) {
+			return priorityCmp;
+		}
+		// to fully comply with compareTo/equals contract.
+		return Long.compare(o1.getKey(), o2.getKey());
+	};
 
 	protected static void insertRandomElements(
 		@Nonnull InternalPriorityQueue<TestElement> priorityQueue,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -53,7 +53,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			new KeyGroupRange(0, 15),
 			true,
 			executionConfig,
-			TestLocalRecoveryConfig.disabled());
+			TestLocalRecoveryConfig.disabled(),
+			mock(PriorityQueueSetFactory.class));
 
 		try {
 			Assert.assertTrue(
@@ -75,7 +76,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			new KeyGroupRange(0, 15),
 			true,
 			executionConfig,
-			TestLocalRecoveryConfig.disabled());
+			TestLocalRecoveryConfig.disabled(),
+			mock(PriorityQueueSetFactory.class));
 
 		try {
 			Assert.assertTrue(
@@ -115,7 +117,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			new KeyGroupRange(0, 15),
 			true,
 			executionConfig,
-			TestLocalRecoveryConfig.disabled());
+			TestLocalRecoveryConfig.disabled(),
+			mock(PriorityQueueSetFactory.class));
 
 		try {
 
@@ -156,7 +159,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			new KeyGroupRange(0, 15),
 			true,
 			executionConfig,
-			TestLocalRecoveryConfig.disabled());
+			TestLocalRecoveryConfig.disabled(),
+			mock(PriorityQueueSetFactory.class));
 		try {
 
 			stateBackend.restore(StateObjectCollection.singleton(stateHandle));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestPriorityQueueSetFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestPriorityQueueSetFactory.java
@@ -23,8 +23,6 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
 
 import javax.annotation.Nonnull;
 
-import java.util.Comparator;
-
 /**
  * Test implementation of a {@link PriorityQueueSetFactory}.
  */
@@ -38,12 +36,18 @@ public class TestPriorityQueueSetFactory implements PriorityQueueSetFactory {
 		this.totalkeyGroups = totalKeyGroups;
 	}
 
+	@Nonnull
 	@Override
 	public <T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
 		@Nonnull String stateName,
 		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
-		@Nonnull Comparator<T> elementComparator,
+		@Nonnull PriorityComparator<T> elementPriorityComparator,
 		@Nonnull KeyExtractorFunction<T> keyExtractor) {
-		return new HeapPriorityQueueSet<>(elementComparator, keyExtractor, 128,keyGroupRange, totalkeyGroups);
+		return new HeapPriorityQueueSet<>(
+			elementPriorityComparator,
+			keyExtractor,
+			128,
+			keyGroupRange,
+			totalkeyGroups);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestPriorityQueueSetFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestPriorityQueueSetFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
+
+import javax.annotation.Nonnull;
+
+import java.util.Comparator;
+
+/**
+ * Test implementation of a {@link PriorityQueueSetFactory}.
+ */
+public class TestPriorityQueueSetFactory implements PriorityQueueSetFactory {
+
+	private final KeyGroupRange keyGroupRange;
+	private final int totalkeyGroups;
+
+	public TestPriorityQueueSetFactory(KeyGroupRange keyGroupRange, int totalKeyGroups) {
+		this.keyGroupRange = keyGroupRange;
+		this.totalkeyGroups = totalKeyGroups;
+	}
+
+	@Override
+	public <T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
+		@Nonnull String stateName,
+		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
+		@Nonnull Comparator<T> elementComparator,
+		@Nonnull KeyExtractorFunction<T> keyExtractor) {
+		return new HeapPriorityQueueSet<>(elementComparator, keyExtractor, 128,keyGroupRange, totalkeyGroups);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetTest.java
@@ -25,7 +25,7 @@ public class HeapPriorityQueueSetTest extends HeapPriorityQueueTest {
 	@Override
 	protected HeapPriorityQueueSet<TestElement> newPriorityQueue(int initialCapacity) {
 		return new HeapPriorityQueueSet<>(
-			TEST_ELEMENT_COMPARATOR,
+			TEST_ELEMENT_PRIORITY_COMPARATOR,
 			KEY_EXTRACTOR_FUNCTION,
 			initialCapacity,
 			KEY_GROUP_RANGE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueTest.java
@@ -89,7 +89,7 @@ public class HeapPriorityQueueTest extends InternalPriorityQueueTestBase {
 
 	@Override
 	protected HeapPriorityQueue<TestElement> newPriorityQueue(int initialCapacity) {
-		return new HeapPriorityQueue<>(TEST_ELEMENT_COMPARATOR, initialCapacity);
+		return new HeapPriorityQueue<>(TEST_ELEMENT_PRIORITY_COMPARATOR, initialCapacity);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
@@ -49,14 +49,18 @@ public abstract class HeapStateBackendTestBase {
 	}
 
 	public <K> HeapKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer) throws Exception {
+		final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 15);
+		final int numKeyGroups = keyGroupRange.getNumberOfKeyGroups();
+
 		return new HeapKeyedStateBackend<>(
 			mock(TaskKvStateRegistry.class),
 			keySerializer,
 			HeapStateBackendTestBase.class.getClassLoader(),
-			16,
-			new KeyGroupRange(0, 15),
+			numKeyGroups,
+			keyGroupRange,
 			async,
 			new ExecutionConfig(),
-			TestLocalRecoveryConfig.disabled());
+			TestLocalRecoveryConfig.disabled(),
+			new HeapPriorityQueueSetFactory(keyGroupRange, numKeyGroups, 128));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueueTest.java
@@ -29,7 +29,7 @@ public class KeyGroupPartitionedPriorityQueueTest extends InternalPriorityQueueT
 	protected InternalPriorityQueue<TestElement> newPriorityQueue(int initialCapacity) {
 		return new KeyGroupPartitionedPriorityQueue<>(
 			KEY_EXTRACTOR_FUNCTION,
-			TEST_ELEMENT_COMPARATOR,
+			TEST_ELEMENT_PRIORITY_COMPARATOR,
 			newFactory(initialCapacity),
 			KEY_GROUP_RANGE, KEY_GROUP_RANGE.getNumberOfKeyGroups());
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RockDBBackendOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RockDBBackendOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/**
+ * Configuration options for the RocksDB backend.
+ */
+public class RockDBBackendOptions {
+
+	/**
+	 * Choice of implementation for priority queue state (e.g. timers).
+	 */
+	public static final ConfigOption<String> PRIORITY_QUEUE_STATE_TYPE = ConfigOptions
+		.key("backend.rocksdb.priority_queue_state_type")
+		.defaultValue(RocksDBStateBackend.PriorityQueueStateType.HEAP.name())
+		.withDescription("This determines the implementation for the priority queue state (e.g. timers). Options are" +
+			"either " + RocksDBStateBackend.PriorityQueueStateType.HEAP.name() + " (heap-based, default) or " +
+			RocksDBStateBackend.PriorityQueueStateType.ROCKS.name() + " for in implementation based on RocksDB.");
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStore.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStore.java
@@ -28,7 +28,6 @@ import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
@@ -61,10 +60,6 @@ public class RocksDBOrderedSetStore<T> implements CachingInternalPriorityQueueSe
 	@Nonnull
 	private final ColumnFamilyHandle columnFamilyHandle;
 
-	/** Read options for RocksDB. */
-	@Nonnull
-	private final ReadOptions readOptions;
-
 	/**
 	 * Serializer for the contained elements. The lexicographical order of the bytes of serialized objects must be
 	 * aligned with their logical order.
@@ -93,14 +88,12 @@ public class RocksDBOrderedSetStore<T> implements CachingInternalPriorityQueueSe
 		@Nonnegative int keyGroupPrefixBytes,
 		@Nonnull RocksDB db,
 		@Nonnull ColumnFamilyHandle columnFamilyHandle,
-		@Nonnull ReadOptions readOptions,
 		@Nonnull TypeSerializer<T> byteOrderProducingSerializer,
 		@Nonnull ByteArrayOutputStreamWithPos outputStream,
 		@Nonnull DataOutputViewStreamWrapper outputView,
 		@Nonnull RocksDBWriteBatchWrapper batchWrapper) {
 		this.db = db;
 		this.columnFamilyHandle = columnFamilyHandle;
-		this.readOptions = readOptions;
 		this.byteOrderProducingSerializer = byteOrderProducingSerializer;
 		this.outputStream = outputStream;
 		this.outputView = outputView;
@@ -169,7 +162,7 @@ public class RocksDBOrderedSetStore<T> implements CachingInternalPriorityQueueSe
 
 		return new RocksToJavaIteratorAdapter(
 			new RocksIteratorWrapper(
-				db.newIterator(columnFamilyHandle, readOptions)));
+				db.newIterator(columnFamilyHandle)));
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStore.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStore.java
@@ -225,6 +225,10 @@ public class RocksDBOrderedSetStore<T> implements CachingInternalPriorityQueueSe
 		private RocksToJavaIteratorAdapter(@Nonnull RocksIteratorWrapper iterator) {
 			this.iterator = iterator;
 			try {
+				// TODO we could check if it is more efficient to make the seek more specific, e.g. with a provided hint
+				// that is lexicographically closer the first expected element in the key-group. I wonder if this could
+				// help to improve the seek if there are many tombstones for elements at the beginning of the key-group
+				// (like for elements that have been removed in previous polling, before they are compacted away).
 				iterator.seek(groupPrefixBytes);
 				deserializeNextElementIfAvailable();
 			} catch (Exception ex) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/CachingInternalPriorityQueueSetWithRocksDBStoreTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/CachingInternalPriorityQueueSetWithRocksDBStoreTest.java
@@ -57,7 +57,6 @@ public class CachingInternalPriorityQueueSetWithRocksDBStoreTest extends Caching
 			prefixBytes,
 			rocksDBResource.getRocksDB(),
 			rocksDBResource.getDefaultColumnFamily(),
-			rocksDBResource.getReadOptions(),
 			TestElementSerializer.INSTANCE,
 			outputStream,
 			outputView,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStoreTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStoreTest.java
@@ -124,7 +124,6 @@ public class RocksDBOrderedSetStoreTest {
 			keyGroupPrefixBytes,
 			rocksDBResource.getRocksDB(),
 			rocksDBResource.getDefaultColumnFamily(),
-			rocksDBResource.getReadOptions(),
 			byteOrderSerializer,
 			outputStreamWithPos,
 			outputView,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -240,7 +240,8 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 				new KeyGroupRange(0, 0),
 				new ExecutionConfig(),
 				enableIncrementalCheckpointing,
-				TestLocalRecoveryConfig.disabled());
+				TestLocalRecoveryConfig.disabled(),
+				RocksDBStateBackend.PriorityQueueStateType.HEAP);
 
 			verify(columnFamilyOptions, Mockito.times(1))
 				.setMergeOperatorName(RocksDBKeyedStateBackend.MERGE_OPERATOR_NAME);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -730,9 +730,11 @@ public abstract class AbstractStreamOperator<OUT>
 		checkTimerServiceInitialization();
 
 		// the following casting is to overcome type restrictions.
-		TypeSerializer<K> keySerializer = (TypeSerializer<K>) getKeyedStateBackend().getKeySerializer();
+		KeyedStateBackend<K> keyedStateBackend = getKeyedStateBackend();
+		TypeSerializer<K> keySerializer = keyedStateBackend.getKeySerializer();
 		InternalTimeServiceManager<K> keyedTimeServiceHandler = (InternalTimeServiceManager<K>) timeServiceManager;
-		return keyedTimeServiceHandler.getInternalTimerService(name, keySerializer, namespaceSerializer, triggerable);
+		TimerSerializer<K, N> timerSerializer = new TimerSerializer<>(keySerializer, namespaceSerializer);
+		return keyedTimeServiceHandler.getInternalTimerService(name, timerSerializer, triggerable);
 	}
 
 	public void processWatermark(Watermark mark) throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -20,16 +20,17 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,6 +50,7 @@ public class InternalTimeServiceManager<K> {
 	private final KeyGroupRange localKeyGroupRange;
 	private final KeyContext keyContext;
 
+	private final PriorityQueueSetFactory priorityQueueSetFactory;
 	private final ProcessingTimeService processingTimeService;
 
 	private final Map<String, HeapInternalTimerService<K, ?>> timerServices;
@@ -57,50 +59,64 @@ public class InternalTimeServiceManager<K> {
 			int totalKeyGroups,
 			KeyGroupRange localKeyGroupRange,
 			KeyContext keyContext,
+			PriorityQueueSetFactory priorityQueueSetFactory,
 			ProcessingTimeService processingTimeService) {
 
 		Preconditions.checkArgument(totalKeyGroups > 0);
 		this.totalKeyGroups = totalKeyGroups;
 		this.localKeyGroupRange = Preconditions.checkNotNull(localKeyGroupRange);
-
+		this.priorityQueueSetFactory = Preconditions.checkNotNull(priorityQueueSetFactory);
 		this.keyContext = Preconditions.checkNotNull(keyContext);
 		this.processingTimeService = Preconditions.checkNotNull(processingTimeService);
 
 		this.timerServices = new HashMap<>();
 	}
 
-	/**
-	 * Returns a {@link InternalTimerService} that can be used to query current processing time
-	 * and event time and to set timers. An operator can have several timer services, where
-	 * each has its own namespace serializer. Timer services are differentiated by the string
-	 * key that is given when requesting them, if you call this method with the same key
-	 * multiple times you will get the same timer service instance in subsequent requests.
-	 *
-	 * <p>Timers are always scoped to a key, the currently active key of a keyed stream operation.
-	 * When a timer fires, this key will also be set as the currently active key.
-	 *
-	 * <p>Each timer has attached metadata, the namespace. Different timer services
-	 * can have a different namespace type. If you don't need namespace differentiation you
-	 * can use {@link VoidNamespaceSerializer} as the namespace serializer.
-	 *
-	 * @param name The name of the requested timer service. If no service exists under the given
-	 *             name a new one will be created and returned.
-	 * @param keySerializer {@code TypeSerializer} for the timer keys.
-	 * @param namespaceSerializer {@code TypeSerializer} for the timer namespace.
-	 * @param triggerable The {@link Triggerable} that should be invoked when timers fire
-	 */
 	@SuppressWarnings("unchecked")
-	public <N> InternalTimerService<N> getInternalTimerService(String name, TypeSerializer<K> keySerializer,
-														TypeSerializer<N> namespaceSerializer, Triggerable<K, N> triggerable) {
+	public <N> InternalTimerService<N> getInternalTimerService(
+		String name,
+		TimerSerializer<K, N> timerSerializer,
+		Triggerable<K, N> triggerable) {
 
+		HeapInternalTimerService<K, N> timerService = registerOrGetTimerService(name, timerSerializer);
+
+		timerService.startTimerService(
+			timerSerializer.getKeySerializer(),
+			timerSerializer.getNamespaceSerializer(),
+			triggerable);
+
+		return timerService;
+	}
+
+	@SuppressWarnings("unchecked")
+	<N> HeapInternalTimerService<K, N> registerOrGetTimerService(String name, TimerSerializer<K, N> timerSerializer) {
 		HeapInternalTimerService<K, N> timerService = (HeapInternalTimerService<K, N>) timerServices.get(name);
 		if (timerService == null) {
-			timerService = new HeapInternalTimerService<>(totalKeyGroups,
-				localKeyGroupRange, keyContext, processingTimeService);
+
+			timerService = new HeapInternalTimerService<>(
+				localKeyGroupRange,
+				keyContext,
+				processingTimeService,
+				createTimerPriorityQueue("__ts_" + name + "/processing_timers", timerSerializer),
+				createTimerPriorityQueue("__ts_" + name + "/event_timers", timerSerializer));
+
 			timerServices.put(name, timerService);
 		}
-		timerService.startTimerService(keySerializer, namespaceSerializer, triggerable);
 		return timerService;
+	}
+
+	Map<String, HeapInternalTimerService<K, ?>> getRegisteredTimerServices() {
+		return Collections.unmodifiableMap(timerServices);
+	}
+
+	private <N> KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> createTimerPriorityQueue(
+		String name,
+		TimerSerializer<K, N> timerSerializer) {
+		return priorityQueueSetFactory.create(
+			name,
+			timerSerializer,
+			InternalTimer.getTimerComparator(),
+			InternalTimer.getKeyExtractorFunction());
 	}
 
 	public void advanceWatermark(Watermark watermark) throws Exception {
@@ -113,7 +129,7 @@ public class InternalTimeServiceManager<K> {
 
 	public void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
 		InternalTimerServiceSerializationProxy<K> serializationProxy =
-			new InternalTimerServiceSerializationProxy<>(timerServices, keyGroupIdx);
+			new InternalTimerServiceSerializationProxy<>(this, keyGroupIdx);
 
 		serializationProxy.write(stream);
 	}
@@ -125,12 +141,8 @@ public class InternalTimeServiceManager<K> {
 
 		InternalTimerServiceSerializationProxy<K> serializationProxy =
 			new InternalTimerServiceSerializationProxy<>(
-				timerServices,
+				this,
 				userCodeClassLoader,
-				totalKeyGroups,
-				localKeyGroupRange,
-				keyContext,
-				processingTimeService,
 				keyGroupIdx);
 
 		serializationProxy.read(stream);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
@@ -19,11 +19,10 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.io.PostVersionedIOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 import java.io.IOException;
 import java.util.Map;
@@ -39,36 +38,24 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	public static final int VERSION = 1;
 
 	/** The key-group timer services to write / read. */
-	private Map<String, HeapInternalTimerService<K, ?>> timerServices;
+	private final InternalTimeServiceManager<K> timerServicesManager;
 
 	/** The user classloader; only relevant if the proxy is used to restore timer services. */
 	private ClassLoader userCodeClassLoader;
 
 	/** Properties of restored timer services. */
-	private int keyGroupIdx;
-	private int totalKeyGroups;
-	private KeyGroupRange localKeyGroupRange;
-	private KeyContext keyContext;
-	private ProcessingTimeService processingTimeService;
+	private final int keyGroupIdx;
+
 
 	/**
 	 * Constructor to use when restoring timer services.
 	 */
 	public InternalTimerServiceSerializationProxy(
-			Map<String, HeapInternalTimerService<K, ?>> timerServicesMapToPopulate,
-			ClassLoader userCodeClassLoader,
-			int totalKeyGroups,
-			KeyGroupRange localKeyGroupRange,
-			KeyContext keyContext,
-			ProcessingTimeService processingTimeService,
-			int keyGroupIdx) {
-
-		this.timerServices = checkNotNull(timerServicesMapToPopulate);
+		InternalTimeServiceManager<K> timerServicesManager,
+		ClassLoader userCodeClassLoader,
+		int keyGroupIdx) {
+		this.timerServicesManager = checkNotNull(timerServicesManager);
 		this.userCodeClassLoader = checkNotNull(userCodeClassLoader);
-		this.totalKeyGroups = totalKeyGroups;
-		this.localKeyGroupRange = checkNotNull(localKeyGroupRange);
-		this.keyContext = checkNotNull(keyContext);
-		this.processingTimeService = checkNotNull(processingTimeService);
 		this.keyGroupIdx = keyGroupIdx;
 	}
 
@@ -76,10 +63,9 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	 * Constructor to use when writing timer services.
 	 */
 	public InternalTimerServiceSerializationProxy(
-			Map<String, HeapInternalTimerService<K, ?>> timerServices,
-			int keyGroupIdx) {
-
-		this.timerServices = checkNotNull(timerServices);
+		InternalTimeServiceManager<K> timerServicesManager,
+		int keyGroupIdx) {
+		this.timerServicesManager = checkNotNull(timerServicesManager);
 		this.keyGroupIdx = keyGroupIdx;
 	}
 
@@ -91,9 +77,11 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 	@Override
 	public void write(DataOutputView out) throws IOException {
 		super.write(out);
+		final Map<String, HeapInternalTimerService<K, ?>> registeredTimerServices =
+			timerServicesManager.getRegisteredTimerServices();
 
-		out.writeInt(timerServices.size());
-		for (Map.Entry<String, HeapInternalTimerService<K, ?>> entry : timerServices.entrySet()) {
+		out.writeInt(registeredTimerServices.size());
+		for (Map.Entry<String, HeapInternalTimerService<K, ?>> entry : registeredTimerServices.entrySet()) {
 			String serviceName = entry.getKey();
 			HeapInternalTimerService<K, ?> timerService = entry.getValue();
 
@@ -111,22 +99,25 @@ public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIORe
 		for (int i = 0; i < noOfTimerServices; i++) {
 			String serviceName = in.readUTF();
 
-			HeapInternalTimerService<K, ?> timerService = timerServices.get(serviceName);
-			if (timerService == null) {
-				timerService = new HeapInternalTimerService<>(
-					totalKeyGroups,
-					localKeyGroupRange,
-					keyContext,
-					processingTimeService);
-				timerServices.put(serviceName, timerService);
-			}
-
 			int readerVersion = wasVersioned ? getReadVersion() : InternalTimersSnapshotReaderWriters.NO_VERSION;
 			InternalTimersSnapshot<?, ?> restoredTimersSnapshot = InternalTimersSnapshotReaderWriters
 				.getReaderForVersion(readerVersion, userCodeClassLoader)
 				.readTimersSnapshot(in);
 
+			HeapInternalTimerService<K, ?> timerService = registerOrGetTimerService(
+				serviceName,
+				restoredTimersSnapshot);
+
 			timerService.restoreTimersForKeyGroup(restoredTimersSnapshot, keyGroupIdx);
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private <N> HeapInternalTimerService<K, N> registerOrGetTimerService(
+		String serviceName, InternalTimersSnapshot<?, ?> restoredTimersSnapshot) {
+		final TypeSerializer<K> keySerializer = (TypeSerializer<K>) restoredTimersSnapshot.getKeySerializer();
+		final TypeSerializer<N> namespaceSerializer = (TypeSerializer<N>) restoredTimersSnapshot.getNamespaceSerializer();
+		TimerSerializer<K, N> timerSerializer = new TimerSerializer<>(keySerializer, namespaceSerializer);
+		return timerServicesManager.registerOrGetTimerService(serviceName, timerSerializer);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -207,6 +207,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			keyedStatedBackend.getNumberOfKeyGroups(),
 			keyGroupRange,
 			keyContext,
+			keyedStatedBackend,
 			processingTimeService);
 
 		// and then initialize the timer services

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
@@ -19,21 +19,18 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.state.KeyExtractorFunction;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
 
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
-import java.util.Comparator;
 
 /**
  * Implementation of {@link InternalTimer} to use with a {@link HeapPriorityQueueSet}.
@@ -43,14 +40,6 @@ import java.util.Comparator;
  */
 @Internal
 public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N>, HeapPriorityQueueElement {
-
-	/** Function to extract the key from a {@link TimerHeapInternalTimer}. */
-	private static final KeyExtractorFunction<TimerHeapInternalTimer<?, ?>> KEY_EXTRACTOR_FUNCTION =
-		TimerHeapInternalTimer::getKey;
-
-	/** Function to compare instances of {@link TimerHeapInternalTimer}. */
-	private static final Comparator<TimerHeapInternalTimer<?, ?>> TIMER_COMPARATOR =
-		(o1, o2) -> Long.compare(o1.getTimestamp(), o2.getTimestamp());
 
 	/** The key for which the timer is scoped. */
 	@Nonnull
@@ -142,18 +131,6 @@ public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N>, 
 				", key=" + key +
 				", namespace=" + namespace +
 				'}';
-	}
-
-	@VisibleForTesting
-	@SuppressWarnings("unchecked")
-	static <T extends TimerHeapInternalTimer> Comparator<T> getTimerComparator() {
-		return (Comparator<T>) TIMER_COMPARATOR;
-	}
-
-	@SuppressWarnings("unchecked")
-	@VisibleForTesting
-	static <T extends TimerHeapInternalTimer> KeyExtractorFunction<T> getKeyExtractorFunction() {
-		return (KeyExtractorFunction<T>) KEY_EXTRACTOR_FUNCTION;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.MathUtils;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A serializer for {@link TimerHeapInternalTimer} objects that produces a serialization format that is aligned with
+ * {@link InternalTimer#getTimerComparator()}.
+ *
+ * @param <K> type of the timer key.
+ * @param <N> type of the timer namespace.
+ */
+public class TimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer<K, N>> {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Serializer for the key. */
+	@Nonnull
+	private final TypeSerializer<K> keySerializer;
+
+	/** Serializer for the namespace. */
+	@Nonnull
+	private final TypeSerializer<N> namespaceSerializer;
+
+	/** The bytes written for one timer, or -1 if variable size. */
+	private final int length;
+
+	/** True iff the serialized type (and composite objects) are immutable. */
+	private final boolean immutableType;
+
+	TimerSerializer(
+		@Nonnull TypeSerializer<K> keySerializer,
+		@Nonnull TypeSerializer<N> namespaceSerializer) {
+		this(
+			keySerializer,
+			namespaceSerializer,
+			computeTotalByteLength(keySerializer, namespaceSerializer),
+			keySerializer.isImmutableType() && namespaceSerializer.isImmutableType());
+	}
+
+	private TimerSerializer(
+		@Nonnull TypeSerializer<K> keySerializer,
+		@Nonnull TypeSerializer<N> namespaceSerializer,
+		int length,
+		boolean immutableType) {
+
+		this.keySerializer = keySerializer;
+		this.namespaceSerializer = namespaceSerializer;
+		this.length = length;
+		this.immutableType = immutableType;
+	}
+
+	private static int computeTotalByteLength(
+		TypeSerializer<?> keySerializer,
+		TypeSerializer<?> namespaceSerializer) {
+		if (keySerializer.getLength() >= 0 && namespaceSerializer.getLength() >= 0) {
+			// timestamp + key + namespace
+			return Long.BYTES + keySerializer.getLength() + namespaceSerializer.getLength();
+		} else {
+			return -1;
+		}
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return immutableType;
+	}
+
+	@Override
+	public TimerSerializer<K, N> duplicate() {
+
+		final TypeSerializer<K> keySerializerDuplicate = keySerializer.duplicate();
+		final TypeSerializer<N> namespaceSerializerDuplicate = namespaceSerializer.duplicate();
+
+		if (keySerializerDuplicate == keySerializer &&
+			namespaceSerializerDuplicate == namespaceSerializer) {
+			// all delegate serializers seem stateless, so this is also stateless.
+			return this;
+		} else {
+			// at least one delegate serializer seems to be stateful, so we return a new instance.
+			return new TimerSerializer<>(
+				keySerializerDuplicate,
+				namespaceSerializerDuplicate,
+				length,
+				immutableType);
+		}
+	}
+
+	@Override
+	public TimerHeapInternalTimer<K, N> createInstance() {
+		return new TimerHeapInternalTimer<>(
+			0L,
+			keySerializer.createInstance(),
+			namespaceSerializer.createInstance());
+	}
+
+	@Override
+	public TimerHeapInternalTimer<K, N> copy(TimerHeapInternalTimer<K, N> from) {
+
+		K keyDuplicate;
+		N namespaceDuplicate;
+		if (isImmutableType()) {
+			keyDuplicate = from.getKey();
+			namespaceDuplicate = from.getNamespace();
+		} else {
+			keyDuplicate = keySerializer.copy(from.getKey());
+			namespaceDuplicate = namespaceSerializer.copy(from.getNamespace());
+		}
+
+		return new TimerHeapInternalTimer<>(from.getTimestamp(), keyDuplicate, namespaceDuplicate);
+	}
+
+	@Override
+	public TimerHeapInternalTimer<K, N> copy(TimerHeapInternalTimer<K, N> from, TimerHeapInternalTimer<K, N> reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public int getLength() {
+		return length;
+	}
+
+	@Override
+	public void serialize(TimerHeapInternalTimer<K, N> record, DataOutputView target) throws IOException {
+		target.writeLong(MathUtils.flipSignBit(record.getTimestamp()));
+		keySerializer.serialize(record.getKey(), target);
+		namespaceSerializer.serialize(record.getNamespace(), target);
+	}
+
+	@Override
+	public TimerHeapInternalTimer<K, N> deserialize(DataInputView source) throws IOException {
+		long timestamp = MathUtils.flipSignBit(source.readLong());
+		K key = keySerializer.deserialize(source);
+		N namespace = namespaceSerializer.deserialize(source);
+		return new TimerHeapInternalTimer<>(timestamp, key, namespace);
+	}
+
+	@Override
+	public TimerHeapInternalTimer<K, N> deserialize(
+		TimerHeapInternalTimer<K, N> reuse,
+		DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		target.writeLong(source.readLong());
+		keySerializer.copy(source, target);
+		namespaceSerializer.copy(source, target);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TimerSerializer<?, ?> that = (TimerSerializer<?, ?>) o;
+		return Objects.equals(keySerializer, that.keySerializer) &&
+			Objects.equals(namespaceSerializer, that.namespaceSerializer);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(keySerializer, namespaceSerializer);
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof TimerSerializer;
+	}
+
+	@Override
+	public TypeSerializerConfigSnapshot snapshotConfiguration() {
+		throw new UnsupportedOperationException("This serializer is currently not used to write state.");
+	}
+
+	@Override
+	public CompatibilityResult<TimerHeapInternalTimer<K, N>> ensureCompatibility(
+		TypeSerializerConfigSnapshot configSnapshot) {
+		throw new UnsupportedOperationException("This serializer is currently not used to write state.");
+	}
+
+	@Nonnull
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+	@Nonnull
+	public TypeSerializer<N> getNamespaceSerializer() {
+		return namespaceSerializer;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
-import org.apache.flink.runtime.state.TestPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
@@ -180,7 +180,8 @@ public class HeapInternalTimerServiceTest {
 		TestKeyContext keyContext = new TestKeyContext();
 
 		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
-		PriorityQueueSetFactory priorityQueueSetFactory = new TestPriorityQueueSetFactory(testKeyGroupRange, maxParallelism);
+		PriorityQueueSetFactory priorityQueueSetFactory =
+			new HeapPriorityQueueSetFactory(testKeyGroupRange, maxParallelism, 128);
 		HeapInternalTimerService<Integer, String> timerService =
 				createAndStartInternalTimerService(mockTriggerable, keyContext, processingTimeService, testKeyGroupRange, priorityQueueSetFactory);
 
@@ -865,7 +866,7 @@ public class HeapInternalTimerServiceTest {
 	}
 
 	protected PriorityQueueSetFactory createQueueFactory(KeyGroupRange keyGroupRange, int numKeyGroups) {
-		return new TestPriorityQueueSetFactory(keyGroupRange, numKeyGroups);
+		return new HeapPriorityQueueSetFactory(keyGroupRange, numKeyGroups, 128);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates `InternalTimerQueue` with keyed state backends (Heap and RocksDB), so that we can use the RocksDB-based version in the job for the first time. 

We introduce the interface `KeyGroupPartitionedPriorityQueue` as an easy adapter to existing snapshotting code. This can probably be removed once the queues are fully integrated with the backend's snapshotting, in a followup PR. 

The PR also addresses an issue with the `TreeOrderedCache` that requires a "proper" `Comparator` (implemented in `TieBreakingPriorityComparator`) and we introduce `PriorityComparator` to give more emphasize to this difference. `TieBreakingPriorityComparator` is likely to also go away once we come up with an improved caching that is not simply based on a tree that requires an aligned comparator/equals contract.

We introduce `PriorityQueueSetFactory` to the keyed state backends, and this is were the queues are build. The current implementation of RocksDB uses an additional RocksDB instance until we are fully integrated with backend snapshotting, because we are otherwise running into trouble with incremental snapshots.

A configuration parameter is introduced to chose the implementation of queues for RocksDB, the default is still using the heap variant for now.

Finally, we introduce an additional method for bulk polling in the `InternalTimerQueue` interface that opens up future optimizations.

## Verifying this change

This change is already covered by existing tests, such as `AbstractEventTimeWindowCheckpointingITCase`, but you would currently need to activate it via 
`RockDBBackendOptions.PRIORITY_QUEUE_STATE_TYPE`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes, if activated)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
