### PR TITLE
[FLINK-9768][release] Speed up binary release

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -60,7 +60,7 @@ make_binary_release() {
   fi
 
   # enable release profile here (to check for the maven version)
-  $MVN clean package $FLAGS -DskipTests -Prelease,scala-${SCALA_VERSION} -Dgpg.skip
+  $MVN clean package $FLAGS -Prelease,scala-${SCALA_VERSION} -pl flink-shaded-hadoop/flink-shaded-hadoop2-uber,flink-dist -am -Dgpg.skip -Dcheckstyle.skip=true -DskipTests -Dmaven.test.skip=true
 
   cd flink-dist/target/flink-*-bin/
   tar czf "${dir_name}.tgz" flink-*


### PR DESCRIPTION
## What is the purpose of the change

This PR speeds up the building of convenience release artifacts.

On my machine this makes the process 30% faster, but YMMV.

## Brief change log

* only build required modules and dependencies; flink-dist and flink-shaded-hadoop2-uber (implicitly required for flink-dist..........)
* skip checkstyle
* skip test compilation

## Verifying this change

Manually verified.
