### PR TITLE
[FLINK-9822] Add Dockerfile for StandaloneJobClusterEntryPoint image

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -223,7 +223,7 @@ public class PackagedProgram {
 		}
 	}
 
-	PackagedProgram(Class<?> entryPointClass, String... args) throws ProgramInvocationException {
+	public PackagedProgram(Class<?> entryPointClass, String... args) throws ProgramInvocationException {
 		this.jarFile = null;
 		this.args = args == null ? new String[0] : args;
 

--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -1,0 +1,50 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+FROM java:8-jre-alpine
+
+# Install requirements
+RUN apk add --no-cache bash snappy
+
+# Flink environment variables
+ENV FLINK_INSTALL_PATH=/opt
+ENV FLINK_HOME $FLINK_INSTALL_PATH/flink
+ENV FLINK_LIB_DIR $FLINK_HOME/lib
+ENV PATH $PATH:$FLINK_HOME/bin
+
+# flink-dist can point to a directory or a tarball on the local system
+ARG flink_dist=NOT_SET
+ARG job_jar=NOT_SET
+
+# Install build dependencies and flink
+ADD $flink_dist $FLINK_INSTALL_PATH
+ADD $job_jar $FLINK_INSTALL_PATH/job.jar
+
+RUN set -x && \
+  ln -s $FLINK_INSTALL_PATH/flink-* $FLINK_HOME && \
+  ln -s $FLINK_INSTALL_PATH/job.jar $FLINK_LIB_DIR && \
+  addgroup -S flink && adduser -D -S -H -G flink -h $FLINK_HOME flink && \
+  chown -R flink:flink $FLINK_INSTALL_PATH/flink-* && \
+  chown -h flink:flink $FLINK_HOME
+
+COPY docker-entrypoint.sh /
+
+USER flink
+EXPOSE 8081 6123
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["--help"]

--- a/flink-container/docker/README.md
+++ b/flink-container/docker/README.md
@@ -1,4 +1,4 @@
-# Apache Flink cluster deployment on docker using docker-compose
+# Apache Flink job cluster deployment on docker using docker-compose
 
 ## Installation
 
@@ -19,7 +19,7 @@ or
 If you want to build the container for a specific version of flink/hadoop/scala
 you can configure it in the respective args:
 
-    docker build --build-arg FLINK_VERSION=1.0.3 --build-arg HADOOP_VERSION=26 --build-arg SCALA_VERSION=2.10 -t "flink:1.0.3-hadoop2.6-scala_2.10" flink
+    docker build --build-arg FLINK_VERSION=1.6.0 --build-arg HADOOP_VERSION=28 --build-arg SCALA_VERSION=2.11 -t "flink:1.6.0-hadoop2.8-scala_2.11" flink
 
 ## Deploy
 

--- a/flink-container/docker/README.md
+++ b/flink-container/docker/README.md
@@ -1,0 +1,44 @@
+# Apache Flink cluster deployment on docker using docker-compose
+
+## Installation
+
+Install the most recent stable version of docker
+https://docs.docker.com/installation/
+
+## Build
+
+Images are based on the official Java Alpine (OpenJDK 8) image. If you want to
+build the flink image run:
+
+    sh build.sh --job-jar /path/to/job/jar/job.jar --image-name flink:job
+
+or
+
+    docker build -t flink .
+
+If you want to build the container for a specific version of flink/hadoop/scala
+you can configure it in the respective args:
+
+    docker build --build-arg FLINK_VERSION=1.0.3 --build-arg HADOOP_VERSION=26 --build-arg SCALA_VERSION=2.10 -t "flink:1.0.3-hadoop2.6-scala_2.10" flink
+
+## Deploy
+
+- Deploy cluster and see config/setup log output (best run in a screen session)
+
+        docker-compose up
+
+- Deploy as a daemon (and return)
+
+        docker-compose up -d
+
+- Scale the cluster up or down to *N* TaskManagers
+
+        docker-compose scale taskmanager=<N>
+
+- Access the Job Manager container
+
+        docker exec -it $(docker ps --filter name=flink_jobmanager --format={{.ID}}) /bin/sh
+
+- Kill the cluster
+
+        docker-compose kill

--- a/flink-container/docker/build.sh
+++ b/flink-container/docker/build.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+usage() {
+  cat <<HERE
+Usage:
+  build.sh --job-jar <path-to-job-jar> --from-local-dist [--image-name <image>]
+  build.sh --job-jar <path-to-job-jar> --from-release --flink-version <x.x.x> --hadoop-version <x.x> --scala-version <x.xx> [--image-name <image>]
+  build.sh --help
+
+  If the --image-name flag is not used the built image name will be 'flink'.
+HERE
+  exit 1
+}
+
+while [[ $# -ge 1 ]]
+do
+key="$1"
+  case $key in
+    --job-jar)
+    JOB_JAR_PATH="$2"
+    ;;
+    --from-local-dist)
+    FROM_LOCAL="true"
+    ;;
+    --from-release)
+    FROM_RELEASE="true"
+    ;;
+    --image-name)
+    IMAGE_NAME="$2"
+    shift
+    ;;
+    --flink-version)
+    FLINK_VERSION="$2"
+    shift
+    ;;
+    --hadoop-version)
+    HADOOP_VERSION="$(echo "$2" | sed 's/\.//')"
+    shift
+    ;;
+    --scala-version)
+    SCALA_VERSION="$2"
+    shift
+    ;;
+    --kubernetes-certificates)
+    CERTIFICATES_DIR="$2"
+    shift
+    ;;
+    --help)
+    usage
+    ;;
+    *)
+    # unknown option
+    ;;
+  esac
+  shift
+done
+
+IMAGE_NAME=${IMAGE_NAME:-flink-job}
+
+# TMPDIR must be contained within the working directory so it is part of the
+# Docker context. (i.e. it can't be mktemp'd in /tmp)
+TMPDIR=_TMP_
+
+cleanup() {
+    rm -rf "${TMPDIR}"
+}
+trap cleanup EXIT
+
+mkdir -p "${TMPDIR}"
+
+JOB_JAR_TARGET="${TMPDIR}/job.jar"
+cp ${JOB_JAR_PATH} ${JOB_JAR_TARGET}
+
+if [ -n "${FROM_RELEASE}" ]; then
+
+  [[ -n "${FLINK_VERSION}" ]] && [[ -n "${HADOOP_VERSION}" ]] && [[ -n "${SCALA_VERSION}" ]] || usage
+
+  FLINK_BASE_URL="$(curl -s https://www.apache.org/dyn/closer.cgi\?preferred\=true)flink/flink-${FLINK_VERSION}/"
+  FLINK_DIST_FILE_NAME="flink-${FLINK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala_${SCALA_VERSION}.tgz"
+  CURL_OUTPUT="${TMPDIR}/${FLINK_DIST_FILE_NAME}"
+
+  echo "Downloading ${FLINK_DIST_FILE_NAME} from ${FLINK_BASE_URL}"
+  curl -s ${FLINK_BASE_URL}${FLINK_DIST_FILE_NAME} --output ${CURL_OUTPUT}
+
+  FLINK_DIST="${CURL_OUTPUT}"
+
+elif [ -n "${FROM_LOCAL}" ]; then
+
+  DIST_DIR="../../flink-dist/target/flink-*-bin"
+  FLINK_DIST="${TMPDIR}/flink.tgz"
+  echo "Using flink dist: ${DIST_DIR}"
+  tar -C ${DIST_DIR} -cvzf "${FLINK_DIST}" .
+
+else
+
+  usage
+
+fi
+
+docker build --build-arg flink_dist="${FLINK_DIST}" --build-arg job_jar="${JOB_JAR_TARGET}" -t "${IMAGE_NAME}" .

--- a/flink-container/docker/docker-compose.yml
+++ b/flink-container/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set the FLINK_DOCKER_IMAGE_NAME environment variable to override the image name to use
+
+version: "2.1"
+services:
+  job-cluster:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}
+    ports:
+      - "8081:8081"
+    command: job-cluster --job-classname ${FLINK_JOB} -Djobmanager.rpc.address=job-cluster
+
+  taskmanager:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}
+    command: task-manager -Djobmanager.rpc.address=job-cluster

--- a/flink-container/docker/docker-entrypoint.sh
+++ b/flink-container/docker/docker-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+### If unspecified, the hostname of the container is taken as the JobManager address
+FLINK_HOME=${FLINK_HOME:-"/opt/flink/bin"}
+
+JOB_CLUSTER="job-cluster"
+TASK_MANAGER="task-manager"
+
+CMD="$1"
+shift;
+
+if [ "${CMD}" == "--help" -o "${CMD}" == "-h" ]; then
+    echo "Usage: $(basename $0) (${JOB_CLUSTER}|${TASK_MANAGER})"
+    exit 0
+elif [ "${CMD}" == "${JOB_CLUSTER}" -o "${CMD}" == "${TASK_MANAGER}" ]; then
+    echo "Starting the ${CMD}"
+    echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
+
+    if [ "${CMD}" == "${TASK_MANAGER}" ]; then
+        exec $FLINK_HOME/bin/taskmanager.sh start-foreground "$@"
+    else
+        exec $FLINK_HOME/bin/standalone-job.sh start-foreground "$@"
+    fi
+fi
+
+exec "$@"

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.6-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-container_${scala.binary.version}</artifactId>
+	<name>flink-container</name>
+	<packaging>jar</packaging>
+
+	<dependencies>
+
+		<!--  set all Flink dependencies to provided, so they and their transitive  -->
+		<!-- dependencies do not get promoted to direct dependencies during shading -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.EntrypointClusterConfiguration;
+
+import javax.annotation.Nonnull;
+
+import java.util.Properties;
+
+/**
+ * Configuration for the {@link StandaloneJobClusterEntryPoint}.
+ */
+final class StandaloneJobClusterConfiguration extends EntrypointClusterConfiguration {
+	@Nonnull
+	private final String jobClassName;
+
+	public StandaloneJobClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args, int restPort, @Nonnull String jobClassName) {
+		super(configDir, dynamicProperties, args, restPort);
+		this.jobClassName = jobClassName;
+	}
+
+	@Nonnull
+	String getJobClassName() {
+		return jobClassName;
+	}
+}

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.Properties;
+
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST_PORT_OPTION;
+
+/**
+ * Parser factory which generates a {@link StandaloneJobClusterConfiguration} from a given
+ * list of command line arguments.
+ */
+public class StandaloneJobClusterConfigurationParserFactory implements ParserResultFactory<StandaloneJobClusterConfiguration> {
+
+	private static final Option JOB_CLASS_NAME_OPTION = Option.builder("j")
+		.longOpt("job-classname")
+		.required(true)
+		.hasArg(true)
+		.argName("job class name")
+		.desc("Class name of the job to run.")
+		.build();
+
+	@Override
+	public Options getOptions() {
+		final Options options = new Options();
+		options.addOption(CONFIG_DIR_OPTION);
+		options.addOption(REST_PORT_OPTION);
+		options.addOption(JOB_CLASS_NAME_OPTION);
+		options.addOption(DYNAMIC_PROPERTY_OPTION);
+
+		return options;
+	}
+
+	@Override
+	public StandaloneJobClusterConfiguration createResult(@Nonnull CommandLine commandLine) {
+		final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+		final Properties dynamicProperties = commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
+		final String restPortString = commandLine.getOptionValue(REST_PORT_OPTION.getOpt(), "-1");
+		final int restPort = Integer.parseInt(restPortString);
+		final String jobClassName = commandLine.getOptionValue(JOB_CLASS_NAME_OPTION.getOpt());
+
+		return new StandaloneJobClusterConfiguration(
+			configDir,
+			dynamicProperties,
+			commandLine.getArgs(),
+			restPort,
+			jobClassName);
+	}
+}

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.ClusterInformation;
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServices;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesConfiguration;
+import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.runtime.util.JvmShutdownSafeguard;
+import org.apache.flink.runtime.util.SignalHandler;
+import org.apache.flink.util.FlinkException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link JobClusterEntrypoint} which is started with a job in a predefined
+ * location.
+ */
+public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
+
+	private  static final String[] EMPTY_ARGS = new String[0];
+
+	@Nonnull
+	private final String jobClassName;
+
+	StandaloneJobClusterEntryPoint(Configuration configuration, @Nonnull String jobClassName) {
+		super(configuration);
+		this.jobClassName = jobClassName;
+	}
+
+	@Override
+	protected JobGraph retrieveJobGraph(Configuration configuration) throws FlinkException {
+		final PackagedProgram packagedProgram = createPackagedProgram();
+		final int defaultParallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
+		try {
+			final JobGraph jobGraph = PackagedProgramUtils.createJobGraph(packagedProgram, configuration, defaultParallelism);
+			jobGraph.setAllowQueuedScheduling(true);
+
+			return jobGraph;
+		} catch (Exception e) {
+			throw new FlinkException("Could not create the JobGraph from the provided user code jar.", e);
+		}
+	}
+
+	private PackagedProgram createPackagedProgram() throws FlinkException {
+		try {
+			final Class<?> mainClass = getClass().getClassLoader().loadClass(jobClassName);
+			return new PackagedProgram(mainClass, EMPTY_ARGS);
+		} catch (ClassNotFoundException | ProgramInvocationException e) {
+			throw new FlinkException("Could not load the provied entrypoint class.", e);
+		}
+	}
+
+	@Override
+	protected void registerShutdownActions(CompletableFuture<ApplicationStatus> terminationFuture) {
+		terminationFuture.thenAccept((status) -> shutDownAndTerminate(0, ApplicationStatus.SUCCEEDED, null, true));
+	}
+
+	@Override
+	protected ResourceManager<?> createResourceManager(
+			Configuration configuration,
+			ResourceID resourceId,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			FatalErrorHandler fatalErrorHandler,
+			ClusterInformation clusterInformation,
+			@Nullable String webInterfaceUrl) throws Exception {
+		final ResourceManagerConfiguration resourceManagerConfiguration = ResourceManagerConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration = ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
+			resourceManagerRuntimeServicesConfiguration,
+			highAvailabilityServices,
+			rpcService.getScheduledExecutor());
+
+		return new StandaloneResourceManager(
+			rpcService,
+			ResourceManager.RESOURCE_MANAGER_NAME,
+			resourceId,
+			resourceManagerConfiguration,
+			highAvailabilityServices,
+			heartbeatServices,
+			resourceManagerRuntimeServices.getSlotManager(),
+			metricRegistry,
+			resourceManagerRuntimeServices.getJobLeaderIdService(),
+			clusterInformation,
+			fatalErrorHandler);
+	}
+
+	public static void main(String[] args) {
+		// startup checks and logging
+		EnvironmentInformation.logEnvironmentInfo(LOG, StandaloneJobClusterEntryPoint.class.getSimpleName(), args);
+		SignalHandler.register(LOG);
+		JvmShutdownSafeguard.installAsShutdownHook(LOG);
+
+		final CommandLineParser<StandaloneJobClusterConfiguration> commandLineParser = new CommandLineParser<>(new StandaloneJobClusterConfigurationParserFactory());
+		StandaloneJobClusterConfiguration clusterConfiguration = null;
+
+		try {
+			clusterConfiguration = commandLineParser.parse(args);
+		} catch (FlinkParseException e) {
+			LOG.error("Could not parse command line arguments {}.", args, e);
+			commandLineParser.printHelp();
+			System.exit(1);
+		}
+
+		Configuration configuration = loadConfiguration(clusterConfiguration);
+
+		configuration.setString(ClusterEntrypoint.EXECUTION_MODE, ExecutionMode.DETACHED.toString());
+
+		StandaloneJobClusterEntryPoint entrypoint = new StandaloneJobClusterEntryPoint(configuration, clusterConfiguration.getJobClassName());
+
+		entrypoint.startCluster();
+	}
+
+}

--- a/flink-container/src/main/resources/log4j.properties
+++ b/flink-container/src/main/resources/log4j.properties
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Convenience file for local debugging of the JobManager/TaskManager.
+log4j.rootLogger=OFF, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+log4j.logger.org.apache.flink.mesos=DEBUG
+log4j.logger.org.apache.flink.mesos.runtime.clusterframework.MesosFlinkResourceManager=INFO

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.entrypoint;
+package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.util.TestLogger;
 
@@ -33,24 +34,28 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
- * Tests for the {@link ClusterConfigurationParserFactory}.
+ * Tests for the {@link StandaloneJobClusterConfigurationParserFactory}.
  */
-public class ClusterConfigurationParserFactoryTest extends TestLogger {
+public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogger {
 
 	@Test
 	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
-		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+		final CommandLineParser<StandaloneJobClusterConfiguration> commandLineParser = new CommandLineParser<>(new StandaloneJobClusterConfigurationParserFactory());
 
 		final String configDir = "/foo/bar";
 		final String key = "key";
 		final String value = "value";
+		final int restPort = 1234;
+		final String jobClassName = "foobar";
 		final String arg1 = "arg1";
 		final String arg2 = "arg2";
-		final String[] args = {"--configDir", configDir, String.format("-D%s=%s", key, value), arg1, arg2};
+		final String[] args = {"--configDir", configDir, "--webui-port", String.valueOf(restPort), "--job-classname", jobClassName, String.format("-D%s=%s", key, value), arg1, arg2};
 
-		final ClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
 		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(jobClassName)));
+		assertThat(clusterConfiguration.getRestPort(), is(equalTo(restPort)));
 		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
 
 		assertThat(dynamicProperties, hasEntry(key, value));
@@ -60,19 +65,22 @@ public class ClusterConfigurationParserFactoryTest extends TestLogger {
 
 	@Test
 	public void testOnlyRequiredArguments() throws FlinkParseException {
-		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+		final CommandLineParser<StandaloneJobClusterConfiguration> commandLineParser = new CommandLineParser<>(new StandaloneJobClusterConfigurationParserFactory());
 
 		final String configDir = "/foo/bar";
-		final String[] args = {"--configDir", configDir};
+		final String jobClassName = "foobar";
+		final String[] args = {"--configDir", configDir, "--job-classname", jobClassName};
 
-		final ClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
 		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(jobClassName)));
+		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
 	}
 
 	@Test(expected = FlinkParseException.class)
 	public void testMissingRequiredArgument() throws FlinkParseException {
-		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+		final CommandLineParser<StandaloneJobClusterConfiguration> commandLineParser = new CommandLineParser<>(new StandaloneJobClusterConfigurationParserFactory());
 		final String[] args = {};
 
 		commandLineParser.parse(args);

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPointTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPointTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link StandaloneJobClusterEntryPoint}.
+ */
+public class StandaloneJobClusterEntryPointTest extends TestLogger {
+
+	@Test
+	public void testJobGraphRetrieval() throws FlinkException {
+		final Configuration configuration = new Configuration();
+		final int parallelism = 42;
+		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+		final StandaloneJobClusterEntryPoint standaloneJobClusterEntryPoint = new StandaloneJobClusterEntryPoint(
+			configuration,
+			TestJob.class.getCanonicalName());
+
+		final JobGraph jobGraph = standaloneJobClusterEntryPoint.retrieveJobGraph(configuration);
+
+		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName())));
+		assertThat(jobGraph.getMaximumParallelism(), is(parallelism));
+	}
+
+}

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/TestJob.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/TestJob.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+
+/**
+ * Test job which is used for {@link StandaloneJobClusterEntryPointTest}.
+ */
+public class TestJob {
+
+	public static void main(String[] args) throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		final DataStreamSource<Integer> source = env.fromElements(1, 2, 3, 4);
+		final SingleOutputStreamOperator<Integer> mapper = source.map(element -> 2 * element);
+		mapper.addSink(new DiscardingSink<>());
+
+		env.execute(TestJob.class.getCanonicalName());
+	}
+}

--- a/flink-container/src/test/resources/log4j-test.properties
+++ b/flink-container/src/test/resources/log4j-test.properties
@@ -1,0 +1,32 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=OFF, console
+
+# Log all infos in the given file
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, console
+
+# log whats going on between the tests
+log4j.logger.org.apache.flink.runtime.leaderelection=OFF
+log4j.logger.org.apache.flink.runtime.leaderretrieval=OFF
+

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -21,6 +21,8 @@ package org.apache.flink.configuration;
 import javax.annotation.Nonnull;
 
 import java.io.File;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * Utility class for {@link Configuration} related helper functions.
@@ -52,6 +54,25 @@ public class ConfigurationUtils {
 	public static String[] parseLocalStateDirectories(Configuration configuration) {
 		String configValue = configuration.getString(CheckpointingOptions.LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS, "");
 		return splitPaths(configValue);
+	}
+
+	/**
+	 * Creates a new {@link Configuration} from the given {@link Properties}.
+	 *
+	 * @param properties to convert into a {@link Configuration}
+	 * @return {@link Configuration} which has been populated by the values of the given {@link Properties}
+	 */
+	@Nonnull
+	public static Configuration createConfiguration(Properties properties) {
+		final Configuration configuration = new Configuration();
+
+		final Set<String> propertyNames = properties.stringPropertyNames();
+
+		for (String propertyName : propertyNames) {
+			configuration.setString(propertyName, properties.getProperty(propertyName));
+		}
+
+		return configuration;
 	}
 
 	@Nonnull

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link ConfigurationUtils}.
+ */
+public class ConfigurationUtilsTest extends TestLogger {
+
+	@Test
+	public void testPropertiesToConfiguration() {
+		final Properties properties = new Properties();
+		final int entries = 10;
+
+		for (int i = 0; i < entries; i++) {
+			properties.setProperty("key" + i, "value" + i);
+		}
+
+		final Configuration configuration = ConfigurationUtils.createConfiguration(properties);
+
+		for (String key : properties.stringPropertyNames()) {
+			assertThat(configuration.getString(key, ""), is(equalTo(properties.getProperty(key))));
+		}
+
+		assertThat(configuration.toMap().size(), is(properties.size()));
+	}
+
+}

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -124,6 +124,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-container_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -19,7 +19,7 @@
 
 # Start a Flink service as a console application. Must be stopped with Ctrl-C
 # or with SIGTERM by kill or the controlling process.
-USAGE="Usage: flink-console.sh (jobmanager|taskmanager|historyserver|zookeeper) [args]"
+USAGE="Usage: flink-console.sh (jobmanager|taskmanager|taskexecutor|zookeeper|historyserver|standalonesession|standalonejob) [args]"
 
 SERVICE=$1
 ARGS=("${@:2}") # get remaining arguments as array
@@ -52,6 +52,10 @@ case $SERVICE in
 
     (standalonesession)
         CLASS_TO_RUN=org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint
+    ;;
+
+    (standalonejob)
+        CLASS_TO_RUN=org.apache.flink.container.entrypoint.StandaloneJobClusterEntryPoint
     ;;
 
     (*)

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Start/stop a Flink daemon.
-USAGE="Usage: flink-daemon.sh (start|stop|stop-all) (jobmanager|taskmanager|zookeeper|historyserver) [args]"
+USAGE="Usage: flink-daemon.sh (start|stop|stop-all) (jobmanager|taskmanager|taskexecutor|zookeeper|historyserver|standalonesession|standalonejob) [args]"
 
 STARTSTOP=$1
 DAEMON=$2
@@ -52,6 +52,10 @@ case $DAEMON in
 
     (standalonesession)
         CLASS_TO_RUN=org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint
+    ;;
+
+    (standalonejob)
+        CLASS_TO_RUN=org.apache.flink.container.entrypoint.StandaloneJobClusterEntryPoint
     ;;
 
     (*)

--- a/flink-dist/src/main/flink-bin/bin/standalone-job.sh
+++ b/flink-dist/src/main/flink-bin/bin/standalone-job.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Start/stop a Flink JobManager.
+USAGE="Usage: standalone-job.sh ((start|start-foreground))|stop"
+
+STARTSTOP=$1
+ENTRY_POINT_NAME="standalonejob"
+
+ARGS=("${@:2}")
+
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "start-foreground" ]] && [[ $STARTSTOP != "stop" ]] || [[ -z JOB_CLASSNAME ]]; then
+  echo $USAGE
+  exit 1
+fi
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+. "$bin"/config.sh
+
+if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
+    if [ ! -z "${FLINK_JM_HEAP_MB}" ] && [ "${FLINK_JM_HEAP}" == 0 ]; then
+	    echo "used deprecated key \`${KEY_JOBM_MEM_MB}\`, please replace with key \`${KEY_JOBM_MEM_SIZE}\`"
+    else
+	    flink_jm_heap_bytes=$(parseBytes ${FLINK_JM_HEAP})
+	    FLINK_JM_HEAP_MB=$(getMebiBytes ${flink_jm_heap_bytes})
+    fi
+
+    if [[ ! ${FLINK_JM_HEAP_MB} =~ $IS_NUMBER ]] || [[ "${FLINK_JM_HEAP_MB}" -lt "0" ]]; then
+        echo "[ERROR] Configured memory size is not a valid value. Please set '${KEY_JOBM_MEM_SIZE}' in ${FLINK_CONF_FILE}."
+        exit 1
+    fi
+
+    if [ "${FLINK_JM_HEAP_MB}" -gt "0" ]; then
+        export JVM_ARGS="$JVM_ARGS -Xms"$FLINK_JM_HEAP_MB"m -Xmx"$FLINK_JM_HEAP_MB"m"
+    fi
+
+    # Add cluster entry point specific JVM options
+    export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_JM}"
+
+    # Startup parameters
+    ARGS+=("--configDir" "${FLINK_CONF_DIR}")
+fi
+
+if [[ $STARTSTOP == "start-foreground" ]]; then
+    exec "${FLINK_BIN_DIR}"/flink-console.sh $ENTRY_POINT_NAME "${ARGS[@]}"
+else
+    "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP $ENTRY_POINT_NAME "${ARGS[@]}"
+fi

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.Properties;
+
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
+
+/**
+ * Parser factory which generates a {@link ClusterConfiguration} from the given
+ * list of command line arguments.
+ */
+public class ClusterConfigurationParserFactory implements ParserResultFactory<ClusterConfiguration> {
+
+	@Override
+	public Options getOptions() {
+		final Options options = new Options();
+		options.addOption(CONFIG_DIR_OPTION);
+		options.addOption(DYNAMIC_PROPERTY_OPTION);
+
+		return options;
+	}
+
+	@Override
+	public ClusterConfiguration createResult(@Nonnull CommandLine commandLine) {
+		final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+
+		final Properties dynamicProperties = commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
+
+		return new ClusterConfiguration(configDir, dynamicProperties, commandLine.getArgs());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -688,14 +689,15 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		Configuration configuration,
 		ScheduledExecutor scheduledExecutor) throws IOException;
 
-	private static EntrypointClusterConfiguration parseArguments(String[] args) throws FlinkParseException {
+	protected static EntrypointClusterConfiguration parseArguments(String[] args) throws FlinkParseException {
 		final CommandLineParser<EntrypointClusterConfiguration> clusterConfigurationParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
 
 		return clusterConfigurationParser.parse(args);
 	}
 
 	protected static Configuration loadConfiguration(EntrypointClusterConfiguration entrypointClusterConfiguration) {
-		final Configuration configuration = GlobalConfiguration.loadConfiguration(entrypointClusterConfiguration.getConfigDir());
+		final Configuration dynamicProperties = ConfigurationUtils.createConfiguration(entrypointClusterConfiguration.getDynamicProperties());
+		final Configuration configuration = GlobalConfiguration.loadConfiguration(entrypointClusterConfiguration.getConfigDir(), dynamicProperties);
 
 		final int restPort = entrypointClusterConfiguration.getRestPort();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfiguration.java
@@ -23,38 +23,18 @@ import javax.annotation.Nonnull;
 import java.util.Properties;
 
 /**
- * Configuration class which contains the parsed command line arguments for
- * the {@link ClusterEntrypoint}.
+ * Basic {@link ClusterConfiguration} for entry points.
  */
-public class ClusterConfiguration {
+public class EntrypointClusterConfiguration extends ClusterConfiguration {
 
-	@Nonnull
-	private final String configDir;
+	private final int restPort;
 
-	@Nonnull
-	private final Properties dynamicProperties;
-
-	@Nonnull
-	private final String[] args;
-
-	public ClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args) {
-		this.configDir = configDir;
-		this.dynamicProperties = dynamicProperties;
-		this.args = args;
+	public EntrypointClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args, int restPort) {
+		super(configDir, dynamicProperties, args);
+		this.restPort = restPort;
 	}
 
-	@Nonnull
-	public String getConfigDir() {
-		return configDir;
-	}
-
-	@Nonnull
-	public Properties getDynamicProperties() {
-		return dynamicProperties;
-	}
-
-	@Nonnull
-	public String[] getArgs() {
-		return args;
+	public int getRestPort() {
+		return restPort;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.Properties;
+
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST_PORT_OPTION;
+
+/**
+ * Parser factory for {@link EntrypointClusterConfiguration}.
+ */
+public class EntrypointClusterConfigurationParserFactory implements ParserResultFactory<EntrypointClusterConfiguration> {
+
+	@Override
+	public Options getOptions() {
+		final Options options = new Options();
+		options.addOption(CONFIG_DIR_OPTION);
+		options.addOption(REST_PORT_OPTION);
+		options.addOption(DYNAMIC_PROPERTY_OPTION);
+
+		return options;
+	}
+
+	@Override
+	public EntrypointClusterConfiguration createResult(@Nonnull CommandLine commandLine) {
+		final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+		final Properties dynamicProperties = commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
+		final String restPortStr = commandLine.getOptionValue(REST_PORT_OPTION.getOpt(), "-1");
+		final int restPort = Integer.parseInt(restPortStr);
+
+		return new EntrypointClusterConfiguration(
+			configDir,
+			dynamicProperties,
+			commandLine.getArgs(),
+			restPort);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/FlinkParseException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/FlinkParseException.java
@@ -18,43 +18,25 @@
 
 package org.apache.flink.runtime.entrypoint;
 
-import javax.annotation.Nonnull;
-
-import java.util.Properties;
+import org.apache.flink.util.FlinkException;
 
 /**
- * Configuration class which contains the parsed command line arguments for
- * the {@link ClusterEntrypoint}.
+ * Exception which indicates that the parsing of command line
+ * arguments failed.
  */
-public class ClusterConfiguration {
+public class FlinkParseException extends FlinkException {
 
-	@Nonnull
-	private final String configDir;
+	private static final long serialVersionUID = 5164983338744708430L;
 
-	@Nonnull
-	private final Properties dynamicProperties;
-
-	@Nonnull
-	private final String[] args;
-
-	public ClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args) {
-		this.configDir = configDir;
-		this.dynamicProperties = dynamicProperties;
-		this.args = args;
+	public FlinkParseException(String message) {
+		super(message);
 	}
 
-	@Nonnull
-	public String getConfigDir() {
-		return configDir;
+	public FlinkParseException(Throwable cause) {
+		super(cause);
 	}
 
-	@Nonnull
-	public Properties getDynamicProperties() {
-		return dynamicProperties;
-	}
-
-	@Nonnull
-	public String[] getArgs() {
-		return args;
+	public FlinkParseException(String message, Throwable cause) {
+		super(message, cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.commons.cli.Option;
+
+/**
+ * Container class for command line options.
+ */
+public class CommandLineOptions {
+
+	public static final Option CONFIG_DIR_OPTION = Option.builder("c")
+		.longOpt("configDir")
+		.required(true)
+		.hasArg(true)
+		.argName("configuration directory")
+		.desc("Directory which contains the configuration file flink-conf.yml.")
+		.build();
+
+	public static final Option REST_PORT_OPTION = Option.builder("r")
+		.longOpt("webui-port")
+		.required(false)
+		.hasArg(true)
+		.argName("rest port")
+		.desc("Port for the rest endpoint and the web UI.")
+		.build();
+
+	public static final Option DYNAMIC_PROPERTY_OPTION = Option.builder("D")
+		.argName("property=value")
+		.numberOfArgs(2)
+		.valueSeparator('=')
+		.desc("use value for given property")
+		.build();
+
+	private CommandLineOptions() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineParser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineParser.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Command line parser which produces a result from the given
+ * command line arguments.
+ */
+public class CommandLineParser<T> {
+
+	@Nonnull
+	private final ParserResultFactory<T> parserResultFactory;
+
+	public CommandLineParser(@Nonnull ParserResultFactory<T> parserResultFactory) {
+		this.parserResultFactory = parserResultFactory;
+	}
+
+	public T parse(@Nonnull String[] args) throws FlinkParseException {
+		final DefaultParser parser = new DefaultParser();
+		final Options options = parserResultFactory.getOptions();
+
+		final CommandLine commandLine;
+		try {
+			commandLine = parser.parse(options, args, true);
+		} catch (ParseException e) {
+			throw new FlinkParseException("Failed to parse the command line arguments.", e);
+		}
+
+		return parserResultFactory.createResult(commandLine);
+	}
+
+	public void printHelp() {
+		final HelpFormatter helpFormatter = new HelpFormatter();
+		helpFormatter.printHelp("", parserResultFactory.getOptions());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ParserResultFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ParserResultFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Parser result factory used by the {@link CommandLineParser}.
+ *
+ * @param <T> type of the parsed result
+ */
+public interface ParserResultFactory<T> {
+
+	/**
+	 * Returns all relevant {@link Options} for parsing the command line
+	 * arguments.
+	 *
+	 * @return Options to use for the parsing
+	 */
+	Options getOptions();
+
+	/**
+	 * Create the result of the command line argument parsing.
+	 *
+	 * @param commandLine to extract the options from
+	 * @return Result of the parsing
+	 */
+	T createResult(@Nonnull CommandLine commandLine);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -19,9 +19,9 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
@@ -29,6 +29,10 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.entrypoint.ClusterConfiguration;
+import org.apache.flink.runtime.entrypoint.ClusterConfigurationParserFactory;
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -274,11 +278,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			LOG.info("Cannot determine the maximum number of open file descriptors");
 		}
 
-		ParameterTool parameterTool = ParameterTool.fromArgs(args);
-
-		final String configDir = parameterTool.get("configDir");
-
-		final Configuration configuration = GlobalConfiguration.loadConfiguration(configDir);
+		final Configuration configuration = loadConfiguration(args);
 
 		try {
 			FileSystem.initialize(configuration);
@@ -301,6 +301,23 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			LOG.error("TaskManager initialization failed.", t);
 			System.exit(STARTUP_FAILURE_RETURN_CODE);
 		}
+	}
+
+	private static Configuration loadConfiguration(String[] args) throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+
+		final ClusterConfiguration clusterConfiguration;
+
+		try {
+			clusterConfiguration = commandLineParser.parse(args);
+		} catch (FlinkParseException e) {
+			LOG.error("Could not parse the command line options.", e);
+			commandLineParser.printHelp();
+			throw e;
+		}
+
+		final Configuration dynamicProperties = ConfigurationUtils.createConfiguration(clusterConfiguration.getDynamicProperties());
+		return GlobalConfiguration.loadConfiguration(clusterConfiguration.getConfigDir(), dynamicProperties);
 	}
 
 	public static void runTaskManager(Configuration configuration, ResourceID resourceId) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterConfigurationParserFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link ClusterConfigurationParserFactory}.
+ */
+public class ClusterConfigurationParserFactoryTest extends TestLogger {
+
+	@Test
+	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final String key = "key";
+		final String value = "value";
+		final String arg1 = "arg1";
+		final String arg2 = "arg2";
+		final String[] args = {"--configDir", configDir, String.format("-D%s=%s", key, value), arg1, arg2};
+
+		final ClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
+
+		assertThat(dynamicProperties, hasEntry(key, value));
+
+		assertThat(clusterConfiguration.getArgs(), arrayContaining(arg1, arg2));
+	}
+
+	@Test
+	public void testOnlyRequiredArguments() throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final String[] args = {"--configDir", configDir};
+
+		final ClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testMissingRequiredArgument() throws FlinkParseException {
+		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
+		final String[] args = {};
+
+		commandLineParser.parse(args);
+		fail("Expected an FlinkParseException.");
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link EntrypointClusterConfigurationParserFactory}.
+ */
+public class EntrypointClusterConfigurationParserFactoryTest extends TestLogger {
+
+	@Test
+	public void testEntrypointClusterConfigurationParsing() throws FlinkParseException {
+		final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final int restPort = 1234;
+		final String key = "key";
+		final String value = "value";
+		final String arg1 = "arg1";
+		final String arg2 = "arg2";
+		final String[] args = {"--configDir", configDir, "-r", String.valueOf(restPort), String.format("-D%s=%s", key, value), arg1, arg2};
+
+		final EntrypointClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getRestPort(), is(equalTo(restPort)));
+		final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
+
+		assertThat(dynamicProperties, hasEntry(key, value));
+
+		assertThat(clusterConfiguration.getArgs(), arrayContaining(arg1, arg2));
+	}
+
+	@Test
+	public void testOnlyRequiredArguments() throws FlinkParseException {
+		final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+
+		final String configDir = "/foo/bar";
+		final String[] args = {"--configDir", configDir};
+
+		final EntrypointClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
+	}
+
+	@Test(expected = FlinkParseException.class)
+	public void testMissingRequiredArgument() throws FlinkParseException {
+		final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+		final String[] args = {};
+
+		commandLineParser.parse(args);
+		fail("Expected an FlinkParseException.");
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@ under the License.
 		<module>flink-formats</module>
 		<module>flink-examples</module>
 		<module>flink-clients</module>
+		<module>flink-container</module>
 		<module>flink-queryable-state</module>
 		<module>flink-tests</module>
 		<module>flink-end-to-end-tests</module>


### PR DESCRIPTION
## What is the purpose of the change

This commit adds a Dockerfile for a standalone job cluster image. The image
contains the Flink distribution and a specified user code jar. The entrypoint
will start the StandaloneJobClusterEntryPoint with the provided job classname.

This PR is based on #6318.

cc @GJL 

## Verifying this change

- Manually tested

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (yes)
