### PR TITLE
[FLINK-9805][rest] Catch JsonProcessingException in RestClient

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
@@ -418,7 +417,7 @@ public class RestClient {
 			try (InputStream in = new ByteBufInputStream(content)) {
 				rawResponse = objectMapper.readTree(in);
 				LOG.debug("Received response {}.", rawResponse);
-			} catch (JsonParseException je) {
+			} catch (JsonProcessingException je) {
 				LOG.error("Response was not valid JSON.", je);
 				// let's see if it was a plain-text message instead
 				content.readerIndex(0);


### PR DESCRIPTION
## What is the purpose of the change

With this PR `RestClient#readRawResponse` catches all JSON-related exceptions. The exact circumstances where a `non-JsonParseException` is thrown isn't clearly defined, but one case when it can occur is when the input is empty.