### PR TITLE
[FLINK-6847][FLINK-6813] [table] TimestampDiff table api and sql support

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -3176,6 +3176,18 @@ TIMESTAMPADD(unit, interval, timevalue)
         <p>E.g., <code>TIMESTAMPADD(WEEK, 1, DATE '2003-01-02')</code> returns <code>2003-01-09</code>.</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+TIMESTAMPDIFF(unit, timestamp1, timestamp2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the (signed) number of timeUnit intervals between timestamp1 and timestamp2. The unit for the interval is given by the unit argument, which should be one of the following values: <code>SECOND</code>, <code>MINUTE</code>, <code>HOUR</code>, <code>DAY</code>, <code>WEEK</code>, <code>MONTH</code>, <code>QUARTER</code>, or <code>YEAR</code>. The unit for the interval could refer <a href="#time-interval-and-point-unit-specifiers">Time Interval and Point Unit Specifiers table</a>. E.g. <code>TIMESTAMPDIFF(DAY, TIMESTAMP '2003-01-02 10:00:00', TIMESTAMP '2003-01-03 10:00:00')</code> leads to <code>1</code>.</p>
+      </td>
+    </tr>
+
   </tbody>
 </table>
 </div>
@@ -3421,6 +3433,18 @@ dateFormat(TIMESTAMP, STRING)
         <p>E.g., <code>dateFormat(ts, '%Y, %d %M')</code> results in strings formatted as "2017, 05 May".</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+timestampDiff(TimeIntervalUnit, datetime1, datetime2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the (signed) number of timeUnit intervals between datetime1 and datetime2. The unit for the interval is given by the unit argument, which should be one of the following values: <code>SECOND</code>, <code>MINUTE</code>, <code>HOUR</code>, <code>DAY</code>, <code>MONTH</code>, or <code>YEAR</code>. The unit for the interval could refer <a href="#time-interval-and-point-unit-specifiers">Time Interval and Point Unit Specifiers table</a>. E.g. <code>timestampDiff(TimeIntervalUnit.DAY, '2003-01-02 10:00:00'.toTimestamp, '2003-01-03 10:00:00'.toTimestamp)</code> leads to <code>1</code>.</p>
+      </td>
+    </tr>
+
     </tbody>
 </table>
 </div>
@@ -3666,6 +3690,18 @@ dateFormat(TIMESTAMP, STRING)
         <p>E.g., <code>dateFormat('ts, "%Y, %d %M")</code> results in strings formatted as "2017, 05 May".</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+timestampDiff(TimeIntervalUnit, datetime1, datetime2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the (signed) number of timeUnit intervals between datetime1 and datetime2. The unit for the interval is given by the unit argument, which should be one of the following values: <code>SECOND</code>, <code>MINUTE</code>, <code>HOUR</code>, <code>DAY</code>, <code>MONTH</code>, or <code>YEAR</code>. The unit for the interval could refer <a href="#time-interval-and-point-unit-specifiers">Time Interval and Point Unit Specifiers table</a>. E.g. <code>timestampDiff(TimeIntervalUnit.DAY, '2003-01-02 10:00:00'.toTimestamp, '2003-01-03 10:00:00'.toTimestamp)</code> leads to <code>1</code>.</p>
+      </td>
+    </tr>
+
   </tbody>
 </table>
 </div>
@@ -5315,6 +5351,67 @@ The following table lists specifiers for date format functions.
   </tr>
   <tr><td>{% highlight text %}%x{% endhighlight %}</td>
   <td><code>x</code>, for any <code>x</code> not listed above</td>
+  </tr>
+  </tbody>
+</table>
+
+Time Interval and Point Unit Specifiers
+----------------------
+
+The following table lists specifiers for time interval and point unit.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Interval Unit</th>
+      <th class="text-center">Point Unit</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr><td>YEAR</td>
+  <td>YEAR</td>
+  </tr>
+  <tr><td>QUARTER</td>
+  <td>QUARTER</td>
+  </tr>
+  <tr><td>MONTH</td>
+  <td>MONTH</td>
+  </tr>
+  <tr><td>WEEK</td>
+  <td>WEEK</td>
+  </tr>
+  <tr><td>DAY</td>
+  <td>DAY</td>
+  </tr>
+  <tr><td>HOUR</td>
+  <td>HOUR</td>
+  </tr>
+  <tr><td>MINUTE</td>
+  <td>MINUTE</td>
+  </tr>
+  <tr><td>SECOND</td>
+  <td>SECOND</td>
+  </tr>
+  <tr><td>YEAR_TO_MONTH</td>
+  <td>MICROSECOND</td>
+  </tr>
+  <tr><td>DAY_TO_HOUR</td>
+  <td>MILLISECOND</td>
+  </tr>
+  <tr><td><DAY_TO_MINUTE/td>
+  <td></td>
+  </tr>
+  <tr><td>DAY_TO_SECOND</td>
+  <td></td>
+  </tr>
+  <tr><td>HOUR_TO_MINUTE</td>
+  <td></td>
+  </tr>
+  <tr><td>HOUR_TO_SECOND</td>
+  <td></td>
+  </tr>
+  <tr><td>MINUTE_TO_SECOND</td>
+  <td></td>
   </tr>
   </tbody>
 </table>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -1107,16 +1107,16 @@ object dateFormat {
 /**
  * Returns the (signed) number of timeUnit intervals between timestamp1 and timestamp2.
  *
- * For example <code>timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate,
- *  "2016-06-18".toDate</code> results in integer as 3
+ * For example <code>timestampDiff(TimeIntervalUnit.DAY, `2016-06-15`.toDate,
+ *  `2016-06-18`.toDate</code> results in integer as 3
  */
 object timestampDiff {
 
   /**
     * Returns the (signed) number of timeUnit intervals between timestamp1 and timestamp2.
     *
-    * For example <code>timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate,
-    *  "2016-06-18".toDate</code> results in integer as 3
+    * For example timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate,
+    *  "2016-06-18".toDate results in integer as 3
     *
     * @param timeIntervalUnit The unit to compute diff.
     * @param timestamp1 The first time,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.{TableException, CurrentRow, CurrentRange, Unb
 import org.apache.flink.table.expressions.ExpressionUtils.{convertArray, toMilliInterval, toMonthInterval, toRowInterval}
 import org.apache.flink.table.api.Table
 import org.apache.flink.table.expressions.TimeIntervalUnit.TimeIntervalUnit
+import org.apache.flink.table.expressions.TimePointUnit.TimePointUnit
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.AggregateFunction
 
@@ -1124,11 +1125,11 @@ object timestampDiff {
     * @return The number of intervals.
     */
   def apply(
-    timeIntervalUnit: TimeIntervalUnit,
+    timePointUnit: TimePointUnit,
     timestamp1: Expression,
     timestamp2: Expression
   ): Expression = {
-    TimestampDiff(timeIntervalUnit, timestamp1, timestamp2)
+    TimestampDiff(timePointUnit, timestamp1, timestamp2)
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -1105,6 +1105,34 @@ object dateFormat {
 }
 
 /**
+ * Returns the (signed) number of timeUnit intervals between timestamp1 and timestamp2.
+ *
+ * For example <code>timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate,
+ *  "2016-06-18".toDate</code> results in integer as 3
+ */
+object timestampDiff {
+
+  /**
+    * Returns the (signed) number of timeUnit intervals between timestamp1 and timestamp2.
+    *
+    * For example <code>timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate,
+    *  "2016-06-18".toDate</code> results in integer as 3
+    *
+    * @param timeIntervalUnit The unit to compute diff.
+    * @param timestamp1 The first time,
+    * @param timestamp2 The second time,
+    * @return The number of intervals.
+    */
+  def apply(
+    timeIntervalUnit: TimeIntervalUnit,
+    timestamp1: Expression,
+    timestamp2: Expression
+  ): Expression = {
+    TimestampDiff(timeIntervalUnit, timestamp1, timestamp2)
+  }
+}
+
+/**
   * Creates an array of literals. The array will be an array of objects (not primitives).
   */
 object array {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -769,10 +769,9 @@ abstract class CodeGenerator(
       case PLUS | DATETIME_PLUS if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
-        val typeName = call.getType().getSqlTypeName()
         requireTemporal(left)
         requireTemporal(right)
-        generateTemporalPlusMinus(plus = true, nullCheck, typeName, left, right, config)
+        generateTemporalPlusMinus(plus = true, nullCheck, resultType, left, right, config)
 
       case MINUS if isNumeric(resultType) =>
         val left = operands.head
@@ -784,10 +783,9 @@ abstract class CodeGenerator(
       case MINUS | MINUS_DATE if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
-        val typeName = call.getType().getSqlTypeName()
         requireTemporal(left)
         requireTemporal(right)
-        generateTemporalPlusMinus(plus = false, nullCheck, typeName, left, right, config)
+        generateTemporalPlusMinus(plus = false, nullCheck, resultType, left, right, config)
 
       case MULTIPLY if isNumeric(resultType) =>
         val left = operands.head

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -769,9 +769,10 @@ abstract class CodeGenerator(
       case PLUS | DATETIME_PLUS if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
+        val typeName = call.getType().getSqlTypeName()
         requireTemporal(left)
         requireTemporal(right)
-        generateTemporalPlusMinus(plus = true, nullCheck, left, right, config)
+        generateTemporalPlusMinus(plus = true, nullCheck, typeName, left, right, config)
 
       case MINUS if isNumeric(resultType) =>
         val left = operands.head
@@ -783,9 +784,10 @@ abstract class CodeGenerator(
       case MINUS | MINUS_DATE if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
+        val typeName = call.getType().getSqlTypeName()
         requireTemporal(left)
         requireTemporal(right)
-        generateTemporalPlusMinus(plus = false, nullCheck, left, right, config)
+        generateTemporalPlusMinus(plus = false, nullCheck, typeName, left, right, config)
 
       case MULTIPLY if isNumeric(resultType) =>
         val left = operands.head

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -508,6 +508,29 @@ object FunctionGenerator {
     new ExtractCallGen(LONG_TYPE_INFO, BuiltInMethod.UNIX_DATE_EXTRACT.method))
 
   addSqlFunction(
+    TIMESTAMP_DIFF,
+    Seq(new GenericTypeInfo(classOf[TimeUnitRange]),
+      SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.TIMESTAMP),
+    new TimestampDiffCallGen)
+
+  addSqlFunction(
+    TIMESTAMP_DIFF,
+    Seq(new GenericTypeInfo(classOf[TimeUnitRange]),
+      SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.DATE),
+    new TimestampDiffCallGen)
+
+  addSqlFunction(
+    TIMESTAMP_DIFF,
+    Seq(new GenericTypeInfo(classOf[TimeUnitRange]),
+      SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.TIMESTAMP),
+    new TimestampDiffCallGen)
+
+  addSqlFunction(
+    TIMESTAMP_DIFF,
+    Seq(new GenericTypeInfo(classOf[TimeUnitRange]), SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.DATE),
+    new TimestampDiffCallGen)
+
+  addSqlFunction(
     FLOOR,
     Seq(SqlTimeTypeInfo.DATE, new GenericTypeInfo(classOf[TimeUnitRange])),
     new FloorCeilCallGen(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.codegen.calls
 
 import java.lang.reflect.Method
 
+import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.calcite.avatica.util.TimeUnitRange
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
@@ -509,25 +510,25 @@ object FunctionGenerator {
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(new GenericTypeInfo(classOf[TimeUnitRange]),
+    Seq(new GenericTypeInfo(classOf[TimeUnit]),
       SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.TIMESTAMP),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(new GenericTypeInfo(classOf[TimeUnitRange]),
+    Seq(new GenericTypeInfo(classOf[TimeUnit]),
       SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.DATE),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(new GenericTypeInfo(classOf[TimeUnitRange]),
+    Seq(new GenericTypeInfo(classOf[TimeUnit]),
       SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.TIMESTAMP),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(new GenericTypeInfo(classOf[TimeUnitRange]), SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.DATE),
+    Seq(new GenericTypeInfo(classOf[TimeUnit]), SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.DATE),
     new TimestampDiffCallGen)
 
   addSqlFunction(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -19,10 +19,8 @@ package org.apache.flink.table.codegen.calls
 
 import java.math.MathContext
 
-import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY
-import org.apache.calcite.avatica.util.{DateTimeUtils, TimeUnitRange}
-import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.avatica.util.{DateTimeUtils, TimeUnit, TimeUnitRange}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.util.BuiltInMethod
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -19,8 +19,11 @@ package org.apache.flink.table.codegen.calls
 
 import java.math.MathContext
 
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY
 import org.apache.calcite.avatica.util.{DateTimeUtils, TimeUnitRange}
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.util.BuiltInMethod
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo._
@@ -825,6 +828,7 @@ object ScalarOperators {
   def generateTemporalPlusMinus(
       plus: Boolean,
       nullCheck: Boolean,
+      typeName: SqlTypeName,
       left: GeneratedExpression,
       right: GeneratedExpression,
       config: TableConfig)
@@ -859,6 +863,35 @@ object ScalarOperators {
       case (SqlTimeTypeInfo.TIMESTAMP, TimeIntervalTypeInfo.INTERVAL_MONTHS) =>
         generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.TIMESTAMP, left, right) {
           (l, r) => s"${qualifyMethod(BuiltInMethod.ADD_MONTHS.method)}($l, $op($r))"
+        }
+
+      case (l: SqlTimeTypeInfo[_], r: SqlTimeTypeInfo[_]) if !plus =>
+        generateOperatorIfNotNull(nullCheck, LONG_TYPE_INFO, left, right) {
+          (ll, rr) => typeName match {
+            case SqlTypeName.INTERVAL_YEAR | SqlTypeName.INTERVAL_MONTH =>
+              (l, r) match {
+                case (SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.DATE) =>
+                  s"${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}" +
+                    s"($ll, $rr * ${MILLIS_PER_DAY}L)"
+                case (SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.TIMESTAMP) =>
+                  s"${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}" +
+                    s"($ll * ${MILLIS_PER_DAY}L, $rr)"
+                case _ =>
+                  s"${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}($ll, $rr)"
+              }
+
+            case _ =>
+              (l, r) match {
+                case (SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.TIMESTAMP) =>
+                  s"$ll $op $rr"
+                case (SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.DATE) =>
+                  s"($ll * ${MILLIS_PER_DAY}L) $op ($rr * ${MILLIS_PER_DAY}L)"
+                case (SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.DATE) =>
+                  s"$ll $op ($rr * ${MILLIS_PER_DAY}L)"
+                case (SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.TIMESTAMP) =>
+                  s"($ll * ${MILLIS_PER_DAY}L) $op $rr"
+              }
+          }
         }
 
       case _ =>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TimestampDiffCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TimestampDiffCallGen.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen.calls
+
+import org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY
+import org.apache.calcite.avatica.util.{TimeUnit, TimeUnitRange}
+import org.apache.calcite.util.BuiltInMethod
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.codegen.CodeGenUtils._
+import org.apache.flink.table.codegen.calls.CallGenerator.generateCallIfArgsNotNull
+import org.apache.flink.table.codegen.{CodeGenException, CodeGenerator, GeneratedExpression}
+
+class TimestampDiffCallGen extends CallGenerator {
+
+  override def generate(codeGenerator: CodeGenerator, operands: Seq[GeneratedExpression])
+  : GeneratedExpression = {
+    val unit = getEnum(operands.head).asInstanceOf[TimeUnitRange].startUnit
+    unit match {
+      case TimeUnit.YEAR |
+           TimeUnit.MONTH |
+           TimeUnit.QUARTER =>
+        (operands(1).resultType, operands(2).resultType) match {
+          case (SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.DATE) =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}(${terms(1)},
+                  |  ${terms(2)} * ${MILLIS_PER_DAY}L) / ${unit.multiplier.intValue()}
+                  |""".stripMargin
+            }
+
+          case (SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.TIMESTAMP) =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}(
+                  |${terms(1)} * ${MILLIS_PER_DAY}L, ${terms(2)}) / ${unit.multiplier.intValue()}
+                  |""".stripMargin
+            }  
+
+          case _ =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |${qualifyMethod(BuiltInMethod.SUBTRACT_MONTHS.method)}(${terms(1)},
+                  |  ${terms(2)}) / ${unit.multiplier.intValue()}
+                  |""".stripMargin
+            }
+        }   
+
+      case TimeUnit.WEEK |
+           TimeUnit.DAY |
+           TimeUnit.HOUR |
+           TimeUnit.MINUTE |
+           TimeUnit.SECOND =>
+        (operands(1).resultType, operands(2).resultType) match {
+          case (SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.TIMESTAMP) =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |(int)((${terms(1)} - ${terms(2)}) / ${unit.multiplier.intValue()})
+                  |""".stripMargin
+            }
+
+          case (SqlTimeTypeInfo.TIMESTAMP, SqlTimeTypeInfo.DATE) =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |(int)((${terms(1)} -
+                  |  ${terms(2)} * ${MILLIS_PER_DAY}L) / ${unit.multiplier.intValue()})
+                  |""".stripMargin
+            }
+
+          case (SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.TIMESTAMP) =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |(int)((${terms(1)} * ${MILLIS_PER_DAY}L -
+                  |  ${terms(2)}) / ${unit.multiplier.intValue()})
+                  |""".stripMargin
+            }
+
+          case (SqlTimeTypeInfo.DATE, SqlTimeTypeInfo.DATE) =>
+            return generateCallIfArgsNotNull(codeGenerator.nullCheck, INT_TYPE_INFO, operands) {
+              (terms) =>
+                s"""
+                  |(int)((${terms(1)} * ${MILLIS_PER_DAY}L -
+                  |  ${terms(2)} * ${MILLIS_PER_DAY}L) / ${unit.multiplier.intValue()})
+                  |""".stripMargin
+            }
+        }
+
+      case _ =>
+        throw new ValidationException(
+          "unit " + unit + " can not be applied to TimestampDiff function")
+     }            
+
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TimestampDiffCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TimestampDiffCallGen.scala
@@ -32,7 +32,7 @@ class TimestampDiffCallGen extends CallGenerator {
 
   override def generate(codeGenerator: CodeGenerator, operands: Seq[GeneratedExpression])
   : GeneratedExpression = {
-    val unit = getEnum(operands.head).asInstanceOf[TimeUnitRange].startUnit
+    val unit = getEnum(operands.head).asInstanceOf[TimeUnit]
     unit match {
       case TimeUnit.YEAR |
            TimeUnit.MONTH |

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -371,7 +371,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     }
 
   lazy val prefixTimestampDiff: PackratParser[Expression] =
-    TIMESTAMPDIFF ~ "(" ~ timeIntervalUnit ~ "," ~ expression ~ "," ~ expression ~ ")" ^^ {
+    TIMESTAMPDIFF ~ "(" ~ timePointUnit ~ "," ~ expression ~ "," ~ expression ~ ")" ^^ {
       case _ ~ _ ~ unit ~ _ ~ operand1 ~ _ ~ operand2 ~ _ => TimestampDiff(unit, operand1, operand2)
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -55,6 +55,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   lazy val TO_TIMESTAMP: Keyword = Keyword("toTimestamp")
   lazy val TRIM: Keyword = Keyword("trim")
   lazy val EXTRACT: Keyword = Keyword("extract")
+  lazy val TIMESTAMPDIFF: Keyword = Keyword("timestampdiff")
   lazy val FLOOR: Keyword = Keyword("floor")
   lazy val CEIL: Keyword = Keyword("ceil")
   lazy val LOG: Keyword = Keyword("log")
@@ -369,6 +370,11 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
       case _ ~ _ ~ operand ~ _ ~ unit ~ _ => Extract(unit, operand)
     }
 
+  lazy val prefixTimestampDiff: PackratParser[Expression] =
+    TIMESTAMPDIFF ~ "(" ~ timeIntervalUnit ~ "," ~ expression ~ "," ~ expression ~ ")" ^^ {
+      case _ ~ _ ~ unit ~ _ ~ operand1 ~ _ ~ operand2 ~ _ => TimestampDiff(unit, operand1, operand2)
+    }
+
   lazy val prefixFloor: PackratParser[Expression] =
     FLOOR ~ "(" ~ expression ~ "," ~ timeIntervalUnit ~ ")" ^^ {
       case _ ~ _ ~ operand ~ _ ~ unit ~ _ => TemporalFloor(unit, operand)
@@ -409,6 +415,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     prefixAs| prefixToTimestamp | prefixToTime | prefixToDate |
     // expressions that take enumerations
     prefixCast | prefixTrim | prefixTrimWithoutArgs | prefixExtract | prefixFloor | prefixCeil |
+    prefixTimestampDiff |
     // expressions that take literals
     prefixGet |
     // expression with special identifier

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/arithmetic.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/arithmetic.scala
@@ -133,15 +133,15 @@ case class Minus(left: Expression, right: Expression) extends BinaryArithmetic {
       ValidationSuccess
     } else if (isTimeInterval(left.resultType) && isTimePoint(right.resultType)) {
       ValidationSuccess
-    } else if (isTimePoint(left.resultType) && isTimePoint(right.resultType) &&
-      left.resultType != SqlTimeTypeInfo.TIME && right.resultType != SqlTimeTypeInfo.TIME) {
+    } else if (isTimePoint(left.resultType) && left.resultType != SqlTimeTypeInfo.TIME
+        && left.resultType == right.resultType) {
       ValidationSuccess
     } else if (isNumeric(left.resultType) && isNumeric(right.resultType)) {
       ValidationSuccess
     } else {
       ValidationFailure(
         s"$this requires Numeric, Intervals of same type, Interval and a time point input" +
-        s"or time points input of timestamp or date, " +
+        s"or time points input of the same timestamp or date, " +
         s"but get $left : ${left.resultType} and $right : ${right.resultType}")
     }
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/time.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/time.scala
@@ -397,12 +397,12 @@ case class TimestampDiff(
       .makeCall(intervalType, SqlStdOperatorTable.MINUS_DATE,
         List(timestamp2.toRexNode, timestamp1.toRexNode))
 
-    val intType = typeFactory.createSqlType(SqlTypeName.INTEGER)
+    val intType = typeFactory.createSqlType(SqlTypeName.BIGINT)
 
     relBuilder.getRexBuilder.makeCast(intType, rexCall)
   }
 
   override def toString: String = s"timestampDiff(${children.mkString(", ")})"
 
-  override private[flink] def resultType = INT_TYPE_INFO
+  override private[flink] def resultType = LONG_TYPE_INFO
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -253,6 +253,7 @@ object FunctionCatalog {
     "temporalOverlaps" -> classOf[TemporalOverlaps],
     "dateTimePlus" -> classOf[Plus],
     "dateFormat" -> classOf[DateFormat],
+    "timestampDiff" -> classOf[TimestampDiff],
 
     // item
     "at" -> classOf[ItemAt],
@@ -442,6 +443,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.BIN,
     ScalarSqlFunctions.HEX,
     SqlStdOperatorTable.TIMESTAMP_ADD,
+    SqlStdOperatorTable.TIMESTAMP_DIFF,
     ScalarSqlFunctions.LOG,
     ScalarSqlFunctions.LPAD,
     ScalarSqlFunctions.RPAD,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2070,6 +2070,144 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
+  def testQuarter(): Unit = {
+    testAllApis(
+      "1997-01-27".toDate.quarter(),
+      "'1997-01-27'.toDate.quarter()",
+      "QUARTER(DATE '1997-01-27')",
+      "1")
+
+    testAllApis(
+      "1997-04-27".toDate.quarter(),
+      "'1997-04-27'.toDate.quarter()",
+      "QUARTER(DATE '1997-04-27')",
+      "2")
+
+    testAllApis(
+      "1997-12-31".toDate.quarter(),
+      "'1997-12-31'.toDate.quarter()",
+      "QUARTER(DATE '1997-12-31')",
+      "4")
+  }
+
+  @Test
+  def testTimestampDiff(): Unit = {
+    testAllApis(
+      timestampDiff(
+        TimeIntervalUnit.DAY,
+        "2018-07-03 11:11:11".toTimestamp,
+        "2018-07-05 11:11:11".toTimestamp),
+      "timestampDiff(DAY, '2018-07-03 11:11:11'.toTimestamp," +
+        "'2018-07-05 11:11:11'.toTimestamp)",
+      "TIMESTAMPDIFF(DAY, " +
+        "TIMESTAMP '2018-07-03 11:11:11', TIMESTAMP '2018-07-05 11:11:11')",
+      "2")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate, "2016-06-16 11:11:11".toTimestamp),
+      "timestampDiff(DAY, '2016-06-15'.toDate, '2016-06-16 11:11:11'.toTimestamp)",
+      "TIMESTAMPDIFF(DAY, DATE '2016-06-15', TIMESTAMP '2016-06-16 11:11:11')",
+      "1")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.DAY, "2016-06-15 11:00:00".toTimestamp, "2016-06-19".toDate),
+      "timestampDiff(DAY, '2016-06-15 11:00:00'.toTimestamp, '2016-06-19'.toDate)",
+      "TIMESTAMPDIFF(DAY, TIMESTAMP '2016-06-15 11:00:00', DATE '2016-06-19')",
+      "3")
+
+    testAllApis(
+      timestampDiff(
+          TimeIntervalUnit.MONTH,
+          "2018-07-03 11:11:11".toTimestamp,
+          "2018-09-05 11:11:11".toTimestamp),
+      "timestampDiff(MONTH, " +
+        "'2018-07-03 11:11:11'.toTimestamp, '2018-09-05 11:11:11'.toTimestamp)",
+      "TIMESTAMPDIFF(MONTH, " +
+        "TIMESTAMP '2018-07-03 11:11:11', TIMESTAMP '2018-09-05 11:11:11')",
+      "2")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.MONTH, "2016-06-15".toDate, "2016-04-18".toDate),
+      "TIMESTAMPDIFF(MONTH, '2016-06-15'.toDate, '2016-04-18'.toDate)",
+      "TIMESTAMPDIFF(MONTH, DATE '2016-06-15', DATE '2016-04-18')",
+      "-1")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.MONTH, "2016-06-15".toDate, "2016-04-14".toDate),
+      "timestampDiff(MONTH, '2016-06-15'.toDate, '2016-04-14'.toDate)",
+      "TIMESTAMPDIFF(MONTH, DATE '2016-06-15', DATE '2016-04-14')",
+      "-2")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.YEAR, "2016-06-15".toDate, "2019-06-16 11:11:11".toTimestamp),
+      "timestampDiff(YEAR, '2016-06-15'.toDate, '2019-06-16 11:11:11'.toTimestamp)",
+      "TIMESTAMPDIFF(YEAR, DATE '2016-06-15', TIMESTAMP '2019-06-16 11:11:11')",
+      "3")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.YEAR, "2016-06-15 11:00:00".toTimestamp, "2013-06-19".toDate),
+      "timestampDiff(YEAR, '2016-06-15 11:00:00'.toTimestamp, '2013-06-19'.toDate)",
+      "TIMESTAMPDIFF(YEAR, TIMESTAMP '2016-06-15 11:00:00', DATE '2013-06-19')",
+      "-2")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.DAY, "2016-06-15".toDate, "2016-06-18".toDate),
+      "timestampDiff(DAY, '2016-06-15'.toDate, '2016-06-18'.toDate)",
+      "TIMESTAMPDIFF(DAY, DATE '2016-06-15', DATE '2016-06-18')",
+      "3")
+
+    testAllApis(
+      timestampDiff(
+        TimeIntervalUnit.HOUR,
+        "2018-07-03 11:11:11".toTimestamp,
+        "2018-07-04 12:12:11".toTimestamp),
+      "timestampDiff(HOUR, '2018-07-03 11:11:11'.toTimestamp," +
+        "'2018-07-04 12:12:11'.toTimestamp)",
+      "TIMESTAMPDIFF(HOUR, " +
+        "TIMESTAMP '2018-07-03 11:11:11', TIMESTAMP '2018-07-04 12:12:11')",
+      "25")
+
+    testAllApis(
+      timestampDiff(
+        TimeIntervalUnit.HOUR,
+        "2018-07-03 11:11:11".toTimestamp,
+        "2018-07-04 12:10:11".toTimestamp),
+      "timestampDiff(HOUR, '2018-07-03 11:11:11'.toTimestamp," +
+        "'2018-07-04 12:10:11'.toTimestamp)",
+      "TIMESTAMPDIFF(HOUR, " +
+        "TIMESTAMP '2018-07-03 11:11:11', TIMESTAMP '2018-07-04 12:10:11')",
+      "24")
+
+    testAllApis(
+      timestampDiff(
+        TimeIntervalUnit.MINUTE,
+        "2018-07-03 11:11:11".toTimestamp,
+        "2018-07-03 12:10:11".toTimestamp),
+      "timestampDiff(MINUTE, '2018-07-03 11:11:11'.toTimestamp," +
+        "'2018-07-03 12:10:11'.toTimestamp)",
+      "TIMESTAMPDIFF(MINUTE, " +
+        "TIMESTAMP '2018-07-03 11:11:11', TIMESTAMP '2018-07-03 12:10:11')",
+      "59")
+
+    testAllApis(
+      timestampDiff(
+        TimeIntervalUnit.SECOND,
+        "2018-07-03 11:11:11".toTimestamp,
+        "2018-07-03 11:12:12".toTimestamp),
+      "timestampDiff(SECOND, '2018-07-03 11:11:11'.toTimestamp," +
+        "'2018-07-03 11:12:12'.toTimestamp)",
+      "TIMESTAMPDIFF(SECOND, " +
+        "TIMESTAMP '2018-07-03 11:11:11', TIMESTAMP '2018-07-03 11:12:12')",
+      "61")
+
+    testAllApis(
+      timestampDiff(TimeIntervalUnit.MINUTE, "2018-07-03".toDate, "2018-07-04".toDate),
+      "timestampDiff(MINUTE, '2018-07-03'.toDate, '2018-07-04'.toDate)",
+      "TIMESTAMPDIFF(MINUTE, DATE '2018-07-03', DATE '2018-07-04')",
+      "1440")
+  }
+
+  @Test
   def testTimestampAdd(): Unit = {
     val data = Seq(
       (1, "2017-11-29 22:58:58.998"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2092,6 +2092,30 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
 
   @Test
   def testTimestampDiff(): Unit = {
+    testTableApi(
+      "2018-07-05 11:11:11".toTimestamp - "2018-07-03 11:11:11".toTimestamp,
+      "'2018-07-05 11:11:11'.toTimestamp - '2018-07-03 11:11:11'.toTimestamp",
+      "172800000"
+    )
+
+    testTableApi(
+      "2018-07-05 11:11:11".toTimestamp - "2018-07-03".toDate,
+      "'2018-07-05 11:11:11'.toTimestamp - '2018-07-03'.toDate",
+      "213071000"
+    )
+
+    testTableApi(
+      "2018-07-03".toDate - "2018-07-05 11:11:11".toTimestamp,
+      "'2018-07-03'.toDate - '2018-07-05 11:11:11'.toTimestamp",
+      "-213071000"
+    )
+
+    testTableApi(
+      "2018-07-05".toDate - "2018-07-03".toDate,
+      "'2018-07-05'.toDate - '2018-07-03'.toDate",
+      "172800000"
+    )
+
     testAllApis(
       timestampDiff(
         TimeIntervalUnit.DAY,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2072,49 +2072,49 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testTimestampDiff(): Unit = {
     val dataMap = Map(
-      ("DAY", TimeIntervalUnit.DAY, "SQL_TSI_DAY") -> Seq(
+      ("DAY", TimePointUnit.DAY, "SQL_TSI_DAY") -> Seq(
         ("2018-07-03 11:11:11", "2018-07-05 11:11:11", "2"), //timestamp, timestamp
         ("2016-06-15", "2016-06-16 11:11:11", "1"), //date, timestamp
         ("2016-06-15 11:00:00", "2016-06-19", "3"), //timestamp, date
         ("2016-06-15", "2016-06-18", "3") //date, date
       ),
-      ("HOUR", TimeIntervalUnit.HOUR, "SQL_TSI_HOUR") -> Seq(
+      ("HOUR", TimePointUnit.HOUR, "SQL_TSI_HOUR") -> Seq(
         ("2018-07-03 11:11:11", "2018-07-04 12:12:11", "25"),
         ("2016-06-15", "2016-06-16 11:11:11", "35"),
         ("2016-06-15 11:00:00", "2016-06-19", "85"),
         ("2016-06-15", "2016-06-12", "-72")
       ),
-      ("MINUTE", TimeIntervalUnit.MINUTE, "SQL_TSI_MINUTE") -> Seq(
+      ("MINUTE", TimePointUnit.MINUTE, "SQL_TSI_MINUTE") -> Seq(
         ("2018-07-03 11:11:11", "2018-07-03 12:10:11", "59"),
         ("2016-06-15", "2016-06-16 11:11:11", "2111"),
         ("2016-06-15 11:00:00", "2016-06-19", "5100"),
         ("2016-06-15", "2016-06-18", "4320")
       ),
-      ("SECOND", TimeIntervalUnit.SECOND, "SQL_TSI_SECOND") -> Seq(
+      ("SECOND", TimePointUnit.SECOND, "SQL_TSI_SECOND") -> Seq(
         ("2018-07-03 11:11:11", "2018-07-03 11:12:12", "61"),
         ("2016-06-15", "2016-06-16 11:11:11", "126671"),
         ("2016-06-15 11:00:00", "2016-06-19", "306000"),
         ("2016-06-15", "2016-06-18", "259200")
       ),
-      ("WEEK", TimeIntervalUnit.WEEK, "SQL_TSI_WEEK") -> Seq(
+      ("WEEK", TimePointUnit.WEEK, "SQL_TSI_WEEK") -> Seq(
         ("2018-05-03 11:11:11", "2018-07-03 11:12:12", "8"),
         ("2016-04-15", "2016-07-16 11:11:11", "13"),
         ("2016-04-15 11:00:00", "2016-09-19", "22"),
         ("2016-08-15", "2016-06-18", "-8")
       ),
-      ("MONTH", TimeIntervalUnit.MONTH, "SQL_TSI_MONTH") -> Seq(
+      ("MONTH", TimePointUnit.MONTH, "SQL_TSI_MONTH") -> Seq(
         ("2018-07-03 11:11:11", "2018-09-05 11:11:11", "2"),
         ("2016-06-15", "2018-06-16 11:11:11", "24"),
         ("2016-06-15 11:00:00", "2018-05-19", "23"),
         ("2016-06-15", "2018-03-18", "21")
       ),
-      ("QUARTER", TimeIntervalUnit.QUARTER, "SQL_TSI_QUARTER") -> Seq(
+      ("QUARTER", TimePointUnit.QUARTER, "SQL_TSI_QUARTER") -> Seq(
         ("2018-01-03 11:11:11", "2018-09-05 11:11:11", "2"),
         ("2016-06-15", "2018-06-16 11:11:11", "8"),
         ("2016-06-15 11:00:00", "2018-05-19", "7"),
         ("2016-06-15", "2018-03-18", "7")
       ),
-      ("YEAR", TimeIntervalUnit.YEAR, "SQL_TSI_YEAR") -> Seq(
+      ("YEAR", TimePointUnit.YEAR, "SQL_TSI_YEAR") -> Seq(
         ("2016-01-03 11:11:11", "2018-09-05 11:11:11", "2"),
         ("2010-06-15", "2018-06-16 11:11:11", "8"),
         ("2016-06-15 11:00:00", "2018-05-19", "1"),
@@ -2186,7 +2186,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     )
 
     testAllApis(
-      timestampDiff(TimeIntervalUnit.DAY, Null(Types.SQL_TIMESTAMP),
+      timestampDiff(TimePointUnit.DAY, Null(Types.SQL_TIMESTAMP),
         "2016-02-24 12:42:25".toTimestamp),
       "timestampDiff(DAY, Null(SQL_TIMESTAMP), '2016-02-24 12:42:25'.toTimestamp)",
       "TIMESTAMPDIFF(DAY, CAST(NULL AS TIMESTAMP), TIMESTAMP '2016-02-24 12:42:25')",
@@ -2194,7 +2194,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     )
 
     testAllApis(
-      timestampDiff(TimeIntervalUnit.DAY, "2016-02-24 12:42:25".toTimestamp,
+      timestampDiff(TimePointUnit.DAY, "2016-02-24 12:42:25".toTimestamp,
         Null(Types.SQL_TIMESTAMP)),
       "timestampDiff(DAY, '2016-02-24 12:42:25'.toTimestamp,  Null(SQL_TIMESTAMP))",
       "TIMESTAMPDIFF(DAY, TIMESTAMP '2016-02-24 12:42:25',  CAST(NULL AS TIMESTAMP))",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -2070,27 +2070,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
-  def testQuarter(): Unit = {
-    testAllApis(
-      "1997-01-27".toDate.quarter(),
-      "'1997-01-27'.toDate.quarter()",
-      "QUARTER(DATE '1997-01-27')",
-      "1")
-
-    testAllApis(
-      "1997-04-27".toDate.quarter(),
-      "'1997-04-27'.toDate.quarter()",
-      "QUARTER(DATE '1997-04-27')",
-      "2")
-
-    testAllApis(
-      "1997-12-31".toDate.quarter(),
-      "'1997-12-31'.toDate.quarter()",
-      "QUARTER(DATE '1997-12-31')",
-      "4")
-  }
-
-  @Test
   def testTimestampDiff(): Unit = {
     testTableApi(
       "2018-07-05 11:11:11".toTimestamp - "2018-07-03 11:11:11".toTimestamp,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.expressions.validation
 import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.flink.table.api.{SqlParserException, ValidationException}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.expressions.TimeIntervalUnit
+import org.apache.flink.table.expressions.{TimeIntervalUnit, TimePointUnit}
 import org.apache.flink.table.expressions.utils.ScalarTypesTestBase
 import org.junit.Test
 
@@ -100,24 +100,16 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testTimestampDiffWithWrongTimeIntervalUnit(): Unit = {
-    testTableApi(
-      timestampDiff(TimeIntervalUnit.YEAR_TO_MONTH,
-        "2016-02-24".toDate, "2016-02-27".toDate), "FAIL", "FAIL")
-  }
-
-  @Test(expected = classOf[ValidationException])
   def testTimestampDiffWithWrongTime(): Unit = {
     testTableApi(
-      timestampDiff(TimeIntervalUnit.DAY, "2016-02-24", "2016-02-27"), "FAIL", "FAIL")
+      timestampDiff(TimePointUnit.DAY, "2016-02-24", "2016-02-27"), "FAIL", "FAIL")
   }
 
   @Test(expected = classOf[ValidationException])
   def testTimestampDiffWithWrongTimeAndUnit(): Unit = {
     testTableApi(
-      timestampDiff(TimeIntervalUnit.MINUTE, "2016-02-24", "2016-02-27"), "FAIL", "FAIL")
+      timestampDiff(TimePointUnit.MINUTE, "2016-02-24", "2016-02-27"), "FAIL", "FAIL")
   }
-
 
   @Test(expected = classOf[ValidationException])
   def testDOWWithTimeWhichIsUnsupported(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.expressions.validation
 import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.flink.table.api.{SqlParserException, ValidationException}
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions.TimeIntervalUnit
 import org.apache.flink.table.expressions.utils.ScalarTypesTestBase
 import org.junit.Test
 
@@ -97,6 +98,26 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
   def testTimestampAddWithWrongQuantity(): Unit = {
     testSqlApi("TIMESTAMPADD(YEAR, 1.0, timestamp '2016-02-24 12:42:25')", "2016-06-16")
   }
+
+  @Test(expected = classOf[ValidationException])
+  def testTimestampDiffWithWrongTimeIntervalUnit(): Unit = {
+    testTableApi(
+      timestampDiff(TimeIntervalUnit.YEAR_TO_MONTH,
+        "2016-02-24".toDate, "2016-02-27".toDate), "FAIL", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testTimestampDiffWithWrongTime(): Unit = {
+    testTableApi(
+      timestampDiff(TimeIntervalUnit.DAY, "2016-02-24", "2016-02-27"), "FAIL", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testTimestampDiffWithWrongTimeAndUnit(): Unit = {
+    testTableApi(
+      timestampDiff(TimeIntervalUnit.MINUTE, "2016-02-24", "2016-02-27"), "FAIL", "FAIL")
+  }
+
 
   @Test(expected = classOf[ValidationException])
   def testDOWWithTimeWhichIsUnsupported(): Unit = {


### PR DESCRIPTION

## What is the purpose of the change
This PR propose to add TimestampDiff sql and table Api.
Sql format is like `TIMESTAMP(DAY, DATE '2018-07-03', DATE '2018-07-04')`, was explained and based on https://github.com/apache/flink/pull/4117
Table Api signature is like `timestampDiff(TimeIntervalUnit.DAY, '2018-07-03'.toDate, '2018-07-04'.toDate)`

## Brief change log
  - *modify `generateTemporalPlusMinus`  in `ScalarOperators.scala` to support sql code gen*
  - *add `timestampDiff` api in `time.scala`*
  - *add timestampDiff expr string parse in `ExpressionParser.scala`*

## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - *add tests to verify sql and table api, in various types combine of unit(YEAR, MONTH...SECOND) and datetime(DATE or TIMESTAMP)*
  - *add validation tests *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
