### PR TITLE
[FLINK-9489] Checkpoint timers as part of managed keyed state instead of raw keyed state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -315,4 +315,9 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	@VisibleForTesting
 	public abstract int numStateEntries();
 
+	// TODO remove this once heap-based timers are working with RocksDB incremental snapshots!
+	public boolean requiresLegacySynchronousTimerSnapshots() {
+		return false;
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/BackendWritableBroadcastState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/BackendWritableBroadcastState.java
@@ -36,7 +36,7 @@ public interface BackendWritableBroadcastState<K, V> extends BroadcastState<K, V
 
 	long write(FSDataOutputStream out) throws IOException;
 
-	void setStateMetaInfo(RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo);
+	void setStateMetaInfo(RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo);
 
-	RegisteredBroadcastBackendStateMetaInfo<K, V> getStateMetaInfo();
+	RegisteredBroadcastStateBackendMetaInfo<K, V> getStateMetaInfo();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -209,7 +209,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 		if (broadcastState == null) {
 			broadcastState = new HeapBroadcastState<>(
-					new RegisteredBroadcastBackendStateMetaInfo<>(
+					new RegisteredBroadcastStateBackendMetaInfo<>(
 							name,
 							OperatorStateHandle.Mode.BROADCAST,
 							broadcastStateKeySerializer,
@@ -227,7 +227,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			final StateMetaInfoSnapshot metaInfoSnapshot = restoredBroadcastStateMetaInfos.get(name);
 
 			@SuppressWarnings("unchecked")
-			RegisteredBroadcastBackendStateMetaInfo<K, V> restoredMetaInfo = new RegisteredBroadcastBackendStateMetaInfo<K, V>(metaInfoSnapshot);
+			RegisteredBroadcastStateBackendMetaInfo<K, V> restoredMetaInfo = new RegisteredBroadcastStateBackendMetaInfo<K, V>(metaInfoSnapshot);
 
 			// check compatibility to determine if state migration is required
 			CompatibilityResult<K> keyCompatibility = CompatibilityUtil.resolveCompatibilityResult(
@@ -247,7 +247,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			if (!keyCompatibility.isRequiresMigration() && !valueCompatibility.isRequiresMigration()) {
 				// new serializer is compatible; use it to replace the old serializer
 				broadcastState.setStateMetaInfo(
-						new RegisteredBroadcastBackendStateMetaInfo<>(
+						new RegisteredBroadcastStateBackendMetaInfo<>(
 								name,
 								OperatorStateHandle.Mode.BROADCAST,
 								broadcastStateKeySerializer,
@@ -510,8 +510,8 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 				// Recreate all PartitionableListStates from the meta info
 				for (StateMetaInfoSnapshot restoredSnapshot : restoredOperatorMetaInfoSnapshots) {
 
-					final RegisteredOperatorBackendStateMetaInfo<?> restoredMetaInfo =
-						new RegisteredOperatorBackendStateMetaInfo<>(restoredSnapshot);
+					final RegisteredOperatorStateBackendMetaInfo<?> restoredMetaInfo =
+						new RegisteredOperatorStateBackendMetaInfo<>(restoredSnapshot);
 
 					if (restoredMetaInfo.getPartitionStateSerializer() == null ||
 						restoredMetaInfo.getPartitionStateSerializer() instanceof UnloadableDummyTypeSerializer) {
@@ -546,8 +546,8 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 				for (StateMetaInfoSnapshot restoredSnapshot : restoredBroadcastMetaInfoSnapshots) {
 
-					final RegisteredBroadcastBackendStateMetaInfo<?, ?> restoredMetaInfo =
-						new RegisteredBroadcastBackendStateMetaInfo<>(restoredSnapshot);
+					final RegisteredBroadcastStateBackendMetaInfo<?, ?> restoredMetaInfo =
+						new RegisteredBroadcastStateBackendMetaInfo<>(restoredSnapshot);
 
 					if (restoredMetaInfo.getKeySerializer() == null || restoredMetaInfo.getValueSerializer() == null ||
 						restoredMetaInfo.getKeySerializer() instanceof UnloadableDummyTypeSerializer ||
@@ -613,7 +613,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		/**
 		 * Meta information of the state, including state name, assignment mode, and serializer
 		 */
-		private RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo;
+		private RegisteredOperatorStateBackendMetaInfo<S> stateMetaInfo;
 
 		/**
 		 * The internal list the holds the elements of the state
@@ -625,12 +625,12 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		 */
 		private final ArrayListSerializer<S> internalListCopySerializer;
 
-		PartitionableListState(RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo) {
+		PartitionableListState(RegisteredOperatorStateBackendMetaInfo<S> stateMetaInfo) {
 			this(stateMetaInfo, new ArrayList<S>());
 		}
 
 		private PartitionableListState(
-				RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo,
+				RegisteredOperatorStateBackendMetaInfo<S> stateMetaInfo,
 				ArrayList<S> internalList) {
 
 			this.stateMetaInfo = Preconditions.checkNotNull(stateMetaInfo);
@@ -643,11 +643,11 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			this(toCopy.stateMetaInfo.deepCopy(), toCopy.internalListCopySerializer.copy(toCopy.internalList));
 		}
 
-		public void setStateMetaInfo(RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo) {
+		public void setStateMetaInfo(RegisteredOperatorStateBackendMetaInfo<S> stateMetaInfo) {
 			this.stateMetaInfo = stateMetaInfo;
 		}
 
-		public RegisteredOperatorBackendStateMetaInfo<S> getStateMetaInfo() {
+		public RegisteredOperatorStateBackendMetaInfo<S> getStateMetaInfo() {
 			return stateMetaInfo;
 		}
 
@@ -741,7 +741,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			// no restored state for the state name; simply create new state holder
 
 			partitionableListState = new PartitionableListState<>(
-				new RegisteredOperatorBackendStateMetaInfo<>(
+				new RegisteredOperatorStateBackendMetaInfo<>(
 					name,
 					partitionStateSerializer,
 					mode));
@@ -757,8 +757,8 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					mode);
 
 			StateMetaInfoSnapshot restoredSnapshot = restoredOperatorStateMetaInfos.get(name);
-			RegisteredOperatorBackendStateMetaInfo<S> metaInfo =
-				new RegisteredOperatorBackendStateMetaInfo<>(restoredSnapshot);
+			RegisteredOperatorStateBackendMetaInfo<S> metaInfo =
+				new RegisteredOperatorStateBackendMetaInfo<>(restoredSnapshot);
 
 			// check compatibility to determine if state migration is required
 			TypeSerializer<S> newPartitionStateSerializer = partitionStateSerializer.duplicate();
@@ -772,7 +772,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			if (!stateCompatibility.isRequiresMigration()) {
 				// new serializer is compatible; use it to replace the old serializer
 				partitionableListState.setStateMetaInfo(
-					new RegisteredOperatorBackendStateMetaInfo<>(name, newPartitionStateSerializer, mode));
+					new RegisteredOperatorStateBackendMetaInfo<>(name, newPartitionStateSerializer, mode));
 			} else {
 				// TODO state migration currently isn't possible.
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
@@ -42,7 +42,7 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
 	/**
 	 * Meta information of the state, including state name, assignment mode, and serializer.
 	 */
-	private RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo;
+	private RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo;
 
 	/**
 	 * The internal map the holds the elements of the state.
@@ -54,11 +54,11 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
 	 */
 	private final MapSerializer<K, V> internalMapCopySerializer;
 
-	HeapBroadcastState(RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo) {
+	HeapBroadcastState(RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo) {
 		this(stateMetaInfo, new HashMap<>());
 	}
 
-	private HeapBroadcastState(final RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo, final Map<K, V> internalMap) {
+	private HeapBroadcastState(final RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo, final Map<K, V> internalMap) {
 
 		this.stateMetaInfo = Preconditions.checkNotNull(stateMetaInfo);
 		this.backingMap = Preconditions.checkNotNull(internalMap);
@@ -70,12 +70,12 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
 	}
 
 	@Override
-	public void setStateMetaInfo(RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo) {
+	public void setStateMetaInfo(RegisteredBroadcastStateBackendMetaInfo<K, V> stateMetaInfo) {
 		this.stateMetaInfo = stateMetaInfo;
 	}
 
 	@Override
-	public RegisteredBroadcastBackendStateMetaInfo<K, V> getStateMetaInfo() {
+	public RegisteredBroadcastStateBackendMetaInfo<K, V> getStateMetaInfo() {
 		return stateMetaInfo;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyExtractorFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyExtractorFunction.java
@@ -28,9 +28,22 @@ import javax.annotation.Nonnull;
 @FunctionalInterface
 public interface KeyExtractorFunction<T> {
 
+	KeyExtractorFunction<? extends Keyed<?>> FOR_KEYED_OBJECTS = new KeyExtractorFunction<Keyed<?>>() {
+		@Nonnull
+		@Override
+		public Object extractKeyFromElement(@Nonnull Keyed<?> element) {
+			return element.getKey();
+		}
+	};
+
 	/**
 	 * Returns the key for the given element by which the key-group can be computed.
 	 */
 	@Nonnull
 	Object extractKeyFromElement(@Nonnull T element);
+
+	@SuppressWarnings("unchecked")
+	static <T extends Keyed<?>> KeyExtractorFunction<T> forKeyedObjects() {
+		return (KeyExtractorFunction<T>) FOR_KEYED_OBJECTS;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
@@ -266,14 +266,15 @@ public class KeyGroupPartitioner<T> {
 	}
 
 	public static <T> StateSnapshotKeyGroupReader createKeyGroupPartitionReader(
-		@Nonnull ElementReaderFunction<T> readerFunction,
-		@Nonnull KeyGroupElementsConsumer<T> elementConsumer) {
+			@Nonnull ElementReaderFunction<T> readerFunction,
+			@Nonnull KeyGroupElementsConsumer<T> elementConsumer) {
 		return new PartitioningResultKeyGroupReader<>(readerFunction, elementConsumer);
 	}
 
 	/**
 	 * General algorithm to read key-grouped state that was written from a {@link PartitioningResult}
-	 * @param <T>
+	 *
+	 * @param <T> type of the elements to read.
 	 */
 	private static class PartitioningResultKeyGroupReader<T> implements StateSnapshotKeyGroupReader {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.Preconditions;
 
@@ -28,7 +29,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
- * Abstract class that contains the base algorithm for partitioning data into key-groups. This algorithm currently works
+ * Class that contains the base algorithm for partitioning data into key-groups. This algorithm currently works
  * with two array (input, output) for optimal algorithmic complexity. Notice that this could also be implemented over a
  * single array, using some cuckoo-hashing-style element replacement. This would have worse algorithmic complexity but
  * better space efficiency. We currently prefer the trade-off in favor of better algorithmic complexity.
@@ -89,7 +90,7 @@ public class KeyGroupPartitioner<T> {
 
 	/** Cached result. */
 	@Nullable
-	protected StateSnapshot.KeyGroupPartitionedSnapshot computedResult;
+	protected StateSnapshot.StateKeyGroupWriter computedResult;
 
 	/**
 	 * Creates a new {@link KeyGroupPartitioner}.
@@ -131,7 +132,7 @@ public class KeyGroupPartitioner<T> {
 	/**
 	 * Partitions the data into key-groups and returns the result via {@link PartitioningResult}.
 	 */
-	public StateSnapshot.KeyGroupPartitionedSnapshot partitionByKeyGroup() {
+	public StateSnapshot.StateKeyGroupWriter partitionByKeyGroup() {
 		if (computedResult == null) {
 			reportAllElementKeyGroups();
 			buildHistogramByAccumulatingCounts();
@@ -198,7 +199,7 @@ public class KeyGroupPartitioner<T> {
 	 * This represents the result of key-group partitioning. The data in {@link #partitionedElements} is partitioned
 	 * w.r.t. {@link KeyGroupPartitioner#keyGroupRange}.
 	 */
-	public static class PartitioningResult<T> implements StateSnapshot.KeyGroupPartitionedSnapshot {
+	private static class PartitioningResult<T> implements StateSnapshot.StateKeyGroupWriter {
 
 		/**
 		 * Function to write one element to a {@link DataOutputView}.
@@ -249,7 +250,7 @@ public class KeyGroupPartitioner<T> {
 		}
 
 		@Override
-		public void writeMappingsInKeyGroup(@Nonnull DataOutputView dov, int keyGroupId) throws IOException {
+		public void writeStateInKeyGroup(@Nonnull DataOutputView dov, int keyGroupId) throws IOException {
 
 			int startOffset = getKeyGroupStartOffsetInclusive(keyGroupId);
 			int endOffset = getKeyGroupEndOffsetExclusive(keyGroupId);
@@ -260,6 +261,42 @@ public class KeyGroupPartitioner<T> {
 			// write mappings
 			for (int i = startOffset; i < endOffset; ++i) {
 				elementWriterFunction.writeElement(partitionedElements[i], dov);
+			}
+		}
+	}
+
+	public static <T> StateTableByKeyGroupReader createKeyGroupPartitionReader(
+		@Nonnull ElementReaderFunction<T> readerFunction,
+		@Nonnull KeyGroupElementsConsumer<T> elementConsumer) {
+		return new PartitioningResultKeyGroupReader<>(readerFunction, elementConsumer);
+	}
+
+	/**
+	 * General algorithm to read key-grouped state that was written from a {@link PartitioningResult}
+	 * @param <T>
+	 */
+	private static class PartitioningResultKeyGroupReader<T> implements StateTableByKeyGroupReader {
+
+		@Nonnull
+		private final ElementReaderFunction<T> readerFunction;
+
+		@Nonnull
+		private final KeyGroupElementsConsumer<T> elementConsumer;
+
+		public PartitioningResultKeyGroupReader(
+			@Nonnull ElementReaderFunction<T> readerFunction,
+			@Nonnull KeyGroupElementsConsumer<T> elementConsumer) {
+
+			this.readerFunction = readerFunction;
+			this.elementConsumer = elementConsumer;
+		}
+
+		@Override
+		public void readMappingsInKeyGroup(@Nonnull DataInputView in, @Nonnegative int keyGroupId) throws IOException {
+			int numElements = in.readInt();
+			for (int i = 0; i < numElements; i++) {
+				T element = readerFunction.readElement(in);
+				elementConsumer.consume(element, keyGroupId);
 			}
 		}
 	}
@@ -280,5 +317,29 @@ public class KeyGroupPartitioner<T> {
 		 * @throws IOException on write-related problems.
 		 */
 		void writeElement(@Nonnull T element, @Nonnull DataOutputView dov) throws IOException;
+	}
+
+	/**
+	 * This functional interface defines how one element is read from a {@link DataInputView}.
+	 *
+	 * @param <T> type of the read elements.
+	 */
+	@FunctionalInterface
+	public interface ElementReaderFunction<T> {
+
+		@Nonnull
+		T readElement(@Nonnull DataInputView div) throws IOException;
+	}
+
+	/**
+	 * Functional interface to consume elements from a key group.
+	 *
+	 * @param <T> type of the consumed elements.
+	 */
+	@FunctionalInterface
+	public interface KeyGroupElementsConsumer<T> {
+
+
+		void consume(@Nonnull T element, @Nonnegative int keyGroupId) throws IOException;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
@@ -265,7 +265,7 @@ public class KeyGroupPartitioner<T> {
 		}
 	}
 
-	public static <T> StateTableByKeyGroupReader createKeyGroupPartitionReader(
+	public static <T> StateSnapshotKeyGroupReader createKeyGroupPartitionReader(
 		@Nonnull ElementReaderFunction<T> readerFunction,
 		@Nonnull KeyGroupElementsConsumer<T> elementConsumer) {
 		return new PartitioningResultKeyGroupReader<>(readerFunction, elementConsumer);
@@ -275,7 +275,7 @@ public class KeyGroupPartitioner<T> {
 	 * General algorithm to read key-grouped state that was written from a {@link PartitioningResult}
 	 * @param <T>
 	 */
-	private static class PartitioningResultKeyGroupReader<T> implements StateTableByKeyGroupReader {
+	private static class PartitioningResultKeyGroupReader<T> implements StateSnapshotKeyGroupReader {
 
 		@Nonnull
 		private final ElementReaderFunction<T> readerFunction;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/Keyed.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/Keyed.java
@@ -16,23 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.heap;
-
-import org.apache.flink.core.memory.DataInputView;
-
-import java.io.IOException;
+package org.apache.flink.runtime.state;
 
 /**
- * Interface for state de-serialization into {@link StateTable}s by key-group.
+ * Interface for objects that have a key attribute.
+ *
+ * @param <K> type of the key.
  */
-interface StateTableByKeyGroupReader {
+public interface Keyed<K> {
 
 	/**
-	 * Read the data for the specified key-group from the input.
-	 *
-	 * @param div        the input
-	 * @param keyGroupId the key-group to write
-	 * @throws IOException on write related problems
+	 * Returns the key attribute.
 	 */
-	void readMappingsInKeyGroup(DataInputView div, int keyGroupId) throws IOException;
+	K getKey();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparable.java
@@ -21,15 +21,13 @@ package org.apache.flink.runtime.state;
 import javax.annotation.Nonnull;
 
 /**
- *
- * @param <T>
+ * Interface for objects that can be compared by priority.
+ * @param <T> type of the compared objects.
  */
 public interface PriorityComparable<T> {
 
 	/**
-	 *
-	 * @param other
-	 * @return
+	 * @see PriorityComparator#comparePriority(Object, Object).
 	 */
 	int comparePriorityTo(@Nonnull T other);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparable.java
@@ -18,27 +18,18 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
-
 import javax.annotation.Nonnull;
 
 /**
- * Factory for {@link KeyGroupedInternalPriorityQueue} instances.
+ *
+ * @param <T>
  */
-public interface PriorityQueueSetFactory {
+public interface PriorityComparable<T> {
 
 	/**
-	 * Creates a {@link KeyGroupedInternalPriorityQueue}.
 	 *
-	 * @param stateName                    unique name for associated with this queue.
-	 * @param byteOrderedElementSerializer a serializer that with a format that is lexicographically ordered in
-	 *                                     alignment with elementPriorityComparator.
-	 * @param <T>                          type of the stored elements.
-	 * @return the queue with the specified unique name.
+	 * @param other
+	 * @return
 	 */
-	@Nonnull
-	<T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T> create(
-		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer);
+	int comparePriorityTo(@Nonnull T other);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityComparator.java
@@ -30,6 +30,8 @@ package org.apache.flink.runtime.state;
 @FunctionalInterface
 public interface PriorityComparator<T> {
 
+	PriorityComparator<? extends PriorityComparable<Object>> FOR_PRIORITY_COMPARABLE_OBJECTS = PriorityComparable::comparePriorityTo;
+
 	/**
 	 * Compares two objects for priority. Returns a negative integer, zero, or a positive integer as the first
 	 * argument has lower, equal to, or higher priority than the second.
@@ -39,4 +41,9 @@ public interface PriorityComparator<T> {
 	 * priority than the second.
 	 */
 	int comparePriority(T left, T right);
+
+	@SuppressWarnings("unchecked")
+	static <T extends PriorityComparable<?>> PriorityComparator<T> forPriorityComparableObjects() {
+		return (PriorityComparator<T>) FOR_PRIORITY_COMPARABLE_OBJECTS;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,28 +34,36 @@ import java.util.Objects;
 public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredStateMetaInfoBase {
 
 	/** The mode how elements in this state are assigned to tasks during restore. */
+	@Nonnull
 	private final OperatorStateHandle.Mode assignmentMode;
 
 	/** The type serializer for the keys in the map state. */
+	@Nonnull
 	private final TypeSerializer<K> keySerializer;
 
 	/** The type serializer for the values in the map state. */
+	@Nonnull
 	private final TypeSerializer<V> valueSerializer;
 
+	/** The precomputed immutable snapshot of this state */
+	@Nullable
+	private StateMetaInfoSnapshot precomputedSnapshot;
+
 	public RegisteredBroadcastBackendStateMetaInfo(
-			final String name,
-			final OperatorStateHandle.Mode assignmentMode,
-			final TypeSerializer<K> keySerializer,
-			final TypeSerializer<V> valueSerializer) {
+			@Nonnull final String name,
+			@Nonnull final OperatorStateHandle.Mode assignmentMode,
+			@Nonnull final TypeSerializer<K> keySerializer,
+			@Nonnull final TypeSerializer<V> valueSerializer) {
 
 		super(name);
-		Preconditions.checkArgument(assignmentMode != null && assignmentMode == OperatorStateHandle.Mode.BROADCAST);
+		Preconditions.checkArgument(assignmentMode == OperatorStateHandle.Mode.BROADCAST);
 		this.assignmentMode = assignmentMode;
-		this.keySerializer = Preconditions.checkNotNull(keySerializer);
-		this.valueSerializer = Preconditions.checkNotNull(valueSerializer);
+		this.keySerializer = keySerializer;
+		this.valueSerializer = valueSerializer;
+		this.precomputedSnapshot = null;
 	}
 
-	public RegisteredBroadcastBackendStateMetaInfo(RegisteredBroadcastBackendStateMetaInfo<K, V> copy) {
+	public RegisteredBroadcastBackendStateMetaInfo(@Nonnull RegisteredBroadcastBackendStateMetaInfo<K, V> copy) {
 		this(
 			Preconditions.checkNotNull(copy).name,
 			copy.assignmentMode,
@@ -68,14 +77,17 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 			snapshot.getName(),
 			OperatorStateHandle.Mode.valueOf(
 				snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE)),
-			(TypeSerializer<K>) snapshot.getTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER),
-			(TypeSerializer<V>) snapshot.getTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
+			(TypeSerializer<K>) Preconditions.checkNotNull(
+				snapshot.getTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER)),
+			(TypeSerializer<V>) Preconditions.checkNotNull(
+				snapshot.getTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER)));
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.BROADCAST == snapshot.getBackendStateType());
 	}
 
 	/**
 	 * Creates a deep copy of the itself.
 	 */
+	@Nonnull
 	public RegisteredBroadcastBackendStateMetaInfo<K, V> deepCopy() {
 		return new RegisteredBroadcastBackendStateMetaInfo<>(this);
 	}
@@ -83,34 +95,23 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
-		Map<String, String> optionsMap = Collections.singletonMap(
-			StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE.toString(),
-			assignmentMode.toString());
-		Map<String, TypeSerializer<?>> serializerMap = new HashMap<>(2);
-		Map<String, TypeSerializerConfigSnapshot> serializerConfigSnapshotsMap = new HashMap<>(2);
-		String keySerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER.toString();
-		String valueSerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString();
-		serializerMap.put(keySerializerKey, keySerializer.duplicate());
-		serializerConfigSnapshotsMap.put(keySerializerKey, keySerializer.snapshotConfiguration());
-		serializerMap.put(valueSerializerKey, valueSerializer.duplicate());
-		serializerConfigSnapshotsMap.put(valueSerializerKey, valueSerializer.snapshotConfiguration());
-
-		return new StateMetaInfoSnapshot(
-			name,
-			StateMetaInfoSnapshot.BackendStateType.BROADCAST,
-			optionsMap,
-			serializerConfigSnapshotsMap,
-			serializerMap);
+		if (precomputedSnapshot == null) {
+			precomputedSnapshot = precomputeSnapshot();
+		}
+		return precomputedSnapshot;
 	}
 
+	@Nonnull
 	public TypeSerializer<K> getKeySerializer() {
 		return keySerializer;
 	}
 
+	@Nonnull
 	public TypeSerializer<V> getValueSerializer() {
 		return valueSerializer;
 	}
 
+	@Nonnull
 	public OperatorStateHandle.Mode getAssignmentMode() {
 		return assignmentMode;
 	}
@@ -151,5 +152,27 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 				", valueSerializer=" + valueSerializer +
 				", assignmentMode=" + assignmentMode +
 				'}';
+	}
+
+	@Nonnull
+	private StateMetaInfoSnapshot precomputeSnapshot() {
+		Map<String, String> optionsMap = Collections.singletonMap(
+			StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE.toString(),
+			assignmentMode.toString());
+		Map<String, TypeSerializer<?>> serializerMap = new HashMap<>(2);
+		Map<String, TypeSerializerConfigSnapshot> serializerConfigSnapshotsMap = new HashMap<>(2);
+		String keySerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER.toString();
+		String valueSerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString();
+		serializerMap.put(keySerializerKey, keySerializer.duplicate());
+		serializerConfigSnapshotsMap.put(keySerializerKey, keySerializer.snapshotConfiguration());
+		serializerMap.put(valueSerializerKey, valueSerializer.duplicate());
+		serializerConfigSnapshotsMap.put(valueSerializerKey, valueSerializer.snapshotConfiguration());
+
+		return new StateMetaInfoSnapshot(
+			name,
+			StateMetaInfoSnapshot.BackendStateType.BROADCAST,
+			optionsMap,
+			serializerConfigSnapshotsMap,
+			serializerMap);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredStateMetaInfoBase {
+public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredStateMetaInfoBase {
 
 	/** The mode how elements in this state are assigned to tasks during restore. */
 	@Nonnull
@@ -49,7 +49,7 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 	@Nullable
 	private StateMetaInfoSnapshot precomputedSnapshot;
 
-	public RegisteredBroadcastBackendStateMetaInfo(
+	public RegisteredBroadcastStateBackendMetaInfo(
 			@Nonnull final String name,
 			@Nonnull final OperatorStateHandle.Mode assignmentMode,
 			@Nonnull final TypeSerializer<K> keySerializer,
@@ -63,7 +63,7 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 		this.precomputedSnapshot = null;
 	}
 
-	public RegisteredBroadcastBackendStateMetaInfo(@Nonnull RegisteredBroadcastBackendStateMetaInfo<K, V> copy) {
+	public RegisteredBroadcastStateBackendMetaInfo(@Nonnull RegisteredBroadcastStateBackendMetaInfo<K, V> copy) {
 		this(
 			Preconditions.checkNotNull(copy).name,
 			copy.assignmentMode,
@@ -72,7 +72,7 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 	}
 
 	@SuppressWarnings("unchecked")
-	public RegisteredBroadcastBackendStateMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
+	public RegisteredBroadcastStateBackendMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
 		this(
 			snapshot.getName(),
 			OperatorStateHandle.Mode.valueOf(
@@ -88,8 +88,8 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 	 * Creates a deep copy of the itself.
 	 */
 	@Nonnull
-	public RegisteredBroadcastBackendStateMetaInfo<K, V> deepCopy() {
-		return new RegisteredBroadcastBackendStateMetaInfo<>(this);
+	public RegisteredBroadcastStateBackendMetaInfo<K, V> deepCopy() {
+		return new RegisteredBroadcastStateBackendMetaInfo<>(this);
 	}
 
 	@Nonnull
@@ -122,12 +122,12 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> extends RegisteredSta
 			return true;
 		}
 
-		if (!(obj instanceof RegisteredBroadcastBackendStateMetaInfo)) {
+		if (!(obj instanceof RegisteredBroadcastStateBackendMetaInfo)) {
 			return false;
 		}
 
-		final RegisteredBroadcastBackendStateMetaInfo other =
-				(RegisteredBroadcastBackendStateMetaInfo) obj;
+		final RegisteredBroadcastStateBackendMetaInfo other =
+				(RegisteredBroadcastStateBackendMetaInfo) obj;
 
 		return Objects.equals(name, other.getName())
 				&& Objects.equals(assignmentMode, other.getAssignmentMode())

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,10 +44,6 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 	@Nonnull
 	private final TypeSerializer<V> valueSerializer;
 
-	/** The precomputed immutable snapshot of this state */
-	@Nullable
-	private StateMetaInfoSnapshot precomputedSnapshot;
-
 	public RegisteredBroadcastStateBackendMetaInfo(
 			@Nonnull final String name,
 			@Nonnull final OperatorStateHandle.Mode assignmentMode,
@@ -60,7 +55,6 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 		this.assignmentMode = assignmentMode;
 		this.keySerializer = keySerializer;
 		this.valueSerializer = valueSerializer;
-		this.precomputedSnapshot = null;
 	}
 
 	public RegisteredBroadcastStateBackendMetaInfo(@Nonnull RegisteredBroadcastStateBackendMetaInfo<K, V> copy) {
@@ -95,10 +89,7 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
-		if (precomputedSnapshot == null) {
-			precomputedSnapshot = precomputeSnapshot();
-		}
-		return precomputedSnapshot;
+		return computeSnapshot();
 	}
 
 	@Nonnull
@@ -155,7 +146,7 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 	}
 
 	@Nonnull
-	private StateMetaInfoSnapshot precomputeSnapshot() {
+	private StateMetaInfoSnapshot computeSnapshot() {
 		Map<String, String> optionsMap = Collections.singletonMap(
 			StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE.toString(),
 			assignmentMode.toString());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * @param <N> Type of namespace
  * @param <S> Type of state value
  */
-public class RegisteredKeyedBackendStateMetaInfo<N, S> extends RegisteredStateMetaInfoBase {
+public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStateMetaInfoBase {
 
 	@Nonnull
 	private final StateDescriptor.Type stateType;
@@ -54,7 +54,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> extends RegisteredStateMe
 	@Nullable
 	private StateMetaInfoSnapshot precomputedSnapshot;
 
-	public RegisteredKeyedBackendStateMetaInfo(
+	public RegisteredKeyValueStateBackendMetaInfo(
 			@Nonnull StateDescriptor.Type stateType,
 			@Nonnull String name,
 			@Nonnull TypeSerializer<N> namespaceSerializer,
@@ -68,7 +68,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> extends RegisteredStateMe
 	}
 
 	@SuppressWarnings("unchecked")
-	public RegisteredKeyedBackendStateMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
+	public RegisteredKeyValueStateBackendMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
 		this(
 			StateDescriptor.Type.valueOf(snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE)),
 			snapshot.getName(),
@@ -104,7 +104,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> extends RegisteredStateMe
 			return false;
 		}
 
-		RegisteredKeyedBackendStateMetaInfo<?, ?> that = (RegisteredKeyedBackendStateMetaInfo<?, ?>) o;
+		RegisteredKeyValueStateBackendMetaInfo<?, ?> that = (RegisteredKeyValueStateBackendMetaInfo<?, ?>) o;
 
 		if (!stateType.equals(that.stateType)) {
 			return false;
@@ -143,7 +143,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> extends RegisteredStateMe
 	 * serializers that are compatible for the restored k/v state bytes.
 	 */
 	@Nonnull
-	public static <N, S> RegisteredKeyedBackendStateMetaInfo<N, S> resolveKvStateCompatibility(
+	public static <N, S> RegisteredKeyValueStateBackendMetaInfo<N, S> resolveKvStateCompatibility(
 		StateMetaInfoSnapshot restoredStateMetaInfoSnapshot,
 		TypeSerializer<N> newNamespaceSerializer,
 		StateDescriptor<?, S> newStateDescriptor) throws StateMigrationException {
@@ -190,7 +190,7 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> extends RegisteredStateMe
 			// TODO state migration currently isn't possible.
 			throw new StateMigrationException("State migration isn't supported, yet.");
 		} else {
-			return new RegisteredKeyedBackendStateMetaInfo<>(
+			return new RegisteredKeyValueStateBackendMetaInfo<>(
 				newStateDescriptor.getType(),
 				newStateDescriptor.getName(),
 				newNamespaceSerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -29,7 +29,6 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,8 +50,6 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	private final TypeSerializer<N> namespaceSerializer;
 	@Nonnull
 	private final TypeSerializer<S> stateSerializer;
-	@Nullable
-	private StateMetaInfoSnapshot precomputedSnapshot;
 
 	public RegisteredKeyValueStateBackendMetaInfo(
 			@Nonnull StateDescriptor.Type stateType,
@@ -64,7 +61,6 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		this.stateType = stateType;
 		this.namespaceSerializer = namespaceSerializer;
 		this.stateSerializer = stateSerializer;
-		this.precomputedSnapshot = null;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -201,14 +197,11 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
-		if (precomputedSnapshot == null) {
-			precomputedSnapshot = precomputeSnapshot();
-		}
-		return precomputedSnapshot;
+		return computeSnapshot();
 	}
 
 	@Nonnull
-	private StateMetaInfoSnapshot precomputeSnapshot() {
+	private StateMetaInfoSnapshot computeSnapshot() {
 		Map<String, String> optionsMap = Collections.singletonMap(
 			StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE.toString(),
 			stateType.toString());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -49,10 +48,6 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 	@Nonnull
 	private final TypeSerializer<S> partitionStateSerializer;
 
-	/** The precomputed immutable snapshot of this state */
-	@Nullable
-	private StateMetaInfoSnapshot precomputedSnapshot;
-
 	public RegisteredOperatorStateBackendMetaInfo(
 			@Nonnull String name,
 			@Nonnull TypeSerializer<S> partitionStateSerializer,
@@ -60,7 +55,6 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 		super(name);
 		this.partitionStateSerializer = partitionStateSerializer;
 		this.assignmentMode = assignmentMode;
-		this.precomputedSnapshot = null;
 	}
 
 	private RegisteredOperatorStateBackendMetaInfo(@Nonnull RegisteredOperatorStateBackendMetaInfo<S> copy) {
@@ -92,10 +86,7 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
-		if (precomputedSnapshot == null) {
-			precomputedSnapshot = precomputeSnapshot();
-		}
-		return precomputedSnapshot;
+		return computeSnapshot();
 	}
 
 	@Nonnull
@@ -142,7 +133,7 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 	}
 
 	@Nonnull
-	private StateMetaInfoSnapshot precomputeSnapshot() {
+	private StateMetaInfoSnapshot computeSnapshot() {
 		Map<String, String> optionsMap = Collections.singletonMap(
 			StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE.toString(),
 			assignmentMode.toString());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
@@ -35,7 +35,7 @@ import java.util.Map;
  *
  * @param <S> Type of the state.
  */
-public class RegisteredOperatorBackendStateMetaInfo<S> extends RegisteredStateMetaInfoBase {
+public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMetaInfoBase {
 
 	/**
 	 * The mode how elements in this state are assigned to tasks during restore
@@ -53,7 +53,7 @@ public class RegisteredOperatorBackendStateMetaInfo<S> extends RegisteredStateMe
 	@Nullable
 	private StateMetaInfoSnapshot precomputedSnapshot;
 
-	public RegisteredOperatorBackendStateMetaInfo(
+	public RegisteredOperatorStateBackendMetaInfo(
 			@Nonnull String name,
 			@Nonnull TypeSerializer<S> partitionStateSerializer,
 			@Nonnull OperatorStateHandle.Mode assignmentMode) {
@@ -63,7 +63,7 @@ public class RegisteredOperatorBackendStateMetaInfo<S> extends RegisteredStateMe
 		this.precomputedSnapshot = null;
 	}
 
-	private RegisteredOperatorBackendStateMetaInfo(@Nonnull RegisteredOperatorBackendStateMetaInfo<S> copy) {
+	private RegisteredOperatorStateBackendMetaInfo(@Nonnull RegisteredOperatorStateBackendMetaInfo<S> copy) {
 		this(
 			Preconditions.checkNotNull(copy).name,
 			copy.partitionStateSerializer.duplicate(),
@@ -71,7 +71,7 @@ public class RegisteredOperatorBackendStateMetaInfo<S> extends RegisteredStateMe
 	}
 
 	@SuppressWarnings("unchecked")
-	public RegisteredOperatorBackendStateMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
+	public RegisteredOperatorStateBackendMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
 		this(
 			snapshot.getName(),
 			(TypeSerializer<S>) Preconditions.checkNotNull(
@@ -85,8 +85,8 @@ public class RegisteredOperatorBackendStateMetaInfo<S> extends RegisteredStateMe
 	 * Creates a deep copy of the itself.
 	 */
 	@Nonnull
-	public RegisteredOperatorBackendStateMetaInfo<S> deepCopy() {
-		return new RegisteredOperatorBackendStateMetaInfo<>(this);
+	public RegisteredOperatorStateBackendMetaInfo<S> deepCopy() {
+		return new RegisteredOperatorStateBackendMetaInfo<>(this);
 	}
 
 	@Nonnull
@@ -118,10 +118,10 @@ public class RegisteredOperatorBackendStateMetaInfo<S> extends RegisteredStateMe
 			return false;
 		}
 
-		return (obj instanceof RegisteredOperatorBackendStateMetaInfo)
-			&& name.equals(((RegisteredOperatorBackendStateMetaInfo) obj).getName())
-			&& assignmentMode.equals(((RegisteredOperatorBackendStateMetaInfo) obj).getAssignmentMode())
-			&& partitionStateSerializer.equals(((RegisteredOperatorBackendStateMetaInfo) obj).getPartitionStateSerializer());
+		return (obj instanceof RegisteredOperatorStateBackendMetaInfo)
+			&& name.equals(((RegisteredOperatorStateBackendMetaInfo) obj).getName())
+			&& assignmentMode.equals(((RegisteredOperatorStateBackendMetaInfo) obj).getAssignmentMode())
+			&& partitionStateSerializer.equals(((RegisteredOperatorStateBackendMetaInfo) obj).getPartitionStateSerializer());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Meta information about a priority queue state in a backend.
+ */
+public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredStateMetaInfoBase {
+
+	@Nonnull
+	private final TypeSerializer<T> elementSerializer;
+
+	@Nonnull
+	private final StateMetaInfoSnapshot precomputedSnapshot;
+
+	public RegisteredPriorityQueueStateBackendMetaInfo(
+		@Nonnull String name,
+		@Nonnull TypeSerializer<T> elementSerializer) {
+
+		super(name);
+		this.elementSerializer = elementSerializer;
+		this.precomputedSnapshot = precomputeSnapshot();
+	}
+
+	@SuppressWarnings("unchecked")
+	public RegisteredPriorityQueueStateBackendMetaInfo(StateMetaInfoSnapshot snapshot) {
+		this(snapshot.getName(),
+			(TypeSerializer<T>) Preconditions.checkNotNull(
+				snapshot.getTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER)));
+		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE == snapshot.getBackendStateType());
+	}
+
+	@Nonnull
+	@Override
+	public StateMetaInfoSnapshot snapshot() {
+		return precomputedSnapshot;
+	}
+
+	@Nonnull
+	public TypeSerializer<T> getElementSerializer() {
+		return elementSerializer;
+	}
+
+	private StateMetaInfoSnapshot precomputeSnapshot() {
+		Map<String, TypeSerializer<?>> serializerMap =
+			Collections.singletonMap(
+				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString(),
+				elementSerializer.duplicate());
+		Map<String, TypeSerializerConfigSnapshot> serializerSnapshotMap =
+			Collections.singletonMap(
+				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString(),
+				elementSerializer.snapshotConfiguration());
+
+		return new StateMetaInfoSnapshot(
+			name,
+			StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE,
+			Collections.emptyMap(),
+			serializerSnapshotMap,
+			serializerMap);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
@@ -36,16 +36,12 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 	@Nonnull
 	private final TypeSerializer<T> elementSerializer;
 
-	@Nonnull
-	private final StateMetaInfoSnapshot precomputedSnapshot;
-
 	public RegisteredPriorityQueueStateBackendMetaInfo(
 		@Nonnull String name,
 		@Nonnull TypeSerializer<T> elementSerializer) {
 
 		super(name);
 		this.elementSerializer = elementSerializer;
-		this.precomputedSnapshot = precomputeSnapshot();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -59,7 +55,7 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
-		return precomputedSnapshot;
+		return computeSnapshot();
 	}
 
 	@Nonnull
@@ -67,7 +63,7 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 		return elementSerializer;
 	}
 
-	private StateMetaInfoSnapshot precomputeSnapshot() {
+	private StateMetaInfoSnapshot computeSnapshot() {
 		Map<String, TypeSerializer<?>> serializerMap =
 			Collections.singletonMap(
 				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString(),
@@ -83,5 +79,9 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 			Collections.emptyMap(),
 			serializerSnapshotMap,
 			serializerMap);
+	}
+
+	public RegisteredPriorityQueueStateBackendMetaInfo deepCopy() {
+		return new RegisteredPriorityQueueStateBackendMetaInfo<>(name, elementSerializer.duplicate());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
@@ -48,11 +48,11 @@ public abstract class RegisteredStateMetaInfoBase {
 		final StateMetaInfoSnapshot.BackendStateType backendStateType = snapshot.getBackendStateType();
 		switch (backendStateType) {
 			case KEY_VALUE:
-				return new RegisteredKeyedBackendStateMetaInfo<>(snapshot);
+				return new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
 			case OPERATOR:
-				return new RegisteredOperatorBackendStateMetaInfo<>(snapshot);
+				return new RegisteredOperatorStateBackendMetaInfo<>(snapshot);
 			case BROADCAST:
-				return new RegisteredBroadcastBackendStateMetaInfo<>(snapshot);
+				return new RegisteredBroadcastStateBackendMetaInfo<>(snapshot);
 			case PRIORITY_QUEUE:
 				return new RegisteredPriorityQueueStateBackendMetaInfo<>(snapshot);
 			default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
@@ -42,4 +42,21 @@ public abstract class RegisteredStateMetaInfoBase {
 
 	@Nonnull
 	public abstract StateMetaInfoSnapshot snapshot();
+
+	public static RegisteredStateMetaInfoBase fromMetaInfoSnapshot(@Nonnull StateMetaInfoSnapshot snapshot) {
+
+		final StateMetaInfoSnapshot.BackendStateType backendStateType = snapshot.getBackendStateType();
+		switch (backendStateType) {
+			case KEY_VALUE:
+				return new RegisteredKeyedBackendStateMetaInfo<>(snapshot);
+			case OPERATOR:
+				return new RegisteredOperatorBackendStateMetaInfo<>(snapshot);
+			case BROADCAST:
+				return new RegisteredBroadcastBackendStateMetaInfo<>(snapshot);
+			case PRIORITY_QUEUE:
+				return new RegisteredPriorityQueueStateBackendMetaInfo<>(snapshot);
+			default:
+				throw new IllegalArgumentException("Unknown backend state type: " + backendStateType);
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotKeyGroupReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotKeyGroupReader.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Interface for state de-serialization into {@link StateTable}s by key-group.
  */
 @Internal
-public interface StateTableByKeyGroupReader {
+public interface StateSnapshotKeyGroupReader {
 
 	/**
 	 * Read the data for the specified key-group from the input.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotRestore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotRestore.java
@@ -36,12 +36,12 @@ public interface StateSnapshotRestore {
 	StateSnapshot stateSnapshot();
 
 	/**
-	 * This method returns a {@link StateTableByKeyGroupReader} that can be used to restore the state on a
+	 * This method returns a {@link StateSnapshotKeyGroupReader} that can be used to restore the state on a
 	 * per-key-group basis. This method tries to return a reader for the given version hint.
 	 *
 	 * @param readVersionHint the required version of the state to read.
 	 * @return a reader that reads state by key-groups, for the given read version.
 	 */
 	@Nonnull
-	StateTableByKeyGroupReader keyGroupReader(int readVersionHint);
+	StateSnapshotKeyGroupReader keyGroupReader(int readVersionHint);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotRestore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotRestore.java
@@ -18,27 +18,30 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.annotation.Internal;
 
 import javax.annotation.Nonnull;
 
 /**
- * Factory for {@link KeyGroupedInternalPriorityQueue} instances.
+ * Interface to deal with state snapshot and restore of state.
+ * TODO find better name?
  */
-public interface PriorityQueueSetFactory {
+@Internal
+public interface StateSnapshotRestore {
 
 	/**
-	 * Creates a {@link KeyGroupedInternalPriorityQueue}.
-	 *
-	 * @param stateName                    unique name for associated with this queue.
-	 * @param byteOrderedElementSerializer a serializer that with a format that is lexicographically ordered in
-	 *                                     alignment with elementPriorityComparator.
-	 * @param <T>                          type of the stored elements.
-	 * @return the queue with the specified unique name.
+	 * Returns a snapshot of the state.
 	 */
 	@Nonnull
-	<T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T> create(
-		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer);
+	StateSnapshot stateSnapshot();
+
+	/**
+	 * This method returns a {@link StateTableByKeyGroupReader} that can be used to restore the state on a
+	 * per-key-group basis. This method tries to return a reader for the given version hint.
+	 *
+	 * @param readVersionHint the required version of the state to read.
+	 * @return a reader that reads state by key-groups, for the given read version.
+	 */
+	@Nonnull
+	StateTableByKeyGroupReader keyGroupReader(int readVersionHint);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateTableByKeyGroupReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateTableByKeyGroupReader.java
@@ -18,27 +18,27 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.heap.StateTable;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
+
 /**
- * Factory for {@link KeyGroupedInternalPriorityQueue} instances.
+ * Interface for state de-serialization into {@link StateTable}s by key-group.
  */
-public interface PriorityQueueSetFactory {
+@Internal
+public interface StateTableByKeyGroupReader {
 
 	/**
-	 * Creates a {@link KeyGroupedInternalPriorityQueue}.
+	 * Read the data for the specified key-group from the input.
 	 *
-	 * @param stateName                    unique name for associated with this queue.
-	 * @param byteOrderedElementSerializer a serializer that with a format that is lexicographically ordered in
-	 *                                     alignment with elementPriorityComparator.
-	 * @param <T>                          type of the stored elements.
-	 * @return the queue with the specified unique name.
+	 * @param div        the input
+	 * @param keyGroupId the key-group to write
+	 * @throws IOException on write related problems
 	 */
-	@Nonnull
-	<T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T> create(
-		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer);
+	void readMappingsInKeyGroup(@Nonnull DataInputView div, @Nonnegative int keyGroupId) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TieBreakingPriorityComparator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TieBreakingPriorityComparator.java
@@ -85,11 +85,6 @@ public class TieBreakingPriorityComparator<T> implements Comparator<T>, Priority
 			return ((Comparable<T>) o1).compareTo(o2);
 		}
 
-//		// we catch this case before moving to more expensive tie breaks.
-//		if (o1.equals(o2)) {
-//			return 0;
-//		}
-
 		// if objects are not equal, their serialized form should somehow differ as well. this can be costly, and...
 		// TODO we should have an alternative approach in the future, e.g. a cache that does not rely on compare to check equality.
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TieBreakingPriorityComparator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TieBreakingPriorityComparator.java
@@ -85,10 +85,10 @@ public class TieBreakingPriorityComparator<T> implements Comparator<T>, Priority
 			return ((Comparable<T>) o1).compareTo(o2);
 		}
 
-		// we catch this case before moving to more expensive tie breaks.
-		if (o1.equals(o2)) {
-			return 0;
-		}
+//		// we catch this case before moving to more expensive tie breaks.
+//		if (o1.equals(o2)) {
+//			return 0;
+//		}
 
 		// if objects are not equal, their serialized form should somehow differ as well. this can be costly, and...
 		// TODO we should have an alternative approach in the future, e.g. a cache that does not rely on compare to check equality.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CachingInternalPriorityQueueSet.java
@@ -351,6 +351,6 @@ public class CachingInternalPriorityQueueSet<E> implements InternalPriorityQueue
 		 * after usage.
 		 */
 		@Nonnull
-		CloseableIterator<E> orderedIterator();;
+		CloseableIterator<E> orderedIterator();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
@@ -204,7 +204,7 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	 * @param keyContext the key context.
 	 * @param metaInfo   the meta information, including the type serializer for state copy-on-write.
 	 */
-	CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo) {
+	CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
 		this(keyContext, metaInfo, 1024);
 	}
 
@@ -217,7 +217,7 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	 * @throws IllegalArgumentException when the capacity is less than zero.
 	 */
 	@SuppressWarnings("unchecked")
-	private CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo, int capacity) {
+	private CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo, int capacity) {
 		super(keyContext, metaInfo);
 
 		// initialized tables to EMPTY_TABLE.
@@ -547,12 +547,12 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	}
 
 	@Override
-	public RegisteredKeyedBackendStateMetaInfo<N, S> getMetaInfo() {
+	public RegisteredKeyValueStateBackendMetaInfo<N, S> getMetaInfo() {
 		return metaInfo;
 	}
 
 	@Override
-	public void setMetaInfo(RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo) {
+	public void setMetaInfo(RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
 		this.metaInfo = metaInfo;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
@@ -871,8 +871,9 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	 *
 	 * @return a snapshot from this {@link CopyOnWriteStateTable}, for checkpointing.
 	 */
+	@Nonnull
 	@Override
-	public CopyOnWriteStateTableSnapshot<K, N, S> createSnapshot() {
+	public CopyOnWriteStateTableSnapshot<K, N, S> stateSnapshot() {
 		return new CopyOnWriteStateTableSnapshot<>(this);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyGroupPartitioner;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -91,7 +91,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 	 * to an output as part of checkpointing.
 	 */
 	@Nullable
-	private StateSnapshot.KeyGroupPartitionedSnapshot partitionedStateTableSnapshot;
+	private StateKeyGroupWriter partitionedStateTableSnapshot;
 
 	/**
 	 * Creates a new {@link CopyOnWriteStateTableSnapshot}.
@@ -135,7 +135,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 	@Nonnull
 	@SuppressWarnings("unchecked")
 	@Override
-	public KeyGroupPartitionedSnapshot partitionByKeyGroup() {
+	public StateKeyGroupWriter getKeyGroupWriter() {
 
 		if (partitionedStateTableSnapshot == null) {
 
@@ -158,6 +158,12 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 		}
 
 		return partitionedStateTableSnapshot;
+	}
+
+	@Nonnull
+	@Override
+	public StateMetaInfoSnapshot getMetaInfoSnapshot() {
+		return owningStateTable.metaInfo.snapshot();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueue.java
@@ -50,7 +50,8 @@ import static org.apache.flink.util.CollectionUtil.MAX_ARRAY_SIZE;
  *
  * @param <T> type of the contained elements.
  */
-public class HeapPriorityQueue<T extends HeapPriorityQueueElement> implements InternalPriorityQueue<T> {
+public class HeapPriorityQueue<T extends HeapPriorityQueueElement>
+	implements InternalPriorityQueue<T> {
 
 	/**
 	 * The index of the head element in the array that represents the heap.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetFactory.java
@@ -21,7 +21,8 @@ package org.apache.flink.runtime.state.heap;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyExtractorFunction;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.PriorityComparator;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 
@@ -29,7 +30,7 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 /**
- *
+ * Factory for {@link HeapPriorityQueueSet}.
  */
 public class HeapPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
@@ -54,14 +55,13 @@ public class HeapPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
 	@Nonnull
 	@Override
-	public <T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
+	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> HeapPriorityQueueSet<T> create(
 		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
-		@Nonnull PriorityComparator<T> elementPriorityComparator,
-		@Nonnull KeyExtractorFunction<T> keyExtractor) {
-		return new HeapPriorityQueueSet<>(
-			elementPriorityComparator,
-			keyExtractor,
+		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+
+		return new HeapPriorityQueueSet<T>(
+			PriorityComparator.forPriorityComparableObjects(),
+			KeyExtractorFunction.forKeyedObjects(),
 			minimumCapacity,
 			keyGroupRange,
 			totalKeyGroups);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSnapshotRestoreWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSnapshotRestoreWrapper.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.KeyExtractorFunction;
+import org.apache.flink.runtime.state.KeyGroupPartitioner;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+import org.apache.flink.runtime.state.StateSnapshotRestore;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+/**
+ * This wrapper combines a HeapPriorityQueue with backend meta data.
+ *
+ * @param <T> type of the queue elements.
+ */
+public class HeapPriorityQueueSnapshotRestoreWrapper<T extends HeapPriorityQueueElement>
+	implements StateSnapshotRestore {
+
+	@Nonnull
+	private final HeapPriorityQueueSet<T> priorityQueue;
+	@Nonnull
+	private final KeyExtractorFunction<T> keyExtractorFunction;
+	@Nonnull
+	private final RegisteredPriorityQueueStateBackendMetaInfo<T> metaInfo;
+	@Nonnull
+	private final KeyGroupRange localKeyGroupRange;
+	@Nonnegative
+	private final int totalKeyGroups;
+
+	public HeapPriorityQueueSnapshotRestoreWrapper(
+		@Nonnull HeapPriorityQueueSet<T> priorityQueue,
+		@Nonnull RegisteredPriorityQueueStateBackendMetaInfo<T> metaInfo,
+		@Nonnull KeyExtractorFunction<T> keyExtractorFunction,
+		@Nonnull KeyGroupRange localKeyGroupRange,
+		int totalKeyGroups) {
+
+		this.priorityQueue = priorityQueue;
+		this.keyExtractorFunction = keyExtractorFunction;
+		this.metaInfo = metaInfo;
+		this.localKeyGroupRange = localKeyGroupRange;
+		this.totalKeyGroups = totalKeyGroups;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nonnull
+	@Override
+	public StateSnapshot stateSnapshot() {
+		final T[] queueDump = (T[]) priorityQueue.toArray(new HeapPriorityQueueElement[priorityQueue.size()]);
+
+		final TypeSerializer<T> elementSerializer = metaInfo.getElementSerializer();
+
+		// turn the flat copy into a deep copy if required.
+		if (!elementSerializer.isImmutableType()) {
+			for (int i = 0; i < queueDump.length; ++i) {
+				queueDump[i] = elementSerializer.copy(queueDump[i]);
+			}
+		}
+
+		return new HeapPriorityQueueStateSnapshot<>(
+			queueDump,
+			keyExtractorFunction,
+			metaInfo,
+			localKeyGroupRange,
+			totalKeyGroups);
+	}
+
+	@Nonnull
+	@Override
+	public StateTableByKeyGroupReader keyGroupReader(int readVersionHint) {
+		final TypeSerializer<T> elementSerializer = metaInfo.getElementSerializer();
+		return KeyGroupPartitioner.createKeyGroupPartitionReader(
+			elementSerializer::deserialize, //we know that this does not deliver nulls, because we never write nulls
+			(element, keyGroupId) -> priorityQueue.add(element));
+	}
+
+	@Nonnull
+	public HeapPriorityQueueSet<T> getPriorityQueue() {
+		return priorityQueue;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSnapshotRestoreWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSnapshotRestoreWrapper.java
@@ -81,7 +81,7 @@ public class HeapPriorityQueueSnapshotRestoreWrapper<T extends HeapPriorityQueue
 		return new HeapPriorityQueueStateSnapshot<>(
 			queueDump,
 			keyExtractorFunction,
-			metaInfo,
+			metaInfo.deepCopy(),
 			localKeyGroupRange,
 			totalKeyGroups);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSnapshotRestoreWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSnapshotRestoreWrapper.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.state.KeyGroupPartitioner;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
-import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+import org.apache.flink.runtime.state.StateSnapshotKeyGroupReader;
 import org.apache.flink.runtime.state.StateSnapshotRestore;
 
 import javax.annotation.Nonnegative;
@@ -88,7 +88,7 @@ public class HeapPriorityQueueSnapshotRestoreWrapper<T extends HeapPriorityQueue
 
 	@Nonnull
 	@Override
-	public StateTableByKeyGroupReader keyGroupReader(int readVersionHint) {
+	public StateSnapshotKeyGroupReader keyGroupReader(int readVersionHint) {
 		final TypeSerializer<T> elementSerializer = metaInfo.getElementSerializer();
 		return KeyGroupPartitioner.createKeyGroupPartitionReader(
 			elementSerializer::deserialize, //we know that this does not deliver nulls, because we never write nulls

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueStateSnapshot.java
@@ -61,7 +61,7 @@ public class HeapPriorityQueueStateSnapshot<T> implements StateSnapshot {
 
 	/** Result of partitioning the snapshot by key-group. */
 	@Nullable
-	private StateKeyGroupWriter partitionedSnapshot;
+	private StateKeyGroupWriter stateKeyGroupWriter;
 
 	HeapPriorityQueueStateSnapshot(
 		@Nonnull T[] heapArrayCopy,
@@ -82,7 +82,7 @@ public class HeapPriorityQueueStateSnapshot<T> implements StateSnapshot {
 	@Override
 	public StateKeyGroupWriter getKeyGroupWriter() {
 
-		if (partitionedSnapshot == null) {
+		if (stateKeyGroupWriter == null) {
 
 			T[] partitioningOutput = (T[]) Array.newInstance(
 				heapArrayCopy.getClass().getComponentType(),
@@ -100,10 +100,10 @@ public class HeapPriorityQueueStateSnapshot<T> implements StateSnapshot {
 					keyExtractor,
 					elementSerializer::serialize);
 
-			partitionedSnapshot = keyGroupPartitioner.partitionByKeyGroup();
+			stateKeyGroupWriter = keyGroupPartitioner.partitionByKeyGroup();
 		}
 
-		return partitionedSnapshot;
+		return stateKeyGroupWriter;
 	}
 
 	@Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -49,6 +49,8 @@ import java.util.function.Predicate;
 public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueue<T> & HeapPriorityQueueElement>
 	implements InternalPriorityQueue<T>, KeyGroupedInternalPriorityQueue<T> {
 
+	static final boolean ENABLE_RELAXED_FIRING_ORDER_OPTIMIZATION = true;
+
 	/** A heap of heap sets. Each sub-heap represents the partition for a key-group.*/
 	@Nonnull
 	private final HeapPriorityQueue<PQ> heapOfkeyGroupedHeaps;
@@ -94,6 +96,22 @@ public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueu
 
 	@Override
 	public void bulkPoll(@Nonnull Predicate<T> canConsume, @Nonnull Consumer<T> consumer) {
+		if (ENABLE_RELAXED_FIRING_ORDER_OPTIMIZATION) {
+			bulkPollRelaxedOrder(canConsume, consumer);
+		} else {
+			bulkPollStrictOrder(canConsume, consumer);
+		}
+	}
+
+	private void bulkPollRelaxedOrder(@Nonnull Predicate<T> canConsume, @Nonnull Consumer<T> consumer) {
+		PQ headList = heapOfkeyGroupedHeaps.peek();
+		while (headList.peek() != null && canConsume.test(headList.peek())) {
+			headList.bulkPoll(canConsume, consumer);
+			heapOfkeyGroupedHeaps.adjustModifiedElement(headList);
+		}
+	}
+
+	private void bulkPollStrictOrder(@Nonnull Predicate<T> canConsume, @Nonnull Consumer<T> consumer) {
 		T element;
 		while ((element = peek()) != null && canConsume.test(element)) {
 			poll();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -49,7 +49,7 @@ import java.util.function.Predicate;
 public class KeyGroupPartitionedPriorityQueue<T, PQ extends InternalPriorityQueue<T> & HeapPriorityQueueElement>
 	implements InternalPriorityQueue<T>, KeyGroupedInternalPriorityQueue<T> {
 
-	static final boolean ENABLE_RELAXED_FIRING_ORDER_OPTIMIZATION = true;
+	static final boolean ENABLE_RELAXED_FIRING_ORDER_OPTIMIZATION = false;
 
 	/** A heap of heap sets. Each sub-heap represents the partition for a key-group.*/
 	@Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
@@ -71,7 +71,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 	 * @param keyContext the key context.
 	 * @param metaInfo the meta information for this state table.
 	 */
-	public NestedMapsStateTable(InternalKeyContext<K> keyContext, RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo) {
+	public NestedMapsStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
 		super(keyContext, metaInfo);
 		this.keyGroupOffset = keyContext.getKeyGroupRange().getStartKeyGroup();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
 import org.apache.flink.runtime.state.StateTransformationFunction;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -34,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -175,7 +177,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 	@Override
 	public Stream<K> getKeys(N namespace) {
 		return Arrays.stream(state)
-			.filter(namespaces -> namespaces != null)
+			.filter(Objects::nonNull)
 			.map(namespaces -> namespaces.getOrDefault(namespace, Collections.emptyMap()))
 			.flatMap(namespaceSate -> namespaceSate.keySet().stream());
 	}
@@ -232,12 +234,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 			setMapForKeyGroup(keyGroupIndex, namespaceMap);
 		}
 
-		Map<K, S> keyedMap = namespaceMap.get(namespace);
-
-		if (keyedMap == null) {
-			keyedMap = new HashMap<>();
-			namespaceMap.put(namespace, keyedMap);
-		}
+		Map<K, S> keyedMap = namespaceMap.computeIfAbsent(namespace, k -> new HashMap<>());
 
 		return keyedMap.put(key, value);
 	}
@@ -302,13 +299,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 			setMapForKeyGroup(keyGroupIndex, namespaceMap);
 		}
 
-		Map<K, S> keyedMap = namespaceMap.get(namespace);
-
-		if (keyedMap == null) {
-			keyedMap = new HashMap<>();
-			namespaceMap.put(namespace, keyedMap);
-		}
-
+		Map<K, S> keyedMap = namespaceMap.computeIfAbsent(namespace, k -> new HashMap<>());
 		keyedMap.put(key, transformation.apply(keyedMap.get(key), value));
 	}
 
@@ -323,8 +314,9 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 		return count;
 	}
 
+	@Nonnull
 	@Override
-	public NestedMapsStateTableSnapshot<K, N, S> createSnapshot() {
+	public NestedMapsStateTableSnapshot<K, N, S> stateSnapshot() {
 		return new NestedMapsStateTableSnapshot<>(this);
 	}
 
@@ -337,7 +329,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 	 */
 	static class NestedMapsStateTableSnapshot<K, N, S>
 			extends AbstractStateTableSnapshot<K, N, S, NestedMapsStateTable<K, N, S>>
-			implements StateSnapshot.KeyGroupPartitionedSnapshot {
+			implements StateSnapshot.StateKeyGroupWriter {
 
 		NestedMapsStateTableSnapshot(NestedMapsStateTable<K, N, S> owningTable) {
 			super(owningTable);
@@ -345,8 +337,14 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 
 		@Nonnull
 		@Override
-		public KeyGroupPartitionedSnapshot partitionByKeyGroup() {
+		public StateKeyGroupWriter getKeyGroupWriter() {
 			return this;
+		}
+
+		@Nonnull
+		@Override
+		public StateMetaInfoSnapshot getMetaInfoSnapshot() {
+			return owningStateTable.metaInfo.snapshot();
 		}
 
 		/**
@@ -359,7 +357,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 		 * implementations).
 		 */
 		@Override
-		public void writeMappingsInKeyGroup(@Nonnull DataOutputView dov, int keyGroupId) throws IOException {
+		public void writeStateInKeyGroup(@Nonnull DataOutputView dov, int keyGroupId) throws IOException {
 			final Map<N, Map<K, S>> keyGroupMap = owningStateTable.getMapForKeyGroup(keyGroupId);
 			if (null != keyGroupMap) {
 				TypeSerializer<K> keySerializer = owningStateTable.keyContext.getKeySerializer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
@@ -21,9 +21,12 @@ package org.apache.flink.runtime.state.heap;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
-import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+import org.apache.flink.runtime.state.StateSnapshotRestore;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
 
 import java.util.stream.Stream;
 
@@ -35,7 +38,7 @@ import java.util.stream.Stream;
  * @param <N> type of namespace
  * @param <S> type of state
  */
-public abstract class StateTable<K, N, S> {
+public abstract class StateTable<K, N, S> implements StateSnapshotRestore {
 
 	/**
 	 * The key context view on the backend. This provides information, such as the currently active key.
@@ -183,12 +186,16 @@ public abstract class StateTable<K, N, S> {
 
 	// Snapshot / Restore -------------------------------------------------------------------------
 
-	abstract StateSnapshot createSnapshot();
-
 	public abstract void put(K key, int keyGroup, N namespace, S state);
 
 	// For testing --------------------------------------------------------------------------------
 
 	@VisibleForTesting
 	public abstract int sizeOfNamespace(Object namespace);
+
+	@Nonnull
+	@Override
+	public StateTableByKeyGroupReader keyGroupReader(int readVersion) {
+		return StateTableByKeyGroupReaders.readerForVersion(this, readVersion);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
-import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.StateSnapshotKeyGroupReader;
 import org.apache.flink.runtime.state.StateSnapshotRestore;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.util.Preconditions;
@@ -48,14 +48,14 @@ public abstract class StateTable<K, N, S> implements StateSnapshotRestore {
 	/**
 	 * Combined meta information such as name and serializers for this state
 	 */
-	protected RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo;
+	protected RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo;
 
 	/**
 	 *
 	 * @param keyContext the key context provides the key scope for all put/get/delete operations.
 	 * @param metaInfo the meta information, including the type serializer for state copy-on-write.
 	 */
-	public StateTable(InternalKeyContext<K> keyContext, RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo) {
+	public StateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
 		this.keyContext = Preconditions.checkNotNull(keyContext);
 		this.metaInfo = Preconditions.checkNotNull(metaInfo);
 	}
@@ -176,11 +176,11 @@ public abstract class StateTable<K, N, S> implements StateSnapshotRestore {
 		return metaInfo.getNamespaceSerializer();
 	}
 
-	public RegisteredKeyedBackendStateMetaInfo<N, S> getMetaInfo() {
+	public RegisteredKeyValueStateBackendMetaInfo<N, S> getMetaInfo() {
 		return metaInfo;
 	}
 
-	public void setMetaInfo(RegisteredKeyedBackendStateMetaInfo<N, S> metaInfo) {
+	public void setMetaInfo(RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
 		this.metaInfo = metaInfo;
 	}
 
@@ -195,7 +195,7 @@ public abstract class StateTable<K, N, S> implements StateSnapshotRestore {
 
 	@Nonnull
 	@Override
-	public StateTableByKeyGroupReader keyGroupReader(int readVersion) {
+	public StateSnapshotKeyGroupReader keyGroupReader(int readVersion) {
 		return StateTableByKeyGroupReaders.readerForVersion(this, readVersion);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.runtime.state.KeyGroupPartitioner;
-import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+import org.apache.flink.runtime.state.StateSnapshotKeyGroupReader;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
- * This class provides a static factory method to create different implementations of {@link StateTableByKeyGroupReader}
+ * This class provides a static factory method to create different implementations of {@link StateSnapshotKeyGroupReader}
  * depending on the provided serialization format version.
  * <p>
  * The implementations are also located here as inner classes.
@@ -48,7 +48,7 @@ class StateTableByKeyGroupReaders {
 	 * @param <S> type of state.
 	 * @return the appropriate reader.
 	 */
-	static <K, N, S> StateTableByKeyGroupReader readerForVersion(StateTable<K, N, S> stateTable, int version) {
+	static <K, N, S> StateSnapshotKeyGroupReader readerForVersion(StateTable<K, N, S> stateTable, int version) {
 		switch (version) {
 			case 1:
 				return new StateTableByKeyGroupReaderV1<>(stateTable);
@@ -62,7 +62,7 @@ class StateTableByKeyGroupReaders {
 		}
 	}
 
-	private static <K, N, S> StateTableByKeyGroupReader createV2PlusReader(StateTable<K, N, S> stateTable) {
+	private static <K, N, S> StateSnapshotKeyGroupReader createV2PlusReader(StateTable<K, N, S> stateTable) {
 		final TypeSerializer<K> keySerializer = stateTable.keyContext.getKeySerializer();
 		final TypeSerializer<N> namespaceSerializer = stateTable.getNamespaceSerializer();
 		final TypeSerializer<S> stateSerializer = stateTable.getStateSerializer();
@@ -75,7 +75,7 @@ class StateTableByKeyGroupReaders {
 		}, (element, keyGroupId1) -> stateTable.put(element.f1, keyGroupId1, element.f0, element.f2));
 	}
 
-	static final class StateTableByKeyGroupReaderV1<K, N, S> implements StateTableByKeyGroupReader {
+	static final class StateTableByKeyGroupReaderV1<K, N, S> implements StateSnapshotKeyGroupReader {
 
 		protected final StateTable<K, N, S> stateTable;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
@@ -19,7 +19,13 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.KeyGroupPartitioner;
+import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 
@@ -35,69 +41,58 @@ class StateTableByKeyGroupReaders {
 	 * Creates a new StateTableByKeyGroupReader that inserts de-serialized mappings into the given table, using the
 	 * de-serialization algorithm that matches the given version.
 	 *
-	 * @param table the {@link StateTable} into which de-serialized mappings are inserted.
+	 * @param stateTable the {@link StateTable} into which de-serialized mappings are inserted.
 	 * @param version version for the de-serialization algorithm.
 	 * @param <K> type of key.
 	 * @param <N> type of namespace.
 	 * @param <S> type of state.
 	 * @return the appropriate reader.
 	 */
-	static <K, N, S> StateTableByKeyGroupReader readerForVersion(StateTable<K, N, S> table, int version) {
+	static <K, N, S> StateTableByKeyGroupReader readerForVersion(StateTable<K, N, S> stateTable, int version) {
 		switch (version) {
 			case 1:
-				return new StateTableByKeyGroupReaderV1<>(table);
+				return new StateTableByKeyGroupReaderV1<>(stateTable);
 			case 2:
 			case 3:
 			case 4:
 			case 5:
-				return new StateTableByKeyGroupReaderV2V3<>(table);
+				return createV2PlusReader(stateTable);
 			default:
 				throw new IllegalArgumentException("Unknown version: " + version);
 		}
 	}
 
-	static abstract class AbstractStateTableByKeyGroupReader<K, N, S>
-			implements StateTableByKeyGroupReader {
+	private static <K, N, S> StateTableByKeyGroupReader createV2PlusReader(StateTable<K, N, S> stateTable) {
+		final TypeSerializer<K> keySerializer = stateTable.keyContext.getKeySerializer();
+		final TypeSerializer<N> namespaceSerializer = stateTable.getNamespaceSerializer();
+		final TypeSerializer<S> stateSerializer = stateTable.getStateSerializer();
+		final Tuple3<N, K, S> buffer = new Tuple3<>();
+		return KeyGroupPartitioner.createKeyGroupPartitionReader((in) -> {
+			buffer.f0 = namespaceSerializer.deserialize(in);
+			buffer.f1 = keySerializer.deserialize(in);
+			buffer.f2 = stateSerializer.deserialize(in);
+			return buffer;
+		}, (element, keyGroupId1) -> stateTable.put(element.f1, keyGroupId1, element.f0, element.f2));
+	}
+
+	static final class StateTableByKeyGroupReaderV1<K, N, S> implements StateTableByKeyGroupReader {
 
 		protected final StateTable<K, N, S> stateTable;
 
-		AbstractStateTableByKeyGroupReader(StateTable<K, N, S> stateTable) {
+		StateTableByKeyGroupReaderV1(StateTable<K, N, S> stateTable) {
 			this.stateTable = stateTable;
 		}
 
 		@Override
-		public abstract void readMappingsInKeyGroup(DataInputView div, int keyGroupId) throws IOException;
-
-		protected TypeSerializer<K> getKeySerializer() {
-			return stateTable.keyContext.getKeySerializer();
-		}
-
-		protected TypeSerializer<N> getNamespaceSerializer() {
-			return stateTable.getNamespaceSerializer();
-		}
-
-		protected TypeSerializer<S> getStateSerializer() {
-			return stateTable.getStateSerializer();
-		}
-	}
-
-	static final class StateTableByKeyGroupReaderV1<K, N, S>
-			extends AbstractStateTableByKeyGroupReader<K, N, S> {
-
-		StateTableByKeyGroupReaderV1(StateTable<K, N, S> stateTable) {
-			super(stateTable);
-		}
-
-		@Override
-		public void readMappingsInKeyGroup(DataInputView inView, int keyGroupId) throws IOException {
+		public void readMappingsInKeyGroup(@Nonnull DataInputView inView, @Nonnegative int keyGroupId) throws IOException {
 
 			if (inView.readByte() == 0) {
 				return;
 			}
 
-			final TypeSerializer<K> keySerializer = getKeySerializer();
-			final TypeSerializer<N> namespaceSerializer = getNamespaceSerializer();
-			final TypeSerializer<S> stateSerializer = getStateSerializer();
+			final TypeSerializer<K> keySerializer = stateTable.keyContext.getKeySerializer();
+			final TypeSerializer<N> namespaceSerializer = stateTable.getNamespaceSerializer();
+			final TypeSerializer<S> stateSerializer = stateTable.getStateSerializer();
 
 			// V1 uses kind of namespace compressing format
 			int numNamespaces = inView.readInt();
@@ -109,30 +104,6 @@ class StateTableByKeyGroupReaders {
 					S state = stateSerializer.deserialize(inView);
 					stateTable.put(key, keyGroupId, namespace, state);
 				}
-			}
-		}
-	}
-
-	private static final class StateTableByKeyGroupReaderV2V3<K, N, S>
-			extends AbstractStateTableByKeyGroupReader<K, N, S> {
-
-		StateTableByKeyGroupReaderV2V3(StateTable<K, N, S> stateTable) {
-			super(stateTable);
-		}
-
-		@Override
-		public void readMappingsInKeyGroup(DataInputView inView, int keyGroupId) throws IOException {
-
-			final TypeSerializer<K> keySerializer = getKeySerializer();
-			final TypeSerializer<N> namespaceSerializer = getNamespaceSerializer();
-			final TypeSerializer<S> stateSerializer = getStateSerializer();
-
-			int numKeys = inView.readInt();
-			for (int i = 0; i < numKeys; ++i) {
-				N namespace = namespaceSerializer.deserialize(inView);
-				K key = keySerializer.deserialize(inView);
-				S state = stateSerializer.deserialize(inView);
-				stateTable.put(key, keyGroupId, namespace, state);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.state.metainfo;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -31,7 +31,7 @@ import java.util.Map;
 
 /**
  * Generalized snapshot for meta information about one state in a state backend
- * (e.g. {@link RegisteredKeyedBackendStateMetaInfo}).
+ * (e.g. {@link RegisteredKeyValueStateBackendMetaInfo}).
  */
 public class StateMetaInfoSnapshot {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state.metainfo;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -30,7 +31,7 @@ import java.util.Map;
 
 /**
  * Generalized snapshot for meta information about one state in a state backend
- * (e.g. {@link org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo}).
+ * (e.g. {@link RegisteredKeyedBackendStateMetaInfo}).
  */
 public class StateMetaInfoSnapshot {
 
@@ -41,7 +42,7 @@ public class StateMetaInfoSnapshot {
 		KEY_VALUE,
 		OPERATOR,
 		BROADCAST,
-		TIMER
+		PRIORITY_QUEUE
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupPartitionerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupPartitionerTestBase.java
@@ -85,11 +85,11 @@ public abstract class KeyGroupPartitionerTestBase<T> extends TestLogger {
 			new ValidatingElementWriterDummy<>(keyExtractorFunction, numberOfKeyGroups, allElementsIdentitySet);
 
 		final KeyGroupPartitioner<T> testInstance = createPartitioner(data, testSize, range, numberOfKeyGroups, validatingElementWriter);
-		final StateSnapshot.KeyGroupPartitionedSnapshot result = testInstance.partitionByKeyGroup();
+		final StateSnapshot.StateKeyGroupWriter result = testInstance.partitionByKeyGroup();
 
 		for (int keyGroup = 0; keyGroup < numberOfKeyGroups; ++keyGroup) {
 			validatingElementWriter.setCurrentKeyGroup(keyGroup);
-			result.writeMappingsInKeyGroup(DUMMY_OUT_VIEW, keyGroup);
+			result.writeStateInKeyGroup(DUMMY_OUT_VIEW, keyGroup);
 		}
 
 		validatingElementWriter.validateAllElementsSeen();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -55,11 +55,11 @@ public class SerializationProxiesTest {
 
 		List<StateMetaInfoSnapshot> stateMetaInfoList = new ArrayList<>();
 
-		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+		stateMetaInfoList.add(new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, "a", namespaceSerializer, stateSerializer).snapshot());
-		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+		stateMetaInfoList.add(new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, "b", namespaceSerializer, stateSerializer).snapshot());
-		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+		stateMetaInfoList.add(new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, "c", namespaceSerializer, stateSerializer).snapshot());
 
 		KeyedBackendSerializationProxy<?> serializationProxy =
@@ -93,11 +93,11 @@ public class SerializationProxiesTest {
 
 		List<StateMetaInfoSnapshot> stateMetaInfoList = new ArrayList<>();
 
-		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+		stateMetaInfoList.add(new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, "a", namespaceSerializer, stateSerializer).snapshot());
-		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+		stateMetaInfoList.add(new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, "b", namespaceSerializer, stateSerializer).snapshot());
-		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+		stateMetaInfoList.add(new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, "c", namespaceSerializer, stateSerializer).snapshot());
 
 		KeyedBackendSerializationProxy<?> serializationProxy =
@@ -132,7 +132,7 @@ public class SerializationProxiesTest {
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 
 		for (StateMetaInfoSnapshot snapshot : serializationProxy.getStateMetaInfoSnapshots()) {
-			final RegisteredKeyedBackendStateMetaInfo<?, ?> restoredMetaInfo = new RegisteredKeyedBackendStateMetaInfo<>(snapshot);
+			final RegisteredKeyValueStateBackendMetaInfo<?, ?> restoredMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
 			Assert.assertTrue(restoredMetaInfo.getNamespaceSerializer() instanceof UnloadableDummyTypeSerializer);
 			Assert.assertTrue(restoredMetaInfo.getStateSerializer() instanceof UnloadableDummyTypeSerializer);
 			Assert.assertEquals(namespaceSerializer.snapshotConfiguration(), snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER));
@@ -147,7 +147,7 @@ public class SerializationProxiesTest {
 		TypeSerializer<?> namespaceSerializer = LongSerializer.INSTANCE;
 		TypeSerializer<?> stateSerializer = DoubleSerializer.INSTANCE;
 
-		StateMetaInfoSnapshot metaInfo = new RegisteredKeyedBackendStateMetaInfo<>(
+		StateMetaInfoSnapshot metaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, name, namespaceSerializer, stateSerializer).snapshot();
 
 		byte[] serialized;
@@ -173,7 +173,7 @@ public class SerializationProxiesTest {
 		TypeSerializer<?> namespaceSerializer = LongSerializer.INSTANCE;
 		TypeSerializer<?> stateSerializer = DoubleSerializer.INSTANCE;
 
-		StateMetaInfoSnapshot snapshot = new RegisteredKeyedBackendStateMetaInfo<>(
+		StateMetaInfoSnapshot snapshot = new RegisteredKeyValueStateBackendMetaInfo<>(
 			StateDescriptor.Type.VALUE, name, namespaceSerializer, stateSerializer).snapshot();
 
 		byte[] serialized;
@@ -198,7 +198,7 @@ public class SerializationProxiesTest {
 				new DataInputViewStreamWrapper(in), classLoader);
 		}
 
-		RegisteredKeyedBackendStateMetaInfo<?, ?> restoredMetaInfo = new RegisteredKeyedBackendStateMetaInfo<>(snapshot);
+		RegisteredKeyValueStateBackendMetaInfo<?, ?> restoredMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
 
 		Assert.assertEquals(name, restoredMetaInfo.getName());
 		Assert.assertTrue(restoredMetaInfo.getNamespaceSerializer() instanceof UnloadableDummyTypeSerializer);
@@ -216,18 +216,18 @@ public class SerializationProxiesTest {
 
 		List<StateMetaInfoSnapshot> stateMetaInfoSnapshots = new ArrayList<>();
 
-		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+		stateMetaInfoSnapshots.add(new RegisteredOperatorStateBackendMetaInfo<>(
 			"a", stateSerializer, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE).snapshot());
-		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+		stateMetaInfoSnapshots.add(new RegisteredOperatorStateBackendMetaInfo<>(
 			"b", stateSerializer, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE).snapshot());
-		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+		stateMetaInfoSnapshots.add(new RegisteredOperatorStateBackendMetaInfo<>(
 			"c", stateSerializer, OperatorStateHandle.Mode.UNION).snapshot());
 
 		List<StateMetaInfoSnapshot> broadcastStateMetaInfoSnapshots = new ArrayList<>();
 
-		broadcastStateMetaInfoSnapshots.add(new RegisteredBroadcastBackendStateMetaInfo<>(
+		broadcastStateMetaInfoSnapshots.add(new RegisteredBroadcastStateBackendMetaInfo<>(
 				"d", OperatorStateHandle.Mode.BROADCAST, keySerializer, valueSerializer).snapshot());
-		broadcastStateMetaInfoSnapshots.add(new RegisteredBroadcastBackendStateMetaInfo<>(
+		broadcastStateMetaInfoSnapshots.add(new RegisteredBroadcastStateBackendMetaInfo<>(
 				"e", OperatorStateHandle.Mode.BROADCAST, valueSerializer, keySerializer).snapshot());
 
 		OperatorBackendSerializationProxy serializationProxy =
@@ -257,7 +257,7 @@ public class SerializationProxiesTest {
 		TypeSerializer<?> stateSerializer = DoubleSerializer.INSTANCE;
 
 		StateMetaInfoSnapshot snapshot =
-			new RegisteredOperatorBackendStateMetaInfo<>(
+			new RegisteredOperatorStateBackendMetaInfo<>(
 				name, stateSerializer, OperatorStateHandle.Mode.UNION).snapshot();
 
 		byte[] serialized;
@@ -274,8 +274,8 @@ public class SerializationProxiesTest {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		RegisteredOperatorBackendStateMetaInfo<?> restoredMetaInfo =
-			new RegisteredOperatorBackendStateMetaInfo<>(snapshot);
+		RegisteredOperatorStateBackendMetaInfo<?> restoredMetaInfo =
+			new RegisteredOperatorStateBackendMetaInfo<>(snapshot);
 
 		Assert.assertEquals(name, restoredMetaInfo.getName());
 		Assert.assertEquals(OperatorStateHandle.Mode.UNION, restoredMetaInfo.getAssignmentMode());
@@ -290,7 +290,7 @@ public class SerializationProxiesTest {
 		TypeSerializer<?> valueSerializer = StringSerializer.INSTANCE;
 
 		StateMetaInfoSnapshot snapshot =
-			new RegisteredBroadcastBackendStateMetaInfo<>(
+			new RegisteredBroadcastStateBackendMetaInfo<>(
 				name, OperatorStateHandle.Mode.BROADCAST, keySerializer, valueSerializer).snapshot();
 
 		byte[] serialized;
@@ -308,8 +308,8 @@ public class SerializationProxiesTest {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
-		RegisteredBroadcastBackendStateMetaInfo<?, ?> restoredMetaInfo =
-			new RegisteredBroadcastBackendStateMetaInfo<>(snapshot);
+		RegisteredBroadcastStateBackendMetaInfo<?, ?> restoredMetaInfo =
+			new RegisteredBroadcastStateBackendMetaInfo<>(snapshot);
 
 		Assert.assertEquals(name, restoredMetaInfo.getName());
 		Assert.assertEquals(
@@ -325,7 +325,7 @@ public class SerializationProxiesTest {
 		TypeSerializer<?> stateSerializer = DoubleSerializer.INSTANCE;
 
 		StateMetaInfoSnapshot snapshot =
-			new RegisteredOperatorBackendStateMetaInfo<>(
+			new RegisteredOperatorStateBackendMetaInfo<>(
 				name, stateSerializer, OperatorStateHandle.Mode.UNION).snapshot();
 
 		byte[] serialized;
@@ -348,8 +348,8 @@ public class SerializationProxiesTest {
 			snapshot = reader.readStateMetaInfoSnapshot(new DataInputViewStreamWrapper(in), classLoader);
 		}
 
-		RegisteredOperatorBackendStateMetaInfo<?> restoredMetaInfo =
-			new RegisteredOperatorBackendStateMetaInfo<>(snapshot);
+		RegisteredOperatorStateBackendMetaInfo<?> restoredMetaInfo =
+			new RegisteredOperatorStateBackendMetaInfo<>(snapshot);
 
 		Assert.assertEquals(name, restoredMetaInfo.getName());
 		Assert.assertTrue(restoredMetaInfo.getPartitionStateSerializer() instanceof UnloadableDummyTypeSerializer);
@@ -365,7 +365,7 @@ public class SerializationProxiesTest {
 		TypeSerializer<?> valueSerializer = StringSerializer.INSTANCE;
 
 		StateMetaInfoSnapshot snapshot =
-			new RegisteredBroadcastBackendStateMetaInfo<>(
+			new RegisteredBroadcastStateBackendMetaInfo<>(
 				broadcastName, OperatorStateHandle.Mode.BROADCAST, keySerializer, valueSerializer).snapshot();
 
 		byte[] serialized;
@@ -393,8 +393,8 @@ public class SerializationProxiesTest {
 			snapshot = reader.readStateMetaInfoSnapshot(new DataInputViewStreamWrapper(in), classLoader);
 		}
 
-		RegisteredBroadcastBackendStateMetaInfo<?, ?> restoredMetaInfo =
-			new RegisteredBroadcastBackendStateMetaInfo<>(snapshot);
+		RegisteredBroadcastStateBackendMetaInfo<?, ?> restoredMetaInfo =
+			new RegisteredBroadcastStateBackendMetaInfo<>(snapshot);
 
 		Assert.assertEquals(broadcastName, restoredMetaInfo.getName());
 		Assert.assertEquals(OperatorStateHandle.Mode.BROADCAST, restoredMetaInfo.getAssignmentMode());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
@@ -55,7 +56,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			true,
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
-			mock(PriorityQueueSetFactory.class),
+			mock(HeapPriorityQueueSetFactory.class),
 			TtlTimeProvider.DEFAULT);
 
 		try {
@@ -79,7 +80,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			true,
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
-			mock(PriorityQueueSetFactory.class),
+			mock(HeapPriorityQueueSetFactory.class),
 			TtlTimeProvider.DEFAULT);
 
 		try {
@@ -121,7 +122,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			true,
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
-			mock(PriorityQueueSetFactory.class),
+			mock(HeapPriorityQueueSetFactory.class),
 			TtlTimeProvider.DEFAULT);
 
 		try {
@@ -164,7 +165,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			true,
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
-			mock(PriorityQueueSetFactory.class),
+			mock(HeapPriorityQueueSetFactory.class),
 			TtlTimeProvider.DEFAULT);
 		try {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.ArrayListSerializer;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.util.TestLogger;
@@ -53,8 +53,8 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 */
 	@Test
 	public void testPutGetRemoveContainsTransform() throws Exception {
-		RegisteredKeyedBackendStateMetaInfo<Integer, ArrayList<Integer>> metaInfo =
-			new RegisteredKeyedBackendStateMetaInfo<>(
+		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
 				IntSerializer.INSTANCE,
@@ -125,8 +125,8 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 */
 	@Test
 	public void testIncrementalRehash() {
-		RegisteredKeyedBackendStateMetaInfo<Integer, ArrayList<Integer>> metaInfo =
-			new RegisteredKeyedBackendStateMetaInfo<>(
+		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
 				IntSerializer.INSTANCE,
@@ -170,8 +170,8 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	@Test
 	public void testRandomModificationsAndCopyOnWriteIsolation() throws Exception {
 
-		final RegisteredKeyedBackendStateMetaInfo<Integer, ArrayList<Integer>> metaInfo =
-			new RegisteredKeyedBackendStateMetaInfo<>(
+		final RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
 				IntSerializer.INSTANCE,
@@ -325,8 +325,8 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 */
 	@Test
 	public void testCopyOnWriteContracts() {
-		RegisteredKeyedBackendStateMetaInfo<Integer, ArrayList<Integer>> metaInfo =
-			new RegisteredKeyedBackendStateMetaInfo<>(
+		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
 				IntSerializer.INSTANCE,
@@ -400,8 +400,8 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 		final TestDuplicateSerializer stateSerializer = new TestDuplicateSerializer();
 		final TestDuplicateSerializer keySerializer = new TestDuplicateSerializer();
 
-		RegisteredKeyedBackendStateMetaInfo<Integer, Integer> metaInfo =
-			new RegisteredKeyedBackendStateMetaInfo<>(
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.VALUE,
 				"test",
 				namespaceSerializer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -356,7 +356,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 
 		// no snapshot taken, we get the original back
 		Assert.assertTrue(stateTable.get(1, 1) == originalState1);
-		CopyOnWriteStateTableSnapshot<Integer, Integer, ArrayList<Integer>> snapshot1 = stateTable.createSnapshot();
+		CopyOnWriteStateTableSnapshot<Integer, Integer, ArrayList<Integer>> snapshot1 = stateTable.stateSnapshot();
 		// after snapshot1 is taken, we get a copy...
 		final ArrayList<Integer> copyState = stateTable.get(1, 1);
 		Assert.assertFalse(copyState == originalState1);
@@ -370,7 +370,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 		Assert.assertTrue(copyState == stateTable.get(1, 1));
 
 		// we take snapshot2
-		CopyOnWriteStateTableSnapshot<Integer, Integer, ArrayList<Integer>> snapshot2 = stateTable.createSnapshot();
+		CopyOnWriteStateTableSnapshot<Integer, Integer, ArrayList<Integer>> snapshot2 = stateTable.stateSnapshot();
 		// after the second snapshot, copy-on-write is active again for old entries
 		Assert.assertFalse(copyState == stateTable.get(1, 1));
 		// and equality still holds
@@ -443,15 +443,15 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 		table.put(2, 0, 1, 2);
 
 
-		final CopyOnWriteStateTableSnapshot<Integer, Integer, Integer> snapshot = table.createSnapshot();
+		final CopyOnWriteStateTableSnapshot<Integer, Integer, Integer> snapshot = table.stateSnapshot();
 
 		try {
-			final StateSnapshot.KeyGroupPartitionedSnapshot partitionedSnapshot = snapshot.partitionByKeyGroup();
+			final StateSnapshot.StateKeyGroupWriter partitionedSnapshot = snapshot.getKeyGroupWriter();
 			namespaceSerializer.disable();
 			keySerializer.disable();
 			stateSerializer.disable();
 
-			partitionedSnapshot.writeMappingsInKeyGroup(
+			partitionedSnapshot.writeStateInKeyGroup(
 				new DataOutputViewStreamWrapper(
 					new ByteArrayOutputStreamWithPos(1024)), 0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/StateTableSnapshotCompatibilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/StateTableSnapshotCompatibilityTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
 import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class StateTableSnapshotCompatibilityTest {
 			cowStateTable.put(r.nextInt(10), r.nextInt(2), list);
 		}
 
-		StateSnapshot snapshot = cowStateTable.createSnapshot();
+		StateSnapshot snapshot = cowStateTable.stateSnapshot();
 
 		final NestedMapsStateTable<Integer, Integer, ArrayList<Integer>> nestedMapsStateTable =
 			new NestedMapsStateTable<>(keyContext, metaInfo);
@@ -83,7 +84,7 @@ public class StateTableSnapshotCompatibilityTest {
 			Assert.assertEquals(entry.getState(), nestedMapsStateTable.get(entry.getKey(), entry.getNamespace()));
 		}
 
-		snapshot = nestedMapsStateTable.createSnapshot();
+		snapshot = nestedMapsStateTable.stateSnapshot();
 		cowStateTable = new CopyOnWriteStateTable<>(keyContext, metaInfo);
 
 		restoreStateTableFromSnapshot(cowStateTable, snapshot, keyContext.getKeyGroupRange());
@@ -102,9 +103,9 @@ public class StateTableSnapshotCompatibilityTest {
 
 		final ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos(1024 * 1024);
 		final DataOutputViewStreamWrapper dov = new DataOutputViewStreamWrapper(out);
-		final StateSnapshot.KeyGroupPartitionedSnapshot keyGroupPartitionedSnapshot = snapshot.partitionByKeyGroup();
+		final StateSnapshot.StateKeyGroupWriter keyGroupPartitionedSnapshot = snapshot.getKeyGroupWriter();
 		for (Integer keyGroup : keyGroupRange) {
-			keyGroupPartitionedSnapshot.writeMappingsInKeyGroup(dov, keyGroup);
+			keyGroupPartitionedSnapshot.writeStateInKeyGroup(dov, keyGroup);
 		}
 
 		final ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(out.getBuf());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/StateTableSnapshotCompatibilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/StateTableSnapshotCompatibilityTest.java
@@ -27,9 +27,9 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.ArrayListSerializer;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.StateSnapshot;
-import org.apache.flink.runtime.state.StateTableByKeyGroupReader;
+import org.apache.flink.runtime.state.StateSnapshotKeyGroupReader;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,8 +47,8 @@ public class StateTableSnapshotCompatibilityTest {
 	@Test
 	public void checkCompatibleSerializationFormats() throws IOException {
 		final Random r = new Random(42);
-		RegisteredKeyedBackendStateMetaInfo<Integer, ArrayList<Integer>> metaInfo =
-			new RegisteredKeyedBackendStateMetaInfo<>(
+		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
 				IntSerializer.INSTANCE,
@@ -111,7 +111,7 @@ public class StateTableSnapshotCompatibilityTest {
 		final ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(out.getBuf());
 		final DataInputViewStreamWrapper div = new DataInputViewStreamWrapper(in);
 
-		final StateTableByKeyGroupReader keyGroupReader =
+		final StateSnapshotKeyGroupReader keyGroupReader =
 			StateTableByKeyGroupReaders.readerForVersion(stateTable, KeyedBackendSerializationProxy.VERSION);
 
 		for (Integer keyGroup : keyGroupRange) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotEnumConstantsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotEnumConstantsTest.java
@@ -32,11 +32,11 @@ public class StateMetaInfoSnapshotEnumConstantsTest {
 		Assert.assertEquals(0, StateMetaInfoSnapshot.BackendStateType.KEY_VALUE.ordinal());
 		Assert.assertEquals(1, StateMetaInfoSnapshot.BackendStateType.OPERATOR.ordinal());
 		Assert.assertEquals(2, StateMetaInfoSnapshot.BackendStateType.BROADCAST.ordinal());
-		Assert.assertEquals(3, StateMetaInfoSnapshot.BackendStateType.TIMER.ordinal());
+		Assert.assertEquals(3, StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE.ordinal());
 		Assert.assertEquals("KEY_VALUE", StateMetaInfoSnapshot.BackendStateType.KEY_VALUE.toString());
 		Assert.assertEquals("OPERATOR", StateMetaInfoSnapshot.BackendStateType.OPERATOR.toString());
 		Assert.assertEquals("BROADCAST", StateMetaInfoSnapshot.BackendStateType.BROADCAST.toString());
-		Assert.assertEquals("TIMER", StateMetaInfoSnapshot.BackendStateType.TIMER.toString());
+		Assert.assertEquals("PRIORITY_QUEUE", StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE.toString());
 	}
 
 	@Test

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -177,7 +177,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBAggregatingState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
 
 import org.rocksdb.ColumnFamilyHandle;
@@ -103,7 +103,7 @@ class RocksDBFoldingState<K, N, T, ACC>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBFoldingState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -2643,7 +2643,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
 		/** Default cache size per key-group. */
-		private static final int DEFAULT_CACHES_SIZE = 8 * 1024;
+		private static final int DEFAULT_CACHES_SIZE = 1024;
 
 		/** A shared buffer to serialize elements for the priority queue. */
 		@Nonnull

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -63,14 +63,18 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.LocalRecoveryDirectoryProvider;
 import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.PriorityComparator;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
 import org.apache.flink.runtime.state.SnapshotDirectory;
 import org.apache.flink.runtime.state.SnapshotResult;
@@ -224,7 +228,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	 * Information about the k/v states as we create them. This is used to retrieve the
 	 * column family that is used for a state and also for sanity checks when restoring.
 	 */
-	private final Map<String, Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>>> kvStateInformation;
+	private final Map<String, Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase>> kvStateInformation;
 
 	/**
 	 * Map of state names to their corresponding restored state meta info.
@@ -256,7 +260,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private final SnapshotStrategy<SnapshotResult<KeyedStateHandle>> snapshotStrategy;
 
 	/** Factory for priority queue state. */
-	private PriorityQueueSetFactory priorityQueueFactory;
+	private final PriorityQueueSetFactory priorityQueueFactory;
+
+	private RocksDBWriteBatchWrapper writeBatchWrapper;
 
 	public RocksDBKeyedStateBackend(
 		String operatorIdentifier,
@@ -322,7 +328,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				this.priorityQueueFactory = new RocksDBPriorityQueueSetFactory();
 				break;
 			default:
-				break;
+				throw new IllegalArgumentException("Unknown priority queue state type: " + priorityQueueStateType);
 		}
 
 		LOG.debug("Setting initial keyed backend uid for operator {} to {}.", this.operatorIdentifier, this.backendUID);
@@ -344,12 +350,15 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <N> Stream<K> getKeys(String state, N namespace) {
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> columnInfo = kvStateInformation.get(state);
-		if (columnInfo == null) {
+		Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> columnInfo = kvStateInformation.get(state);
+		if (columnInfo == null || !(columnInfo.f1 instanceof RegisteredKeyedBackendStateMetaInfo)) {
 			return Stream.empty();
 		}
 
-		final TypeSerializer<N> namespaceSerializer = (TypeSerializer<N>) columnInfo.f1.getNamespaceSerializer();
+		RegisteredKeyedBackendStateMetaInfo<N, ?> registeredKeyValueStateBackendMetaInfo =
+			(RegisteredKeyedBackendStateMetaInfo<N, ?>) columnInfo.f1;
+
+		final TypeSerializer<N> namespaceSerializer = registeredKeyValueStateBackendMetaInfo.getNamespaceSerializer();
 		final ByteArrayOutputStreamWithPos namespaceOutputStream = new ByteArrayOutputStreamWithPos(8);
 		boolean ambiguousKeyPossible = RocksDBKeySerializationUtils.isAmbiguousKeyPossible(keySerializer, namespaceSerializer);
 		final byte[] nameSpaceBytes;
@@ -396,6 +405,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		// working on the disposed object results in SEGFAULTS.
 		if (db != null) {
 
+			IOUtils.closeQuietly(writeBatchWrapper);
+
 			// RocksDB's native memory management requires that *all* CFs (including default) are closed before the
 			// DB is closed. See:
 			// https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#opening-a-database-with-column-families
@@ -403,14 +414,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			IOUtils.closeQuietly(defaultColumnFamily);
 
 			// ... continue with the ones created by Flink...
-			for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> columnMetaData :
+			for (Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> columnMetaData :
 				kvStateInformation.values()) {
 				IOUtils.closeQuietly(columnMetaData.f0);
-			}
-
-			// ... then close the priority queue related resources ...
-			if (priorityQueueFactory instanceof AutoCloseable) {
-				IOUtils.closeQuietly((AutoCloseable) priorityQueueFactory);
 			}
 
 			// ... and finally close the DB instance ...
@@ -431,13 +437,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	@Nonnull
 	@Override
-	public <T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
+	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T>
+	create(
 		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
-		@Nonnull PriorityComparator<T> elementComparator,
-		@Nonnull KeyExtractorFunction<T> keyExtractor) {
-
-		return priorityQueueFactory.create(stateName, byteOrderedElementSerializer, elementComparator, keyExtractor);
+		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+		return priorityQueueFactory.create(stateName, byteOrderedElementSerializer);
 	}
 
 	private void cleanInstanceBasePath() {
@@ -482,6 +486,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	@Override
 	public void restore(Collection<KeyedStateHandle> restoreState) throws Exception {
+
 		LOG.info("Initializing RocksDB keyed state backend.");
 
 		if (LOG.isDebugEnabled()) {
@@ -534,6 +539,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private void createDB() throws IOException {
 		List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>(1);
 		this.db = openDB(instanceRocksDBPath.getAbsolutePath(), Collections.emptyList(), columnFamilyHandles);
+		this.writeBatchWrapper = new RocksDBWriteBatchWrapper(db, writeOptions);
 		this.defaultColumnFamily = columnFamilyHandles.get(0);
 	}
 
@@ -679,7 +685,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			for (StateMetaInfoSnapshot restoredMetaInfo : restoredMetaInfos) {
 
-				Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> registeredColumn =
+				Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> registeredColumn =
 					rocksDBKeyedStateBackend.kvStateInformation.get(restoredMetaInfo.getName());
 
 				if (registeredColumn == null) {
@@ -689,8 +695,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 						nameBytes,
 						rocksDBKeyedStateBackend.columnOptions);
 
-					RegisteredKeyedBackendStateMetaInfo<?, ?> stateMetaInfo =
-						new RegisteredKeyedBackendStateMetaInfo<>(restoredMetaInfo);
+					RegisteredStateMetaInfoBase stateMetaInfo =
+						RegisteredStateMetaInfoBase.fromMetaInfoSnapshot(restoredMetaInfo);
 
 					rocksDBKeyedStateBackend.restoredKvStateMetaInfos.put(restoredMetaInfo.getName(), restoredMetaInfo);
 
@@ -987,12 +993,12 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			ColumnFamilyHandle columnFamilyHandle,
 			StateMetaInfoSnapshot stateMetaInfoSnapshot) throws RocksDBException {
 
-			Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> registeredStateMetaInfoEntry =
+			Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> registeredStateMetaInfoEntry =
 				stateBackend.kvStateInformation.get(stateMetaInfoSnapshot.getName());
 
 			if (null == registeredStateMetaInfoEntry) {
-				RegisteredKeyedBackendStateMetaInfo<?, ?> stateMetaInfo =
-					new RegisteredKeyedBackendStateMetaInfo<>(stateMetaInfoSnapshot);
+				RegisteredStateMetaInfoBase stateMetaInfo =
+					RegisteredStateMetaInfoBase.fromMetaInfoSnapshot(stateMetaInfoSnapshot);
 
 				registeredStateMetaInfoEntry =
 					new Tuple2<>(
@@ -1037,6 +1043,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 					stateBackend.db = restoreDBInfo.db;
 					stateBackend.defaultColumnFamily = restoreDBInfo.defaultColumnFamilyHandle;
+					stateBackend.writeBatchWrapper =
+						new RocksDBWriteBatchWrapper(stateBackend.db, stateBackend.writeOptions);
 
 					for (int i = 0; i < restoreDBInfo.stateMetaInfoSnapshots.size(); ++i) {
 						getOrRegisterColumnFamilyHandle(
@@ -1061,6 +1069,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					Collections.emptyList(),
 					columnFamilyHandles);
 				stateBackend.defaultColumnFamily = columnFamilyHandles.get(0);
+				stateBackend.writeBatchWrapper =
+					new RocksDBWriteBatchWrapper(stateBackend.db, stateBackend.writeOptions);
 			}
 		}
 
@@ -1115,13 +1125,14 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			// extract and store the default column family which is located at the first index
 			stateBackend.defaultColumnFamily = columnFamilyHandles.remove(0);
+			stateBackend.writeBatchWrapper = new RocksDBWriteBatchWrapper(stateBackend.db, stateBackend.writeOptions);
 
 			for (int i = 0; i < columnFamilyDescriptors.size(); ++i) {
 				StateMetaInfoSnapshot stateMetaInfoSnapshot = stateMetaInfoSnapshots.get(i);
 
 				ColumnFamilyHandle columnFamilyHandle = columnFamilyHandles.get(i);
-				RegisteredKeyedBackendStateMetaInfo<?, ?> stateMetaInfo =
-					new RegisteredKeyedBackendStateMetaInfo<>(stateMetaInfoSnapshot);
+				RegisteredStateMetaInfoBase stateMetaInfo =
+					RegisteredStateMetaInfoBase.fromMetaInfoSnapshot(stateMetaInfoSnapshot);
 
 				stateBackend.kvStateInformation.put(
 					stateMetaInfoSnapshot.getName(),
@@ -1294,7 +1305,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			StateDescriptor<?, S> stateDesc,
 			TypeSerializer<N> namespaceSerializer) throws StateMigrationException {
 
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> stateInfo =
+		Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> stateInfo =
 			kvStateInformation.get(stateDesc.getName());
 
 		RegisteredKeyedBackendStateMetaInfo<N, S> newMetaInfo;
@@ -1323,7 +1334,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				namespaceSerializer,
 				stateDesc.getSerializer());
 
-			ColumnFamilyHandle columnFamily = createColumnFamily(stateName, db);
+			ColumnFamilyHandle columnFamily = createColumnFamily(stateName);
 
 			stateInfo = Tuple2.of(columnFamily, newMetaInfo);
 			kvStateInformation.put(stateDesc.getName(), stateInfo);
@@ -1335,7 +1346,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	/**
 	 * Creates a column family handle for use with a k/v state.
 	 */
-	private ColumnFamilyHandle createColumnFamily(String stateName, RocksDB db) {
+	private ColumnFamilyHandle createColumnFamily(String stateName) {
 		byte[] nameBytes = stateName.getBytes(ConfigConstants.DEFAULT_CHARSET);
 		Preconditions.checkState(!Arrays.equals(RocksDB.DEFAULT_COLUMN_FAMILY, nameBytes),
 			"The chosen state name 'default' collides with the name of the default column family!");
@@ -1382,7 +1393,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	public int numStateEntries() {
 		int count = 0;
 
-		for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> column : kvStateInformation.values()) {
+		for (Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> column : kvStateInformation.values()) {
+			//TODO maybe filter only for k/v states
 			try (RocksIteratorWrapper rocksIterator = getRocksIterator(db, column.f0)) {
 				rocksIterator.seekToFirst();
 
@@ -1405,7 +1417,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@VisibleForTesting
 	static final class RocksDBMergeIterator implements AutoCloseable {
 
-		private final PriorityQueue<MergeIterator> heap;
+		private final PriorityQueue<RocksDBKeyedStateBackend.MergeIterator> heap;
 		private final int keyGroupPrefixByteCount;
 		private boolean newKeyGroup;
 		private boolean newKVState;
@@ -1763,6 +1775,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			final CloseableRegistry snapshotCloseableRegistry = new CloseableRegistry();
 
+			// flush everything into db before taking a snapshot
+			writeBatchWrapper.flush();
+
 			final RocksDBFullSnapshotOperation<K> snapshotOperation =
 				new RocksDBFullSnapshotOperation<>(
 					RocksDBKeyedStateBackend.this,
@@ -1982,7 +1997,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			this.copiedColumnFamilyHandles = new ArrayList<>(stateBackend.kvStateInformation.size());
 
-			for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> tuple2 :
+			for (Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> tuple2 :
 				stateBackend.kvStateInformation.values()) {
 				// snapshot meta info
 				this.stateMetaInfoSnapshots.add(tuple2.f1.snapshot());
@@ -2433,7 +2448,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				"assuming the following (shared) files as base: {}.", checkpointId, lastCompletedCheckpoint, baseSstFiles);
 
 			// save meta data
-			for (Map.Entry<String, Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>>> stateMetaInfoEntry
+			for (Map.Entry<String, Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase>> stateMetaInfoEntry
 				: stateBackend.kvStateInformation.entrySet()) {
 				stateMetaInfoSnapshots.add(stateMetaInfoEntry.getValue().f1.snapshot());
 			}
@@ -2625,7 +2640,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	/**
 	 * Encapsulates the logic and resources in connection with creating priority queue state structures.
 	 */
-	class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory, AutoCloseable {
+	class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
 		/** Default cache size per key-group. */
 		private static final int DEFAULT_CACHES_SIZE = 8 * 1024;
@@ -2638,68 +2653,47 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		@Nonnull
 		private final DataOutputViewStreamWrapper elementSerializationOutView;
 
-		/** A shared {@link RocksDBWriteBatchWrapper} to batch modifications to priority queues. */
-		@Nonnull
-		private final RocksDBWriteBatchWrapper writeBatchWrapper;
-
-		/** Map to track all column families created to back priority queues. */
-		@Nonnull
-		private final Map<String, ColumnFamilyHandle> priorityQueueColumnFamilies;
-
-		/** The mandatory default column family, so that we can close it later. */
-		@Nonnull
-		private final ColumnFamilyHandle defaultColumnFamily;
-
-		/** Path of the RocksDB instance that holds the priority queues. */
-		@Nonnull
-		private final File pqInstanceRocksDBPath;
-
-		/** RocksDB instance that holds the priority queues. */
-		@Nonnull
-		private final RocksDB pqDb;
-
-		RocksDBPriorityQueueSetFactory() throws IOException {
-			this.pqInstanceRocksDBPath = new File(instanceBasePath, "pqdb");
-			if (pqInstanceRocksDBPath.exists()) {
-				try {
-					FileUtils.deleteDirectory(pqInstanceRocksDBPath);
-				} catch (IOException ex) {
-					LOG.warn("Could not delete instance path for PQ RocksDB: " + pqInstanceRocksDBPath, ex);
-				}
-			}
-			List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>(1);
-			this.pqDb = openDB(pqInstanceRocksDBPath.getAbsolutePath(), Collections.emptyList(), columnFamilyHandles);
+		RocksDBPriorityQueueSetFactory() {
 			this.elementSerializationOutStream = new ByteArrayOutputStreamWithPos();
 			this.elementSerializationOutView = new DataOutputViewStreamWrapper(elementSerializationOutStream);
-			this.writeBatchWrapper = new RocksDBWriteBatchWrapper(pqDb, writeOptions);
-			this.defaultColumnFamily = columnFamilyHandles.get(0);
-			this.priorityQueueColumnFamilies = new HashMap<>();
 		}
 
 		@Nonnull
 		@Override
-		public <T extends HeapPriorityQueueElement> KeyGroupedInternalPriorityQueue<T> create(
+		public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T>
+		create(
 			@Nonnull String stateName,
-			@Nonnull TypeSerializer<T> byteOrderedElementSerializer,
-			@Nonnull PriorityComparator<T> elementPriorityComparator,
-			@Nonnull KeyExtractorFunction<T> keyExtractor) {
+			@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
 
-			final ColumnFamilyHandle columnFamilyHandle =
-				priorityQueueColumnFamilies.computeIfAbsent(
-					stateName,
-					(name) -> RocksDBKeyedStateBackend.this.createColumnFamily(name, pqDb));
+			final PriorityComparator<T> priorityComparator =
+				PriorityComparator.forPriorityComparableObjects();
+
+			Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> entry =
+				kvStateInformation.get(stateName);
+
+			if (entry == null) {
+				RegisteredPriorityQueueStateBackendMetaInfo<T> metaInfo =
+					new RegisteredPriorityQueueStateBackendMetaInfo<>(stateName, byteOrderedElementSerializer);
+
+				final ColumnFamilyHandle columnFamilyHandle = createColumnFamily(stateName);
+
+				entry = new Tuple2<>(columnFamilyHandle, metaInfo);
+				kvStateInformation.put(stateName, entry);
+			}
+
+			final ColumnFamilyHandle columnFamilyHandle = entry.f0;
 
 			@Nonnull
 			TieBreakingPriorityComparator<T> tieBreakingComparator =
 				new TieBreakingPriorityComparator<>(
-					elementPriorityComparator,
+					priorityComparator,
 					byteOrderedElementSerializer,
 					elementSerializationOutStream,
 					elementSerializationOutView);
 
 			return new KeyGroupPartitionedPriorityQueue<>(
-				keyExtractor,
-				elementPriorityComparator,
+				KeyExtractorFunction.forKeyedObjects(),
+				priorityComparator,
 				new KeyGroupPartitionedPriorityQueue.PartitionQueueSetFactory<T, CachingInternalPriorityQueueSet<T>>() {
 					@Nonnull
 					@Override
@@ -2714,7 +2708,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 							new RocksDBOrderedSetStore<>(
 								keyGroupId,
 								keyGroupPrefixBytes,
-								pqDb,
+								db,
 								columnFamilyHandle,
 								byteOrderedElementSerializer,
 								elementSerializationOutStream,
@@ -2727,20 +2721,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				keyGroupRange,
 				numberOfKeyGroups);
 		}
+	}
 
-		@Override
-		public void close() {
-			IOUtils.closeQuietly(writeBatchWrapper);
-			for (ColumnFamilyHandle columnFamilyHandle : priorityQueueColumnFamilies.values()) {
-				IOUtils.closeQuietly(columnFamilyHandle);
-			}
-			IOUtils.closeQuietly(defaultColumnFamily);
-			IOUtils.closeQuietly(pqDb);
-			try {
-				FileUtils.deleteDirectory(pqInstanceRocksDBPath);
-			} catch (IOException ex) {
-				LOG.warn("Could not delete instance path for PQ RocksDB: " + pqInstanceRocksDBPath, ex);
-			}
-		}
+	@Override
+	public boolean requiresLegacySynchronousTimerSnapshots() {
+		return priorityQueueFactory instanceof HeapPriorityQueueSetFactory;
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
@@ -257,7 +257,7 @@ class RocksDBListState<K, N, V>
 	@SuppressWarnings("unchecked")
 	static <E, K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBListState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -30,7 +30,7 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
@@ -616,7 +616,7 @@ class RocksDBMapState<K, N, UK, UV>
 	@SuppressWarnings("unchecked")
 	static <UK, UV, K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBMapState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStore.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOrderedSetStore.java
@@ -159,7 +159,6 @@ public class RocksDBOrderedSetStore<T> implements CachingInternalPriorityQueueSe
 	public RocksToJavaIteratorAdapter orderedIterator() {
 
 		flushWriteBatch();
-
 		return new RocksToJavaIteratorAdapter(
 			new RocksIteratorWrapper(
 				db.newIterator(columnFamilyHandle)));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -172,7 +172,7 @@ class RocksDBReducingState<K, N, V>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBReducingState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.RegisteredKeyedBackendStateMetaInfo;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -116,7 +116,7 @@ class RocksDBValueState<K, N, V>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBValueState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
@@ -102,6 +102,10 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
 		batch.clear();
 	}
 
+	public WriteOptions getOptions() {
+		return options;
+	}
+
 	@Override
 	public void close() throws RocksDBException {
 		if (batch.count() != 0) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -402,7 +402,11 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @param context context that provides information and means required for taking a snapshot
 	 */
 	public void snapshotState(StateSnapshotContext context) throws Exception {
-		if (getKeyedStateBackend() != null) {
+		final KeyedStateBackend<?> keyedStateBackend = getKeyedStateBackend();
+		//TODO all of this can be removed once heap-based timers are integrated with RocksDB incremental snapshots
+		if (keyedStateBackend instanceof AbstractKeyedStateBackend &&
+			((AbstractKeyedStateBackend<?>) keyedStateBackend).requiresLegacySynchronousTimerSnapshots()) {
+
 			KeyedStateCheckpointOutputStream out;
 
 			try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyExtractorFunction;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.PriorityComparator;
 
 import javax.annotation.Nonnull;
@@ -31,7 +33,7 @@ import javax.annotation.Nonnull;
  * @param <N> Type of the namespace to which timers are scoped.
  */
 @Internal
-public interface InternalTimer<K, N> {
+public interface InternalTimer<K, N> extends PriorityComparable<InternalTimer<?, ?>>, Keyed<K> {
 
 	/** Function to extract the key from a {@link InternalTimer}. */
 	KeyExtractorFunction<InternalTimer<?, ?>> KEY_EXTRACTOR_FUNCTION = InternalTimer::getKey;
@@ -48,6 +50,7 @@ public interface InternalTimer<K, N> {
 	 * Returns the key that is bound to this timer.
 	 */
 	@Nonnull
+	@Override
 	K getKey();
 
 	/**
@@ -55,14 +58,4 @@ public interface InternalTimer<K, N> {
 	 */
 	@Nonnull
 	N getNamespace();
-
-	@SuppressWarnings("unchecked")
-	static <T extends InternalTimer> PriorityComparator<T> getTimerComparator() {
-		return (PriorityComparator<T>) TIMER_COMPARATOR;
-	}
-
-	@SuppressWarnings("unchecked")
-	static <T extends InternalTimer> KeyExtractorFunction<T> getKeyExtractorFunction() {
-		return (KeyExtractorFunction<T>) KEY_EXTRACTOR_FUNCTION;
-	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -19,15 +19,19 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.runtime.DataInputViewStream;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -96,7 +100,7 @@ public class InternalTimersSnapshotReaderWriters {
 		public final void writeTimersSnapshot(DataOutputView out) throws IOException {
 			writeKeyAndNamespaceSerializers(out);
 
-			TimerHeapInternalTimer.TimerSerializer<K, N> timerSerializer = new TimerHeapInternalTimer.TimerSerializer<>(
+			LegacyTimerSerializer<K, N> timerSerializer = new LegacyTimerSerializer<>(
 				timersSnapshot.getKeySerializer(),
 				timersSnapshot.getNamespaceSerializer());
 
@@ -215,8 +219,8 @@ public class InternalTimersSnapshotReaderWriters {
 
 			restoreKeyAndNamespaceSerializers(restoredTimersSnapshot, in);
 
-			TimerHeapInternalTimer.TimerSerializer<K, N> timerSerializer =
-				new TimerHeapInternalTimer.TimerSerializer<>(
+			LegacyTimerSerializer<K, N> timerSerializer =
+				new LegacyTimerSerializer<>(
 					restoredTimersSnapshot.getKeySerializer(),
 					restoredTimersSnapshot.getNamespaceSerializer());
 
@@ -287,6 +291,122 @@ public class InternalTimersSnapshotReaderWriters {
 			restoredTimersSnapshot.setKeySerializerConfigSnapshot(serializersAndConfigs.get(0).f1);
 			restoredTimersSnapshot.setNamespaceSerializer((TypeSerializer<N>) serializersAndConfigs.get(1).f0);
 			restoredTimersSnapshot.setNamespaceSerializerConfigSnapshot(serializersAndConfigs.get(1).f1);
+		}
+	}
+
+	/**
+	 * A {@link TypeSerializer} used to serialize/deserialize a {@link TimerHeapInternalTimer}.
+	 */
+	public static class LegacyTimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer<K, N>> {
+
+		private static final long serialVersionUID = 1119562170939152304L;
+
+		@Nonnull
+		private final TypeSerializer<K> keySerializer;
+
+		@Nonnull
+		private final TypeSerializer<N> namespaceSerializer;
+
+		LegacyTimerSerializer(@Nonnull TypeSerializer<K> keySerializer, @Nonnull TypeSerializer<N> namespaceSerializer) {
+			this.keySerializer = keySerializer;
+			this.namespaceSerializer = namespaceSerializer;
+		}
+
+		@Override
+		public boolean isImmutableType() {
+			return false;
+		}
+
+		@Override
+		public TypeSerializer<TimerHeapInternalTimer<K, N>> duplicate() {
+
+			final TypeSerializer<K> keySerializerDuplicate = keySerializer.duplicate();
+			final TypeSerializer<N> namespaceSerializerDuplicate = namespaceSerializer.duplicate();
+
+			if (keySerializerDuplicate == keySerializer &&
+				namespaceSerializerDuplicate == namespaceSerializer) {
+				// all delegate serializers seem stateless, so this is also stateless.
+				return this;
+			} else {
+				// at least one delegate serializer seems to be stateful, so we return a new instance.
+				return new LegacyTimerSerializer<>(keySerializerDuplicate, namespaceSerializerDuplicate);
+			}
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> createInstance() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> copy(TimerHeapInternalTimer<K, N> from) {
+			return new TimerHeapInternalTimer<>(from.getTimestamp(), from.getKey(), from.getNamespace());
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> copy(TimerHeapInternalTimer<K, N> from, TimerHeapInternalTimer<K, N> reuse) {
+			return copy(from);
+		}
+
+		@Override
+		public int getLength() {
+			// we do not have fixed length
+			return -1;
+		}
+
+		@Override
+		public void serialize(TimerHeapInternalTimer<K, N> record, DataOutputView target) throws IOException {
+			keySerializer.serialize(record.getKey(), target);
+			namespaceSerializer.serialize(record.getNamespace(), target);
+			LongSerializer.INSTANCE.serialize(record.getTimestamp(), target);
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> deserialize(DataInputView source) throws IOException {
+			K key = keySerializer.deserialize(source);
+			N namespace = namespaceSerializer.deserialize(source);
+			Long timestamp = LongSerializer.INSTANCE.deserialize(source);
+			return new TimerHeapInternalTimer<>(timestamp, key, namespace);
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> deserialize(TimerHeapInternalTimer<K, N> reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			keySerializer.copy(source, target);
+			namespaceSerializer.copy(source, target);
+			LongSerializer.INSTANCE.copy(source, target);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj == this ||
+				(obj != null && obj.getClass() == getClass() &&
+					keySerializer.equals(((LegacyTimerSerializer) obj).keySerializer) &&
+					namespaceSerializer.equals(((LegacyTimerSerializer) obj).namespaceSerializer));
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return true;
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		@Override
+		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
+		}
+
+		@Override
+		public CompatibilityResult<TimerHeapInternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -209,7 +209,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			keyGroupRange,
 			keyContext,
 			keyedStatedBackend,
-			processingTimeService);
+			processingTimeService,
+			keyedStatedBackend.requiresLegacySynchronousTimerSnapshots());
 
 		// and then initialize the timer services
 		for (KeyGroupStatePartitionStreamProvider streamProvider : rawKeyedStates) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.core.memory.DataInputView;
@@ -31,8 +32,8 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * A serializer for {@link TimerHeapInternalTimer} objects that produces a serialization format that is aligned with
- * {@link InternalTimer#getTimerComparator()}.
+ * A serializer for {@link TimerHeapInternalTimer} objects that produces a serialization format that is
+ * lexicographically aligned the priority of the timers.
  *
  * @param <K> type of the timer key.
  * @param <N> type of the timer namespace.
@@ -201,13 +202,14 @@ public class TimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer
 
 	@Override
 	public TypeSerializerConfigSnapshot snapshotConfiguration() {
-		throw new UnsupportedOperationException("This serializer is currently not used to write state.");
+		return new TimerSerializerConfigSnapshot<>(keySerializer, namespaceSerializer);
 	}
 
 	@Override
 	public CompatibilityResult<TimerHeapInternalTimer<K, N>> ensureCompatibility(
 		TypeSerializerConfigSnapshot configSnapshot) {
-		throw new UnsupportedOperationException("This serializer is currently not used to write state.");
+		//TODO this is just a mock (assuming no serializer updates) for now and needs a proper implementation! change this before release.
+		return CompatibilityResult.compatible();
 	}
 
 	@Nonnull
@@ -218,5 +220,26 @@ public class TimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer
 	@Nonnull
 	public TypeSerializer<N> getNamespaceSerializer() {
 		return namespaceSerializer;
+	}
+
+	/**
+	 * Snaphot of a {@link TimerSerializer}.
+	 *
+	 * @param <K> type of key.
+	 * @param <N> type of namespace.
+	 */
+	public static class TimerSerializerConfigSnapshot<K, N> extends CompositeTypeSerializerConfigSnapshot {
+
+		public TimerSerializerConfigSnapshot() {
+		}
+
+		public TimerSerializerConfigSnapshot(TypeSerializer<K> keySerializer, TypeSerializer<N> namespaceSerializer) {
+			super(keySerializer, namespaceSerializer);
+		}
+
+		@Override
+		public int getVersion() {
+			return 0;
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
@@ -910,8 +910,6 @@ public class HeapInternalTimerServiceTest {
 		PriorityQueueSetFactory priorityQueueSetFactory) {
 		return priorityQueueSetFactory.create(
 			name,
-			timerSerializer,
-			InternalTimer.getTimerComparator(),
-			InternalTimer.getKeyExtractorFunction());
+			timerSerializer);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates priority queue state (timers) with the snapshotting of Flink's state backend ans also already includes backwards compatibility (FLINK-9490). Core idea is to have a common abstraction for how state is registered in the state backend and how snapshots operator on such state (`StateSnapshotRestore`, `RegisteredStateMetaInfoBase`). With this, the new state integrates more or less seemless with existing snapshot logic. The notable exception is a current lack of integration of RocksDB state backend with heap-based priority queue state. This can currently still use the old snapshot code without causing any regression using a temporary path (see `AbstractStreamOperator.snapshotState(...)`. As a result, after this PR Flink supports asynchronous snapshots for (heap kv / heap queue), (rocks kv / rocks queue) (full and incremental), (rocks kv / heap queue) (only full)  and _still uses synchronous snapshots for (rocks kv / heap queue) (only incremental)_.

**DISCLAIMER:** This work was created in a bit of a rush to make it into the 1.6 release and still has some **known rough edges** and **could have some bugs** left that we could fix up in the test phase. Here is a list of some things that already come to my mind:

- Integrate heap-based timers with incremental RocksDB snapshots, then kick out some code.
- Check proper integration with serializer upgrade story (!!)
- After that, we can also remove the key-partitioning in the set structure from `HeapPriorityQueueSet`.
- Improve integration of the batch wrapper.
- Improve general state registration logic in the backends, there is potential to remove duplicated code, and generally still improve the integration of the queue state a bit.
- Improve performance of RocksDB based timers, e.g. byte[] based cache, seek sharp to the next potential timer instead of seeking to the key-group start, bulkPoll.
- Improve some class/interface/method names.
- Defensive checks against attempts to register a different state type under an existing name.
- Add tests, e.g. bulkPoll etc.

## Verifying this change

This change is already covered by existing tests, but I would add some more eventually. You can activate RocksDB based timers by using the RocksDB backend and setting `RockDBBackendOptions.PRIORITY_QUEUE_STATE_TYPE` to `ROCKS`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs only for now)
