### PR TITLE
[FLINK-9794] [jdbc] JDBCOutputFormat does not consider idle connection and multithreads synchronization

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
@@ -119,11 +119,22 @@ public class JDBCAppendTableSinkBuilder {
 		return this;
 	}
 
+	/**
+	 * Specify the interval that the idle connection will be checked.
+	 * @param idleConnectionCheckInterval the interval in milliseconds that the
+	 *                                    idle connection will be checked.
+	 */
 	public JDBCAppendTableSinkBuilder setIdleConnectionCheckInterval(long idleConnectionCheckInterval) {
 		this.idleConnectionCheckInterval = idleConnectionCheckInterval;
 		return this;
 	}
 
+	/**
+	 * Specify the time in seconds to wait for the database operation used to
+	 * validate the connection to complete.
+	 * @param idleConnectionCheckTimeout time in seconds to wait while validating
+	 *                                   the connection.
+	 */
 	public JDBCAppendTableSinkBuilder setIdleConnectionCheckTimeout(int idleConnectionCheckTimeout) {
 		this.idleConnectionCheckTimeout = idleConnectionCheckTimeout;
 		return this;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
@@ -36,7 +36,7 @@ public class JDBCAppendTableSinkBuilder {
 	private String query;
 	private int batchSize = DEFAULT_BATCH_INTERVAL;
 	private int[] parameterTypes;
-	private long idleConnectionCheckInterval = DEFAULT_IDLE_CONNECTION_CHECK_INTERVAL;
+	private int idleConnectionCheckInterval = DEFAULT_IDLE_CONNECTION_CHECK_INTERVAL;
 	private int idleConnectionCheckTimeout = DEFAULT_IDLE_CONNECTION_CHECK_TIMEOUT;
 
 	/**
@@ -121,10 +121,10 @@ public class JDBCAppendTableSinkBuilder {
 
 	/**
 	 * Specify the interval that the idle connection will be checked.
-	 * @param idleConnectionCheckInterval the interval in milliseconds that the
+	 * @param idleConnectionCheckInterval the interval in seconds that the
 	 *                                    idle connection will be checked.
 	 */
-	public JDBCAppendTableSinkBuilder setIdleConnectionCheckInterval(long idleConnectionCheckInterval) {
+	public JDBCAppendTableSinkBuilder setIdleConnectionCheckInterval(int idleConnectionCheckInterval) {
 		this.idleConnectionCheckInterval = idleConnectionCheckInterval;
 		return this;
 	}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkBuilder.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.java.io.jdbc.JDBCOutputFormat.DEFAULT_BATCH_INTERVAL;
+import static org.apache.flink.api.java.io.jdbc.JDBCOutputFormat.DEFAULT_IDLE_CONNECTION_CHECK_INTERVAL;
+import static org.apache.flink.api.java.io.jdbc.JDBCOutputFormat.DEFAULT_IDLE_CONNECTION_CHECK_TIMEOUT;
 
 /**
  * A builder to configure and build the JDBCAppendTableSink.
@@ -34,6 +36,8 @@ public class JDBCAppendTableSinkBuilder {
 	private String query;
 	private int batchSize = DEFAULT_BATCH_INTERVAL;
 	private int[] parameterTypes;
+	private long idleConnectionCheckInterval = DEFAULT_IDLE_CONNECTION_CHECK_INTERVAL;
+	private int idleConnectionCheckTimeout = DEFAULT_IDLE_CONNECTION_CHECK_TIMEOUT;
 
 	/**
 	 * Specify the username of the JDBC connection.
@@ -115,6 +119,16 @@ public class JDBCAppendTableSinkBuilder {
 		return this;
 	}
 
+	public JDBCAppendTableSinkBuilder setIdleConnectionCheckInterval(long idleConnectionCheckInterval) {
+		this.idleConnectionCheckInterval = idleConnectionCheckInterval;
+		return this;
+	}
+
+	public JDBCAppendTableSinkBuilder setIdleConnectionCheckTimeout(int idleConnectionCheckTimeout) {
+		this.idleConnectionCheckTimeout = idleConnectionCheckTimeout;
+		return this;
+	}
+
 	/**
 	 * Finalizes the configuration and checks validity.
 	 *
@@ -133,6 +147,8 @@ public class JDBCAppendTableSinkBuilder {
 			.setDrivername(driverName)
 			.setBatchInterval(batchSize)
 			.setSqlTypes(parameterTypes)
+			.setIdleConnectionCheckInterval(idleConnectionCheckInterval)
+			.setIdleConnectionCheckTimeout(idleConnectionCheckTimeout)
 			.finish();
 
 		return new JDBCAppendTableSink(format);

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -130,23 +130,20 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 	 */
 	@Override
 	public void writeRecord(Row row) throws IOException {
-
 		if (typesArray != null && typesArray.length > 0 && typesArray.length != row.getArity()) {
 			LOG.warn("Column SQL types array doesn't match arity of passed Row! Check the passed array...");
 		}
-		synchronized (this) {
-			try {
-				fillStmt(row);
-				upload.addBatch();
-				batchCount++;
-			} catch (SQLException e) {
-				throw new RuntimeException("Preparation of JDBC statement failed.", e);
-			}
+		try {
+			fillStmt(row);
+			upload.addBatch();
+			batchCount++;
+		} catch (SQLException e) {
+			throw new RuntimeException("Preparation of JDBC statement failed.", e);
+		}
 
-			if (batchCount >= batchInterval) {
-				// execute batch
-				flush();
-			}
+		if (batchCount >= batchInterval) {
+			// execute batch
+			flush();
 		}
 	}
 
@@ -241,10 +238,8 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 
 	void flush() {
 		try {
-			synchronized (this) {
-				upload.executeBatch();
-				batchCount = 0;
-			}
+			upload.executeBatch();
+			batchCount = 0;
 		} catch (SQLException e) {
 			throw new RuntimeException("Execution of JDBC statement failed.", e);
 		}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix bugs in original implementation of `JDBCOutputFormat`, which does not consider idle connection and multithreads synchronization .

- The Connection was established when JDBCOutputFormat is opened, and will be used all the time. But if this connection lies idle for a long time, the database will force close the connection, thus errors may occur.
- ~~The flush() method is called when batchCount exceeds the threshold, but it is also called while snapshotting state. So two threads may modify upload and batchCount, but without synchronization.~~
- We don't need synchronization here, because there is already synchronization in ```StreamTask```.

## Brief change log

  - Using a Timer to test the jdbc connection periodically and keep it alive
  - ~~Add synchronization for batch operation~~

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
