### PR TITLE
Mutual authentication for internal communication

### DIFF
--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -53,9 +53,14 @@
             <td>File system path (URI) where Flink persists metadata in high-availability setups.</td>
         </tr>
         <tr>
-            <td><h5>security.ssl.enabled</h5></td>
+            <td><h5>security.ssl.internal.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
-            <td>Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules.</td>
+            <td>Turns on SSL for internal network communication. Optionally, specific components may override this through their own settings (rpc, data transport, REST, etc).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Turns on SSL for external communication via the REST endpoints.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -13,9 +13,34 @@
             <td>The comma separated list of standard SSL algorithms to be supported. Read more &#60;a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites"&#62;here&#60;/a&#62;.</td>
         </tr>
         <tr>
-            <td><h5>security.ssl.enabled</h5></td>
+            <td><h5>security.ssl.internal.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
-            <td>Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules.</td>
+            <td>Turns on SSL for internal network communication. Optionally, specific components may override this through their own settings (rpc, data transport, REST, etc).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.internal.key-password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The secret to decrypt the key in the keystore for Flink's internal endpoints (rpc, data transport, blob server).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.internal.keystore</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The Java keystore file with SSL Key and Certificate, to be used Flink's internal endpoints (rpc, data transport, blob server).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.internal.keystore-password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The secret to decrypt the keystore file for Flink's for Flink's internal endpoints (rpc, data transport, blob server).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.internal.truststore</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The truststore file containing the public CA certificates to verify the peer for Flink's internal endpoints (rpc, data transport, blob server).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.internal.truststore-password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The password to decrypt the truststore for Flink's internal endpoints (rpc, data transport, blob server).</td>
         </tr>
         <tr>
             <td><h5>security.ssl.key-password</h5></td>
@@ -36,6 +61,36 @@
             <td><h5>security.ssl.protocol</h5></td>
             <td style="word-wrap: break-word;">"TLSv1.2"</td>
             <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Turns on SSL for external communication via the REST endpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.key-password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The secret to decrypt the key in the keystore for Flink's external REST endpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.keystore</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The Java keystore file with SSL Key and Certificate, to be used Flink's external REST endpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.keystore-password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The secret to decrypt the keystore file for Flink's for Flink's external REST endpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.truststore</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The truststore file containing the public CA certificates to verify the peer for Flink's external REST endpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.rest.truststore-password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The password to decrypt the truststore for Flink's external REST endpoints.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.truststore</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -35,7 +35,7 @@
         <tr>
             <td><h5>taskmanager.data.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
-            <td>Enable SSL support for the taskmanager data transport. This is applicable only when the global ssl flag security.ssl.enabled is set to true</td>
+            <td>Enable SSL support for the taskmanager data transport. This is applicable only when the global flag for internal SSL (security.ssl.internal.enabled) is set to true</td>
         </tr>
         <tr>
             <td><h5>taskmanager.debug.memory.log</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -80,7 +80,7 @@ public class HistoryServerOptions {
 
 	/**
 	 * Enables/Disables SSL support for the HistoryServer web-frontend. Only relevant if
-	 * {@link SecurityOptions#SSL_ENABLED} is enabled.
+	 * {@link SecurityOptions#SSL_REST_ENABLED} is enabled.
 	 */
 	public static final ConfigOption<Boolean> HISTORY_SERVER_WEB_SSL_ENABLED =
 		key("historyserver.web.ssl.enabled")

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -85,14 +85,40 @@ public class SecurityOptions {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Enable SSL support.
+	 * Enable SSL for internal (rpc, data transport, blob server) and external (HTTP/REST) communication.
+	 *
+	 * @deprecated Use {@link #SSL_INTERNAL_ENABLED} and {@link #SSL_REST_ENABLED} instead.
 	 */
-	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_SECURITY)
+	@Deprecated
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("security.ssl.enabled")
 			.defaultValue(false)
-			.withDescription("Turns on SSL for internal network communication. This can be optionally overridden by" +
-				" flags defined in different transport modules.");
+			.withDescription("Turns on SSL for internal and external network communication." +
+					"This can be overridden by 'security.ssl.internal.enabled', 'security.ssl.external.enabled'. " +
+					"Specific internal components (rpc, data transport, blob server) may optionally override " +
+					"this through their own settings.");
+
+	/**
+	 * Enable SSL for internal communication (akka rpc, netty data transport, blob server).
+	 */
+	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_SECURITY)
+	public static final ConfigOption<Boolean> SSL_INTERNAL_ENABLED =
+			key("security.ssl.internal.enabled")
+			.defaultValue(false)
+			.withDescription("Turns on SSL for internal network communication. " +
+					"Optionally, specific components may override this through their own settings " +
+					"(rpc, data transport, REST, etc).");
+
+	/**
+	 * Enable SSL for external REST endpoints.
+	 */
+	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_SECURITY)
+	public static final ConfigOption<Boolean> SSL_REST_ENABLED =
+			key("security.ssl.rest.enabled")
+			.defaultValue(false)
+			.withDescription("Turns on SSL for external communication via the REST endpoints.");
+
+	// ----------------- certificates (internal + external) -------------------
 
 	/**
 	 * The Java keystore file containing the flink endpoint key and certificate.
@@ -134,6 +160,102 @@ public class SecurityOptions {
 		key("security.ssl.truststore-password")
 			.noDefaultValue()
 			.withDescription("The secret to decrypt the truststore.");
+
+	// ----------------------- certificates (internal) ------------------------
+
+	/**
+	 * For internal SSL, the Java keystore file containing the private key and certificate.
+	 */
+	public static final ConfigOption<String> SSL_INTERNAL_KEYSTORE =
+			key("security.ssl.internal.keystore")
+					.noDefaultValue()
+					.withDescription("The Java keystore file with SSL Key and Certificate, " +
+							"to be used Flink's internal endpoints (rpc, data transport, blob server).");
+
+	/**
+	 * For internal SSL, the password to decrypt the keystore file containing the certificate.
+	 */
+	public static final ConfigOption<String> SSL_INTERNAL_KEYSTORE_PASSWORD =
+			key("security.ssl.internal.keystore-password")
+					.noDefaultValue()
+					.withDescription("The secret to decrypt the keystore file for Flink's " +
+							"for Flink's internal endpoints (rpc, data transport, blob server).");
+
+	/**
+	 * For internal SSL, the password to decrypt the private key.
+	 */
+	public static final ConfigOption<String> SSL_INTERNAL_KEY_PASSWORD =
+			key("security.ssl.internal.key-password")
+					.noDefaultValue()
+					.withDescription("The secret to decrypt the key in the keystore " +
+							"for Flink's internal endpoints (rpc, data transport, blob server).");
+
+	/**
+	 * For internal SSL, the truststore file containing the public CA certificates to verify the ssl peers.
+	 */
+	public static final ConfigOption<String> SSL_INTERNAL_TRUSTSTORE =
+			key("security.ssl.internal.truststore")
+					.noDefaultValue()
+					.withDescription("The truststore file containing the public CA certificates to verify the peer " +
+							"for Flink's internal endpoints (rpc, data transport, blob server).");
+
+	/**
+	 * For internal SSL, the secret to decrypt the truststore.
+	 */
+	public static final ConfigOption<String> SSL_INTERNAL_TRUSTSTORE_PASSWORD =
+			key("security.ssl.internal.truststore-password")
+					.noDefaultValue()
+					.withDescription("The password to decrypt the truststore " +
+							"for Flink's internal endpoints (rpc, data transport, blob server).");
+
+	// ----------------------- certificates (external) ------------------------
+
+	/**
+	 * For external (REST) SSL, the Java keystore file containing the private key and certificate.
+	 */
+	public static final ConfigOption<String> SSL_REST_KEYSTORE =
+			key("security.ssl.rest.keystore")
+					.noDefaultValue()
+					.withDescription("The Java keystore file with SSL Key and Certificate, " +
+							"to be used Flink's external REST endpoints.");
+
+	/**
+	 * For external (REST) SSL, the password to decrypt the keystore file containing the certificate.
+	 */
+	public static final ConfigOption<String> SSL_REST_KEYSTORE_PASSWORD =
+			key("security.ssl.rest.keystore-password")
+					.noDefaultValue()
+					.withDescription("The secret to decrypt the keystore file for Flink's " +
+							"for Flink's external REST endpoints.");
+
+	/**
+	 * For external (REST) SSL, the password to decrypt the private key.
+	 */
+	public static final ConfigOption<String> SSL_REST_KEY_PASSWORD =
+			key("security.ssl.rest.key-password")
+					.noDefaultValue()
+					.withDescription("The secret to decrypt the key in the keystore " +
+							"for Flink's external REST endpoints.");
+
+	/**
+	 * For external (REST) SSL, the truststore file containing the public CA certificates to verify the ssl peers.
+	 */
+	public static final ConfigOption<String> SSL_REST_TRUSTSTORE =
+			key("security.ssl.rest.truststore")
+					.noDefaultValue()
+					.withDescription("The truststore file containing the public CA certificates to verify the peer " +
+							"for Flink's external REST endpoints.");
+
+	/**
+	 * For external (REST) SSL, the secret to decrypt the truststore.
+	 */
+	public static final ConfigOption<String> SSL_REST_TRUSTSTORE_PASSWORD =
+			key("security.ssl.rest.truststore-password")
+					.noDefaultValue()
+					.withDescription("The password to decrypt the truststore " +
+							"for Flink's external REST endpoints.");
+
+	// ------------------------ ssl parameters --------------------------------
 
 	/**
 	 * SSL protocol version to be supported.

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -116,7 +116,7 @@ public class TaskManagerOptions {
 		key("taskmanager.data.ssl.enabled")
 			.defaultValue(true)
 			.withDescription("Enable SSL support for the taskmanager data transport. This is applicable only when the" +
-				" global ssl flag " + SecurityOptions.SSL_ENABLED.key() + " is set to true");
+				" global flag for internal SSL (" + SecurityOptions.SSL_INTERNAL_ENABLED.key() + ") is set to true");
 
 	/**
 	 * The initial registration backoff between two consecutive registration attempts. The backoff

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.HistoryServerOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.history.FsJobArchivist;
+import org.apache.flink.runtime.net.SSLEngineFactory;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.rest.handler.legacy.DashboardConfigHandler;
 import org.apache.flink.runtime.rest.handler.router.Router;
@@ -41,8 +42,6 @@ import org.apache.flink.util.ShutdownHookUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLContext;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -89,7 +88,7 @@ public class HistoryServer {
 
 	private final HistoryServerArchiveFetcher archiveFetcher;
 
-	private final SSLContext serverSSLContext;
+	private final SSLEngineFactory serverSSLFactory;
 	private WebFrontendBootstrap netty;
 
 	private final Object startupShutdownLock = new Object();
@@ -143,15 +142,15 @@ public class HistoryServer {
 		Preconditions.checkNotNull(numFinishedPolls);
 
 		this.config = config;
-		if (config.getBoolean(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED) && SSLUtils.getSSLEnabled(config)) {
+		if (config.getBoolean(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED) && SSLUtils.isRestSSLEnabled(config)) {
 			LOG.info("Enabling SSL for the history server.");
 			try {
-				this.serverSSLContext = SSLUtils.createSSLServerContext(config);
+				this.serverSSLFactory = SSLUtils.createRestServerSSLEngineFactory(config);
 			} catch (Exception e) {
 				throw new IOException("Failed to initialize SSLContext for the history server.", e);
 			}
 		} else {
-			this.serverSSLContext = null;
+			this.serverSSLFactory = null;
 		}
 
 		webAddress = config.getString(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS);
@@ -231,7 +230,7 @@ public class HistoryServer {
 
 			archiveFetcher.start();
 
-			netty = new WebFrontendBootstrap(router, LOG, webDir, serverSSLContext, webAddress, webPort, config);
+			netty = new WebFrontendBootstrap(router, LOG, webDir, serverSSLFactory, webAddress, webPort, config);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -84,7 +83,7 @@ public final class BlobClient implements Closeable {
 
 		try {
 			// create an SSL socket if configured
-			if (clientConfig.getBoolean(SecurityOptions.SSL_ENABLED) && clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
+			if (SSLUtils.isInternalSSLEnabled(clientConfig) && clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
 				LOG.info("Using ssl connection to the blob server");
 
 				socket = SSLUtils.createSSLClientSocketFactory(clientConfig).createSocket(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -30,9 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLSocket;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -68,7 +66,7 @@ public final class BlobClient implements Closeable {
 	private static final Logger LOG = LoggerFactory.getLogger(BlobClient.class);
 
 	/** The socket connection to the BLOB server. */
-	private Socket socket;
+	private final Socket socket;
 
 	/**
 	 * Instantiates a new BLOB client.
@@ -82,41 +80,28 @@ public final class BlobClient implements Closeable {
 	 *         thrown if the connection to the BLOB server could not be established
 	 */
 	public BlobClient(InetSocketAddress serverAddress, Configuration clientConfig) throws IOException {
+		Socket socket = null;
 
 		try {
-			// Check if ssl is enabled
-			SSLContext clientSSLContext = null;
-			if (clientConfig != null &&
-				clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
-
-				clientSSLContext = SSLUtils.createSSLClientContext(clientConfig);
-			}
-
-			if (clientSSLContext != null) {
-
+			// create an SSL socket if configured
+			if (clientConfig.getBoolean(SecurityOptions.SSL_ENABLED) && clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
 				LOG.info("Using ssl connection to the blob server");
 
-				SSLSocket sslSocket = (SSLSocket) clientSSLContext.getSocketFactory().createSocket(
+				socket = SSLUtils.createSSLClientSocketFactory(clientConfig).createSocket(
 					serverAddress.getAddress(),
 					serverAddress.getPort());
-
-				// Enable hostname verification for remote SSL connections
-				if (!serverAddress.getAddress().isLoopbackAddress()) {
-					SSLParameters newSSLParameters = sslSocket.getSSLParameters();
-					SSLUtils.setSSLVerifyHostname(clientConfig, newSSLParameters);
-					sslSocket.setSSLParameters(newSSLParameters);
-				}
-				this.socket = sslSocket;
-			} else {
-				this.socket = new Socket();
-				this.socket.connect(serverAddress);
 			}
-
+			else {
+				socket = new Socket();
+				socket.connect(serverAddress);
+			}
 		}
 		catch (Exception e) {
 			BlobUtils.closeSilently(socket, LOG);
 			throw new IOException("Could not connect to BlobServer at address " + serverAddress, e);
 		}
+
+		this.socket = socket;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
@@ -176,7 +175,7 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 		final Iterator<Integer> ports = NetUtils.getPortRangeFromString(serverPortRange);
 
 		final ServerSocketFactory socketFactory;
-		if (config.getBoolean(SecurityOptions.SSL_ENABLED) && config.getBoolean(BlobServerOptions.SSL_ENABLED)) {
+		if (SSLUtils.isInternalSSLEnabled(config) && config.getBoolean(BlobServerOptions.SSL_ENABLED)) {
 			try {
 				socketFactory = SSLUtils.createSSLServerSocketFactory(config);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
@@ -33,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
+import javax.net.ServerSocketFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -77,9 +78,6 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 
 	/** The server socket listening for incoming connections. */
 	private final ServerSocket serverSocket;
-
-	/** The SSL server context if ssl is enabled for the connections. */
-	private final SSLContext serverSSLContext;
 
 	/** Blob Server configuration. */
 	private final Configuration blobServiceConfiguration;
@@ -172,40 +170,30 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 
 		this.shutdownHook = ShutdownHookUtil.addShutdownHook(this, getClass().getSimpleName(), LOG);
 
-		if (config.getBoolean(BlobServerOptions.SSL_ENABLED)) {
-			try {
-				serverSSLContext = SSLUtils.createSSLServerContext(config);
-			} catch (Exception e) {
-				throw new IOException("Failed to initialize SSLContext for the blob server", e);
-			}
-		} else {
-			serverSSLContext = null;
-		}
-
 		//  ----------------------- start the server -------------------
 
-		String serverPortRange = config.getString(BlobServerOptions.PORT);
+		final String serverPortRange = config.getString(BlobServerOptions.PORT);
+		final Iterator<Integer> ports = NetUtils.getPortRangeFromString(serverPortRange);
 
-		Iterator<Integer> ports = NetUtils.getPortRangeFromString(serverPortRange);
+		final ServerSocketFactory socketFactory;
+		if (config.getBoolean(SecurityOptions.SSL_ENABLED) && config.getBoolean(BlobServerOptions.SSL_ENABLED)) {
+			try {
+				socketFactory = SSLUtils.createSSLServerSocketFactory(config);
+			}
+			catch (Exception e) {
+				throw new IOException("Failed to initialize SSL for the blob server", e);
+			}
+		}
+		else {
+			socketFactory = ServerSocketFactory.getDefault();
+		}
 
 		final int finalBacklog = backlog;
-		ServerSocket socketAttempt = NetUtils.createSocketFromPorts(ports, new NetUtils.SocketFactory() {
-			@Override
-			public ServerSocket createSocket(int port) throws IOException {
-				if (serverSSLContext == null) {
-					return new ServerSocket(port, finalBacklog);
-				} else {
-					LOG.info("Enabling ssl for the blob server");
-					return serverSSLContext.getServerSocketFactory().createServerSocket(port, finalBacklog);
-				}
-			}
-		});
+		this.serverSocket = NetUtils.createSocketFromPorts(ports,
+				(port) -> socketFactory.createServerSocket(port, finalBacklog));
 
-		if (socketAttempt == null) {
-			throw new IOException("Unable to allocate socket for blob server in specified port range: " + serverPortRange);
-		} else {
-			SSLUtils.setSSLVerAndCipherSuites(socketAttempt, config);
-			this.serverSocket = socketAttempt;
+		if (serverSocket == null) {
+			throw new IOException("Unable to open BLOB Server in specified port range: " + serverPortRange);
 		}
 
 		// start the server thread

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
@@ -31,6 +30,7 @@ import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaSe
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
@@ -103,7 +103,7 @@ public class HighAvailabilityServicesUtils {
 					"%s must be set",
 					RestOptions.ADDRESS.key());
 				final int port = configuration.getInteger(RestOptions.PORT);
-				final boolean enableSSL = configuration.getBoolean(SecurityOptions.SSL_ENABLED);
+				final boolean enableSSL = SSLUtils.isRestSSLEnabled(configuration);
 				final String protocol = enableSSL ? "https://" : "http://";
 
 				return new StandaloneHaServices(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
+import org.apache.flink.runtime.net.SSLEngineFactory;
+
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.Bootstrap;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
@@ -34,9 +36,9 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
@@ -52,7 +54,8 @@ class NettyClient {
 
 	private Bootstrap bootstrap;
 
-	private SSLContext clientSSLContext = null;
+	@Nullable
+	private SSLEngineFactory clientSSLFactory;
 
 	NettyClient(NettyConfig config) {
 		this.config = config;
@@ -112,7 +115,7 @@ class NettyClient {
 		}
 
 		try {
-			clientSSLContext = config.createClientSSLContext();
+			clientSSLFactory = config.createClientSSLEngineFactory();
 		} catch (Exception e) {
 			throw new IOException("Failed to initialize SSL Context for the Netty client", e);
 		}
@@ -177,18 +180,10 @@ class NettyClient {
 			public void initChannel(SocketChannel channel) throws Exception {
 
 				// SSL handler should be added first in the pipeline
-				if (clientSSLContext != null) {
-					SSLEngine sslEngine = clientSSLContext.createSSLEngine(
+				if (clientSSLFactory != null) {
+					SSLEngine sslEngine = clientSSLFactory.createSSLEngine(
 						serverSocketAddress.getAddress().getCanonicalHostName(),
 						serverSocketAddress.getPort());
-					sslEngine.setUseClientMode(true);
-
-					// Enable hostname verification for remote SSL connections
-					if (!serverSocketAddress.getAddress().isLoopbackAddress()) {
-						SSLParameters newSSLParameters = sslEngine.getSSLParameters();
-						config.setSSLVerifyHostname(newSSLParameters);
-						sslEngine.setSSLParameters(newSSLParameters);
-					}
 
 					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}
@@ -200,7 +195,7 @@ class NettyClient {
 			return bootstrap.connect(serverSocketAddress);
 		}
 		catch (ChannelException e) {
-			if ( (e.getCause() instanceof java.net.SocketException &&
+			if ((e.getCause() instanceof java.net.SocketException &&
 					e.getCause().getMessage().equals("Too many open files")) ||
 				(e.getCause() instanceof ChannelException &&
 						e.getCause().getCause() instanceof java.net.SocketException &&

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -213,6 +213,10 @@ public class NettyConfig {
 		return config.getBoolean(TaskManagerOptions.NETWORK_CREDIT_MODEL);
 	}
 
+	public Configuration getConfig() {
+		return config;
+	}
+
 	@Override
 	public String toString() {
 		String format = "NettyConfig [" +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLEngineFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLEngineFactory.java
@@ -36,15 +36,20 @@ public class SSLEngineFactory {
 
 	private final boolean clientMode;
 
+	final boolean clientAuthentication;
+
 	public SSLEngineFactory(
 			final SSLContext sslContext,
 			final String[] enabledProtocols,
 			final String[] enabledCipherSuites,
-			final boolean clientMode) {
+			final boolean clientMode,
+			final boolean clientAuthentication) {
+
 		this.sslContext = requireNonNull(sslContext, "sslContext must not be null");
 		this.enabledProtocols = requireNonNull(enabledProtocols, "enabledProtocols must not be null");
 		this.enabledCipherSuites = requireNonNull(enabledCipherSuites, "cipherSuites must not be null");
 		this.clientMode = clientMode;
+		this.clientAuthentication = clientAuthentication;
 	}
 
 	public SSLEngine createSSLEngine() {
@@ -63,5 +68,8 @@ public class SSLEngineFactory {
 		sslEngine.setEnabledProtocols(enabledProtocols);
 		sslEngine.setEnabledCipherSuites(enabledCipherSuites);
 		sslEngine.setUseClientMode(clientMode);
+		if (!clientMode) {
+			sslEngine.setNeedClientAuth(clientAuthentication);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLEngineFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLEngineFactory.java
@@ -49,9 +49,19 @@ public class SSLEngineFactory {
 
 	public SSLEngine createSSLEngine() {
 		final SSLEngine sslEngine = sslContext.createSSLEngine();
+		configureSSLEngine(sslEngine);
+		return sslEngine;
+	}
+
+	public SSLEngine createSSLEngine(String hostname, int port) {
+		final SSLEngine sslEngine = sslContext.createSSLEngine(hostname, port);
+		configureSSLEngine(sslEngine);
+		return sslEngine;
+	}
+
+	private void configureSSLEngine(SSLEngine sslEngine) {
 		sslEngine.setEnabledProtocols(enabledProtocols);
 		sslEngine.setEnabledCipherSuites(enabledCipherSuites);
 		sslEngine.setUseClientMode(clientMode);
-		return sslEngine;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -108,7 +108,8 @@ public class SSLUtils {
 				sslContext,
 				getEnabledProtocols(config),
 				getEnabledCipherSuites(config),
-				false);
+				false,
+				true);
 	}
 
 	/**
@@ -124,6 +125,7 @@ public class SSLUtils {
 				sslContext,
 				getEnabledProtocols(config),
 				getEnabledCipherSuites(config),
+				true,
 				true);
 	}
 
@@ -142,6 +144,7 @@ public class SSLUtils {
 				sslContext,
 				getEnabledProtocols(config),
 				getEnabledCipherSuites(config),
+				false,
 				false);
 	}
 
@@ -160,7 +163,8 @@ public class SSLUtils {
 				sslContext,
 				getEnabledProtocols(config),
 				getEnabledCipherSuites(config),
-				true);
+				true,
+				false);
 	}
 
 	private static String[] getEnabledProtocols(final Configuration config) {
@@ -352,6 +356,7 @@ public class SSLUtils {
 		private void configureServerSocket(SSLServerSocket socket) {
 			socket.setEnabledProtocols(protocols);
 			socket.setEnabledCipherSuites(cipherSuites);
+			socket.setNeedClientAuth(true);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -18,58 +18,59 @@
 
 package org.apache.flink.runtime.net;
 
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.util.Preconditions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.security.KeyStore;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Common utilities to manage SSL transport settings.
  */
 public class SSLUtils {
 
-	private static final Logger LOG = LoggerFactory.getLogger(SSLUtils.class);
+	/**
+	 * Checks whether SSL for internal communication (rpc, data transport, blob server) is enabled.
+	 */
+	public static boolean isInternalSSLEnabled(Configuration sslConfig) {
+		@SuppressWarnings("deprecation")
+		final boolean fallbackFlag = sslConfig.getBoolean(SecurityOptions.SSL_ENABLED);
+		return sslConfig.getBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, fallbackFlag);
+	}
 
 	/**
-	 * Retrieves the global ssl flag from configuration.
-	 *
-	 * @param sslConfig
-	 *        The application configuration
-	 * @return true if global ssl flag is set
+	 * Checks whether SSL for the external REST endpoint is enabled.
 	 */
-	public static boolean getSSLEnabled(Configuration sslConfig) {
-		return sslConfig.getBoolean(SecurityOptions.SSL_ENABLED);
+	public static boolean isRestSSLEnabled(Configuration sslConfig) {
+		@SuppressWarnings("deprecation")
+		final boolean fallbackFlag = sslConfig.getBoolean(SecurityOptions.SSL_ENABLED);
+		return sslConfig.getBoolean(SecurityOptions.SSL_REST_ENABLED, fallbackFlag);
 	}
 
 	/**
 	 * Creates a factory for SSL Server Sockets from the given configuration.
+	 * SSL Server Sockets are always part of internal communication.
 	 */
 	public static ServerSocketFactory createSSLServerSocketFactory(Configuration config) throws Exception {
-		SSLContext sslContext = createSSLServerContext(config);
+		SSLContext sslContext = createInternalSSLContext(config);
 		if (sslContext == null) {
 			throw new IllegalConfigurationException("SSL is not enabled");
 		}
@@ -83,9 +84,10 @@ public class SSLUtils {
 
 	/**
 	 * Creates a factory for SSL Client Sockets from the given configuration.
+	 * SSL Client Sockets are always part of internal communication.
 	 */
 	public static SocketFactory createSSLClientSocketFactory(Configuration config) throws Exception {
-		SSLContext sslContext = createSSLServerContext(config);
+		SSLContext sslContext = createInternalSSLContext(config);
 		if (sslContext == null) {
 			throw new IllegalConfigurationException("SSL is not enabled");
 		}
@@ -94,51 +96,71 @@ public class SSLUtils {
 	}
 
 	/**
-	 * Creates a {@link SSLEngineFactory} to be used by the Server.
-	 *
-	 * @param config The application configuration.
+	 * Creates a SSLEngineFactory to be used by internal communication server endpoints.
 	 */
-	public static SSLEngineFactory createServerSSLEngineFactory(final Configuration config) throws Exception {
-		return createSSLEngineFactory(config, false);
-	}
-
-	/**
-	 * Creates a {@link SSLEngineFactory} to be used by the Client.
-	 * @param config The application configuration.
-	 */
-	public static SSLEngineFactory createClientSSLEngineFactory(final Configuration config) throws Exception {
-		return createSSLEngineFactory(config, true);
-	}
-
-	private static SSLEngineFactory createSSLEngineFactory(
-			final Configuration config,
-			final boolean clientMode) throws Exception {
-
-		final SSLContext sslContext = clientMode ?
-			createSSLClientContext(config) :
-			createSSLServerContext(config);
-
-		checkState(sslContext != null, "%s it not enabled", SecurityOptions.SSL_ENABLED.key());
+	public static SSLEngineFactory createInternalServerSSLEngineFactory(final Configuration config) throws Exception {
+		SSLContext sslContext = createInternalSSLContext(config);
+		if (sslContext == null) {
+			throw new IllegalConfigurationException("SSL is not enabled for internal communication.");
+		}
 
 		return new SSLEngineFactory(
-			sslContext,
-			getEnabledProtocols(config),
-			getEnabledCipherSuites(config),
-			clientMode);
+				sslContext,
+				getEnabledProtocols(config),
+				getEnabledCipherSuites(config),
+				false);
 	}
 
 	/**
-	 * Sets SSL version and cipher suites for SSLEngine.
-	 *
-	 * @param engine SSLEngine to be handled
-	 * @param config The application configuration
-	 * @deprecated Use {@link #createClientSSLEngineFactory(Configuration)} or
-	 * {@link #createServerSSLEngineFactory(Configuration)}.
+	 * Creates a SSLEngineFactory to be used by internal communication client endpoints.
 	 */
-	@Deprecated
-	public static void setSSLVerAndCipherSuites(SSLEngine engine, Configuration config) {
-		engine.setEnabledProtocols(getEnabledProtocols(config));
-		engine.setEnabledCipherSuites(getEnabledCipherSuites(config));
+	public static SSLEngineFactory createInternalClientSSLEngineFactory(final Configuration config) throws Exception {
+		SSLContext sslContext = createInternalSSLContext(config);
+		if (sslContext == null) {
+			throw new IllegalConfigurationException("SSL is not enabled for internal communication.");
+		}
+
+		return new SSLEngineFactory(
+				sslContext,
+				getEnabledProtocols(config),
+				getEnabledCipherSuites(config),
+				true);
+	}
+
+	/**
+	 * Creates a {@link SSLEngineFactory} to be used by the REST Servers.
+	 *
+	 * @param config The application configuration.
+	 */
+	public static SSLEngineFactory createRestServerSSLEngineFactory(final Configuration config) throws Exception {
+		SSLContext sslContext = createRestServerSSLContext(config);
+		if (sslContext == null) {
+			throw new IllegalConfigurationException("SSL is not enabled for REST endpoints.");
+		}
+
+		return new SSLEngineFactory(
+				sslContext,
+				getEnabledProtocols(config),
+				getEnabledCipherSuites(config),
+				false);
+	}
+
+	/**
+	 * Creates a {@link SSLEngineFactory} to be used by the REST Clients.
+	 *
+	 * @param config The application configuration.
+	 */
+	public static SSLEngineFactory createRestClientSSLEngineFactory(final Configuration config) throws Exception {
+		SSLContext sslContext = createRestClientSSLContext(config);
+		if (sslContext == null) {
+			throw new IllegalConfigurationException("SSL is not enabled for REST endpoints.");
+		}
+
+		return new SSLEngineFactory(
+				sslContext,
+				getEnabledProtocols(config),
+				getEnabledCipherSuites(config),
+				true);
 	}
 
 	private static String[] getEnabledProtocols(final Configuration config) {
@@ -152,120 +174,138 @@ public class SSLUtils {
 	}
 
 	/**
-	 * Sets SSL options to verify peer's hostname in the certificate.
-	 *
-	 * @param sslConfig
-	 *        The application configuration
-	 * @param sslParams
-	 *        The SSL parameters that need to be updated
+	 * Creates the SSL Context for internal SSL, if internal SSL is configured.
+	 * For internal SSL, the client and server side configuration are identical, because
+	 * of mutual authentication.
 	 */
-	public static void setSSLVerifyHostname(Configuration sslConfig, SSLParameters sslParams) {
+	@Nullable
+	public static SSLContext createInternalSSLContext(Configuration config) throws Exception {
+		checkNotNull(config, "config");
 
-		Preconditions.checkNotNull(sslConfig);
-		Preconditions.checkNotNull(sslParams);
-
-		boolean verifyHostname = sslConfig.getBoolean(SecurityOptions.SSL_VERIFY_HOSTNAME);
-		if (verifyHostname) {
-			sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+		if (!isInternalSSLEnabled(config)) {
+			return null;
 		}
+		String keystoreFilePath = getAndCheckOption(
+				config, SecurityOptions.SSL_INTERNAL_KEYSTORE, SecurityOptions.SSL_KEYSTORE);
+
+		String keystorePassword = getAndCheckOption(
+				config, SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, SecurityOptions.SSL_KEYSTORE_PASSWORD);
+
+		String certPassword = getAndCheckOption(
+				config, SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, SecurityOptions.SSL_KEY_PASSWORD);
+
+		String trustStoreFilePath = getAndCheckOption(
+				config, SecurityOptions.SSL_INTERNAL_TRUSTSTORE, SecurityOptions.SSL_TRUSTSTORE);
+
+		String trustStorePassword = getAndCheckOption(
+				config, SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
+
+		String sslProtocolVersion = config.getString(SecurityOptions.SSL_PROTOCOL);
+
+		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (InputStream keyStoreFile = Files.newInputStream(new File(keystoreFilePath).toPath())) {
+			keyStore.load(keyStoreFile, keystorePassword.toCharArray());
+		}
+
+		KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (InputStream trustStoreFile = Files.newInputStream(new File(trustStoreFilePath).toPath())) {
+			trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
+		}
+
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		kmf.init(keyStore, certPassword.toCharArray());
+
+		TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		tmf.init(trustStore);
+
+		SSLContext sslContext = SSLContext.getInstance(sslProtocolVersion);
+		sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+
+		return sslContext;
 	}
 
 	/**
-	 * Creates the SSL Context for the client if SSL is configured.
-	 *
-	 * @param sslConfig
-	 *        The application configuration
-	 * @return The SSLContext object which can be used by the ssl transport client
-	 * 	       Returns null if SSL is disabled
-	 * @throws Exception
-	 *         Thrown if there is any misconfiguration
+	 * Creates an SSL context for the external REST endpoint server.
 	 */
 	@Nullable
-	public static SSLContext createSSLClientContext(Configuration sslConfig) throws Exception {
+	public static SSLContext createRestServerSSLContext(Configuration config) throws Exception {
+		checkNotNull(config, "config");
 
-		Preconditions.checkNotNull(sslConfig);
-		SSLContext clientSSLContext = null;
-
-		if (getSSLEnabled(sslConfig)) {
-			LOG.debug("Creating client SSL context from configuration");
-
-			String trustStoreFilePath = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE);
-			String trustStorePassword = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
-			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
-
-			Preconditions.checkNotNull(trustStoreFilePath, SecurityOptions.SSL_TRUSTSTORE.key() + " was not configured.");
-			Preconditions.checkNotNull(trustStorePassword, SecurityOptions.SSL_TRUSTSTORE_PASSWORD.key() + " was not configured.");
-
-			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-
-			FileInputStream trustStoreFile = null;
-			try {
-				trustStoreFile = new FileInputStream(new File(trustStoreFilePath));
-				trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
-			} finally {
-				if (trustStoreFile != null) {
-					trustStoreFile.close();
-				}
-			}
-
-			TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
-				TrustManagerFactory.getDefaultAlgorithm());
-			trustManagerFactory.init(trustStore);
-
-			clientSSLContext = SSLContext.getInstance(sslProtocolVersion);
-			clientSSLContext.init(null, trustManagerFactory.getTrustManagers(), null);
+		if (!isRestSSLEnabled(config)) {
+			return null;
 		}
 
-		return clientSSLContext;
+		String keystoreFilePath = getAndCheckOption(
+				config, SecurityOptions.SSL_REST_KEYSTORE, SecurityOptions.SSL_KEYSTORE);
+
+		String keystorePassword = getAndCheckOption(
+				config, SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, SecurityOptions.SSL_KEYSTORE_PASSWORD);
+
+		String certPassword = getAndCheckOption(
+				config, SecurityOptions.SSL_REST_KEY_PASSWORD, SecurityOptions.SSL_KEY_PASSWORD);
+
+		String sslProtocolVersion = config.getString(SecurityOptions.SSL_PROTOCOL);
+
+		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (InputStream keyStoreFile = Files.newInputStream(new File(keystoreFilePath).toPath())) {
+			keyStore.load(keyStoreFile, keystorePassword.toCharArray());
+		}
+
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		kmf.init(keyStore, certPassword.toCharArray());
+
+		SSLContext sslContext = SSLContext.getInstance(sslProtocolVersion);
+		sslContext.init(kmf.getKeyManagers(), null, null);
+
+		return sslContext;
 	}
 
 	/**
-	 * Creates the SSL Context for the server if SSL is configured.
-	 *
-	 * @param sslConfig
-	 *        The application configuration
-	 * @return The SSLContext object which can be used by the ssl transport server
-	 * 	       Returns null if SSL is disabled
-	 * @throws Exception
-	 *         Thrown if there is any misconfiguration
+	 * Creates an SSL context for clients against the external REST endpoint.
 	 */
 	@Nullable
-	public static SSLContext createSSLServerContext(Configuration sslConfig) throws Exception {
+	public static SSLContext createRestClientSSLContext(Configuration config) throws Exception {
+		checkNotNull(config, "config");
 
-		Preconditions.checkNotNull(sslConfig);
-		SSLContext serverSSLContext = null;
-
-		if (getSSLEnabled(sslConfig)) {
-			LOG.debug("Creating server SSL context from configuration");
-
-			String keystoreFilePath = sslConfig.getString(SecurityOptions.SSL_KEYSTORE);
-
-			String keystorePassword = sslConfig.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD);
-
-			String certPassword = sslConfig.getString(SecurityOptions.SSL_KEY_PASSWORD);
-
-			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
-
-			Preconditions.checkNotNull(keystoreFilePath, SecurityOptions.SSL_KEYSTORE.key() + " was not configured.");
-			Preconditions.checkNotNull(keystorePassword, SecurityOptions.SSL_KEYSTORE_PASSWORD.key() + " was not configured.");
-			Preconditions.checkNotNull(certPassword, SecurityOptions.SSL_KEY_PASSWORD.key() + " was not configured.");
-
-			KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-			try (FileInputStream keyStoreFile = new FileInputStream(new File(keystoreFilePath))) {
-				ks.load(keyStoreFile, keystorePassword.toCharArray());
-			}
-
-			// Set up key manager factory to use the server key store
-			KeyManagerFactory kmf = KeyManagerFactory.getInstance(
-					KeyManagerFactory.getDefaultAlgorithm());
-			kmf.init(ks, certPassword.toCharArray());
-
-			// Initialize the SSLContext
-			serverSSLContext = SSLContext.getInstance(sslProtocolVersion);
-			serverSSLContext.init(kmf.getKeyManagers(), null, null);
+		if (!isRestSSLEnabled(config)) {
+			return null;
 		}
 
-		return serverSSLContext;
+		String trustStoreFilePath = getAndCheckOption(
+				config, SecurityOptions.SSL_REST_TRUSTSTORE, SecurityOptions.SSL_TRUSTSTORE);
+
+		String trustStorePassword = getAndCheckOption(
+				config, SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
+
+		String sslProtocolVersion = config.getString(SecurityOptions.SSL_PROTOCOL);
+
+		KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (InputStream trustStoreFile = Files.newInputStream(new File(trustStoreFilePath).toPath())) {
+			trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
+		}
+
+		TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		tmf.init(trustStore);
+
+		SSLContext sslContext = SSLContext.getInstance(sslProtocolVersion);
+		sslContext.init(null, tmf.getTrustManagers(), null);
+
+		return sslContext;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	private static String getAndCheckOption(Configuration config, ConfigOption<String> primaryOption, ConfigOption<String> fallbackOption) {
+		String value = config.getString(primaryOption, config.getString(fallbackOption));
+		if (value != null) {
+			return value;
+		}
+		else {
+			throw new IllegalConfigurationException("The config option " + primaryOption.key() +
+					" or " + fallbackOption.key() + " is missing.");
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLEngineFactory;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ConfigurationException;
@@ -91,10 +90,9 @@ public final class RestClientConfiguration {
 		Preconditions.checkNotNull(config);
 
 		final SSLEngineFactory sslEngineFactory;
-		final boolean enableSSL = config.getBoolean(SecurityOptions.SSL_ENABLED);
-		if (enableSSL) {
+		if (SSLUtils.isRestSSLEnabled(config)) {
 			try {
-				sslEngineFactory = SSLUtils.createClientSSLEngineFactory(config);
+				sslEngineFactory = SSLUtils.createRestClientSSLEngineFactory(config);
 			} catch (Exception e) {
 				throw new ConfigurationException("Failed to initialize SSLContext for the web frontend", e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.net.SSLEngineFactory;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -157,10 +156,9 @@ public final class RestServerEndpointConfiguration {
 		final int port = config.getInteger(RestOptions.PORT);
 
 		final SSLEngineFactory sslEngineFactory;
-		final boolean enableSSL = config.getBoolean(SecurityOptions.SSL_ENABLED) && config.getBoolean(WebOptions.SSL_ENABLED);
-		if (enableSSL) {
+		if (SSLUtils.isRestSSLEnabled(config)) {
 			try {
-				sslEngineFactory = SSLUtils.createServerSSLEngineFactory(config);
+				sslEngineFactory = SSLUtils.createRestServerSSLEngineFactory(config);
 			} catch (Exception e) {
 				throw new ConfigurationException("Failed to initialize SSLEngineFactory for REST server endpoint.", e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -130,7 +130,7 @@ public class AkkaRpcServiceUtils {
 		checkNotNull(config, "config is null");
 
 		final boolean sslEnabled = config.getBoolean(AkkaOptions.SSL_ENABLED) &&
-				SSLUtils.getSSLEnabled(config);
+				SSLUtils.isInternalSSLEnabled(config);
 
 		return getRpcUrl(
 			hostname,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -336,21 +336,31 @@ object AkkaUtils {
     val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
 
     val akkaEnableSSLConfig = configuration.getBoolean(AkkaOptions.SSL_ENABLED) &&
-          SSLUtils.getSSLEnabled(configuration)
+          SSLUtils.isInternalSSLEnabled(configuration)
 
     val retryGateClosedFor = configuration.getLong(AkkaOptions.RETRY_GATE_CLOSED_FOR)
 
     val akkaEnableSSL = if (akkaEnableSSLConfig) "on" else "off"
 
-    val akkaSSLKeyStore = configuration.getString(SecurityOptions.SSL_KEYSTORE)
+    val akkaSSLKeyStore = configuration.getString(
+                              SecurityOptions.SSL_INTERNAL_KEYSTORE,
+                              configuration.getString(SecurityOptions.SSL_KEYSTORE))
 
-    val akkaSSLKeyStorePassword = configuration.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD)
+    val akkaSSLKeyStorePassword = configuration.getString(
+                              SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD,
+                              configuration.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD))
 
-    val akkaSSLKeyPassword = configuration.getString(SecurityOptions.SSL_KEY_PASSWORD)
+    val akkaSSLKeyPassword = configuration.getString(
+                              SecurityOptions.SSL_INTERNAL_KEY_PASSWORD,
+                              configuration.getString(SecurityOptions.SSL_KEY_PASSWORD))
 
-    val akkaSSLTrustStore = configuration.getString(SecurityOptions.SSL_TRUSTSTORE)
+    val akkaSSLTrustStore = configuration.getString(
+                              SecurityOptions.SSL_INTERNAL_TRUSTSTORE,
+                              configuration.getString(SecurityOptions.SSL_TRUSTSTORE))
 
-    val akkaSSLTrustStorePassword = configuration.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD)
+    val akkaSSLTrustStorePassword = configuration.getString(
+                              SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD,
+                              configuration.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD))
 
     val akkaSSLProtocol = configuration.getString(SecurityOptions.SSL_PROTOCOL)
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -453,6 +453,7 @@ object AkkaUtils {
          |          protocol = $akkaSSLProtocol
          |          enabled-algorithms = $akkaSSLAlgorithms
          |          random-number-generator = ""
+         |          require-mutual-authentication = on
          |        }
          |      }
          |    }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.net.SSLUtilsTest;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -55,40 +55,25 @@ public class BlobClientSslTest extends BlobClientTest {
 	 */
 	@BeforeClass
 	public static void startSSLServer() throws IOException {
-		Configuration config = new Configuration();
-		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
-			temporarySslFolder.newFolder().getAbsolutePath());
-		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		Configuration config = SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporarySslFolder.newFolder().getAbsolutePath());
+
 		blobSslServer = new BlobServer(config, new VoidBlobStore());
 		blobSslServer.start();
 
-		sslClientConfig = new Configuration();
-		sslClientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		sslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		sslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+		sslClientConfig = config;
 	}
 
 	@BeforeClass
 	public static void startNonSSLServer() throws IOException {
-		Configuration config = new Configuration();
-		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
-			temporarySslFolder.newFolder().getAbsolutePath());
-		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		Configuration config = SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporarySslFolder.newFolder().getAbsolutePath());
 		config.setBoolean(BlobServerOptions.SSL_ENABLED, false);
-		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+
 		blobNonSslServer = new BlobServer(config, new VoidBlobStore());
 		blobNonSslServer.start();
 
-		nonSslClientConfig = new Configuration();
-		nonSslClientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		nonSslClientConfig.setBoolean(BlobServerOptions.SSL_ENABLED, false);
-		nonSslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		nonSslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+		nonSslClientConfig = config;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -151,15 +151,14 @@ public class NettyClientServerSslTest {
 		NettyTestUtil.shutdown(serverAndClient);
 	}
 
-	private Configuration createSslConfig() throws Exception {
-
+	private static Configuration createSslConfig() throws Exception {
 		Configuration flinkConfig = new Configuration();
-		flinkConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		flinkConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		flinkConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		flinkConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-		flinkConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		flinkConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+		flinkConfig.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/local127.keystore");
+		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
+		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
+		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, "src/test/resources/local127.truststore");
+		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
 		return flinkConfig;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
+import org.apache.flink.runtime.net.SSLUtilsTest;
 import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
@@ -35,6 +37,10 @@ import java.net.InetAddress;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests for the SSL connection between Netty Server and Client used for the
+ * data plane.
+ */
 public class NettyClientServerSslTest {
 
 	/**
@@ -42,24 +48,9 @@ public class NettyClientServerSslTest {
 	 */
 	@Test
 	public void testValidSslConnection() throws Exception {
-		NettyProtocol protocol = new NettyProtocol(null, null, true) {
-			@Override
-			public ChannelHandler[] getServerChannelHandlers() {
-				return new ChannelHandler[0];
-			}
+		NettyProtocol protocol = new NoOpProtocol();
 
-			@Override
-			public ChannelHandler[] getClientChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-		};
-
-		NettyConfig nettyConfig = new NettyConfig(
-			InetAddress.getLoopbackAddress(),
-			NetUtils.getAvailablePort(),
-			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
-			1,
-			createSslConfig());
+		NettyConfig nettyConfig = createNettyConfig(createSslConfig());
 
 		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
 
@@ -77,28 +68,13 @@ public class NettyClientServerSslTest {
 	 */
 	@Test
 	public void testInvalidSslConfiguration() throws Exception {
-		NettyProtocol protocol = new NettyProtocol(null, null, true) {
-			@Override
-			public ChannelHandler[] getServerChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-
-			@Override
-			public ChannelHandler[] getClientChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-		};
+		NettyProtocol protocol = new NoOpProtocol();
 
 		Configuration config = createSslConfig();
 		// Modify the keystore password to an incorrect one
-		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "invalidpassword");
+		config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "invalidpassword");
 
-		NettyConfig nettyConfig = new NettyConfig(
-			InetAddress.getLoopbackAddress(),
-			NetUtils.getAvailablePort(),
-			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
-			1,
-			config);
+		NettyConfig nettyConfig = createNettyConfig(config);
 
 		NettyTestUtil.NettyServerAndClient serverAndClient = null;
 		try {
@@ -116,29 +92,14 @@ public class NettyClientServerSslTest {
 	 */
 	@Test
 	public void testSslHandshakeError() throws Exception {
-		NettyProtocol protocol = new NettyProtocol(null, null, true) {
-			@Override
-			public ChannelHandler[] getServerChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-
-			@Override
-			public ChannelHandler[] getClientChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-		};
+		NettyProtocol protocol = new NoOpProtocol();
 
 		Configuration config = createSslConfig();
 
 		// Use a server certificate which is not present in the truststore
-		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/untrusted.keystore");
+		config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/untrusted.keystore");
 
-		NettyConfig nettyConfig = new NettyConfig(
-			InetAddress.getLoopbackAddress(),
-			NetUtils.getAvailablePort(),
-			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
-			1,
-			config);
+		NettyConfig nettyConfig = createNettyConfig(config);
 
 		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
 
@@ -151,14 +112,60 @@ public class NettyClientServerSslTest {
 		NettyTestUtil.shutdown(serverAndClient);
 	}
 
-	private static Configuration createSslConfig() throws Exception {
-		Configuration flinkConfig = new Configuration();
-		flinkConfig.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/local127.keystore");
-		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
-		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
-		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		flinkConfig.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
-		return flinkConfig;
+	@Test
+	public void testClientUntrustedCertificate() throws Exception {
+		final Configuration serverConfig = createSslConfig();
+		final Configuration clientConfig = createSslConfig();
+
+		// give the client a different keystore / certificate
+		clientConfig.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/untrusted.keystore");
+
+		final NettyConfig nettyServerConfig = createNettyConfig(serverConfig);
+		final NettyConfig nettyClientConfig = createNettyConfig(clientConfig);
+
+		final NettyBufferPool bufferPool = new NettyBufferPool(1);
+		final NettyProtocol protocol = new NoOpProtocol();
+
+		final NettyServer server = NettyTestUtil.initServer(nettyServerConfig, protocol, bufferPool);
+		final NettyClient client = NettyTestUtil.initClient(nettyClientConfig, protocol, bufferPool);
+		final NettyServerAndClient serverAndClient = new NettyServerAndClient(server, client);
+
+		final Channel ch = NettyTestUtil.connect(serverAndClient);
+		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
+
+		// Attempting to write data over ssl should fail
+		assertFalse(ch.writeAndFlush("test").await().isSuccess());
+
+		NettyTestUtil.shutdown(serverAndClient);
+	}
+
+	private static Configuration createSslConfig() {
+		return SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores();
+	}
+
+	private static NettyConfig createNettyConfig(Configuration config) {
+		return new NettyConfig(
+				InetAddress.getLoopbackAddress(),
+				NetUtils.getAvailablePort(),
+				NettyTestUtil.DEFAULT_SEGMENT_SIZE,
+				1,
+				config);
+	}
+
+	private static final class NoOpProtocol extends NettyProtocol {
+
+		NoOpProtocol() {
+			super(null, null, true);
+		}
+
+		@Override
+		public ChannelHandler[] getServerChannelHandlers() {
+			return new ChannelHandler[0];
+		}
+
+		@Override
+		public ChannelHandler[] getClientChannelHandlers() {
+			return new ChannelHandler[0];
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -22,20 +22,17 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
 
-import org.hamcrest.collection.IsArrayContainingInAnyOrder;
-import org.junit.Assert;
 import org.junit.Test;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLServerSocket;
 
 import java.net.ServerSocket;
-import java.util.Arrays;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -45,125 +42,43 @@ import static org.junit.Assert.fail;
  */
 public class SSLUtilsTest {
 
-	/**
-	 * Tests if SSL Client Context is created given a valid SSL configuration.
-	 */
-	@Test
-	public void testCreateSSLClientContext() throws Exception {
+	public static final String TRUST_STORE_PATH = SSLUtilsTest.class.getResource("/local127.truststore").getFile();
+	public static final String KEY_STORE_PATH = SSLUtilsTest.class.getResource("/local127.keystore").getFile();
+	public static final String UNTRUSTED_KEY_STORE_PATH = SSLUtilsTest.class.getResource("/local127.keystore").getFile();
 
-		Configuration clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
-
-		SSLContext clientContext = SSLUtils.createSSLClientContext(clientConfig);
-		Assert.assertNotNull(clientContext);
-	}
+	public static final String TRUST_STORE_PASSWORD = "password";
+	public static final String KEY_STORE_PASSWORD = "password";
+	public static final String KEY_PASSWORD = "password";
 
 	/**
-	 * Tests if SSL Client Context is not created if SSL is not configured.
+	 * Tests whether activation of internal / REST SSL evaluates the config flags correctly.
 	 */
-	@Test
-	public void testCreateSSLClientContextWithSSLDisabled() throws Exception {
+	@SuppressWarnings("deprecation")
+	public void checkEnableSSL() {
+		// backwards compatibility
+		Configuration oldConf = new Configuration();
+		oldConf.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		assertTrue(SSLUtils.isInternalSSLEnabled(oldConf));
+		assertTrue(SSLUtils.isRestSSLEnabled(oldConf));
 
-		Configuration clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, false);
+		// new options take precedence
+		Configuration newOptions = new Configuration();
+		newOptions.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		newOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+		assertTrue(SSLUtils.isInternalSSLEnabled(newOptions));
+		assertFalse(SSLUtils.isRestSSLEnabled(newOptions));
 
-		SSLContext clientContext = SSLUtils.createSSLClientContext(clientConfig);
-		Assert.assertNull(clientContext);
-	}
-
-	/**
-	 * Tests if SSL Client Context creation fails with bad SSL configuration.
-	 */
-	@Test
-	public void testCreateSSLClientContextMisconfiguration() {
-
-		Configuration clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "badpassword");
-
-		try {
-			SSLContext clientContext = SSLUtils.createSSLClientContext(clientConfig);
-			Assert.fail("SSL client context created even with bad SSL configuration ");
-		} catch (Exception e) {
-			// Exception here is valid
-		}
-	}
-
-	/**
-	 * Tests if SSL Server Context is created given a valid SSL configuration.
-	 */
-	@Test
-	public void testCreateSSLServerContext() throws Exception {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-
-		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-		Assert.assertNotNull(serverContext);
-	}
-
-	/**
-	 * Tests if SSL Server Context is not created if SSL is disabled.
-	 */
-	@Test
-	public void testCreateSSLServerContextWithSSLDisabled() throws Exception {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, false);
-
-		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-		Assert.assertNull(serverContext);
-	}
-
-	/**
-	 * Tests if SSL Server Context creation fails with bad SSL configuration.
-	 */
-	@Test
-	public void testCreateSSLServerContextMisconfiguration() {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "badpassword");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "badpassword");
-
-		try {
-			SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-			Assert.fail("SSL server context created even with bad SSL configuration ");
-		} catch (Exception e) {
-			// Exception here is valid
-		}
-	}
-
-	/**
-	 * Tests if SSL Server Context creation fails with bad SSL configuration.
-	 */
-	@Test
-	public void testCreateSSLServerContextWithMultiProtocols() {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1,TLSv1.2");
-
-		try {
-			SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-			Assert.fail("SSL server context created even with multiple protocols set ");
-		} catch (Exception e) {
-			// Exception here is valid
-		}
+		// new options take precedence
+		Configuration precedence = new Configuration();
+		precedence.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		precedence.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
+		precedence.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+		assertFalse(SSLUtils.isInternalSSLEnabled(precedence));
+		assertFalse(SSLUtils.isRestSSLEnabled(precedence));
 	}
 
 	@Test
-	public void testSocketFactoriesWhenSslDisables() throws Exception {
+	public void testSocketFactoriesWhenSslDisabled() throws Exception {
 		Configuration config = new Configuration();
 
 		try {
@@ -177,16 +92,243 @@ public class SSLUtilsTest {
 		} catch (IllegalConfigurationException ignored) {}
 	}
 
+	// ------------------------ REST client --------------------------
+
+	/**
+	 * Tests if REST Client SSL is created given a valid SSL configuration.
+	 */
+	@Test
+	public void testRESTClientSSL() throws Exception {
+		Configuration clientConfig = createRestSslConfigWithTrustStore();
+
+		SSLEngineFactory ssl = SSLUtils.createRestClientSSLEngineFactory(clientConfig);
+		assertNotNull(ssl);
+	}
+
+	/**
+	 * Tests that REST Client SSL Client is not created if SSL is not configured.
+	 */
+	@Test
+	public void testRESTClientSSLDisabled() throws Exception {
+		Configuration clientConfig = createRestSslConfigWithTrustStore();
+		clientConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+
+		try {
+			SSLUtils.createRestClientSSLEngineFactory(clientConfig);
+			fail("exception expected");
+		} catch (IllegalConfigurationException ignored) {}
+	}
+
+	/**
+	 * Tests that REST Client SSL creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testRESTClientSSLMissingTrustStore() throws Exception {
+		Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		config.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "some password");
+
+		try {
+			SSLUtils.createRestClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (IllegalConfigurationException ignored) {}
+	}
+
+	/**
+	 * Tests that REST Client SSL creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testRESTClientSSLMissingPassword() throws Exception {
+		Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		config.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_PATH);
+
+		try {
+			SSLUtils.createRestClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (IllegalConfigurationException ignored) {}
+	}
+
+	/**
+	 * Tests that REST Client SSL creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testRESTClientSSLWrongPassword() throws Exception {
+		Configuration clientConfig = createRestSslConfigWithTrustStore();
+		clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "badpassword");
+
+		try {
+			SSLUtils.createRestClientSSLEngineFactory(clientConfig);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	// ------------------------ server --------------------------
+
+	/**
+	 * Tests that REST Server SSL Engine is created given a valid SSL configuration.
+	 */
+	@Test
+	public void testRESTServerSSL() throws Exception {
+		Configuration serverConfig = createRestSslConfigWithKeyStore();
+
+		SSLEngineFactory ssl = SSLUtils.createRestServerSSLEngineFactory(serverConfig);
+		assertNotNull(ssl);
+	}
+
+	/**
+	 * Tests that REST Server SSL Engine is not created if SSL is disabled.
+	 */
+	@Test
+	public void testRESTServerSSLDisabled() throws Exception {
+		Configuration serverConfig = createRestSslConfigWithKeyStore();
+		serverConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+
+		try {
+			SSLUtils.createRestServerSSLEngineFactory(serverConfig);
+			fail("exception expected");
+		} catch (IllegalConfigurationException ignored) {}
+	}
+
+	/**
+	 * Tests that REST Server SSL Engine creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testRESTServerSSLBadKeystorePassword() {
+		Configuration serverConfig = createRestSslConfigWithKeyStore();
+		serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "badpassword");
+
+		try {
+			SSLUtils.createRestServerSSLEngineFactory(serverConfig);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	/**
+	 * Tests that REST Server SSL Engine creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testRESTServerSSLBadKeyPassword() {
+		Configuration serverConfig = createRestSslConfigWithKeyStore();
+		serverConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "badpassword");
+
+		try {
+			SSLUtils.createRestServerSSLEngineFactory(serverConfig);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	// ----------------------- mutual auth contexts --------------------------
+
+	@Test
+	public void testInternalSSL() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
+		assertNotNull(SSLUtils.createInternalServerSSLEngineFactory(config));
+		assertNotNull(SSLUtils.createInternalClientSSLEngineFactory(config));
+	}
+
+	@Test
+	public void testInternalSSLDisables() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
+		config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
+
+		try {
+			SSLUtils.createInternalServerSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+
+		try {
+			SSLUtils.createInternalClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	@Test
+	public void testInternalSSLKeyStoreOnly() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyStore();
+
+		try {
+			SSLUtils.createInternalServerSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+
+		try {
+			SSLUtils.createInternalClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	@Test
+	public void testInternalSSLTrustStoreOnly() throws Exception {
+		final Configuration config = createInternalSslConfigWithTrustStore();
+
+		try {
+			SSLUtils.createInternalServerSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+
+		try {
+			SSLUtils.createInternalClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	@Test
+	public void testInternalSSLWrongKeystorePassword() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
+		config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "badpw");
+
+		try {
+			SSLUtils.createInternalServerSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+
+		try {
+			SSLUtils.createInternalClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	@Test
+	public void testInternalSSLWrongTruststorePassword() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
+		config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "badpw");
+
+		try {
+			SSLUtils.createInternalServerSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+
+		try {
+			SSLUtils.createInternalClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	@Test
+	public void testInternalSSLWrongKeyPassword() throws Exception {
+		final Configuration config = createInternalSslConfigWithKeyAndTrustStores();
+		config.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "badpw");
+
+		try {
+			SSLUtils.createInternalServerSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+
+		try {
+			SSLUtils.createInternalClientSSLEngineFactory(config);
+			fail("exception expected");
+		} catch (Exception ignored) {}
+	}
+
+	// -------------------- protocols and cipher suites -----------------------
+
 	/**
 	 * Tests if SSLUtils set the right ssl version and cipher suites for SSLServerSocket.
 	 */
 	@Test
 	public void testSetSSLVersionAndCipherSuitesForSSLServerSocket() throws Exception {
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		Configuration serverConfig = createInternalSslConfigWithKeyAndTrustStores();
 
 		// set custom protocol and cipher suites
 		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1.1");
@@ -202,43 +344,9 @@ public class SSLUtilsTest {
 			assertEquals(1, protocols.length);
 			assertEquals("TLSv1.1", protocols[0]);
 			assertEquals(2, algorithms.length);
-			assertThat(algorithms, IsArrayContainingInAnyOrder.arrayContainingInAnyOrder(
+			assertThat(algorithms, arrayContainingInAnyOrder(
 					"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA256"));
 		}
-	}
-
-	/**
-	 * Tests if SSLUtils set the right ssl version and cipher suites for SSLEngine.
-	 */
-	@Test
-	public void testSetSSLVersionAndCipherSuitesForSSLEngine() throws Exception {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1");
-		serverConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256");
-
-		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-		SSLEngine engine = serverContext.createSSLEngine();
-
-		String[] protocols = engine.getEnabledProtocols();
-		String[] algorithms = engine.getEnabledCipherSuites();
-
-		Assert.assertNotEquals(1, protocols.length);
-		Assert.assertNotEquals(2, algorithms.length);
-
-		SSLUtils.setSSLVerAndCipherSuites(engine, serverConfig);
-		protocols = engine.getEnabledProtocols();
-		algorithms = engine.getEnabledCipherSuites();
-
-		Assert.assertEquals(1, protocols.length);
-		Assert.assertEquals("TLSv1", protocols[0]);
-		Assert.assertEquals(2, algorithms.length);
-		Assert.assertTrue(algorithms[0].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[0].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
-		Assert.assertTrue(algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
 	}
 
 	/**
@@ -246,22 +354,88 @@ public class SSLUtilsTest {
 	 */
 	@Test
 	public void testCreateSSLEngineFactory() throws Exception {
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		Configuration serverConfig = createInternalSslConfigWithKeyAndTrustStores();
+
+		// set custom protocol and cipher suites
 		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1");
 		serverConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256");
 
-		final SSLEngineFactory serverSSLEngineFactory = SSLUtils.createServerSSLEngineFactory(serverConfig);
+		final SSLEngineFactory serverSSLEngineFactory = SSLUtils.createInternalServerSSLEngineFactory(serverConfig);
 		final SSLEngine sslEngine = serverSSLEngineFactory.createSSLEngine();
 
-		assertThat(
-			Arrays.asList(sslEngine.getEnabledProtocols()),
-			contains("TLSv1"));
-		assertThat(
-			Arrays.asList(sslEngine.getEnabledCipherSuites()),
-			containsInAnyOrder("TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
+		assertEquals(1, sslEngine.getEnabledProtocols().length);
+		assertEquals("TLSv1", sslEngine.getEnabledProtocols()[0]);
+
+		assertEquals(2, sslEngine.getEnabledCipherSuites().length);
+		assertThat(sslEngine.getEnabledCipherSuites(), arrayContainingInAnyOrder(
+				"TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
+	}
+
+	// ------------------------------- utils ----------------------------------
+
+	public static Configuration createRestSslConfigWithKeyStore() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		addRestKeyStoreConfig(config);
+		return config;
+	}
+
+	public static Configuration createRestSslConfigWithTrustStore() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		addRestTrustStoreConfig(config);
+		return config;
+	}
+
+	public static Configuration createRestSslConfigWithKeyAndTrustStores() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		addRestKeyStoreConfig(config);
+		addRestTrustStoreConfig(config);
+		return config;
+	}
+
+	public static Configuration createInternalSslConfigWithKeyStore() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		addInternalKeyStoreConfig(config);
+		return config;
+	}
+
+	public static Configuration createInternalSslConfigWithTrustStore() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		addInternalTrustStoreConfig(config);
+		return config;
+	}
+
+	public static Configuration createInternalSslConfigWithKeyAndTrustStores() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		addInternalKeyStoreConfig(config);
+		addInternalTrustStoreConfig(config);
+		return config;
+	}
+
+	private static void addRestKeyStoreConfig(Configuration config) {
+		config.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_PATH);
+		config.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
+		config.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, KEY_PASSWORD);
+	}
+
+	private static void addRestTrustStoreConfig(Configuration config) {
+		config.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_PATH);
+		config.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
+	}
+
+	private static void addInternalKeyStoreConfig(Configuration config) {
+		config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, KEY_STORE_PATH);
+		config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
+		config.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, KEY_PASSWORD);
+	}
+
+	private static void addInternalTrustStoreConfig(Configuration config) {
+		config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_PATH);
+		config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -138,12 +138,12 @@ public class RestServerEndpointITCase extends TestLogger {
 			.getFile()).getAbsolutePath();
 
 		final Configuration sslConfig = new Configuration(config);
-		sslConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		sslConfig.setString(SecurityOptions.SSL_TRUSTSTORE, truststorePath);
-		sslConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
-		sslConfig.setString(SecurityOptions.SSL_KEYSTORE, keystorePath);
-		sslConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		sslConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		sslConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+		sslConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, truststorePath);
+		sslConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+		sslConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, keystorePath);
+		sslConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+		sslConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
 
 		return Arrays.asList(new Object[][]{
 			{config}, {sslConfig}
@@ -164,7 +164,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		config.setString(WebOptions.UPLOAD_DIR, temporaryFolder.newFolder().getCanonicalPath());
 
 		defaultSSLContext = SSLContext.getDefault();
-		final SSLContext sslClientContext = SSLUtils.createSSLClientContext(config);
+		final SSLContext sslClientContext = SSLUtils.createRestClientSSLContext(config);
 		if (sslClientContext != null) {
 			SSLContext.setDefault(sslClientContext);
 		}
@@ -209,7 +209,9 @@ public class RestServerEndpointITCase extends TestLogger {
 
 	@After
 	public void teardown() throws Exception {
-		SSLContext.setDefault(defaultSSLContext);
+		if (defaultSSLContext != null) {
+			SSLContext.setDefault(defaultSSLContext);
+		}
 
 		if (restClient != null) {
 			restClient.shutdown(timeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
+import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
+import org.apache.flink.util.TestLogger;
+
+import akka.actor.ActorSystem;
+import akka.actor.Terminated;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test validates that the RPC service gives a good message when it cannot
+ * connect to an RpcEndpoint.
+ */
+public class RpcSSLAuthITCase extends TestLogger {
+
+	private static final String KEY_STORE_FILE = RpcSSLAuthITCase.class.getResource("/local127.keystore").getFile();
+	private static final String TRUST_STORE_FILE = RpcSSLAuthITCase.class.getResource("/local127.truststore").getFile();
+	private static final String UNTRUSTED_KEY_STORE_FILE = RpcSSLAuthITCase.class.getResource("/untrusted.keystore").getFile();
+
+	@Test
+	public void testConnectFailure() throws Exception {
+
+		// !!! This config has KEY_STORE_FILE / TRUST_STORE_FILE !!!
+		Configuration sslConfig1 = new Configuration();
+		sslConfig1.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		sslConfig1.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, KEY_STORE_FILE);
+		sslConfig1.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_FILE);
+		sslConfig1.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
+		sslConfig1.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
+		sslConfig1.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
+		sslConfig1.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+
+		// !!! This config has KEY_STORE_FILE / UNTRUSTED_KEY_STORE_FILE !!!
+		// If this is presented by a client, it will trust the server, but the server will
+		// not trust this client in case client auth is enabled.
+		Configuration sslConfig2 = new Configuration();
+		sslConfig2.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+		sslConfig2.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, UNTRUSTED_KEY_STORE_FILE);
+		sslConfig2.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_FILE);
+		sslConfig2.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
+		sslConfig2.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
+		sslConfig2.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
+		sslConfig2.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+
+		ActorSystem actorSystem1 = null;
+		ActorSystem actorSystem2 = null;
+		RpcService rpcService1 = null;
+		RpcService rpcService2 = null;
+
+		try {
+			actorSystem1 = AkkaUtils.createActorSystem(sslConfig1, "localhost", 0);
+			actorSystem2 = AkkaUtils.createActorSystem(sslConfig2, "localhost", 0);
+
+			// to test whether the test is still good:
+			//   - create actorSystem2 with sslConfig1 (same as actorSystem1) and see that both can connect
+			//   - set 'require-mutual-authentication = off' in the AkkaUtils ssl config section
+
+			// we start the RPC service with a very long timeout to ensure that the test
+			// can only pass if the connection problem is not recognized merely via a timeout
+			rpcService1 = new AkkaRpcService(actorSystem1, Time.of(10000000, TimeUnit.SECONDS));
+			rpcService2 = new AkkaRpcService(actorSystem2, Time.of(10000000, TimeUnit.SECONDS));
+
+			TestEndpoint endpoint = new TestEndpoint(rpcService1);
+			endpoint.start();
+
+			CompletableFuture<TestGateway> future = rpcService2.connect(endpoint.getAddress(), TestGateway.class);
+			TestGateway gateway = future.get(10000000, TimeUnit.SECONDS);
+
+			CompletableFuture<String> fooFuture = gateway.foo();
+			fooFuture.get();
+
+			fail("should never complete normally");
+		}
+		catch (ExecutionException e) {
+			// that is what we want
+			assertTrue(e.getCause() instanceof RpcConnectionException);
+		}
+		finally {
+			final CompletableFuture<Void> rpcTerminationFuture1 = rpcService1 != null ?
+					rpcService1.stopService() :
+					CompletableFuture.completedFuture(null);
+
+			final CompletableFuture<Void> rpcTerminationFuture2 = rpcService2 != null ?
+					rpcService2.stopService() :
+					CompletableFuture.completedFuture(null);
+
+			final CompletableFuture<Terminated> actorSystemTerminationFuture1 = actorSystem1 != null ?
+					FutureUtils.toJava(actorSystem1.terminate()) :
+					CompletableFuture.completedFuture(null);
+
+			final CompletableFuture<Terminated> actorSystemTerminationFuture2 = actorSystem2 != null ?
+					FutureUtils.toJava(actorSystem2.terminate()) :
+					CompletableFuture.completedFuture(null);
+
+			FutureUtils
+				.waitForAll(Arrays.asList(
+						rpcTerminationFuture1, rpcTerminationFuture2,
+						actorSystemTerminationFuture1, actorSystemTerminationFuture2))
+				.get();
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Test RPC endpoint
+	// ------------------------------------------------------------------------
+
+	/** doc. */
+	public interface TestGateway extends RpcGateway {
+
+		CompletableFuture<String> foo();
+	}
+
+	/** doc. */
+	public static class TestEndpoint extends RpcEndpoint implements TestGateway {
+
+		public TestEndpoint(RpcService rpcService) {
+			super(rpcService);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@Override
+		public CompletableFuture<String> foo() {
+			return CompletableFuture.completedFuture("bar");
+		}
+	}
+}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaSslITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaSslITCase.scala
@@ -54,7 +54,7 @@ class AkkaSslITCase(_system: ActorSystem)
       config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1)
       config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1)
 
-      config.setBoolean(SecurityOptions.SSL_ENABLED, true)
+      config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true)
       config.setString(SecurityOptions.SSL_KEYSTORE,
         getClass.getResource("/local127.keystore").getPath)
       config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password")
@@ -81,7 +81,7 @@ class AkkaSslITCase(_system: ActorSystem)
         config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1)
         config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1)
 
-        config.setBoolean(SecurityOptions.SSL_ENABLED, true)
+        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true)
         config.setString(SecurityOptions.SSL_KEYSTORE,
           getClass.getResource("/local127.keystore").getPath)
         config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password")
@@ -103,7 +103,7 @@ class AkkaSslITCase(_system: ActorSystem)
       val config = new Configuration()
       config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1)
       config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1)
-      config.setBoolean(SecurityOptions.SSL_ENABLED, false)
+      config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false)
 
       val cluster = new TestingCluster(config, false)
 
@@ -121,7 +121,7 @@ class AkkaSslITCase(_system: ActorSystem)
         config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1)
         config.setString(AkkaOptions.ASK_TIMEOUT, "2 s")
 
-        config.setBoolean(SecurityOptions.SSL_ENABLED, true)
+        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true)
         config.setString(SecurityOptions.SSL_KEYSTORE, "invalid.keystore")
         config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password")
         config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password")
@@ -143,7 +143,7 @@ class AkkaSslITCase(_system: ActorSystem)
         config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1)
         config.setString(AkkaOptions.ASK_TIMEOUT, "2 s")
 
-        config.setBoolean(SecurityOptions.SSL_ENABLED, true)
+        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true)
 
         val cluster = new TestingCluster(config, false)
 


### PR DESCRIPTION
** This is based on #6324 - hence the first commit in this PR should be discarded from review**

## What is the purpose of the change

Splits the SSL configuration into **internal communication** *(RPC, data transport, blob server)* and **external/REST** communication. Also activates mutual authentication for all internal communication.

This continues the security features of Flink as outlined in
http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/Discuss-FLIP-26-SSL-Mutual-Authentication-td22188.html

Most of these changes are straightforward, the most important thing for reviewers to check would be (in my opinion) whether the configuration keys make sense:

  - One can configure SSL independently for internal and external/REST communication
  - This is due to feedback from users that internal communication needs to be protected more and by Flink itself, while external communication is frequently protected by REST proxies (often as side car processes to the JobManager / Dispatcher)
  - All keytore and password settings now exist additionally in the `security.ssl.internal.*` and `security.ssl.rest.*` key namespace. The `security.ssl.*` config keys still exist and are used if the more specific key is not set. This is meant both for backwards compatibility, and to make it easy to use a uniform config across internal/external communication.

## Brief change log

  - Introduces new config option families: `security.ssl.internal.*` and `security.ssl.rest.*`
  - Adds code to fall back to the `security.ssl.*` keys if no internal or rest specific options are set
  - Refactors all instantiation of `SSLEngine` and `SSL(Server)Socket` to go through factories. That way, the different endpoint instantiations do not need to apply configurations themselves.
  - Activates mutual auth for akka/rpc via akka config, plus adds a test
  - Activates mutual auth in the SSL Socket/Engine factories (netty / blob) and adds a test

## Verifying this change

  - There are additional unit tests checking that clients with untrusted certificates cannot connect.
  - Verifying end-to-end works by building the code, enabling internal SSL in the flink-conf.yaml, starting a standalone cluster, checking the logs and akka urls for SSL entries

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? Docs coming in a separate PR once we have agreement on the config keys
