### PR TITLE
[FLINK-9811][rest] Add test for jar handler interactions 

### DIFF
--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -135,7 +135,35 @@ under the License.
 							<goal>test-jar</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>test-program-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>org/apache/flink/runtime/webmonitor/handlers/utils/TestProgram.java</include>
+							</includes>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.runtime.webmonitor.handlers.utils.TestProgram</mainClass>
+								</manifest>
+							</archive>
+							<finalName>test-program</finalName>
+						</configuration>
+					</execution>
 				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<targetDir>${project.build.directory}</targetDir>
+					</systemPropertyVariables>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListInfo.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListInfo.java
@@ -41,7 +41,7 @@ public class JarListInfo implements ResponseBody {
 	private String address;
 
 	@JsonProperty(JAR_LIST_FIELD_FILES)
-	private List<JarFileInfo> jarFileList;
+	public List<JarFileInfo> jarFileList;
 
 	@JsonCreator
 	public JarListInfo(
@@ -85,10 +85,10 @@ public class JarListInfo implements ResponseBody {
 		public static final String JAR_FILE_FIELD_ENTRY = "entry";
 
 		@JsonProperty(JAR_FILE_FIELD_ID)
-		private String id;
+		public String id;
 
 		@JsonProperty(JAR_FILE_FIELD_NAME)
-		private String name;
+		public String name;
 
 		@JsonProperty(JAR_FILE_FIELD_UPLOADED)
 		private long uploaded;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanMessageParameters.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanMessageParameters.java
@@ -31,7 +31,7 @@ import java.util.Collections;
  */
 public class JarPlanMessageParameters extends MessageParameters {
 
-	private final JarIdPathParameter jarIdPathParameter = new JarIdPathParameter();
+	public final JarIdPathParameter jarIdPathParameter = new JarIdPathParameter();
 
 	private final EntryClassQueryParameter entryClassQueryParameter = new EntryClassQueryParameter();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -35,13 +35,10 @@ import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
-import org.apache.flink.runtime.util.ScalaUtils;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.FlinkException;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
-
-import akka.actor.AddressFromURIString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,7 +48,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -112,7 +108,7 @@ public class JarRunHandler extends
 		CompletableFuture<Integer> blobServerPortFuture = gateway.getBlobServerPort(timeout);
 
 		CompletableFuture<JobGraph> jarUploadFuture = jobGraphFuture.thenCombine(blobServerPortFuture, (jobGraph, blobServerPort) -> {
-			final InetSocketAddress address = new InetSocketAddress(getDispatcherHost(gateway), blobServerPort);
+			final InetSocketAddress address = new InetSocketAddress(gateway.getHostname(), blobServerPort);
 			try {
 				ClientUtils.extractAndUploadJobGraphFiles(jobGraph, () -> new BlobClient(address, configuration));
 			} catch (FlinkException e) {
@@ -181,16 +177,5 @@ public class JarRunHandler extends
 			jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
 			return jobGraph;
 		}, executor);
-	}
-
-	private static String getDispatcherHost(DispatcherGateway gateway) {
-		String dispatcherAddress = gateway.getAddress();
-		final Optional<String> host = ScalaUtils.toJava(AddressFromURIString.parse(dispatcherAddress).host());
-
-		return host.orElseGet(() -> {
-			// if the dispatcher address does not contain a host part, then assume it's running
-			// on the same machine as the handler
-			return "localhost";
-		});
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
@@ -133,7 +133,7 @@ public class JarSubmissionITCase {
 		return handler.handleRequest(planRequest, restfulGateway)
 			.get();
 	}
-	
+
 	private static JarRunResponseBody runJar(JarRunHandler handler, String jarName, DispatcherGateway restfulGateway) throws Exception {
 		final JarRunMessageParameters runParameters = JarRunHeaders.getInstance().getUnresolvedMessageParameters();
 		HandlerRequest<EmptyRequestBody, JarRunMessageParameters> runRequest = new HandlerRequest<>(

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobPlanInfo;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.net.ConnectException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Tests the entire lifecycle of a jar submission.
+ */
+public class JarSubmissionITCase {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testJarSubmission() throws Exception {
+		final TestingDispatcherGateway restfulGateway = new TestingDispatcherGateway.Builder().build();
+		final JarHandlers handlers = new JarHandlers(temporaryFolder.newFolder().toPath(), restfulGateway);
+		final JarUploadHandler uploadHandler = handlers.uploadHandler;
+		final JarListHandler listHandler = handlers.listHandler;
+		final JarPlanHandler planHandler = handlers.planHandler;
+		final JarRunHandler runHandler = handlers.runHandler;
+		final JarDeleteHandler deleteHandler = handlers.deleteHandler;
+
+		// targetDir property is set via surefire configuration
+		final Path originalJar = Paths.get(System.getProperty("targetDir")).resolve("test-program.jar");
+		final Path jar = Files.copy(originalJar, temporaryFolder.getRoot().toPath().resolve("test-program.jar"));
+
+		final String storedJarPath = uploadJar(uploadHandler, jar, restfulGateway);
+		final String storedJarName = Paths.get(storedJarPath).getFileName().toString();
+
+		final JarListInfo postUploadListResponse = listJars(listHandler, restfulGateway);
+		Assert.assertEquals(1, postUploadListResponse.jarFileList.size());
+		final JarListInfo.JarFileInfo listEntry = postUploadListResponse.jarFileList.iterator().next();
+		Assert.assertEquals(jar.getFileName().toString(), listEntry.name);
+		Assert.assertEquals(storedJarName, listEntry.id);
+
+		final JobPlanInfo planResponse = showPlan(planHandler, storedJarName, restfulGateway);
+		// we're only interested in the core functionality so checking for a small detail is sufficient
+		Assert.assertThat(planResponse.getJsonPlan(), containsString("TestProgram.java:29"));
+
+		try {
+			runJar(runHandler, storedJarName, restfulGateway);
+			Assert.fail("We assume the actual job submission to fail.");
+		} catch (Exception e) {
+			final Optional<ConnectException> expected = ExceptionUtils.findThrowable(e, ConnectException.class);
+			if (expected.isPresent()) {
+				// we use a bogus dispatcher address causing the blob upload to fail
+				// at that point we've already processed the jar however, which is all we're interested in
+			} else {
+				throw e;
+			}
+		}
+
+		deleteJar(deleteHandler, storedJarName, restfulGateway);
+
+		final JarListInfo postDeleteListResponse = listJars(listHandler, restfulGateway);
+		Assert.assertEquals(0, postDeleteListResponse.jarFileList.size());
+	}
+
+	private static String uploadJar(JarUploadHandler handler, Path jar, RestfulGateway restfulGateway) throws Exception {
+		HandlerRequest<EmptyRequestBody, EmptyMessageParameters> uploadRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			EmptyMessageParameters.getInstance(),
+			Collections.emptyMap(),
+			Collections.emptyMap(),
+			Collections.singletonList(jar.toFile()));
+		final JarUploadResponseBody uploadResponse = handler.handleRequest(uploadRequest, restfulGateway)
+			.get();
+		return uploadResponse.getFilename();
+	}
+
+	private static JarListInfo listJars(JarListHandler handler, RestfulGateway restfulGateway) throws Exception {
+		HandlerRequest<EmptyRequestBody, EmptyMessageParameters> listRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			EmptyMessageParameters.getInstance());
+		return handler.handleRequest(listRequest, restfulGateway)
+			.get();
+	}
+
+	private static JobPlanInfo showPlan(JarPlanHandler handler, String jarName, RestfulGateway restfulGateway) throws Exception {
+		JarPlanMessageParameters planParameters = JarPlanHeaders.getInstance().getUnresolvedMessageParameters();
+		HandlerRequest<EmptyRequestBody, JarPlanMessageParameters> planRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			planParameters,
+			Collections.singletonMap(planParameters.jarIdPathParameter.getKey(), jarName),
+			Collections.emptyMap(),
+			Collections.emptyList());
+		return handler.handleRequest(planRequest, restfulGateway)
+			.get();
+	}
+	
+	private static JarRunResponseBody runJar(JarRunHandler handler, String jarName, DispatcherGateway restfulGateway) throws Exception {
+		final JarRunMessageParameters runParameters = JarRunHeaders.getInstance().getUnresolvedMessageParameters();
+		HandlerRequest<EmptyRequestBody, JarRunMessageParameters> runRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			runParameters,
+			Collections.singletonMap(runParameters.jarIdPathParameter.getKey(), jarName),
+			Collections.emptyMap(),
+			Collections.emptyList());
+		return handler.handleRequest(runRequest, restfulGateway)
+			.get();
+	}
+
+	private static void deleteJar(JarDeleteHandler handler, String jarName, RestfulGateway restfulGateway) throws Exception {
+		JarDeleteMessageParameters deleteParameters = JarDeleteHeaders.getInstance().getUnresolvedMessageParameters();
+		HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> deleteRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			deleteParameters,
+			Collections.singletonMap(deleteParameters.jarIdPathParameter.getKey(), jarName),
+			Collections.emptyMap(),
+			Collections.emptyList());
+		handler.handleRequest(deleteRequest, restfulGateway)
+			.get();
+	}
+
+	private static class JarHandlers {
+		final JarUploadHandler uploadHandler;
+		final JarListHandler listHandler;
+		final JarPlanHandler planHandler;
+		final JarRunHandler runHandler;
+		final JarDeleteHandler deleteHandler;
+
+		JarHandlers(final Path jarDir, final TestingDispatcherGateway restfulGateway) {
+			final GatewayRetriever<TestingDispatcherGateway> gatewayRetriever = () -> CompletableFuture.completedFuture(restfulGateway);
+			final CompletableFuture<String> localAddressFuture = CompletableFuture.completedFuture("shazam://localhost:12345");
+			final Time timeout = Time.seconds(10);
+			final Map<String, String> responseHeaders = Collections.emptyMap();
+			final Executor executor = TestingUtils.defaultExecutor();
+
+			uploadHandler = new JarUploadHandler(
+				localAddressFuture,
+				gatewayRetriever,
+				timeout,
+				responseHeaders,
+				JarUploadHeaders.getInstance(),
+				jarDir,
+				executor);
+
+			listHandler = new JarListHandler(
+				localAddressFuture,
+				gatewayRetriever,
+				timeout,
+				responseHeaders,
+				JarListHeaders.getInstance(),
+				jarDir.toFile(),
+				executor);
+
+			planHandler = new JarPlanHandler(
+				localAddressFuture,
+				gatewayRetriever,
+				timeout,
+				responseHeaders,
+				JarPlanHeaders.getInstance(),
+				jarDir,
+				new Configuration(),
+				executor);
+
+			runHandler = new JarRunHandler(
+				localAddressFuture,
+				gatewayRetriever,
+				timeout,
+				responseHeaders,
+				JarRunHeaders.getInstance(),
+				jarDir,
+				new Configuration(),
+				executor);
+
+			deleteHandler = new JarDeleteHandler(
+				localAddressFuture,
+				gatewayRetriever,
+				timeout,
+				responseHeaders,
+				JarDeleteHeaders.getInstance(),
+				jarDir,
+				executor);
+		}
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/utils/TestProgram.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/utils/TestProgram.java
@@ -16,29 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.webmonitor.handlers;
+package org.apache.flink.runtime.webmonitor.handlers.utils;
 
-import org.apache.flink.runtime.rest.messages.MessageParameters;
-import org.apache.flink.runtime.rest.messages.MessagePathParameter;
-import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
-
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.api.java.ExecutionEnvironment;
 
 /**
- * Message parameters for {@link JarDeleteHandler}.
+ * Simple test program.
  */
-public class JarDeleteMessageParameters extends MessageParameters {
-
-	public JarIdPathParameter jarIdPathParameter = new JarIdPathParameter();
-
-	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singletonList(jarIdPathParameter);
-	}
-
-	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.emptyList();
+public class TestProgram {
+	public static void main(String[] args) throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.fromElements("hello", "world").print();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobPlanInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobPlanInfo.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.rest.handler.job.JobPlanHandler;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
@@ -53,6 +54,11 @@ public class JobPlanInfo implements ResponseBody {
 	@JsonCreator
 	public JobPlanInfo(@JsonProperty(FIELD_NAME_PLAN) RawJson jsonPlan) {
 		this.jsonPlan = jsonPlan;
+	}
+
+	@JsonIgnore
+	public String getJsonPlan() {
+		return jsonPlan.json;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlobServerResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlobServerResource.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * TODO: add javadoc.
+ * A simple {@link ExternalResource} to be used by tests that require a {@link BlobServer}.
  */
 public class BlobServerResource extends ExternalResource {
 	private static final Logger LOG = LoggerFactory.getLogger(BlobServerResource.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlobServerResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlobServerResource.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * TODO: add javadoc.
+ */
+public class BlobServerResource extends ExternalResource {
+	private static final Logger LOG = LoggerFactory.getLogger(BlobServerResource.class);
+	private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private BlobServer blobServer;
+
+	protected void before() throws Throwable {
+		temporaryFolder.create();
+
+		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		blobServer = new BlobServer(config, new VoidBlobStore());
+		blobServer.start();
+	}
+
+	protected void after() {
+		temporaryFolder.delete();
+
+		try {
+			blobServer.close();
+		} catch (IOException e) {
+			LOG.error("Exception while shutting down blob server.", e);
+		}
+	}
+
+	public int getBlobServerPort() {
+		return blobServer.getPort();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds an ITCase for the interactions between jar handlers.

The test goes through the following life-cycle:
* upload jar
* list jars, expect uploaded jar
* show plan for uploaded jar
* run uploaded jar, expect failure during upload to blobserver (no cluster is started)
* delete uploaded jar
* list jars, expect empty list

## Brief change log

* sync dispatcher hostname retrieval in `JarRunHandler` with `JobSubmitHandler`

*  add `TestProgram` class and `maven-jar-plugin` execution to create a test jar for the test
* modify visibility of various `*MessageParameter` classes to make them usable for java code
* add `JarSubmissionITCase`

## Verifying this change

Manually verified. The assertions made are fairly straight-forward.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
