### PR TITLE
[FLINK-9816][network] add option to configure SSL engine provider for TM communication

### DIFF
--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -38,6 +38,11 @@
             <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
         </tr>
         <tr>
+            <td><h5>security.ssl.provider</h5></td>
+            <td style="word-wrap: break-word;">"JDK"</td>
+            <td>The SSL engine provider to use for the ssl transport: JDK or OPENSSL. If OPENSSL is selected but not available, flink will automatically fall back to JDK. Please note: OPENSSL requires a custom build of [`netty-tcnative`](http://netty.io/wiki/forked-tomcat-native.html#wiki-h2-4) in our shaded package namespace which is not (yet) available but can be built manually.</td>
+        </tr>
+        <tr>
             <td><h5>security.ssl.truststore</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer’s certificate.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -95,6 +95,18 @@ public class SecurityOptions {
 				" flags defined in different transport modules.");
 
 	/**
+	 * SSL engine provider.
+	 */
+	public static final ConfigOption<String> SSL_PROVIDER =
+		key("security.ssl.provider")
+			.defaultValue("JDK")
+			.withDescription("The SSL engine provider to use for the ssl transport: JDK or OPENSSL. " +
+				"If OPENSSL is selected but not available, flink will automatically fall back to JDK. " +
+				"Please note: OPENSSL requires a custom build of " +
+				"[`netty-tcnative`](http://netty.io/wiki/forked-tomcat-native.html#wiki-h2-4) in our " +
+				"shaded package namespace which is not (yet) available but can be built manually.");
+
+	/**
 	 * The Java keystore file containing the flink endpoint key and certificate.
 	 */
 	public static final ConfigOption<String> SSL_KEYSTORE =

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -47,7 +47,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     fi
 
     if [ ! -z "${FLINK_TM_HEAP_MB}" ] && [ "${FLINK_TM_HEAP}" == 0 ]; then
-	    echo "used deprecated key \`${KEY_TASKM_MEM_MB}\`, pelase replace with key \`${KEY_TASKM_MEM_SIZE}\`"
+	    echo "used deprecated key \`${KEY_TASKM_MEM_MB}\`, please replace with key \`${KEY_TASKM_MEM_SIZE}\`"
     else
 	    flink_tm_heap_bytes=$(parseBytes ${FLINK_TM_HEAP})
 	    FLINK_TM_HEAP_MB=$(getMebiBytes ${flink_tm_heap_bytes})

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -245,7 +245,7 @@ public class NettyConfig {
 		String def = "use Netty's default";
 		String man = "manual";
 
-		return String.format(format, serverAddress, serverPort, getSSLEnabled() ? "true":"false",
+		return String.format(format, serverAddress, serverPort, getSSLEnabled() ? "true" : "false",
 				memorySegmentSize, getTransportType(), getServerNumThreads(),
 				getServerNumThreads() == 0 ? def : man,
 				getClientNumThreads(), getClientNumThreads() == 0 ? def : man,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -31,13 +31,10 @@ import org.apache.flink.shaded.netty4.io.netty.channel.epoll.EpollServerSocketCh
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
-import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -61,7 +58,7 @@ class NettyServer {
 
 	private ChannelFuture bindFuture;
 
-	private SSLContext serverSSLContext = null;
+	private SslContext serverSSLContext = null;
 
 	private InetSocketAddress localAddress;
 
@@ -152,10 +149,8 @@ class NettyServer {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
-					config.setSSLVerAndCipherSuites(sslEngine);
-					sslEngine.setUseClientMode(false);
-					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
+					channel.pipeline().addLast("ssl",
+						serverSSLContext.newHandler(channel.alloc()));
 				}
 
 				channel.pipeline().addLast(protocol.getServerChannelHandlers());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -163,6 +163,88 @@ public class SSLUtils {
 	}
 
 	/**
+	 * SSL engine provider.
+	 */
+	public enum SSLProvider {
+		JDK,
+		/**
+		 * OpenSSL with fallback to JDK if not available.
+		 */
+		OPENSSL;
+
+		public static SSLProvider fromString(String value) {
+			Preconditions.checkNotNull(value);
+			if (value.equalsIgnoreCase("OPENSSL")) {
+				return OPENSSL;
+			} else if (value.equalsIgnoreCase("JDK")) {
+				return JDK;
+			} else {
+				throw new IllegalArgumentException("Unknown SSL provider: " + value);
+			}
+		}
+	}
+
+	/**
+	 * Instances needed to set up an SSL client connection.
+	 */
+	public static class SSLClientTools {
+		public final SSLProvider preferredSslProvider;
+		public final String sslProtocolVersion;
+		public final TrustManagerFactory trustManagerFactory;
+
+		public SSLClientTools(
+				SSLProvider preferredSslProvider,
+				String sslProtocolVersion,
+				TrustManagerFactory trustManagerFactory) {
+			this.preferredSslProvider = preferredSslProvider;
+			this.sslProtocolVersion = sslProtocolVersion;
+			this.trustManagerFactory = trustManagerFactory;
+		}
+	}
+
+	/**
+	 * Creates necessary helper objects to use for creating an SSL Context for the client if SSL is
+	 * configured.
+	 *
+	 * @param sslConfig
+	 *        The application configuration
+	 * @return The SSLClientTools object which can be used for creating some SSL context object;
+	 * 	       returns <tt>null</tt> if SSL is disabled.
+	 * @throws Exception
+	 *         Thrown if there is any misconfiguration
+	 */
+	@Nullable
+	public static SSLClientTools createSSLClientTools(Configuration sslConfig) throws Exception {
+		Preconditions.checkNotNull(sslConfig);
+
+		if (getSSLEnabled(sslConfig)) {
+			LOG.debug("Creating client SSL context from configuration");
+
+			String trustStoreFilePath = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE);
+			String trustStorePassword = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
+			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
+			SSLProvider sslProvider = SSLProvider.fromString(sslConfig.getString(SecurityOptions.SSL_PROVIDER));
+
+			Preconditions.checkNotNull(trustStoreFilePath, SecurityOptions.SSL_TRUSTSTORE.key() + " was not configured.");
+			Preconditions.checkNotNull(trustStorePassword, SecurityOptions.SSL_TRUSTSTORE_PASSWORD.key() + " was not configured.");
+
+			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+
+			try (FileInputStream trustStoreFile = new FileInputStream(new File(trustStoreFilePath))) {
+				trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
+			}
+
+			TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+				TrustManagerFactory.getDefaultAlgorithm());
+			trustManagerFactory.init(trustStore);
+
+			return new SSLClientTools(sslProvider, sslProtocolVersion, trustManagerFactory);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Creates the SSL Context for the client if SSL is configured.
 	 *
 	 * @param sslConfig
@@ -174,41 +256,83 @@ public class SSLUtils {
 	 */
 	@Nullable
 	public static SSLContext createSSLClientContext(Configuration sslConfig) throws Exception {
-
 		Preconditions.checkNotNull(sslConfig);
 		SSLContext clientSSLContext = null;
 
 		if (getSSLEnabled(sslConfig)) {
-			LOG.debug("Creating client SSL context from configuration");
+			SSLClientTools clientTools = createSSLClientTools(sslConfig);
 
-			String trustStoreFilePath = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE);
-			String trustStorePassword = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
-			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
-
-			Preconditions.checkNotNull(trustStoreFilePath, SecurityOptions.SSL_TRUSTSTORE.key() + " was not configured.");
-			Preconditions.checkNotNull(trustStorePassword, SecurityOptions.SSL_TRUSTSTORE_PASSWORD.key() + " was not configured.");
-
-			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-
-			FileInputStream trustStoreFile = null;
-			try {
-				trustStoreFile = new FileInputStream(new File(trustStoreFilePath));
-				trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
-			} finally {
-				if (trustStoreFile != null) {
-					trustStoreFile.close();
-				}
-			}
-
-			TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
-				TrustManagerFactory.getDefaultAlgorithm());
-			trustManagerFactory.init(trustStore);
-
-			clientSSLContext = SSLContext.getInstance(sslProtocolVersion);
-			clientSSLContext.init(null, trustManagerFactory.getTrustManagers(), null);
+			clientSSLContext = SSLContext.getInstance(clientTools.sslProtocolVersion);
+			clientSSLContext.init(null, clientTools.trustManagerFactory.getTrustManagers(), null);
 		}
 
 		return clientSSLContext;
+	}
+
+	/**
+	 * Instances needed to set up an SSL client connection.
+	 */
+	public static class SSLServerTools {
+		public final SSLProvider preferredSslProvider;
+		public final String sslProtocolVersion;
+		public final String[] ciphers;
+		public final KeyManagerFactory keyManagerFactory;
+
+		public SSLServerTools(
+				SSLProvider preferredSslProvider,
+				String sslProtocolVersion,
+				String[] ciphers,
+				KeyManagerFactory keyManagerFactory) {
+			this.preferredSslProvider = preferredSslProvider;
+			this.sslProtocolVersion = sslProtocolVersion;
+			this.ciphers = ciphers;
+			this.keyManagerFactory = keyManagerFactory;
+		}
+	}
+
+	/**
+	 * Creates necessary helper objects to use for creating an SSL Context for the server if SSL is
+	 * configured.
+	 *
+	 * @param sslConfig
+	 *        The application configuration
+	 * @return The SSLServerTools object which can be used for creating some SSL context object;
+	 * 	       returns <tt>null</tt> if SSL is disabled.
+	 * @throws Exception
+	 *         Thrown if there is any misconfiguration
+	 */
+	@Nullable
+	public static SSLServerTools createSSLServerTools(Configuration sslConfig) throws Exception {
+		Preconditions.checkNotNull(sslConfig);
+
+		if (getSSLEnabled(sslConfig)) {
+			LOG.debug("Creating server SSL context from configuration");
+
+			String keystoreFilePath = sslConfig.getString(SecurityOptions.SSL_KEYSTORE);
+			String keystorePassword = sslConfig.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD);
+			String certPassword = sslConfig.getString(SecurityOptions.SSL_KEY_PASSWORD);
+			SSLProvider sslProvider = SSLProvider.fromString(sslConfig.getString(SecurityOptions.SSL_PROVIDER));
+			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
+			String[] sslCipherSuites = sslConfig.getString(SecurityOptions.SSL_ALGORITHMS).split(",");
+
+			Preconditions.checkNotNull(keystoreFilePath, SecurityOptions.SSL_KEYSTORE.key() + " was not configured.");
+			Preconditions.checkNotNull(keystorePassword, SecurityOptions.SSL_KEYSTORE_PASSWORD.key() + " was not configured.");
+			Preconditions.checkNotNull(certPassword, SecurityOptions.SSL_KEY_PASSWORD.key() + " was not configured.");
+
+			KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+			try (FileInputStream keyStoreFile = new FileInputStream(new File(keystoreFilePath))) {
+				ks.load(keyStoreFile, keystorePassword.toCharArray());
+			}
+
+			// Set up key manager factory to use the server key store
+			KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+				KeyManagerFactory.getDefaultAlgorithm());
+			kmf.init(ks, certPassword.toCharArray());
+
+			return new SSLServerTools(sslProvider, sslProtocolVersion, sslCipherSuites, kmf);
+		}
+
+		return null;
 	}
 
 	/**
@@ -228,35 +352,14 @@ public class SSLUtils {
 		SSLContext serverSSLContext = null;
 
 		if (getSSLEnabled(sslConfig)) {
-			LOG.debug("Creating server SSL context from configuration");
-
-			String keystoreFilePath = sslConfig.getString(SecurityOptions.SSL_KEYSTORE);
-
-			String keystorePassword = sslConfig.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD);
-
-			String certPassword = sslConfig.getString(SecurityOptions.SSL_KEY_PASSWORD);
-
-			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
-
-			Preconditions.checkNotNull(keystoreFilePath, SecurityOptions.SSL_KEYSTORE.key() + " was not configured.");
-			Preconditions.checkNotNull(keystorePassword, SecurityOptions.SSL_KEYSTORE_PASSWORD.key() + " was not configured.");
-			Preconditions.checkNotNull(certPassword, SecurityOptions.SSL_KEY_PASSWORD.key() + " was not configured.");
-
-			KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-			try (FileInputStream keyStoreFile = new FileInputStream(new File(keystoreFilePath))) {
-				ks.load(keyStoreFile, keystorePassword.toCharArray());
-			}
-
-			// Set up key manager factory to use the server key store
-			KeyManagerFactory kmf = KeyManagerFactory.getInstance(
-					KeyManagerFactory.getDefaultAlgorithm());
-			kmf.init(ks, certPassword.toCharArray());
+			SSLServerTools serverTools = createSSLServerTools(sslConfig);
 
 			// Initialize the SSLContext
-			serverSSLContext = SSLContext.getInstance(sslProtocolVersion);
-			serverSSLContext.init(kmf.getKeyManagers(), null, null);
+			serverSSLContext = SSLContext.getInstance(serverTools.sslProtocolVersion);
+			serverSSLContext.init(serverTools.keyManagerFactory.getKeyManagers(), null, null);
 		}
 
 		return serverSSLContext;
 	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -160,6 +160,7 @@ public class NettyClientServerSslTest {
 		flinkConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
 		flinkConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
 		flinkConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+//		flinkConfig.setString(SecurityOptions.SSL_PROVIDER, "OPENSSL");
 		return flinkConfig;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Netty has the ability to run with different `SSLEngine` implementations but with our current setup, we are fixed to the JDK implementation, although one based on OpenSSL is expected to be faster [1].
We should make this configurable and ideally also provide everything needed to run with OpenSSL in the future (the last part is not part of this PR).

[1] https://netty.io/wiki/requirements-for-4.x.html#benefits-of-using-openssl

## Brief change log

- allow selecting the SSL engine provider via `security.ssl.provider`
- set up Netty SSL handler with its `SslContextBuilder` (in `NettyConfig`) to have this flexibility

## Verifying this change

This change can be verified as follows:

- I verified by running an SSL setup with 2 TMs and submitting a job through the WebUI with the default `JDK` SSL engine and `OPENSSL` using a custom build using `netty-tcnative` with statically linked boringssl libraries from http://netty.io/wiki/forked-tomcat-native.html
-  there is an end-to-end test in #6327 which is currently blocked on the CLI submission not working with SSL

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **docs, JavaDocs**
