### PR TITLE
[Flink-9691]  [Kinesis Connector] Attempt to call getRecords() at correct frequency.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -210,7 +210,7 @@ public class ShardConsumer<T> implements Runnable {
 					if (fetchIntervalMillis != 0) {
 						long elapsedTimeNanos = System.nanoTime() - lastTimeNanos;
 						long sleepTimeMillis = fetchIntervalMillis - (elapsedTimeNanos / 1_000_000);
-						if(sleepTimeMillis > 0) {
+						if (sleepTimeMillis > 0) {
 							Thread.sleep(sleepTimeMillis);
 						}
 						lastTimeNanos = System.nanoTime();

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -207,7 +207,7 @@ public class ShardConsumer<T> implements Runnable {
 					// we can close this consumer thread once we've reached the end of the subscribed shard
 					break;
 				} else {
-				if (fetchIntervalMillis != 0) {
+					if (fetchIntervalMillis != 0) {
 						long elapsedTimeNanos = System.nanoTime() - lastTimeNanos;
 						long sleepTimeMillis = fetchIntervalMillis - (elapsedTimeNanos / 1_000_000);
 						if(sleepTimeMillis > 0) {


### PR DESCRIPTION

## What is the purpose of the change

The purpose of this change is to make the Kinesis connector call getRecords() on the interval specified by the SHARD_GETRECORDS_INTERVAL_MILLIS configuration parameter.  Without this change the Kinesis Connector sleeps() for the given interval regardless of how long it takes to process the records.  This hurts badly when trying read through a backlog of data for example.  With this change we instead time the loop and sleep() for the specified interval MINUS any time spent processing.  This is more in line with what user's expect and makes the connector perform much better when there is a backlog of data to read through.

## Brief change log
Time the run loop and subtract that time from the time spent sleeping.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
