### PR TITLE
[FLINK-9575]: Remove job-related BLOBS only if the job was removed suce…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -574,11 +574,11 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		return jobManagerRunnerTerminationFuture.thenRunAsync(
 			() -> {
 				jobManagerMetricGroup.removeJob(jobId);
-				blobServer.cleanupJob(jobId, cleanupHA);
 
 				if (cleanupHA) {
 					try {
 						submittedJobGraphStore.removeJobGraph(jobId);
+						blobServer.cleanupJob(jobId, cleanupHA);
 					} catch (Exception e) {
 						log.warn("Could not properly remove job {} from submitted job graph store.", jobId);
 					}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1775,7 +1775,6 @@ class JobManager(
       case None => None
     }
 
-
     futureOption
   }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -313,17 +313,16 @@ public class DispatcherTest extends TestLogger {
 			.setJobID(TEST_JOB_ID)
 			.setState(JobStatus.CANCELED)
 			.build();
-
-
+		
 		dispatcher.completeJobExecution(executionGraph);
 
-		assertThat(dispatcher.listJobs(TIMEOUT).get(), is(not(empty())));
+		//Assert that blob was not removed, since exception was thrown while removing the job
 		assertThat(blobServer.getFile(TEST_JOB_ID, key), notNullValue(File.class));
 
 		submittedJobGraphStore.setRemovalFailure(null);
-
 		dispatcher.completeJobExecution(executionGraph);
-		assertThat(dispatcher.listJobs(TIMEOUT).get(), is(empty()));
+		//Job removing did not throw exception now, blob should be null
+
 		expectedException.expect(NoSuchFileException.class);
 		blobServer.getFile(TEST_JOB_ID, key);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -103,6 +103,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -103,7 +103,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -313,16 +312,14 @@ public class DispatcherTest extends TestLogger {
 			.setJobID(TEST_JOB_ID)
 			.setState(JobStatus.CANCELED)
 			.build();
-		
-		dispatcher.completeJobExecution(executionGraph);
 
+		dispatcher.completeJobExecution(executionGraph);
 		//Assert that blob was not removed, since exception was thrown while removing the job
 		assertThat(blobServer.getFile(TEST_JOB_ID, key), notNullValue(File.class));
-
 		submittedJobGraphStore.setRemovalFailure(null);
 		dispatcher.completeJobExecution(executionGraph);
-		//Job removing did not throw exception now, blob should be null
 
+		//Job removing did not throw exception now, blob should be null
 		expectedException.expect(NoSuchFileException.class);
 		blobServer.getFile(TEST_JOB_ID, key);
 	}
@@ -658,6 +655,7 @@ public class DispatcherTest extends TestLogger {
 		void setRecoveryFailure(@Nullable Exception recoveryFailure) {
 			this.recoveryFailure = recoveryFailure;
 		}
+
 		void setRemovalFailure(@Nullable Exception removalFailure) {
 			this.removalFailure = removalFailure;
 		}
@@ -673,7 +671,7 @@ public class DispatcherTest extends TestLogger {
 
 		@Override
 		public synchronized void removeJobGraph(JobID jobId) throws Exception {
-			if(removalFailure != null) {
+			if (removalFailure != null) {
 				throw removalFailure;
 			} else {
 				super.removeJobGraph(jobId);


### PR DESCRIPTION
## What is the purpose of the change

Currently flink removes all blobs connected with the job, no matter if the job itself was removed successfully. This is not the desired behavior.

## Brief change log
- Blobs and data will be removed only if the job itself will be removed sucessfully

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
