### PR TITLE
[FLINK-9810][rest] Close jar file in JarListHandler

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -103,8 +103,7 @@ public class JarListHandler extends AbstractRestHandler<RestfulGateway, EmptyReq
 
 					List<JarListInfo.JarEntryInfo> jarEntryList = new ArrayList<>();
 					String[] classes = new String[0];
-					try {
-						JarFile jar = new JarFile(f);
+					try (JarFile jar = new JarFile(f)) {
 						Manifest manifest = jar.getManifest();
 						String assemblerClass = null;
 


### PR DESCRIPTION
## What is the purpose of the change

Small cleanup in the `JarListHandler` to properly close listed jars, as otherwise subsequent delete operations could fail.