### PR TITLE
[FLINK-9380]: Modified end to end test runner script to stop deleting logs if tests fail

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -37,15 +37,10 @@ export EXIT_CODE=0
 echo "Flink dist directory: $FLINK_DIR"
 
 TEST_ROOT=`pwd`
-TEST_INFRA_DIR="$0"
-TEST_INFRA_DIR=`dirname "$TEST_INFRA_DIR"`
+TEST_INFRA_DIR="$END_TO_END_DIR/test-scripts/"
 cd $TEST_INFRA_DIR
 TEST_INFRA_DIR=`pwd`
 cd $TEST_ROOT
-
-# used to randomize created directories
-export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
-echo "TEST_DATA_DIR: $TEST_DATA_DIR"
 
 function print_mem_use_osx {
     declare -a mem_types=("active" "inactive" "wired down")
@@ -278,6 +273,12 @@ function check_logs_for_non_empty_out_files {
     cat $FLINK_DIR/log/*.out
     EXIT_CODE=1
   fi
+}
+
+function shutdown_all {
+	stop_cluster
+  tm_kill_all
+  jm_kill_all
 }
 
 function stop_cluster {
@@ -536,10 +537,12 @@ function end_timer {
 
 function clean_stdout_files {
     rm ${FLINK_DIR}/log/*.out
+    echo "Deleted all stdout files under ${FLINK_DIR}/log/"
 }
 
 function clean_log_files {
     rm ${FLINK_DIR}/log/*
+    echo "Deleted all files under ${FLINK_DIR}/log/"
 }
 
 # Expect a string to appear in the log files of the task manager before a given timeout

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -276,7 +276,7 @@ function check_logs_for_non_empty_out_files {
 }
 
 function shutdown_all {
-	stop_cluster
+  stop_cluster
   tm_kill_all
   jm_kill_all
 }

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -32,7 +32,12 @@ function run_test {
     printf "\n==============================================================================\n"
     printf "Running '${description}'\n"
     printf "==============================================================================\n"
-    start_timer
+
+    # used to randomize created directories
+		export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
+		echo "TEST_DATA_DIR: $TEST_DATA_DIR"
+
+		start_timer
     ${command}
     exit_code="$?"
     time_elapsed=$(end_timer)
@@ -41,8 +46,8 @@ function run_test {
     check_logs_for_exceptions
     check_logs_for_non_empty_out_files
 
-    cleanup
-
+		# Investigate exit_code for failures of test executable as well as EXIT_CODE for failures of the test.
+		# Do not clean up if either fails.
     if [[ ${exit_code} == 0 ]]; then
         if [[ ${EXIT_CODE} != 0 ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files\n\n"
@@ -58,20 +63,32 @@ function run_test {
         fi
     fi
 
-    if [[ ${exit_code} != 0 ]]; then
+    if [[ ${exit_code} == 0 ]]; then
+        cleanup
+    else
         exit "${exit_code}"
     fi
 }
 
-# Shuts down the cluster and cleans up all temporary folders and files. Make sure to clean up even in case of failures.
-function cleanup {
-  stop_cluster
-  tm_kill_all
-  jm_kill_all
-  rm -rf $TEST_DATA_DIR 2> /dev/null
-  revert_default_config
-  clean_log_files
-  clean_stdout_files
+# Shuts down cluster and reverts changes to cluster configs
+function cleanup_proc {
+	shutdown_all
+	revert_default_config
 }
 
-trap cleanup EXIT
+# Cleans up all temporary folders and files
+function cleanup_files {
+	clean_log_files
+
+	rm -rf ${TEST_DATA_DIR} 2> /dev/null
+	echo "Deleted ${TEST_DATA_DIR}"
+}
+
+# Shuts down the cluster and cleans up all temporary folders and files.
+function cleanup {
+	cleanup_proc
+	cleanup_files
+}
+
+trap cleanup SIGINT
+trap cleanup_proc EXIT

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -34,10 +34,10 @@ function run_test {
     printf "==============================================================================\n"
 
     # used to randomize created directories
-		export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
-		echo "TEST_DATA_DIR: $TEST_DATA_DIR"
+    export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
+    echo "TEST_DATA_DIR: $TEST_DATA_DIR"
 
-		start_timer
+    start_timer
     ${command}
     exit_code="$?"
     time_elapsed=$(end_timer)
@@ -46,8 +46,8 @@ function run_test {
     check_logs_for_exceptions
     check_logs_for_non_empty_out_files
 
-		# Investigate exit_code for failures of test executable as well as EXIT_CODE for failures of the test.
-		# Do not clean up if either fails.
+    # Investigate exit_code for failures of test executable as well as EXIT_CODE for failures of the test.
+    # Do not clean up if either fails.
     if [[ ${exit_code} == 0 ]]; then
         if [[ ${EXIT_CODE} != 0 ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files\n\n"
@@ -72,22 +72,22 @@ function run_test {
 
 # Shuts down cluster and reverts changes to cluster configs
 function cleanup_proc {
-	shutdown_all
-	revert_default_config
+    shutdown_all
+    revert_default_config
 }
 
 # Cleans up all temporary folders and files
 function cleanup_files {
-	clean_log_files
+    clean_log_files
 
-	rm -rf ${TEST_DATA_DIR} 2> /dev/null
-	echo "Deleted ${TEST_DATA_DIR}"
+    rm -rf ${TEST_DATA_DIR} 2> /dev/null
+    echo "Deleted ${TEST_DATA_DIR}"
 }
 
 # Shuts down the cluster and cleans up all temporary folders and files.
 function cleanup {
-	cleanup_proc
-	cleanup_files
+    cleanup_proc
+    cleanup_files
 }
 
 trap cleanup SIGINT


### PR DESCRIPTION
## What is the purpose of the change

This pull request modifies a couple of end to end test runner scripts to save logs of failed tests. Currently, logs are deleted irrespective of a test's result, making it difficult to debug failed tests. 

## Brief change log

  - *Modified EXIT trap to only cleanup the process instead of cleaning up logs as well*
  - *Added SIGINT trap to clean up everything on test process interrupt*
  - *Export TEST_DATA_DIR inside test-runner-common.sh _instead of common.sh_. This allows all test scripts to inherit this variable instead of generating it again on their own via common.sh*
  - *Split operations inside cleanup() into cleanup_proc() and cleanup_files()*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
