### PR TITLE
 [FLINK-9061][checkpointing] add entropy to s3 path for better scalability

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -180,6 +180,26 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	}
 
 	/**
+	 * Creates a new entropy based {@code RocksDBStateBackend} that stores its checkpoint data in the
+	 * file system and location defined by the given URI.
+	 *
+	 * <p>A state backend that stores checkpoints in HDFS or S3 must specify the file system
+	 * host and port in the URI, or have the Hadoop configuration that describes the file system
+	 * (host / high-availability group / possibly credentials) either referenced from the Flink
+	 * config, or included in the classpath.
+	 *
+	 * @param checkpointDataUri The URI describing the filesystem and path to the checkpoint data directory.
+	 * @param enableIncrementalCheckpointing True if incremental checkpointing is enabled.
+	 * @param entropyInjectionKey The string that specifies entropy key in the checkpoint uri
+	 *
+	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
+	 */
+	public RocksDBStateBackend(URI checkpointDataUri, boolean enableIncrementalCheckpointing, String entropyInjectionKey) throws IOException {
+		this(new FsStateBackend(checkpointDataUri, entropyInjectionKey),
+			enableIncrementalCheckpointing);
+	}
+
+	/**
 	 * Creates a new {@code RocksDBStateBackend} that uses the given state backend to store its
 	 * checkpoint data streams. Typically, one would supply a filesystem or database state backend
 	 * here where the snapshots from RocksDB would be stored.
@@ -208,6 +228,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 		this.checkpointStreamBackend = requireNonNull(checkpointStreamBackend);
 		this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
 	}
+
 
 	// ------------------------------------------------------------------------
 	//  State backend methods

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
@@ -44,12 +44,16 @@ public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBSt
 	/** The key under which the config stores the directory where RocksDB should be stored. */
 	public static final String ROCKSDB_CHECKPOINT_DIRECTORY_URI_CONF_KEY = "state.backend.rocksdb.checkpointdir";
 
+	/** The key defines the pattern in checkpoint uri where entropy value should be injected or substituted. */
+	public static final String CHECKPOINT_DIRECTORY_ENTROPY_KEY_CONF_KEY = "state.backend.fs.checkpointdir.injectEntropy.key";
+
 	@Override
 	public RocksDBStateBackend createFromConfig(Configuration config)
 			throws IllegalConfigurationException, IOException {
 
 		final String checkpointDirURI = config.getString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
 		final String rocksdbLocalPath = config.getString(ROCKSDB_CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
+		final String entropyInjectionKey = config.getString(CHECKPOINT_DIRECTORY_ENTROPY_KEY_CONF_KEY, "__ENTROPY_KEY__");
 
 		if (checkpointDirURI == null) {
 			throw new IllegalConfigurationException(
@@ -59,7 +63,8 @@ public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBSt
 
 		try {
 			Path path = new Path(checkpointDirURI);
-			RocksDBStateBackend backend = new RocksDBStateBackend(path.toUri());
+			RocksDBStateBackend backend = new RocksDBStateBackend(path.toUri(),
+				true, entropyInjectionKey);
 			if (rocksdbLocalPath != null) {
 				String[] directories = rocksdbLocalPath.split(",|" + File.pathSeparator);
 				backend.setDbStoragePaths(directories);

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -102,6 +102,12 @@ under the License.
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.4</version>
+		</dependency>
 		
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -104,12 +104,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-text</artifactId>
-			<version>1.4</version>
-		</dependency>
-		
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 		</dependency>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import java.net.URISyntaxException;
-import org.apache.commons.text.RandomStringGenerator;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FSDataOutputStream;
@@ -155,17 +155,11 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 		String chkpointPath = originalUri.getPath();
 		String retPath = chkpointPath;
 
-		if (!entropyInjectionKey.isEmpty() && chkpointPath.contains(entropyInjectionKey)) {
-			final String randomChars = new RandomStringGenerator.Builder()
-				.withinRange('0', 'z')
-				.filteredBy(Character::isLetterOrDigit)
-				.build()
-				.generate(DEFAULT_RANDOM_ENTROPY_LENGTH);
-			retPath = chkpointPath.replaceAll(entropyInjectionKey, randomChars);
-			LOG.debug("Entropy injected checkpoint path {}", retPath);
-		} else {
-			if (entropyInjectionKey.isEmpty()) {
-				LOG.warn("Entropy inject key is empty, hence entropy not injected");
+		if (!entropyInjectionKey.isEmpty()) {
+			if (chkpointPath.contains(entropyInjectionKey)) {
+				final String randomChars = RandomStringUtils.randomAlphanumeric(DEFAULT_RANDOM_ENTROPY_LENGTH);
+				retPath = chkpointPath.replaceAll(entropyInjectionKey, randomChars);
+				LOG.debug("Entropy injected checkpoint path {}", retPath);
 			} else {
 				LOG.warn("Entropy inject key is non-empty: {} , however key is not found in checkpoint path : {}", entropyInjectionKey, chkpointPath);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSavepointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsSavepointStreamFactory.java
@@ -39,11 +39,12 @@ public class FsSavepointStreamFactory extends FsCheckpointStreamFactory {
 			JobID jobId,
 			int fileStateSizeThreshold) throws IOException {
 
-		super(checkpointDataUri, jobId, fileStateSizeThreshold);
+		super(checkpointDataUri, jobId, fileStateSizeThreshold,"");
 	}
 
 	@Override
-	protected Path createBasePath(FileSystem fs, Path checkpointDirectory, JobID jobID) throws IOException {
+	protected Path createBasePath(FileSystem fs, Path checkpointDirectory, JobID jobID,
+								  String entropyInjectionKey) throws IOException {
 		// No checkpoint specific directory required as the savepoint directory
 		// is already unique.
 		return checkpointDirectory;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
@@ -38,12 +38,19 @@ public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend
 	 * rather than in files */
 	public static final String MEMORY_THRESHOLD_CONF_KEY = "state.backend.fs.memory-threshold";
 
+	/** The key defines the pattern in checkpoint uri where entropy value should be injected or substituted */
+	public static final String CHECKPOINT_DIRECTORY_ENTROPY_KEY_CONF_KEY = "state.backend.fs.checkpointdir.injectEntropy.key";
+
+
 
 	@Override
 	public FsStateBackend createFromConfig(Configuration config) throws IllegalConfigurationException {
 		final String checkpointDirURI = config.getString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
 		final int memoryThreshold = config.getInteger(
 			MEMORY_THRESHOLD_CONF_KEY, FsStateBackend.DEFAULT_FILE_STATE_THRESHOLD);
+
+		final String entropyInjectionKey = config.getString(CHECKPOINT_DIRECTORY_ENTROPY_KEY_CONF_KEY, "__ENTROPY_KEY__");
+
 
 		if (checkpointDirURI == null) {
 			throw new IllegalConfigurationException(
@@ -53,7 +60,7 @@ public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend
 
 		try {
 			Path path = new Path(checkpointDirURI);
-			return new FsStateBackend(path.toUri(), memoryThreshold);
+			return new FsStateBackend(path.toUri(), memoryThreshold, entropyInjectionKey);
 		}
 		catch (IOException | IllegalArgumentException e) {
 			throw new IllegalConfigurationException("Invalid configuration for the state backend", e);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds entropy to the checkpoint path based upon a user defined pattern in the configuration for better s3 scalability*


## Brief change log
  - *Read the entropy pattern from the config*
  - *In the checkpoint path for FSbackend, substitute the entropy key with a 4 character random alpha numeric string*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests under FileStateBackendTest to cover different scenarios for the entropy substitution*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)