### PR TITLE
[FLINK-9733] Make location for job graph files configurable

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -25,11 +25,14 @@ import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A configuration object for {@link RestClusterClient}s.
  */
 public final class RestClusterClientConfiguration {
+
+	public static final String SERIALIZED_JOBGRAPH_LOCATION_KEY = "rest.serialized-jobgraph-location";
 
 	private final RestClientConfiguration restClientConfiguration;
 
@@ -39,19 +42,24 @@ public final class RestClusterClientConfiguration {
 
 	private final long retryDelay;
 
+	private final String serializedJobGraphLocation;
+
 	private RestClusterClientConfiguration(
 			final RestClientConfiguration endpointConfiguration,
 			final long awaitLeaderTimeout,
 			final int retryMaxAttempts,
-			final long retryDelay) {
+			final long retryDelay,
+			final String serializedJobGraphLocation) {
 		checkArgument(awaitLeaderTimeout >= 0, "awaitLeaderTimeout must be equal to or greater than 0");
 		checkArgument(retryMaxAttempts >= 0, "retryMaxAttempts must be equal to or greater than 0");
 		checkArgument(retryDelay >= 0, "retryDelay must be equal to or greater than 0");
+		checkNotNull(serializedJobGraphLocation, "serialized job graph location can not be null");
 
 		this.restClientConfiguration = Preconditions.checkNotNull(endpointConfiguration);
 		this.awaitLeaderTimeout = awaitLeaderTimeout;
 		this.retryMaxAttempts = retryMaxAttempts;
 		this.retryDelay = retryDelay;
+		this.serializedJobGraphLocation = serializedJobGraphLocation;
 	}
 
 	public RestClientConfiguration getRestClientConfiguration() {
@@ -79,13 +87,22 @@ public final class RestClusterClientConfiguration {
 		return retryDelay;
 	}
 
+	/**
+	 * Client-side configuration for the location of the serialized job graph.
+	 */
+	public String getSerializedJobGraphLocation() {
+		return serializedJobGraphLocation;
+	}
+
 	public static RestClusterClientConfiguration fromConfiguration(Configuration config) throws ConfigurationException {
 		RestClientConfiguration restClientConfiguration = RestClientConfiguration.fromConfiguration(config);
 
 		final long awaitLeaderTimeout = config.getLong(RestOptions.AWAIT_LEADER_TIMEOUT);
 		final int retryMaxAttempts = config.getInteger(RestOptions.RETRY_MAX_ATTEMPTS);
 		final long retryDelay = config.getLong(RestOptions.RETRY_DELAY);
+		final String jobGraphStorePath = config.getString(SERIALIZED_JOBGRAPH_LOCATION_KEY, "");
 
-		return new RestClusterClientConfiguration(restClientConfiguration, awaitLeaderTimeout, retryMaxAttempts, retryDelay);
+		return new RestClusterClientConfiguration(restClientConfiguration, awaitLeaderTimeout,
+			retryMaxAttempts, retryDelay, jobGraphStorePath);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -107,5 +107,4 @@ public class RestOptions {
 		key("rest.client.max-content-length")
 			.defaultValue(104_857_600)
 			.withDescription("The maximum content length in bytes that the client will handle.");
-
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request make location for job graph files configurable*


## Brief change log

  - *Add a config item 'rest.jobgraph-store-path' to `RestOptions`*
  - *make the config item can be accessed in `RestClusterClientConfiguration`*
  - *Use the config item when submit job in `RestClusterClient`*


## Verifying this change

This change added tests and can be verified as follows:

TBD

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
