### PR TITLE
[FLINK-9829] fix the wrapper classes be compared by symbol of '==' directly in BigDecSerializer.java

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BigDecSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BigDecSerializer.java
@@ -49,7 +49,7 @@ public final class BigDecSerializer extends TypeSerializerSingleton<BigDecimal> 
 	public BigDecimal copy(BigDecimal from) {
 		return from;
 	}
-	
+
 	@Override
 	public BigDecimal copy(BigDecimal from, BigDecimal reuse) {
 		return from;
@@ -69,17 +69,17 @@ public final class BigDecSerializer extends TypeSerializerSingleton<BigDecimal> 
 		}
 		// fast paths for 0, 1, 10
 		// only reference equality is checked because equals would be too expensive
-		else if (record == BigDecimal.ZERO) {
+		else if (BigDecimal.ZERO.equals(record)) {
 			BigIntSerializer.writeBigInteger(BigInteger.ZERO, target);
 			target.writeInt(0);
 			return;
 		}
-		else if (record == BigDecimal.ONE) {
+		else if (BigDecimal.ONE.equals(record)) {
 			BigIntSerializer.writeBigInteger(BigInteger.ONE, target);
 			target.writeInt(0);
 			return;
 		}
-		else if (record == BigDecimal.TEN) {
+		else if (BigDecimal.TEN.equals(record)) {
 			BigIntSerializer.writeBigInteger(BigInteger.TEN, target);
 			target.writeInt(0);
 			return;


### PR DESCRIPTION
## What is the purpose of the change
  - fix the wrapper classes be compared by symbol of '==' directly in BigDecSerializer.java

## Brief change log

  - The wrapper classes should be compared by equals method rather than by symbol of '==' directly
  - should use `equal` method

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
