### PR TITLE
[FLINK-9785][network] add remote address information to LocalTransportException instances

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -168,7 +168,8 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
 					"This indicates that the remote task manager was lost.", remoteAddr, cause);
 			} else {
 				final SocketAddress localAddr = ctx.channel().localAddress();
-				tex = new LocalTransportException(cause.getMessage() + " (connection to '" + remoteAddr + "')", localAddr, cause);
+				tex = new LocalTransportException(
+					String.format("%s (connection to '%s')", cause.getMessage(), remoteAddr), localAddr, cause);
 			}
 
 			notifyAllChannelsOfErrorAndClose(tex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -167,7 +167,8 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
 				tex = new RemoteTransportException("Lost connection to task manager '" + remoteAddr + "'. " +
 					"This indicates that the remote task manager was lost.", remoteAddr, cause);
 			} else {
-				tex = new LocalTransportException(cause.getMessage(), ctx.channel().localAddress(), cause);
+				final SocketAddress localAddr = ctx.channel().localAddress();
+				tex = new LocalTransportException(cause.getMessage() + " (connection to '" + remoteAddr + "')", localAddr, cause);
 			}
 
 			notifyAllChannelsOfErrorAndClose(tex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
@@ -118,8 +118,8 @@ public class PartitionRequestClient {
 					SocketAddress remoteAddr = future.channel().remoteAddress();
 					inputChannel.onError(
 							new LocalTransportException(
-									"Sending the partition request to '" + remoteAddr + "' failed.",
-									future.channel().localAddress(), future.cause()
+								String.format("Sending the partition request to '%s' failed.", remoteAddr),
+								future.channel().localAddress(), future.cause()
 							));
 				}
 			}
@@ -162,8 +162,8 @@ public class PartitionRequestClient {
 								if (!future.isSuccess()) {
 									SocketAddress remoteAddr = future.channel().remoteAddress();
 									inputChannel.onError(new LocalTransportException(
-											"Sending the task event to '" + remoteAddr + "' failed.",
-											future.channel().localAddress(), future.cause()
+										String.format("Sending the task event to '%s' failed.", remoteAddr),
+										future.channel().localAddress(), future.cause()
 									));
 								}
 							}
@@ -198,7 +198,7 @@ public class PartitionRequestClient {
 		if (closeReferenceCounter.isDisposed()) {
 			final SocketAddress localAddr = tcpChannel.localAddress();
 			final SocketAddress remoteAddr = tcpChannel.remoteAddress();
-			throw new LocalTransportException("Channel to '" + remoteAddr + "'closed.", localAddr);
+			throw new LocalTransportException(String.format("Channel to '%s' closed.", remoteAddr), localAddr);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
-import org.apache.flink.runtime.io.network.NetworkClientHandler;
 import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.NetworkClientHandler;
 import org.apache.flink.runtime.io.network.netty.exception.LocalTransportException;
 import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
@@ -34,8 +34,8 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * Factory for {@link PartitionRequestClient} instances.
- * <p>
- * Instances of partition requests clients are shared among several {@link RemoteInputChannel}
+ *
+ * <p>Instances of partition requests clients are shared among several {@link RemoteInputChannel}
  * instances.
  */
 class PartitionRequestClientFactory {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -220,8 +220,10 @@ class PartitionRequestClientFactory {
 			}
 			else {
 				notifyOfError(new LocalTransportException(
-						"Connecting to remote task manager + '" + connectionId.getAddress() +
-								"' has been cancelled.", null));
+					String.format(
+						"Connecting to remote task manager '%s' has been cancelled.",
+						connectionId.getAddress()),
+					null));
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -165,8 +165,10 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter impleme
 			}
 			else {
 				SocketAddress localAddr = ctx.channel().localAddress();
-				tex = new LocalTransportException(cause.getMessage() + " (connection to '" + remoteAddr + "')",
-					localAddr, cause);
+				tex = new LocalTransportException(
+					String.format("%s (connection to '%s')", cause.getMessage(), remoteAddr),
+					localAddr,
+					cause);
 			}
 
 			notifyAllChannelsOfErrorAndClose(tex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -164,7 +164,9 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter impleme
 								+ "that the remote task manager was lost.", remoteAddr, cause);
 			}
 			else {
-				tex = new LocalTransportException(cause.getMessage(), ctx.channel().localAddress(), cause);
+				SocketAddress localAddr = ctx.channel().localAddress();
+				tex = new LocalTransportException(cause.getMessage() + " (connection to '" + remoteAddr + "')",
+					localAddr, cause);
 			}
 
 			notifyAllChannelsOfErrorAndClose(tex);


### PR DESCRIPTION
## What is the purpose of the change

In contrast to the messages inside `RemoteTransportException`s, `LocalTransportException` instances did not contain information about the remote end which complicated debugging and correlating different log files.

## Brief change log

- add remote address information to `LocalTransportException` instantiations

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
