### PR TITLE
[FLINK-9763] [sql-client] Flink SQL Client bat script

### DIFF
--- a/flink-libraries/flink-sql-client/bin/sql-client.bat
+++ b/flink-libraries/flink-sql-client/bin/sql-client.bat
@@ -1,0 +1,40 @@
+::###############################################################################
+::  Licensed to the Apache Software Foundation (ASF) under one
+::  or more contributor license agreements.  See the NOTICE file
+::  distributed with this work for additional information
+::  regarding copyright ownership.  The ASF licenses this file
+::  to you under the Apache License, Version 2.0 (the
+::  "License"); you may not use this file except in compliance
+::  with the License.  You may obtain a copy of the License at
+::
+::      http://www.apache.org/licenses/LICENSE-2.0
+::
+::  Unless required by applicable law or agreed to in writing, software
+::  distributed under the License is distributed on an "AS IS" BASIS,
+::  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+::  See the License for the specific language governing permissions and
+:: limitations under the License.
+::###############################################################################
+
+@echo off
+setlocal
+
+SET bin=%~dp0
+SET FLINK_ROOT_DIR=%bin%..
+SET FLINK_LIB_DIR=%FLINK_ROOT_DIR%\lib
+SET FLINK_OPT_DIR=%FLINK_ROOT_DIR%\opt
+
+SET JVM_ARGS=-Xmx512m
+
+SET FLINK_JM_CLASSPATH=%FLINK_LIB_DIR%\*
+SET FLINK_SQL_CLIENT_CLASSPATH=%FLINK_OPT_DIR%\*
+
+FOR %%I IN ("%FLINK_OPT_DIR%\flink-sql-client*.jar") DO SET "FLINK_SQL_CLIENT_JAR=%%~fI"
+
+if exist %FLINK_LIB_DIR%\flink-sql-client*.jar (
+    java %JVM_ARGS% -cp "%FLINK_JM_CLASSPATH%"; org.apache.flink.table.client.SqlClient %*
+) else (
+    java %JVM_ARGS% -cp "%FLINK_JM_CLASSPATH%;%FLINK_SQL_CLIENT_CLASSPATH%"; org.apache.flink.table.client.SqlClient %* -jar %FLINK_SQL_CLIENT_JAR%
+)
+
+endlocal

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliView.java
@@ -193,10 +193,10 @@ public abstract class CliView<OP extends Enum<OP>, OUT> {
 		final List<String> lines = new ArrayList<>();
 
 		// title part
-		client.getTerminal().writer().println(computeTitleLine().toAnsi());
+		client.getTerminal().writer().println(computeTitleLine().toAnsi(client.getTerminal()));
 
 		// header part
-		headerLines.forEach(l -> client.getTerminal().writer().println(l.toAnsi()));
+		headerLines.forEach(l -> client.getTerminal().writer().println(l.toAnsi(client.getTerminal())));
 
 		// main part
 		// update vertical offset
@@ -218,7 +218,7 @@ public abstract class CliView<OP extends Enum<OP>, OUT> {
 		Stream.concat(mainHeaderLines.stream(), windowedMainLines.stream()).forEach(l -> {
 			if (offsetX < l.length()) {
 				final AttributedString windowX = l.substring(offsetX, Math.min(l.length(), offsetX + width));
-				client.getTerminal().writer().println(windowX.toAnsi());
+				client.getTerminal().writer().println(windowX.toAnsi(client.getTerminal()));
 			} else {
 				client.getTerminal().writer().println(); // nothing to show for this line
 			}
@@ -233,9 +233,9 @@ public abstract class CliView<OP extends Enum<OP>, OUT> {
 		IntStream.range(0, footerLines.size()).forEach((i) -> {
 			final AttributedString l = footerLines.get(i);
 			if (i == footerLines.size() - 1) {
-				client.getTerminal().writer().print(l.toAnsi());
+				client.getTerminal().writer().print(l.toAnsi(client.getTerminal()));
 			} else {
-				client.getTerminal().writer().println(l.toAnsi());
+				client.getTerminal().writer().println(l.toAnsi(client.getTerminal()));
 			}
 		});
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a bat script for launching SQL client under Windows. See FLINK-9763 for more details.

## Brief change log

  - .bat script created
  - minor bugs in cli code fixed, correct terminal codes is now used

## Verifying this change

This change is already covered by existing tests, such as flink-SQL-client tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
