### PR TITLE
[FLINK-9703] [flink-mesos] Expose Prometheus port for TM through Mesos

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -42,12 +42,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
-import java.util.stream.Collectors;
 
 import scala.Option;
 
@@ -337,15 +337,16 @@ public class LaunchableMesosWorker implements LaunchableTask {
 	/**
 	 * Get port keys representing the TM's configured endpoints. This includes mandatory TM endpoints such as
 	 * data and rpc as well as optionally configured endpoints for services such as prometheus reporter
-	 * @return The Set of port keys to expose from the TM container
+	 *
+	 * @return A deterministicly ordered Set of port keys to expose from the TM container
 	 */
 	private Set<String> getPortKeys() {
-		Set<String> tmPortKeys = containerSpec.getDynamicConfiguration().keySet().stream()
+		LinkedHashSet<String> tmPortKeys = new LinkedHashSet<>(Arrays.asList(TM_PORT_KEYS));
+		containerSpec.getDynamicConfiguration().keySet().stream()
 			.filter(key -> key.endsWith(".port"))  // This matches property naming convention
 			.peek(key -> LOG.debug("Adding port key " + key + " to mesos request"))
-			.collect(Collectors.toSet());
+			.forEach(tmPortKeys::add);
 
-		tmPortKeys.addAll(Arrays.asList(TM_PORT_KEYS));
 		return tmPortKeys;
 	}
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -343,7 +343,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 	private Set<String> getPortKeys() {
 		LinkedHashSet<String> tmPortKeys = new LinkedHashSet<>(Arrays.asList(TM_PORT_KEYS));
 		containerSpec.getDynamicConfiguration().keySet().stream()
-			.filter(key -> key.endsWith(".port"))  // This matches property naming convention
+			.filter(key -> key.endsWith(".port") || key.endsWith(".ports"))  // This matches property naming convention
 			.peek(key -> LOG.debug("Adding port key " + key + " to mesos request"))
 			.forEach(tmPortKeys::add);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -66,9 +66,10 @@ public class LaunchableMesosWorker implements LaunchableTask {
 	/**
 	 * The set of configuration keys to be dynamically configured with a port allocated from Mesos.
 	 */
-	private static final String[] TM_PORT_KEYS = {
+	static final String[] TM_PORT_KEYS = {
 		"taskmanager.rpc.port",
 		"taskmanager.data.port"};
+	static final String PORT_ASSIGNMENT_KEY = "mesos.resourcemanager.tasks.port-assignments";
 
 	private final MesosArtifactResolver resolver;
 	private final ContainerSpecification containerSpec;
@@ -147,7 +148,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public int getPorts() {
-			return getPortKeys().size();
+			return extractPortKeys(LaunchableMesosWorker.this.containerSpec.getDynamicConfiguration()).size();
 		}
 
 		@Override
@@ -235,8 +236,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		}
 
 		// take needed ports for the TM
-		Set<String> tmPortKeys = getPortKeys();
-
+		Set<String> tmPortKeys = extractPortKeys(containerSpec.getDynamicConfiguration());
 		List<Protos.Resource> portResources = allocation.takeRanges("ports", tmPortKeys.size(), roles);
 		taskInfo.addAllResources(portResources);
 		Iterator<String> portsToAssign = tmPortKeys.iterator();
@@ -335,17 +335,22 @@ public class LaunchableMesosWorker implements LaunchableTask {
 	}
 
 	/**
-	 * Get port keys representing the TM's configured endpoints. This includes mandatory TM endpoints such as
+	 * Get the port keys representing the TM's configured endpoints. This includes mandatory TM endpoints such as
 	 * data and rpc as well as optionally configured endpoints for services such as prometheus reporter
 	 *
 	 * @return A deterministicly ordered Set of port keys to expose from the TM container
+	 * @param config
 	 */
-	private Set<String> getPortKeys() {
+	static Set<String> extractPortKeys(Configuration config) {
 		LinkedHashSet<String> tmPortKeys = new LinkedHashSet<>(Arrays.asList(TM_PORT_KEYS));
-		containerSpec.getDynamicConfiguration().keySet().stream()
-			.filter(key -> key.endsWith(".port") || key.endsWith(".ports"))  // This matches property naming convention
-			.peek(key -> LOG.debug("Adding port key " + key + " to mesos request"))
-			.forEach(tmPortKeys::add);
+
+		if (config.containsKey(PORT_ASSIGNMENT_KEY)) {
+			String portAssignments = config.getString(PORT_ASSIGNMENT_KEY, "");
+			Arrays.stream(portAssignments.split(","))
+				.map(String::trim)
+				.peek(key -> LOG.debug("Adding port key " + key + " to mesos request"))
+				.forEach(tmPortKeys::add);
+		}
 
 		return tmPortKeys;
 	}

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
@@ -1,0 +1,35 @@
+package org.apache.flink.mesos.runtime.clusterframework;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test that mesos config are extracted correctly from the configuration.
+ */
+public class LaunchableMesosWorkerTest {
+
+	@Test
+	public void canGetPortKeys() {
+		// Setup
+		Configuration config = new Configuration();
+		config.setString(LaunchableMesosWorker.PORT_ASSIGNMENT_KEY, "someport.here,anotherport");
+
+		// Act
+		Set<String> portKeys = LaunchableMesosWorker.extractPortKeys(config);
+
+		// Assert
+		assertEquals("Must get right number of port keys", 4, portKeys.size());
+		Iterator<String> iterator = portKeys.iterator();
+		assertEquals("port key must be correct", LaunchableMesosWorker.TM_PORT_KEYS[0], iterator.next());
+		assertEquals("port key must be correct", LaunchableMesosWorker.TM_PORT_KEYS[1], iterator.next());
+		assertEquals("port key must be correct", "someport.here", iterator.next());
+		assertEquals("port key must be correct", "anotherport", iterator.next());
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

To enable Task Managers, when set up by mesos, to expose a port for Prometheus monitoring.

## Brief change log

  - If `metrics.reporter.prom.port` is configured, make sure Mesos also assigns a port for it, when starting a task manager. It doesn't currently, which means the combination of mesos and prometheus  currently broken, when using prometheus in the recommended way, which is scraping (pull).

## Verifying this change

This change is already covered by existing tests, such as MesosResourceAllocationTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes, it makes the combination of mesis
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no