### PR TITLE
[FLINK-9818] Add cluster component command line parser

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -223,7 +223,7 @@ public class PackagedProgram {
 		}
 	}
 
-	PackagedProgram(Class<?> entryPointClass, String... args) throws ProgramInvocationException {
+	public PackagedProgram(Class<?> entryPointClass, String... args) throws ProgramInvocationException {
 		this.jarFile = null;
 		this.args = args == null ? new String[0] : args;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.Properties;
+
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
+
+/**
+ * Parser factory which generates a {@link ClusterConfiguration} from the given
+ * list of command line arguments.
+ */
+public class ClusterConfigurationParserFactory implements ParserResultFactory<ClusterConfiguration> {
+
+	@Override
+	public Options getOptions() {
+		final Options options = new Options();
+		options.addOption(CONFIG_DIR_OPTION);
+		options.addOption(DYNAMIC_PROPERTY_OPTION);
+
+		return options;
+	}
+
+	@Override
+	public ClusterConfiguration createResult(@Nonnull CommandLine commandLine) {
+		final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+
+		final Properties dynamicProperties = commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
+
+		return new ClusterConfiguration(configDir, dynamicProperties, commandLine.getArgs());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfiguration.java
@@ -23,38 +23,18 @@ import javax.annotation.Nonnull;
 import java.util.Properties;
 
 /**
- * Configuration class which contains the parsed command line arguments for
- * the {@link ClusterEntrypoint}.
+ * Basic {@link ClusterConfiguration} for entry points.
  */
-public class ClusterConfiguration {
+public class EntrypointClusterConfiguration extends ClusterConfiguration {
 
-	@Nonnull
-	private final String configDir;
+	private final int restPort;
 
-	@Nonnull
-	private final Properties dynamicProperties;
-
-	@Nonnull
-	private final String[] args;
-
-	public ClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args) {
-		this.configDir = configDir;
-		this.dynamicProperties = dynamicProperties;
-		this.args = args;
+	public EntrypointClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args, int restPort) {
+		super(configDir, dynamicProperties, args);
+		this.restPort = restPort;
 	}
 
-	@Nonnull
-	public String getConfigDir() {
-		return configDir;
-	}
-
-	@Nonnull
-	public Properties getDynamicProperties() {
-		return dynamicProperties;
-	}
-
-	@Nonnull
-	public String[] getArgs() {
-		return args;
+	public int getRestPort() {
+		return restPort;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.Properties;
+
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST_PORT_OPTION;
+
+/**
+ * Parser factory for {@link EntrypointClusterConfiguration}.
+ */
+public class EntrypointClusterConfigurationParserFactory implements ParserResultFactory<EntrypointClusterConfiguration> {
+
+	@Override
+	public Options getOptions() {
+		final Options options = new Options();
+		options.addOption(CONFIG_DIR_OPTION);
+		options.addOption(REST_PORT_OPTION);
+		options.addOption(DYNAMIC_PROPERTY_OPTION);
+
+		return options;
+	}
+
+	@Override
+	public EntrypointClusterConfiguration createResult(@Nonnull CommandLine commandLine) {
+		final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+		final Properties dynamicProperties = commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
+		final String restPortStr = commandLine.getOptionValue(REST_PORT_OPTION.getOpt(), "-1");
+		final int restPort = Integer.parseInt(restPortStr);
+
+		return new EntrypointClusterConfiguration(
+			configDir,
+			dynamicProperties,
+			commandLine.getArgs(),
+			restPort);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/FlinkParseException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/FlinkParseException.java
@@ -18,43 +18,25 @@
 
 package org.apache.flink.runtime.entrypoint;
 
-import javax.annotation.Nonnull;
-
-import java.util.Properties;
+import org.apache.flink.util.FlinkException;
 
 /**
- * Configuration class which contains the parsed command line arguments for
- * the {@link ClusterEntrypoint}.
+ * Exception which indicates that the parsing of command line
+ * arguments failed.
  */
-public class ClusterConfiguration {
+public class FlinkParseException extends FlinkException {
 
-	@Nonnull
-	private final String configDir;
+	private static final long serialVersionUID = 5164983338744708430L;
 
-	@Nonnull
-	private final Properties dynamicProperties;
-
-	@Nonnull
-	private final String[] args;
-
-	public ClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args) {
-		this.configDir = configDir;
-		this.dynamicProperties = dynamicProperties;
-		this.args = args;
+	public FlinkParseException(String message) {
+		super(message);
 	}
 
-	@Nonnull
-	public String getConfigDir() {
-		return configDir;
+	public FlinkParseException(Throwable cause) {
+		super(cause);
 	}
 
-	@Nonnull
-	public Properties getDynamicProperties() {
-		return dynamicProperties;
-	}
-
-	@Nonnull
-	public String[] getArgs() {
-		return args;
+	public FlinkParseException(String message, Throwable cause) {
+		super(message, cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.commons.cli.Option;
+
+/**
+ * Container class for command line options.
+ */
+public class CommandLineOptions {
+
+	public static final Option CONFIG_DIR_OPTION = Option.builder("c")
+		.longOpt("configDir")
+		.required(true)
+		.hasArg(true)
+		.argName("configuration directory")
+		.desc("Directory which contains the configuration file flink-conf.yml.")
+		.build();
+
+	public static final Option REST_PORT_OPTION = Option.builder("r")
+		.longOpt("webui-port")
+		.required(false)
+		.hasArg(true)
+		.argName("rest port")
+		.desc("Port for the rest endpoint and the web UI.")
+		.build();
+
+	public static final Option DYNAMIC_PROPERTY_OPTION = Option.builder("D")
+		.argName("property=value")
+		.numberOfArgs(2)
+		.valueSeparator('=')
+		.desc("use value for given property")
+		.build();
+
+	private CommandLineOptions() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineParser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineParser.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Command line parser which produces a result from the given
+ * command line arguments.
+ */
+public class CommandLineParser<T> {
+
+	@Nonnull
+	private final ParserResultFactory<T> parserResultFactory;
+
+	public CommandLineParser(@Nonnull ParserResultFactory<T> parserResultFactory) {
+		this.parserResultFactory = parserResultFactory;
+	}
+
+	public T parse(@Nonnull String[] args) throws FlinkParseException {
+		final DefaultParser parser = new DefaultParser();
+		final Options options = parserResultFactory.getOptions();
+
+		final CommandLine commandLine;
+		try {
+			commandLine = parser.parse(options, args, true);
+		} catch (ParseException e) {
+			throw new FlinkParseException("Failed to parse the command line arguments.", e);
+		}
+
+		return parserResultFactory.createResult(commandLine);
+	}
+
+	public void printHelp() {
+		final HelpFormatter helpFormatter = new HelpFormatter();
+		helpFormatter.printHelp("", parserResultFactory.getOptions());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ParserResultFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ParserResultFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Parser result factory used by the {@link CommandLineParser}.
+ *
+ * @param <T> type of the parsed result
+ */
+public interface ParserResultFactory<T> {
+
+	/**
+	 * Returns all relevant {@link Options} for parsing the command line
+	 * arguments.
+	 *
+	 * @return Options to use for the parsing
+	 */
+	Options getOptions();
+
+	/**
+	 * Create the result of the command line argument parsing.
+	 *
+	 * @param commandLine to extract the options from
+	 * @return Result of the parsing
+	 */
+	T createResult(@Nonnull CommandLine commandLine);
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link ClusterConfigurationParserFactory}.
+ */
+public class ClusterConfigurationParserFactoryTest extends TestLogger {
+
+	@Test
+	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final String key = "key";
+		final String value = "value";
+		final String arg1 = "arg1";
+		final String arg2 = "arg2";
+		final String[] args = {"--configDir", configDir, String.format("-D%s=%s", key, value), arg1, arg2};
+
+		final ClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
+
+		assertThat(dynamicProperties, hasEntry(key, value));
+
+		assertThat(clusterConfiguration.getArgs(), arrayContaining(arg1, arg2));
+	}
+
+	@Test
+	public void testOnlyRequiredArguments() throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final String[] args = {"--configDir", configDir};
+
+		final ClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testMissingRequiredArgument() throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+		final String[] args = {};
+
+		commandLineParser.parse(args);
+		fail("Expected an FlinkParseException.");
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link EntrypointClusterConfigurationParserFactory}.
+ */
+public class EntrypointClusterConfigurationParserFactoryTest extends TestLogger {
+
+	@Test
+	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
+		final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final int restPort = 1234;
+		final String key = "key";
+		final String value = "value";
+		final String arg1 = "arg1";
+		final String arg2 = "arg2";
+		final String[] args = {"--configDir", configDir, "-r", String.valueOf(restPort), String.format("-D%s=%s", key, value), arg1, arg2};
+
+		final EntrypointClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getRestPort(), is(equalTo(restPort)));
+		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
+
+		assertThat(dynamicProperties, hasEntry(key, value));
+
+		assertThat(clusterConfiguration.getArgs(), arrayContaining(arg1, arg2));
+	}
+
+	@Test
+	public void testOnlyRequiredArguments() throws FlinkParseException {
+		final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final String[] args = {"--configDir", configDir};
+
+		final EntrypointClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testMissingRequiredArgument() throws FlinkParseException {
+		final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+		final String[] args = {};
+
+		commandLineParser.parse(args);
+		fail("Expected an FlinkParseException.");
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The cluster component command line parser is responsible for parsing the common command line
arguments with which the cluster components are started. These include the configDir, webui-port
and dynamic properties.

cc @GJL

## Verifying this change

- Added `EntrypointClusterConfigurationParserFactoryTest` and `ClusterConfigurationParserFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
