### PR TITLE
[FLINK-9754][release] Remove references to scala profiles

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -60,7 +60,7 @@ make_binary_release() {
   fi
 
   # enable release profile here (to check for the maven version)
-  $MVN clean package $FLAGS -DskipTests -Prelease,scala-${SCALA_VERSION} -Dgpg.skip
+  $MVN clean package $FLAGS -DskipTests -Prelease -Dgpg.skip
 
   cd flink-dist/target/flink-*-bin/
   tar czf "${dir_name}.tgz" flink-*

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -41,5 +41,5 @@ cd ..
 echo "Deploying to repository.apache.org"
 
 echo "Deploying Scala 2.11 version"
-$MVN clean deploy -Prelease,docs-and-source,scala-2.11 -DskipTests -DretryFailedDeploymentCount=10
+$MVN clean deploy -Prelease,docs-and-source -DskipTests -DretryFailedDeploymentCount=10
 


### PR DESCRIPTION
## What is the purpose of the change

This PR removes references to `scala_X.Y` profiles from the release scripts. These profiles have been removed in 1.5.0 already and currently cause the release scripts to fail. 
