### PR TITLE
[FLINK-8858] [sql-client] Add support for INSERT INTO in SQL Client

### DIFF
--- a/flink-libraries/flink-sql-client/pom.xml
+++ b/flink-libraries/flink-sql-client/pom.xml
@@ -177,16 +177,16 @@ under the License.
 				<version>2.4</version>
 				<executions>
 					<execution>
-						<id>create-table-source-factory-jar</id>
+						<id>create-table-factories-jar</id>
 						<phase>process-test-classes</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>
 						<configuration>
-							<finalName>table-source-factory</finalName>
+							<finalName>table-factories</finalName>
 							<attach>false</attach>
 							<descriptors>
-								<descriptor>src/test/assembly/test-table-source-factory.xml</descriptor>
+								<descriptor>src/test/assembly/test-table-factories.xml</descriptor>
 							</descriptors>
 						</configuration>
 					</execution>

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -97,11 +97,31 @@ public class SqlClient {
 			// add shutdown hook
 			Runtime.getRuntime().addShutdownHook(new EmbeddedShutdownThread(context, executor));
 
-			// start CLI
-			final CliClient cli = new CliClient(context, executor);
-			cli.open();
+			// do the actual work
+			openCli(context, executor);
 		} else {
 			throw new SqlClientException("Gateway mode is not supported yet.");
+		}
+	}
+
+	/**
+	 * Opens the CLI client for executing SQL statements.
+	 *
+	 * @param context session context
+	 * @param executor executor
+	 */
+	private void openCli(SessionContext context, Executor executor) {
+		final CliClient cli = new CliClient(context, executor);
+		// interactive CLI mode
+		if (options.getUpdateStatement() == null) {
+			cli.open();
+		}
+		// execute single update statement
+		else {
+			final boolean success = cli.submitUpdate(options.getUpdateStatement());
+			if (!success) {
+				throw new SqlClientException("Could not submit given SQL update statement to cluster.");
+			}
 		}
 	}
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
@@ -33,14 +33,23 @@ public class CliOptions {
 	private final URL defaults;
 	private final List<URL> jars;
 	private final List<URL> libraryDirs;
+	private final String updateStatement;
 
-	public CliOptions(boolean isPrintHelp, String sessionId, URL environment, URL defaults, List<URL> jars, List<URL> libraryDirs) {
+	public CliOptions(
+			boolean isPrintHelp,
+			String sessionId,
+			URL environment,
+			URL defaults,
+			List<URL> jars,
+			List<URL> libraryDirs,
+			String updateStatement) {
 		this.isPrintHelp = isPrintHelp;
 		this.sessionId = sessionId;
 		this.environment = environment;
 		this.defaults = defaults;
 		this.jars = jars;
 		this.libraryDirs = libraryDirs;
+		this.updateStatement = updateStatement;
 	}
 
 	public boolean isPrintHelp() {
@@ -65,5 +74,9 @@ public class CliOptions {
 
 	public List<URL> getLibraryDirs() {
 		return libraryDirs;
+	}
+
+	public String getUpdateStatement() {
+		return updateStatement;
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
@@ -103,6 +103,19 @@ public class CliOptionsParser {
 				"functions, table sources, or sinks. Can be used multiple times.")
 			.build();
 
+	public static final Option OPTION_UPDATE = Option
+			.builder("u")
+			.required(false)
+			.longOpt("update")
+			.numberOfArgs(1)
+			.argName("SQL update statement")
+			.desc(
+				"Instructs the SQL Client to immediately execute the given update statement after " +
+				"starting up. The process is shut down after the statement has been submitted to " +
+				"the cluster and returns an appropriate return code. Currently, this feature is " +
+				"only supported for INSERT INTO statements that declare the target sink table.")
+			.build();
+
 	private static final Options EMBEDDED_MODE_CLIENT_OPTIONS = getEmbeddedModeClientOptions(new Options());
 	private static final Options GATEWAY_MODE_CLIENT_OPTIONS = getGatewayModeClientOptions(new Options());
 	private static final Options GATEWAY_MODE_GATEWAY_OPTIONS = getGatewayModeGatewayOptions(new Options());
@@ -118,6 +131,7 @@ public class CliOptionsParser {
 		options.addOption(OPTION_DEFAULTS);
 		options.addOption(OPTION_JAR);
 		options.addOption(OPTION_LIBRARY);
+		// options.addOption(OPTION_UPDATE);
 		return options;
 	}
 
@@ -125,6 +139,7 @@ public class CliOptionsParser {
 		buildGeneralOptions(options);
 		options.addOption(OPTION_SESSION);
 		options.addOption(OPTION_ENVIRONMENT);
+		// options.addOption(OPTION_UPDATE);
 		return options;
 	}
 
@@ -218,7 +233,8 @@ public class CliOptionsParser {
 				checkUrl(line, CliOptionsParser.OPTION_ENVIRONMENT),
 				checkUrl(line, CliOptionsParser.OPTION_DEFAULTS),
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
-				checkUrls(line, CliOptionsParser.OPTION_LIBRARY)
+				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
+				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt())
 			);
 		}
 		catch (ParseException e) {
@@ -236,7 +252,8 @@ public class CliOptionsParser {
 				checkUrl(line, CliOptionsParser.OPTION_ENVIRONMENT),
 				null,
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
-				checkUrls(line, CliOptionsParser.OPTION_LIBRARY)
+				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
+				line.getOptionValue(CliOptionsParser.OPTION_UPDATE.getOpt())
 			);
 		}
 		catch (ParseException e) {
@@ -254,7 +271,8 @@ public class CliOptionsParser {
 				null,
 				checkUrl(line, CliOptionsParser.OPTION_DEFAULTS),
 				checkUrls(line, CliOptionsParser.OPTION_JAR),
-				checkUrls(line, CliOptionsParser.OPTION_LIBRARY)
+				checkUrls(line, CliOptionsParser.OPTION_LIBRARY),
+				null
 			);
 		}
 		catch (ParseException e) {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -49,6 +49,7 @@ public final class CliStrings {
 		.append(formatCommand(SqlCommand.DESCRIBE, "Describes the schema of a table with the given name."))
 		.append(formatCommand(SqlCommand.EXPLAIN, "Describes the execution plan of a query or table with the given name."))
 		.append(formatCommand(SqlCommand.SELECT, "Executes a SQL SELECT query on the Flink cluster."))
+		.append(formatCommand(SqlCommand.INSERT_INTO, "Inserts the results of a SQL SELECT query into a declared table sink."))
 		.append(formatCommand(SqlCommand.SOURCE, "Reads a SQL SELECT query from a file and executes it on the Flink cluster."))
 		.append(formatCommand(SqlCommand.SET, "Sets a session configuration property. Syntax: 'SET <key>=<value>'. Use 'SET' for listing all properties."))
 		.append(formatCommand(SqlCommand.RESET, "Resets all session configuration properties."))
@@ -122,11 +123,17 @@ public final class CliStrings {
 
 	public static final String MESSAGE_RESULT_QUIT = "Result retrieval cancelled.";
 
+	public static final String MESSAGE_SUBMITTING_STATEMENT = "Submitting SQL update statement to the cluster...";
+
+	public static final String MESSAGE_STATEMENT_SUBMITTED = "Table update statement has been successfully submitted to the cluster:";
+
 	public static final String MESSAGE_INVALID_PATH = "Path is invalid.";
 
 	public static final String MESSAGE_MAX_SIZE_EXCEEDED = "The given file exceeds the maximum number of characters.";
 
 	public static final String MESSAGE_WILL_EXECUTE = "Executing the following statement:";
+
+	public static final String MESSAGE_UNSUPPORTED_SQL = "Unsupported SQL statement.";
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.client.cli;
 
+import java.util.Optional;
+
 /**
  * Simple parser for determining the type of command and its parameters.
  */
@@ -27,7 +29,7 @@ public final class SqlCommandParser {
 		// private
 	}
 
-	public static SqlCommandCall parse(String stmt) {
+	public static Optional<SqlCommandCall> parse(String stmt) {
 		String trimmed = stmt.trim();
 		// remove ';' at the end because many people type it intuitively
 		if (trimmed.endsWith(";")) {
@@ -43,10 +45,11 @@ public final class SqlCommandParser {
 					// match
 					if (tokenCount < cmd.tokens.length && token.equalsIgnoreCase(cmd.tokens[tokenCount])) {
 						if (tokenCount == cmd.tokens.length - 1) {
-							return new SqlCommandCall(
+							final SqlCommandCall call = new SqlCommandCall(
 								cmd,
 								splitOperands(cmd, trimmed, trimmed.substring(Math.min(pos, trimmed.length())))
 							);
+							return Optional.of(call);
 						}
 					} else {
 						// next sql command
@@ -56,7 +59,7 @@ public final class SqlCommandParser {
 				}
 			}
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	private static String[] splitOperands(SqlCommand cmd, String originalCall, String operands) {
@@ -69,6 +72,7 @@ public final class SqlCommandParser {
 					return new String[] {operands.substring(0, delimiter), operands.substring(delimiter + 1)};
 				}
 			case SELECT:
+			case INSERT_INTO:
 				return new String[] {originalCall};
 			default:
 				return new String[] {operands};
@@ -90,9 +94,11 @@ public final class SqlCommandParser {
 		DESCRIBE("describe"),
 		EXPLAIN("explain"),
 		SELECT("select"),
+		INSERT_INTO("insert into"),
 		SET("set"),
 		RESET("reset"),
-		SOURCE("source");
+		SOURCE("source"),
+		STATUS("status");
 
 		public final String command;
 		public final String[] tokens;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -88,6 +88,15 @@ public interface Executor {
 	void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException;
 
 	/**
+	 * Submits a Flink SQL update statement such as INSERT INTO.
+	 *
+	 * @param session context in with the statement is executed
+	 * @param statement SQL update statement (currently only INSERT INTO is supported)
+	 * @return information about the target of the submitted Flink job
+	 */
+	ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException;
+
+	/**
 	 * Stops the executor.
 	 */
 	void stop(SessionContext session);

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ProgramTargetDescriptor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ProgramTargetDescriptor.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway;
+
+import org.apache.flink.api.common.JobID;
+
+/**
+ * Describes the target where a table program has been submitted to.
+ */
+public class ProgramTargetDescriptor {
+
+	private final String clusterId;
+
+	private final String jobId;
+
+	private final String webInterfaceUrl;
+
+	public ProgramTargetDescriptor(String clusterId, String jobId, String webInterfaceUrl) {
+		this.clusterId = clusterId;
+		this.jobId = jobId;
+		this.webInterfaceUrl = webInterfaceUrl;
+	}
+
+	public String getClusterId() {
+		return clusterId;
+	}
+
+	public String getJobId() {
+		return jobId;
+	}
+
+	public String getWebInterfaceUrl() {
+		return webInterfaceUrl;
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"Cluster ID: %s\n" +
+			"Job ID: %s\n" +
+			"Web interface: %s",
+			clusterId, jobId, webInterfaceUrl);
+	}
+
+	/**
+	 * Creates a program target description from deployment classes.
+	 *
+	 * @param clusterId cluster id
+	 * @param jobId job id
+	 * @param <C> cluster id type
+	 * @return program target descriptor
+	 */
+	public static <C> ProgramTargetDescriptor of(C clusterId, JobID jobId, String webInterfaceUrl) {
+		String clusterIdString;
+		try {
+			// check if cluster id has a toString method
+			clusterId.getClass().getDeclaredMethod("toString");
+			clusterIdString = clusterId.toString();
+		} catch (NoSuchMethodException e) {
+			clusterIdString = clusterId.getClass().getSimpleName();
+		}
+		return new ProgramTargetDescriptor(clusterIdString, jobId.toString(), webInterfaceUrl);
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -169,6 +169,14 @@ public class ExecutionContext<T> {
 		return new EnvironmentInstance();
 	}
 
+	public Map<String, TableSource<?>> getTableSources() {
+		return tableSources;
+	}
+
+	public Map<String, TableSink<?>> getTableSinks() {
+		return tableSinks;
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	private static CommandLine createCommandLine(Deployment deployment, Options commandLineOptions) {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -31,16 +31,22 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.table.api.QueryConfig;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.client.gateway.local.result.BasicResult;
+import org.apache.flink.table.client.gateway.local.result.ChangelogResult;
+import org.apache.flink.table.client.gateway.local.result.DynamicResult;
+import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.StringUtils;
 
@@ -277,6 +283,12 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		return executeUpdateInternal(context, statement);
+	}
+
+	@Override
 	public void stop(SessionContext session) {
 		resultStore.getResults().forEach((resultId) -> {
 			try {
@@ -329,14 +341,43 @@ public class LocalExecutor implements Executor {
 		}
 	}
 
-	private <T> ResultDescriptor executeQueryInternal(ExecutionContext<T> context, String query) {
+	private <C> ProgramTargetDescriptor executeUpdateInternal(ExecutionContext<C> context, String statement) {
+		final ExecutionContext.EnvironmentInstance envInst = context.createEnvironmentInstance();
+
+		applyUpdate(envInst.getTableEnvironment(), envInst.getQueryConfig(), statement);
+
+		// create job graph with dependencies
+		final String jobName = context.getSessionContext().getName() + ": " + statement;
+		final JobGraph jobGraph;
+		try {
+			jobGraph = envInst.createJobGraph(jobName);
+		} catch (Throwable t) {
+			// catch everything such that the statement does not crash the executor
+			throw new SqlExecutionException("Invalid SQL statement.", t);
+		}
+
+		// create execution
+		final BasicResult<C> result = new BasicResult<>();
+		final ProgramDeployer<C> deployer = new ProgramDeployer<>(
+			context, jobName, jobGraph, result, false);
+
+		// blocking deployment
+		deployer.run();
+
+		return ProgramTargetDescriptor.of(
+			result.getClusterId(),
+			jobGraph.getJobID(),
+			result.getWebInterfaceUrl());
+	}
+
+	private <C> ResultDescriptor executeQueryInternal(ExecutionContext<C> context, String query) {
 		final ExecutionContext.EnvironmentInstance envInst = context.createEnvironmentInstance();
 
 		// create table
 		final Table table = createTable(envInst.getTableEnvironment(), query);
 
 		// initialize result
-		final DynamicResult<T> result = resultStore.createResult(
+		final DynamicResult<C> result = resultStore.createResult(
 			context.getMergedEnvironment(),
 			table.getSchema().withoutTimeAttributes(),
 			envInst.getExecutionConfig());
@@ -352,7 +393,7 @@ public class LocalExecutor implements Executor {
 			// it not stored in the result store
 			result.close();
 			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Invalid SQL statement.", t);
+			throw new SqlExecutionException("Invalid SQL query.", t);
 		}
 
 		// store the result with a unique id (the job id for now)
@@ -360,7 +401,8 @@ public class LocalExecutor implements Executor {
 		resultStore.storeResult(resultId, result);
 
 		// create execution
-		final ProgramDeployer<T> deployer = new ProgramDeployer<>(context, jobName, jobGraph, result);
+		final ProgramDeployer<C> deployer = new ProgramDeployer<>(
+			context, jobName, jobGraph, result, true);
 
 		// start result retrieval
 		result.startRetrieval(deployer);
@@ -371,13 +413,29 @@ public class LocalExecutor implements Executor {
 			result.isMaterialized());
 	}
 
-	private Table createTable(TableEnvironment tableEnv, String query) {
+	/**
+	 * Creates a table using the given query in the given table environment.
+	 */
+	private Table createTable(TableEnvironment tableEnv, String selectQuery) {
 		// parse and validate query
 		try {
-			return tableEnv.sqlQuery(query);
+			return tableEnv.sqlQuery(selectQuery);
 		} catch (Throwable t) {
 			// catch everything such that the query does not crash the executor
 			throw new SqlExecutionException("Invalid SQL statement.", t);
+		}
+	}
+
+	/**
+	 * Applies the given update statement to the given table environment with query configuration.
+	 */
+	private void applyUpdate(TableEnvironment tableEnv, QueryConfig queryConfig, String updateStatement) {
+		// parse and validate statement
+		try {
+			tableEnv.sqlUpdate(updateStatement, queryConfig);
+		} catch (Throwable t) {
+			// catch everything such that the statement does not crash the executor
+			throw new SqlExecutionException("Invalid SQL update statement.", t);
 		}
 	}
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -29,6 +29,10 @@ import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.config.Deployment;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.local.result.ChangelogCollectStreamResult;
+import org.apache.flink.table.client.gateway.local.result.DynamicResult;
+import org.apache.flink.table.client.gateway.local.result.MaterializedCollectBatchResult;
+import org.apache.flink.table.client.gateway.local.result.MaterializedCollectStreamResult;
 import org.apache.flink.types.Row;
 
 import java.net.InetAddress;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/BasicResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/BasicResult.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local.result;
+
+/**
+ * Basic result of a table program that has been submitted to a cluster.
+ *
+ * @param <C> cluster id to which this result belongs to
+ */
+public class BasicResult<C> implements Result<C> {
+
+	protected C clusterId;
+	protected String webInterfaceUrl;
+
+	@Override
+	public void setClusterInformation(C clusterId, String webInterfaceUrl) {
+		if (this.clusterId != null || this.webInterfaceUrl != null) {
+			throw new IllegalStateException("Cluster information is already present.");
+		}
+		this.clusterId = clusterId;
+		this.webInterfaceUrl = webInterfaceUrl;
+	}
+
+	public C getClusterId() {
+		if (this.clusterId == null) {
+			throw new IllegalStateException("Cluster ID has not been set.");
+		}
+		return clusterId;
+	}
+
+	public String getWebInterfaceUrl() {
+		if (this.webInterfaceUrl == null) {
+			throw new IllegalStateException("Cluster web interface URL has not been set.");
+		}
+		return webInterfaceUrl;
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
+package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local.result;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.types.Row;
+
+import java.util.List;
+
+/**
+ * A result that is represented as a changelog consisting of insert and delete records.
+ *
+ * @param <C> cluster id to which this result belongs to
+ */
+public interface ChangelogResult<C> extends DynamicResult<C> {
+
+	/**
+	 * Retrieves the available result records.
+	 */
+	TypedResult<List<Tuple2<Boolean, Row>>> retrieveChanges();
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
+package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -29,6 +29,8 @@ import org.apache.flink.streaming.experimental.SocketStreamIterator;
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.client.gateway.local.CollectStreamTableSink;
+import org.apache.flink.table.client.gateway.local.ProgramDeployer;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
@@ -40,7 +42,7 @@ import java.net.InetAddress;
  *
  * @param <C> cluster id to which this result belongs to
  */
-public abstract class CollectStreamResult<C> implements DynamicResult<C> {
+public abstract class CollectStreamResult<C> extends BasicResult<C> implements DynamicResult<C> {
 
 	private final TypeInformation<Row> outputType;
 	private final SocketStreamIterator<Tuple2<Boolean, Row>> iterator;
@@ -48,7 +50,6 @@ public abstract class CollectStreamResult<C> implements DynamicResult<C> {
 	private final ResultRetrievalThread retrievalThread;
 	private final JobMonitoringThread monitoringThread;
 	private ProgramDeployer<C> deployer;
-	private C clusterId;
 
 	protected final Object resultLock;
 	protected SqlExecutionException executionException;
@@ -74,14 +75,6 @@ public abstract class CollectStreamResult<C> implements DynamicResult<C> {
 		collectTableSink = new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer);
 		retrievalThread = new ResultRetrievalThread();
 		monitoringThread = new JobMonitoringThread();
-	}
-
-	@Override
-	public void setClusterId(C clusterId) {
-		if (this.clusterId != null) {
-			throw new IllegalStateException("Cluster id is already present.");
-		}
-		this.clusterId = clusterId;
 	}
 
 	@Override

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
+package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.client.gateway.local.ProgramDeployer;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
@@ -29,12 +30,7 @@ import org.apache.flink.types.Row;
  *
  * @param <C> type of the cluster id to which this result belongs to
  */
-public interface DynamicResult<C> {
-
-	/**
-	 * Sets the cluster id of the cluster this result comes from. This method should only be called once.
-	 */
-	void setClusterId(C clusterId);
+public interface DynamicResult<C> extends Result<C> {
 
 	/**
 	 * Returns whether this result is materialized such that snapshots can be taken or results

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
+package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.client.gateway.local.CollectBatchTableSink;
+import org.apache.flink.table.client.gateway.local.ProgramDeployer;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.AbstractID;
@@ -35,7 +37,7 @@ import java.util.List;
 /**
  * Collects results using accumulators and returns them as table snapshots.
  */
-public class MaterializedCollectBatchResult<C> implements MaterializedResult<C> {
+public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements MaterializedResult<C> {
 
 	private final TypeInformation<Row> outputType;
 	private final String accumulatorName;
@@ -44,7 +46,6 @@ public class MaterializedCollectBatchResult<C> implements MaterializedResult<C> 
 	private final Thread retrievalThread;
 
 	private ProgramDeployer<C> deployer;
-	private C clusterId;
 	private int pageSize;
 	private int pageCount;
 	private SqlExecutionException executionException;
@@ -61,14 +62,6 @@ public class MaterializedCollectBatchResult<C> implements MaterializedResult<C> 
 		retrievalThread = new ResultRetrievalThread();
 
 		pageCount = 0;
-	}
-
-	@Override
-	public void setClusterId(C clusterId) {
-		if (this.clusterId != null) {
-			throw new IllegalStateException("Cluster id is already present.");
-		}
-		this.clusterId = clusterId;
 	}
 
 	@Override

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
+package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedResult.java
@@ -16,23 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
+package org.apache.flink.table.client.gateway.local.result;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
 
 import java.util.List;
 
 /**
- * A result that is represented as a changelog consisting of insert and delete records.
+ * A result that is materialized and can be viewed by navigating through a snapshot.
  *
  * @param <C> cluster id to which this result belongs to
  */
-public interface ChangelogResult<C> extends DynamicResult<C> {
+public interface MaterializedResult<C> extends DynamicResult<C> {
 
 	/**
-	 * Retrieves the available result records.
+	 * Takes a snapshot of the current table and returns the number of pages for navigating
+	 * through the snapshot.
 	 */
-	TypedResult<List<Tuple2<Boolean, Row>>> retrieveChanges();
+	TypedResult<Integer> snapshot(int pageSize);
+
+	/**
+	 * Retrieves a page of a snapshotted result.
+	 */
+	List<Row> retrievePage(int page);
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/Result.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/Result.java
@@ -16,28 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.local;
-
-import org.apache.flink.table.client.gateway.TypedResult;
-import org.apache.flink.types.Row;
-
-import java.util.List;
+package org.apache.flink.table.client.gateway.local.result;
 
 /**
- * A result that is materialized and can be viewed by navigating through a snapshot.
+ * A result of a table program submission to a cluster.
  *
- * @param <C> cluster id to which this result belongs to
+ * @param <C> type of the cluster id to which this result belongs to
  */
-public interface MaterializedResult<C> extends DynamicResult<C> {
+public interface Result<C> {
 
 	/**
-	 * Takes a snapshot of the current table and returns the number of pages for navigating
-	 * through the snapshot.
+	 * Sets the cluster information of the cluster this result comes from. This method should only be called once.
 	 */
-	TypedResult<Integer> snapshot(int pageSize);
+	void setClusterInformation(C clusterId, String webInterfaceUrl);
 
-	/**
-	 * Retrieves a page of a snapshotted result.
-	 */
-	List<Row> retrievePage(int page);
 }

--- a/flink-libraries/flink-sql-client/src/test/assembly/test-table-factories.xml
+++ b/flink-libraries/flink-sql-client/src/test/assembly/test-table-factories.xml
@@ -32,6 +32,8 @@ under the License.
 			<includes>
 				<include>org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.class</include>
 				<include>org/apache/flink/table/client/gateway/utils/TestTableSourceFactory$*.class</include>
+				<include>org/apache/flink/table/client/gateway/utils/TestTableSinkFactory.class</include>
+				<include>org/apache/flink/table/client/gateway/utils/TestTableSinkFactory$*.class</include>
 			</includes>
 		</fileSet>
 	</fileSets>

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
+import org.apache.flink.table.client.gateway.ResultDescriptor;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link CliClient}.
+ */
+public class CliClientTest {
+
+	private static final String INSERT_INTO_STATEMENT = "INSERT INTO MyTable SELECT * FROM MyOtherTable";
+	private static final String SELECT_STATEMENT = "SELECT * FROM MyOtherTable";
+
+	@Test
+	public void testUpdateSubmission() {
+		verifyUpdateSubmission(INSERT_INTO_STATEMENT, false, false);
+	}
+
+	@Test
+	public void testFailedUpdateSubmission() {
+		// fail at executor
+		verifyUpdateSubmission(INSERT_INTO_STATEMENT, true, true);
+
+		// fail early in client
+		verifyUpdateSubmission(SELECT_STATEMENT, false, true);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private void verifyUpdateSubmission(String statement, boolean failExecution, boolean testFailure) {
+		final SessionContext context = new SessionContext("test-session", new Environment());
+
+		final MockExecutor mockExecutor = new MockExecutor();
+		mockExecutor.failExecution = failExecution;
+		final CliClient client = new CliClient(context, mockExecutor);
+
+		if (testFailure) {
+			assertFalse(client.submitUpdate(statement));
+		} else {
+			assertTrue(client.submitUpdate(statement));
+			assertEquals(statement, mockExecutor.receivedStatement);
+			assertEquals(context, mockExecutor.receivedContext);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static class MockExecutor implements Executor {
+
+		public boolean failExecution;
+
+		public SessionContext receivedContext;
+		public String receivedStatement;
+
+		@Override
+		public void start() throws SqlExecutionException {
+			// nothing to do
+		}
+
+		@Override
+		public Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public List<String> listTables(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public String explainStatement(SessionContext session, String statement) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session, String resultId) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
+		public void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException {
+
+		}
+
+		@Override
+		public ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException {
+			receivedContext = session;
+			receivedStatement = statement;
+			if (failExecution) {
+				throw new SqlExecutionException("Fail execution.");
+			}
+			return new ProgramTargetDescriptor("testClusterId", "testJobId", "http://testcluster:1234");
+		}
+
+		@Override
+		public void stop(SessionContext session) {
+			// nothing to do
+		}
+	}
+}

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -41,20 +41,24 @@ import static org.junit.Assert.assertEquals;
  */
 public class DependencyTest {
 
+	public static final String CONNECTOR_TYPE_VALUE = "test-connector";
+	public static final String TEST_PROPERTY = "test-property";
+	public static final String CONNECTOR_TEST_PROPERTY = "connector.test-property";
+
 	private static final String FACTORY_ENVIRONMENT_FILE = "test-sql-client-factory.yaml";
-	private static final String TABLE_SOURCE_FACTORY_JAR_FILE = "table-source-factory-test-jar.jar";
+	private static final String TABLE_FACTORY_JAR_FILE = "table-factories-test-jar.jar";
 
 	@Test
-	public void testTableSourceFactoryDiscovery() throws Exception {
+	public void testTableFactoryDiscovery() throws Exception {
 		// create environment
 		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_0", "test-table-source-factory");
-		replaceVars.put("$VAR_1", "test-property");
+		replaceVars.put("$VAR_0", CONNECTOR_TYPE_VALUE);
+		replaceVars.put("$VAR_1", TEST_PROPERTY);
 		replaceVars.put("$VAR_2", "test-value");
 		final Environment env = EnvironmentFileUtil.parseModified(FACTORY_ENVIRONMENT_FILE, replaceVars);
 
 		// create executor with dependencies
-		final URL dependency = Paths.get("target", TABLE_SOURCE_FACTORY_JAR_FILE).toUri().toURL();
+		final URL dependency = Paths.get("target", TABLE_FACTORY_JAR_FILE).toUri().toURL();
 		final LocalExecutor executor = new LocalExecutor(
 			env,
 			Collections.singletonList(dependency),

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
@@ -51,6 +51,7 @@ public class EnvironmentTest {
 		tables.add("TableNumber1");
 		tables.add("TableNumber2");
 		tables.add("NewTable");
+		tables.add("TableSourceSink");
 
 		assertEquals(tables, merged.getTables().keySet());
 		assertTrue(merged.getExecution().isStreamingExecution());

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactory.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactory.java
@@ -20,24 +20,21 @@ package org.apache.flink.table.client.gateway.utils;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.client.gateway.local.DependencyTest;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.SchemaValidator;
-import org.apache.flink.table.factories.StreamTableSourceFactory;
-import org.apache.flink.table.sources.DefinedProctimeAttribute;
-import org.apache.flink.table.sources.DefinedRowtimeAttributes;
-import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
-import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.factories.StreamTableSinkFactory;
+import org.apache.flink.table.sinks.AppendStreamTableSink;
+import org.apache.flink.table.sinks.StreamTableSink;
+import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.flink.table.client.gateway.local.DependencyTest.CONNECTOR_TEST_PROPERTY;
 import static org.apache.flink.table.client.gateway.local.DependencyTest.CONNECTOR_TYPE_VALUE;
@@ -50,9 +47,9 @@ import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA_NAME;
 import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA_TYPE;
 
 /**
- * Table source factory for testing the classloading in {@link DependencyTest}.
+ * Table sink factory for testing the classloading in {@link DependencyTest}.
  */
-public class TestTableSourceFactory implements StreamTableSourceFactory<Row> {
+public class TestTableSinkFactory implements StreamTableSinkFactory<Row> {
 
 	@Override
 	public Map<String, String> requiredContext() {
@@ -74,35 +71,27 @@ public class TestTableSourceFactory implements StreamTableSourceFactory<Row> {
 	}
 
 	@Override
-	public StreamTableSource<Row> createStreamTableSource(Map<String, String> properties) {
+	public StreamTableSink<Row> createStreamTableSink(Map<String, String> properties) {
 		final DescriptorProperties params = new DescriptorProperties(true);
 		params.putProperties(properties);
-		final Optional<String> proctime = SchemaValidator.deriveProctimeAttribute(params);
-		final List<RowtimeAttributeDescriptor> rowtime = SchemaValidator.deriveRowtimeAttributes(params);
-		return new TestTableSource(
-			SchemaValidator.deriveTableSourceSchema(params),
-			properties.get(CONNECTOR_TEST_PROPERTY),
-			proctime.orElse(null),
-			rowtime);
+		return new TestTableSink(
+				SchemaValidator.deriveTableSinkSchema(params),
+				properties.get(CONNECTOR_TEST_PROPERTY));
 	}
 
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Test table source.
+	 * Test table sink.
 	 */
-	public static class TestTableSource implements StreamTableSource<Row>, DefinedRowtimeAttributes, DefinedProctimeAttribute {
+	public static class TestTableSink implements TableSink<Row>, AppendStreamTableSink<Row> {
 
 		private final TableSchema schema;
 		private final String property;
-		private final String proctime;
-		private final List<RowtimeAttributeDescriptor> rowtime;
 
-		public TestTableSource(TableSchema schema, String property, String proctime, List<RowtimeAttributeDescriptor> rowtime) {
+		public TestTableSink(TableSchema schema, String property) {
 			this.schema = schema;
 			this.property = property;
-			this.proctime = proctime;
-			this.rowtime = rowtime;
 		}
 
 		public String getProperty() {
@@ -110,33 +99,28 @@ public class TestTableSourceFactory implements StreamTableSourceFactory<Row> {
 		}
 
 		@Override
-		public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
-			return null;
-		}
-
-		@Override
-		public TypeInformation<Row> getReturnType() {
+		public TypeInformation<Row> getOutputType() {
 			return Types.ROW(schema.getColumnNames(), schema.getTypes());
 		}
 
 		@Override
-		public TableSchema getTableSchema() {
-			return schema;
+		public String[] getFieldNames() {
+			return schema.getColumnNames();
 		}
 
 		@Override
-		public String explainSource() {
-			return "TestTableSource";
+		public TypeInformation<?>[] getFieldTypes() {
+			return schema.getTypes();
 		}
 
 		@Override
-		public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
-			return rowtime;
+		public TableSink<Row> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+			return new TestTableSink(new TableSchema(fieldNames, fieldTypes), property);
 		}
 
 		@Override
-		public String getProctimeAttribute() {
-			return proctime;
+		public void emitDataStream(DataStream<Row> dataStream) {
+			// do nothing
 		}
 	}
 }

--- a/flink-libraries/flink-sql-client/src/test/resources/test-factory-services-file
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-factory-services-file
@@ -18,3 +18,4 @@
 #==============================================================================
 
 org.apache.flink.table.client.gateway.utils.TestTableSourceFactory
+org.apache.flink.table.client.gateway.utils.TestTableSinkFactory

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -62,6 +62,23 @@ tables:
           type: VARCHAR
       line-delimiter: "\n"
       comment-prefix: "#"
+  - name: TableSourceSink
+    type: both
+    schema:
+      - name: BooleanField
+        type: BOOLEAN
+      - name: StringField
+        type: VARCHAR
+    connector:
+      type: filesystem
+      path: "$VAR_4"
+    format:
+      type: csv
+      fields:
+        - name: BooleanField
+          type: BOOLEAN
+        - name: StringField
+          type: VARCHAR
 
 functions:
   - name: scalarUDF

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -25,7 +25,7 @@
 
 tables:
   - name: TableNumber1
-    type: source
+    type: both
     schema:
       - name: IntegerField1
         type: INT

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
@@ -22,9 +22,8 @@ import org.apache.calcite.plan.{RelOptCluster, RelOptTable, RelTraitSet}
 import org.apache.calcite.rel.RelWriter
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
-import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.plan.schema.{BatchTableSourceTable, StreamTableSourceTable, TableSourceSinkTable, TableSourceTable}
+import org.apache.flink.table.plan.schema.TableSourceSinkTable
 import org.apache.flink.table.sources.{TableSource, TableSourceUtil}
 
 import scala.collection.JavaConverters._


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for the SQL `INSERT INTO` statement in SQL Client. This PR depends on #6323 for finalizing the unified table sinks. The PR adds support for submitting `INSERT INTO` statements in the CLI shell as well as using the `-u` command line option. The command line option is the basis for end-to-end testing of the SQL Client (FLINK-8970).


## Brief change log

- Refactor the `XXXResult` classes
- Add `INSERT INTO` support to CLI and local executor
- Add `-u` command line parameter


## Verifying this change

- `DependencyTest` has been adapted
- New test `o.a.f.table.client.gateway.local.LocalExecutorITCase#testStreamQueryExecutionSink`
- New test `o.a.f.table.client.gateway.local.ExecutionContextTest#testSourceSinks` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
