### PR TITLE
[FLINK-9772] Documentation of Hadoop API outdated

### DIFF
--- a/docs/dev/batch/hadoop_compatibility.md
+++ b/docs/dev/batch/hadoop_compatibility.md
@@ -73,11 +73,13 @@ if you only want to use your Hadoop data types. See the
 
 ### Using Hadoop InputFormats
 
-Hadoop input formats can be used to create a data source by using
+Hadoop input formats can be created by using
 one of the methods `readHadoopFile` or `createHadoopInput` of the
-`ExecutionEnvironment`. The former is used for input formats derived
+`HadoopInputs` which is a utility class to use Apache Hadoop InputFormats with Apache Flink. 
+The former is used for input formats derived
 from `FileInputFormat` while the latter has to be used for general purpose
-input formats.
+input formats. Then, you can use method `createInput` of the `ExecutionEnvironment` 
+to create a Flink data source.
 
 The resulting `DataSet` contains 2-tuples where the first field
 is the key and the second field is the value retrieved from the Hadoop
@@ -92,7 +94,8 @@ The following example shows how to use Hadoop's `TextInputFormat`.
 ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
 DataSet<Tuple2<LongWritable, Text>> input =
-    env.readHadoopFile(new TextInputFormat(), LongWritable.class, Text.class, textPath);
+    env.createInput(HadoopInputs.readHadoopFile(new TextInputFormat(),
+                        LongWritable.class, Text.class, textPath));
 
 // Do something with the data.
 [...]
@@ -105,7 +108,8 @@ DataSet<Tuple2<LongWritable, Text>> input =
 val env = ExecutionEnvironment.getExecutionEnvironment
 
 val input: DataSet[(LongWritable, Text)] =
-  env.readHadoopFile(new TextInputFormat, classOf[LongWritable], classOf[Text], textPath)
+  env.createInput(HadoopInputs.readHadoopFile(
+                    new TextInputFormat, classOf[LongWritable], classOf[Text], textPath))
 
 // Do something with the data.
 [...]


### PR DESCRIPTION
## What is the purpose of the change

*This pull request updated some outdated documentation of Hadoop compatibility*

## Brief change log

  - *Updated some outdated documentation of Hadoop compatibility*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
