### PR TITLE
[FLINK-9801][build] Add missing example dependencies to flink-dist

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -144,12 +144,16 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<!-- the example jars are included via assemblies -->
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-examples-streaming_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<!-- the example jars are included via assemblies -->
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Default file system support. The Hadoop and MapR dependencies -->
@@ -514,8 +518,6 @@ under the License.
 								<excludes>
 									<exclude>org.slf4j:slf4j-log4j12</exclude>
 									<exclude>log4j:log4j</exclude>
-									<!-- the example jars are included via assemblies -->
-									<exclude>org.apache.flink:flink-examples-*</exclude>
 								</excludes>
 							</artifactSet>
 							<transformers>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -140,6 +140,18 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-examples-streaming_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- Default file system support. The Hadoop and MapR dependencies -->
 		<!--       are optional, so not being added to the dist jar        -->
 
@@ -502,6 +514,8 @@ under the License.
 								<excludes>
 									<exclude>org.slf4j:slf4j-log4j12</exclude>
 									<exclude>log4j:log4j</exclude>
+									<!-- the example jars are included via assemblies -->
+									<exclude>org.apache.flink:flink-examples-*</exclude>
 								</excludes>
 							</artifactSet>
 							<transformers>


### PR DESCRIPTION
## What is the purpose of the change

With this PR `flink-dist` explicitly depends on `flink-examples-batch` and `flink-examples-streaming`, to ensure that both modules are built
a) before flink-dist
b) when compiling flink-dist with the `-am` flag.

## Brief change log

* add dependencies to both modules
* add exclusions to shade-plugin so they aren't included in the `flink-dist` jar

## Verifying this change

Manually verified.

a) run `mvn validate -pl flink-dist -am` and check that both example modules are in the reactor build before flink-dist
b) compile flink-dist and check that code from neither module is present in flink-dist
