### PR TITLE
Add *.snapshot binary files to RAT exclusion list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1095,6 +1095,7 @@ under the License.
 
 						<!-- snapshots -->
 						<exclude>**/src/test/resources/*-snapshot</exclude>
+						<exclude>**/src/test/resources/*.snapshot</exclude>
 						<exclude>**/src/test/resources/*-savepoint</exclude>
 						<exclude>flink-core/src/test/resources/serialized-kryo-serializer-1.3</exclude>
 						<exclude>flink-core/src/test/resources/type-without-avro-serialized-using-kryo</exclude>


### PR DESCRIPTION
## What is the purpose of the change

This patch adds binary *.snapshot files to the RAT plugin exclusion list to avoid RAT error when running `mvn clean verify` in flink root directory.


## Brief change log

- Add binary *.snapshot files to the RAT plugin exclusion list to avoid RAT error

## Verifying this change

This change is already covered by existing tests, such as `mvn clean verify` in flink root directory.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
