### PR TITLE
[FLINK-9675] [fs] Avoid FileInputStream/FileOutputStream

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -28,9 +28,9 @@ import javax.annotation.Nullable;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 
 /**
  * Global configuration object for Flink. Similar to Java properties configuration
@@ -160,7 +160,7 @@ public final class GlobalConfiguration {
 	private static Configuration loadYAMLResource(File file) {
 		final Configuration config = new Configuration();
 
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)))){
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(file.toPath())))){
 
 			String line;
 			int lineNo = 0;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataInputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataInputStream.java
@@ -24,9 +24,10 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import javax.annotation.Nonnull;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 
 /**
  * The <code>LocalDataInputStream</code> class is a wrapper class for a data
@@ -36,7 +37,7 @@ import java.nio.channels.FileChannel;
 public class LocalDataInputStream extends FSDataInputStream {
 
 	/** The file input stream used to read data from.*/
-	private final FileInputStream fis;
+	private final InputStream fis;
 	private final FileChannel fileChannel;
 
 	/**
@@ -47,8 +48,8 @@ public class LocalDataInputStream extends FSDataInputStream {
 	 * @throws IOException Thrown if the data input stream cannot be created.
 	 */
 	public LocalDataInputStream(File file) throws IOException {
-		this.fis = new FileInputStream(file);
-		this.fileChannel = fis.getChannel();
+		this.fis = Files.newInputStream(file.toPath());
+		this.fileChannel = FileChannel.open(file.toPath());
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataOutputStream.java
@@ -22,8 +22,11 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FSDataOutputStream;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 /**
  * The <code>LocalDataOutputStream</code> class is a wrapper class for a data
@@ -33,7 +36,10 @@ import java.io.IOException;
 public class LocalDataOutputStream extends FSDataOutputStream {
 
 	/** The file output stream used to write data.*/
-	private final FileOutputStream fos;
+	private final OutputStream fos;
+
+	/** The file channel used to manipulate file.*/
+	private final FileChannel fileChannel;
 
 	/**
 	 * Constructs a new <code>LocalDataOutputStream</code> object from a given {@link File} object.
@@ -44,7 +50,8 @@ public class LocalDataOutputStream extends FSDataOutputStream {
 	 *         thrown if the data output stream cannot be created
 	 */
 	public LocalDataOutputStream(final File file) throws IOException {
-		this.fos = new FileOutputStream(file);
+		this.fos = Files.newOutputStream(file.toPath());
+		fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.SYNC);
 	}
 
 	@Override
@@ -69,11 +76,11 @@ public class LocalDataOutputStream extends FSDataOutputStream {
 
 	@Override
 	public void sync() throws IOException {
-		fos.getFD().sync();
+
 	}
 
 	@Override
 	public long getPos() throws IOException {
-		return fos.getChannel().position();
+		return fileChannel.position();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
@@ -25,7 +25,6 @@ import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
@@ -170,8 +169,8 @@ class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
 				if (src.length() > expectedLength) {
 					// can happen if we co from persist to recovering for commit directly
 					// truncate the trailing junk away
-					try (FileOutputStream fos = new FileOutputStream(src, true)) {
-						fos.getChannel().truncate(expectedLength);
+					try (FileChannel channel = FileChannel.open(src.toPath(), StandardOpenOption.APPEND)) {
+						channel.truncate(expectedLength);
 					}
 				} else if (src.length() < expectedLength) {
 					throw new IOException("Missing data in tmp file: " + src);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
@@ -37,8 +37,9 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -165,8 +166,8 @@ public class KryoSerializerCompatibilityTest {
 				new KryoSerializer<>(FakeAvroClass.class, executionConfig);
 
 			try (
-				FileInputStream f = new FileInputStream("src/test/resources/type-with-avro-serialized-using-kryo");
-				DataInputViewStreamWrapper inputView = new DataInputViewStreamWrapper(f)) {
+				InputStream inputStream = Files.newInputStream(new File("src/test/resources/type-with-avro-serialized-using-kryo").toPath());
+				DataInputViewStreamWrapper inputView = new DataInputViewStreamWrapper(inputStream)) {
 
 				thrown.expectMessage("Could not find required Avro dependency");
 				kryoSerializer.deserialize(inputView);
@@ -217,8 +218,8 @@ public class KryoSerializerCompatibilityTest {
 				new KryoSerializer<>(FakeClass.class, executionConfig);
 
 			try (
-				FileInputStream f = new FileInputStream("src/test/resources/type-without-avro-serialized-using-kryo");
-				DataInputViewStreamWrapper inputView = new DataInputViewStreamWrapper(f)) {
+				InputStream inputStream = Files.newInputStream(new File("src/test/resources/type-without-avro-serialized-using-kryo").toPath());
+				DataInputViewStreamWrapper inputView = new DataInputViewStreamWrapper(inputStream)) {
 
 				FakeClass myTestClass = kryoSerializer.deserialize(inputView);
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -61,7 +61,6 @@ import java.io.BufferedInputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -74,6 +73,7 @@ import java.net.InetSocketAddress;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -2596,7 +2596,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
             LOG.debug("parsing File " + file);
           }
           doc = parse(builder, new BufferedInputStream(
-              new FileInputStream(file)), ((Path)resource).toString());
+			  Files.newInputStream(file.toPath())), ((Path)resource).toString());
         }
       } else if (resource instanceof InputStream) {
         doc = parse(builder, (InputStream) resource, null);

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -24,7 +24,6 @@ import java.io.BufferedInputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,6 +34,7 @@ import java.io.Writer;
 import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -2547,7 +2547,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
 						LOG.debug("parsing File " + file);
 					}
 					doc = parse(builder, new BufferedInputStream(
-						new FileInputStream(file)), ((Path)resource).toString());
+						Files.newInputStream(file.toPath())), ((Path)resource).toString());
 				}
 			} else if (resource instanceof InputStream) {
 				doc = parse(builder, (InputStream) resource, null);

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -57,6 +57,7 @@ import java.net.InetSocketAddress;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -2564,7 +2565,7 @@ public class Configuration implements Iterable<Entry<String,String>>,
             LOG.debug("parsing File " + file);
           }
           doc = parse(builder, new BufferedInputStream(
-              new FileInputStream(file)), ((Path)resource).toString());
+			  Files.newInputStream(file.toPath())), ((Path)resource).toString());
         }
       } else if (resource instanceof InputStream) {
         doc = parse(builder, (InputStream) resource, null);

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -27,14 +27,13 @@ import org.apache.flink.util.Preconditions;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -172,7 +171,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 		if (!file.exists()) {
 			throw new FileNotFoundException("Properties file " + file.getAbsolutePath() + " does not exist");
 		}
-		try (FileInputStream fis = new FileInputStream(file)) {
+		try (InputStream fis = Files.newInputStream(file.toPath())) {
 			return fromPropertiesFile(fis);
 		}
 	}
@@ -569,7 +568,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 		}
 		Properties defaultProps = new Properties();
 		defaultProps.putAll(this.defaultData);
-		try (final OutputStream out = new FileOutputStream(file)) {
+		try (final OutputStream out = Files.newOutputStream(file.toPath())) {
 			defaultProps.store(out, "Default file created by Flink's ParameterUtil.createPropertiesFile()");
 		}
 	}

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -26,12 +26,13 @@ import org.junit.rules.ExpectedException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -140,7 +141,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		Assert.assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 
-		try (FileInputStream fis = new FileInputStream(propertiesFile)) {
+		try (InputStream fis = Files.newInputStream(propertiesFile.toPath())) {
 			parameter = ParameterTool.fromPropertiesFile(fis);
 		}
 		Assert.assertEquals(2, parameter.getNumberOfParameters());

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -55,10 +55,11 @@ import org.apache.commons.cli.PosixParser;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -154,7 +155,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 		String jobGraphFile = configuration.getString(JOB_GRAPH_FILE_PATH, "job.graph");
 		File fp = new File(jobGraphFile);
 
-		try (FileInputStream input = new FileInputStream(fp);
+		try (InputStream input = Files.newInputStream(fp.toPath());
 			ObjectInputStream obInput = new ObjectInputStream(input)) {
 
 			return (JobGraph) obInput.readObject();

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/PlanJSONDumpGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/PlanJSONDumpGenerator.java
@@ -43,10 +43,10 @@ import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.apache.flink.util.StringUtils;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -91,7 +91,7 @@ public class PlanJSONDumpGenerator {
 	public void dumpOptimizerPlanAsJSON(OptimizedPlan plan, File toFile) throws IOException {
 		PrintWriter pw = null;
 		try {
-			pw = new PrintWriter(new FileOutputStream(toFile), false);
+			pw = new PrintWriter(Files.newOutputStream(toFile.toPath()), false);
 			dumpOptimizerPlanAsJSON(plan, pw);
 			pw.flush();
 		} finally {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -35,12 +35,12 @@ import java.io.Closeable;
 import java.io.EOFException;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -142,7 +142,7 @@ public final class BlobClient implements Closeable {
 			try (
 				final BlobClient bc = new BlobClient(serverAddress, blobClientConfig);
 				final InputStream is = bc.getInternal(jobId, blobKey);
-				final OutputStream os = new FileOutputStream(localJarFile)
+				final OutputStream os = Files.newOutputStream(localJarFile.toPath())
 			) {
 				while (true) {
 					final int read = is.read(buf);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -40,8 +40,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -631,7 +633,7 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 		File incomingFile = createTemporaryFilename();
 		MessageDigest md = BlobUtils.createMessageDigest();
 		BlobKey blobKey = null;
-		try (FileOutputStream fos = new FileOutputStream(incomingFile)) {
+		try (OutputStream fos = Files.newOutputStream(incomingFile.toPath())) {
 			// read stream
 			byte[] buf = new byte[BUFFER_SIZE];
 			while (true) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -26,13 +26,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketException;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -253,7 +252,7 @@ class BlobServerConnection extends Thread {
 				int blobLen = (int) blobFile.length();
 				writeLength(blobLen, outputStream);
 
-				try (FileInputStream fis = new FileInputStream(blobFile)) {
+				try (InputStream fis = Files.newInputStream(blobFile.toPath())) {
 					int bytesRemaining = blobLen;
 					while (bytesRemaining > 0) {
 						int read = fis.read(buf);
@@ -398,7 +397,7 @@ class BlobServerConnection extends Thread {
 			throws IOException {
 		MessageDigest md = BlobUtils.createMessageDigest();
 
-		try (FileOutputStream fos = new FileOutputStream(incomingFile)) {
+		try (OutputStream fos = Files.newOutputStream(incomingFile.toPath())) {
 			while (true) {
 				final int bytesExpected = readLength(inputStream);
 				if (bytesExpected == -1) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -100,7 +99,7 @@ public class FileSystemBlobStore implements BlobStoreService {
 
 		boolean success = false;
 		try (InputStream is = fileSystem.open(fromPath);
-			FileOutputStream fos = new FileOutputStream(toFile)) {
+			OutputStream fos = java.nio.file.Files.newOutputStream(toFile.toPath())) {
 			LOG.debug("Copying from {} to {}.", fromBlobPath, toFile);
 
 			// not using IOUtils.copyBytes(is, fos) here to be able to create a hash on-the-fly

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
@@ -45,10 +45,11 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -230,8 +231,8 @@ public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphSt
 		final File archivedExecutionGraphFile = getExecutionGraphFile(jobId);
 
 		if (archivedExecutionGraphFile.exists()) {
-			try (FileInputStream fileInputStream = new FileInputStream(archivedExecutionGraphFile)) {
-				return InstantiationUtil.deserializeObject(fileInputStream, getClass().getClassLoader());
+			try (InputStream inputStream = Files.newInputStream(archivedExecutionGraphFile.toPath())) {
+				return InstantiationUtil.deserializeObject(inputStream, getClass().getClassLoader());
 			}
 		} else {
 			throw new FileNotFoundException("Could not find file for archived execution graph " + jobId +
@@ -242,8 +243,8 @@ public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphSt
 	private void storeArchivedExecutionGraph(ArchivedExecutionGraph archivedExecutionGraph) throws IOException {
 		final File archivedExecutionGraphFile = getExecutionGraphFile(archivedExecutionGraph.getJobID());
 
-		try (FileOutputStream fileOutputStream = new FileOutputStream(archivedExecutionGraphFile)) {
-			InstantiationUtil.serializeObject(fileOutputStream, archivedExecutionGraph);
+		try (OutputStream outputStream = Files.newOutputStream(archivedExecutionGraphFile.toPath())) {
+			InstantiationUtil.serializeObject(outputStream, archivedExecutionGraph);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -29,13 +29,13 @@ import org.apache.flink.util.StringUtils;
 import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UTFDataFormatException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -550,7 +550,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 				else {
 					spillingChannel.close();
 
-					BufferedInputStream inStream = new BufferedInputStream(new FileInputStream(spillFile), 2 * 1024 * 1024);
+					BufferedInputStream inStream = new BufferedInputStream(Files.newInputStream(spillFile.toPath()), 2 * 1024 * 1024);
 					this.spillFileReader = new DataInputViewStreamWrapper(inStream);
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -109,9 +109,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -829,8 +830,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			if (file.exists()) {
 				final TransientBlobCache transientBlobService = blobCacheService.getTransientBlobService();
 				final TransientBlobKey transientBlobKey;
-				try (FileInputStream fileInputStream = new FileInputStream(file)) {
-					transientBlobKey = transientBlobService.putTransient(fileInputStream);
+				try (InputStream inputStream = Files.newInputStream(file.toPath())) {
+					transientBlobKey = transientBlobService.putTransient(inputStream);
 				} catch (IOException e) {
 					log.debug("Could not upload file {}.", fileType, e);
 					return FutureUtils.completedExceptionally(new FlinkException("Could not upload file " + fileType + '.', e));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JarFileCreator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JarFileCreator.java
@@ -23,9 +23,10 @@ import org.apache.flink.shaded.asm5.org.objectweb.asm.ClassReader;
 import org.apache.flink.shaded.asm5.org.objectweb.asm.Opcodes;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ArrayList;
@@ -190,7 +191,7 @@ public class JarFileCreator {
 			this.outputFile.delete();
 		}
 
-		try ( FileOutputStream fos = new FileOutputStream(this.outputFile); JarOutputStream jos = new JarOutputStream(fos, new Manifest())) {
+		try (OutputStream fos = Files.newOutputStream(this.outputFile.toPath()); JarOutputStream jos = new JarOutputStream(fos, new Manifest())) {
 			final Iterator<Class<?>> it = this.classSet.iterator();
 			while (it.hasNext()) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/FlinkZooKeeperQuorumPeer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/FlinkZooKeeperQuorumPeer.java
@@ -33,10 +33,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -97,7 +97,7 @@ public class FlinkZooKeeperQuorumPeer {
 
 		Properties zkProps = new Properties();
 
-		try (InputStream inStream = new FileInputStream(new File(zkConfigFile))) {
+		try (InputStream inStream = Files.newInputStream(new File(zkConfigFile).toPath())) {
 			zkProps.load(inStream);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
@@ -73,10 +73,11 @@ import org.junit.rules.TemporaryFolder;
 import javax.annotation.Nonnull;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.SocketAddress;
+import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Map;
@@ -263,8 +264,8 @@ public class AbstractTaskManagerFileHandlerTest extends TestLogger {
 
 	private static TransientBlobKey storeFileInBlobServer(File fileToStore) throws IOException {
 		// store the requested file in the BlobServer
-		try (FileInputStream fileInputStream = new FileInputStream(fileToStore)) {
-			return blobServer.getTransientBlobService().putTransient(fileInputStream);
+		try (InputStream inputStream = Files.newInputStream(fileToStore.toPath())) {
+			return blobServer.getTransientBlobService().putTransient(inputStream);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendSnapshotMigrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendSnapshotMigrationTest.java
@@ -36,8 +36,9 @@ import org.apache.flink.util.Preconditions;
 import org.junit.Test;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
+import java.io.File;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class HeapKeyedStateBackendSnapshotMigrationTest extends HeapStateBackend
 			final Integer namespace3 = 3;
 
 			final SnapshotResult<KeyedStateHandle> stateHandles;
-			try (BufferedInputStream bis = new BufferedInputStream((new FileInputStream(resource.getFile())))) {
+			try (BufferedInputStream bis = new BufferedInputStream(Files.newInputStream(new File(resource.getFile()).toPath()))) {
 				stateHandles = InstantiationUtil.deserializeObject(bis, Thread.currentThread().getContextClassLoader());
 			}
 
@@ -226,7 +227,7 @@ public class HeapKeyedStateBackendSnapshotMigrationTest extends HeapStateBackend
 
 		try (final HeapKeyedStateBackend<String> keyedBackend = createKeyedBackend()) {
 			final KeyGroupsStateHandle stateHandle;
-			try (BufferedInputStream bis = new BufferedInputStream((new FileInputStream(resource.getFile())))) {
+			try (BufferedInputStream bis = new BufferedInputStream((Files.newInputStream(new File(resource.getFile()).toPath())))) {
 				stateHandle = InstantiationUtil.deserializeObject(bis, Thread.currentThread().getContextClassLoader());
 			}
 			keyedBackend.restore(StateObjectCollection.singleton(stateHandle));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JarFileCreatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JarFileCreatorTest.java
@@ -36,8 +36,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarInputStream;
@@ -261,7 +261,7 @@ public class JarFileCreatorTest {
 
 	private boolean validate(Set<String> expected, File out) throws IOException {
 		int count = expected.size();
-		try (JarInputStream jis = new JarInputStream(new FileInputStream(out))) {
+		try (JarInputStream jis = new JarInputStream(Files.newInputStream(out.toPath()))) {
 			ZipEntry ze;
 			while ((ze = jis.getNextEntry()) != null) {
 				count--;

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/JarHelper.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/JarHelper.java
@@ -20,10 +20,10 @@ package org.apache.flink.api.java;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
@@ -76,7 +76,7 @@ public class JarHelper {
 		}
 
 		mDestJarName = destJar.getCanonicalPath();
-		FileOutputStream fout = new FileOutputStream(destJar);
+		OutputStream fout = Files.newOutputStream(destJar.toPath());
 		JarOutputStream jout = new JarOutputStream(fout);
 		//jout.setLevel(0);
 		try {
@@ -94,7 +94,7 @@ public class JarHelper {
 	 */
 	public void unjarDir(File jarFile, File destDir) throws IOException {
 		BufferedOutputStream dest = null;
-		FileInputStream fis = new FileInputStream(jarFile);
+		InputStream fis = Files.newInputStream(jarFile.toPath());
 		unjar(fis, destDir);
 	}
 
@@ -122,7 +122,7 @@ public class JarHelper {
 				System.out.println("unjarring " + destFile +
 					" from " + entry.getName());
 			}
-			FileOutputStream fos = new FileOutputStream(destFile);
+			OutputStream fos = Files.newOutputStream(destFile.toPath());
 			dest = new BufferedOutputStream(fos, BUFFER_SIZE);
 			try {
 				while ((count = jis.read(data, 0, BUFFER_SIZE)) != -1) {
@@ -181,7 +181,7 @@ public class JarHelper {
 			if (mVerbose) {
 				System.out.println("adding " + dirOrFile2jar.getPath());
 			}
-			FileInputStream fis = new FileInputStream(dirOrFile2jar);
+			InputStream fis = Files.newInputStream(dirOrFile2jar.toPath());
 			try {
 				JarEntry entry = new JarEntry(path + dirOrFile2jar.getName());
 				entry.setTime(dirOrFile2jar.lastModified());

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
@@ -18,7 +18,8 @@
 
 package org.apache.flink.api.scala
 
-import java.io.{BufferedReader, File, FileOutputStream}
+import java.io.{BufferedReader, File}
+import java.nio.file.Files
 
 import org.apache.flink.api.java.{JarHelper, ScalaShellRemoteEnvironment, ScalaShellRemoteStreamEnvironment}
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
@@ -179,7 +180,7 @@ class FlinkILoop(
 
           // compiled classes for commands from shell
           val writeFile = new File(lineDir.getAbsolutePath, f.name)
-          val outputStream = new FileOutputStream(writeFile)
+          val outputStream = Files.newOutputStream(writeFile.toPath)
           val inputStream = f.input
 
           // copy file contents

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.api.scala
 
 import java.io._
+import java.nio.channels.{Channels, FileChannel}
 
 import org.apache.flink.annotation.Internal
 import org.apache.flink.api.common.InvalidProgramException
@@ -26,7 +27,6 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.Map
 import scala.collection.mutable.Set
-
 import org.apache.flink.shaded.asm5.org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
 import org.apache.flink.shaded.asm5.org.objectweb.asm.Opcodes._
 
@@ -196,8 +196,8 @@ object ClosureCleaner {
     try {
       if (in.isInstanceOf[FileInputStream] && out.isInstanceOf[FileOutputStream]) {
         // When both streams are File stream, use transferTo to improve copy performance.
-        val inChannel = in.asInstanceOf[FileInputStream].getChannel()
-        val outChannel = out.asInstanceOf[FileOutputStream].getChannel()
+        val inChannel = Channels.newChannel(in).asInstanceOf[FileChannel]
+        val outChannel = Channels.newChannel(out).asInstanceOf[FileChannel]
         val size = inChannel.size()
 
         // In case transferTo method transferred less data than we have required.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -56,9 +56,9 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -681,7 +681,7 @@ public class StreamGraph extends StreamingPlan {
 	public void dumpStreamingPlanAsJSON(File file) throws IOException {
 		PrintWriter pw = null;
 		try {
-			pw = new PrintWriter(new FileOutputStream(file), false);
+			pw = new PrintWriter(Files.newOutputStream(file.toPath()), false);
 			pw.write(getStreamingPlanAsJSON());
 			pw.flush();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
@@ -41,8 +41,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -173,7 +173,7 @@ public class ReinterpretDataStreamAsKeyedStreamITCase {
 			int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
 			din = new DataInputStream(
 				new BufferedInputStream(
-					new FileInputStream(allPartitions.get(subtaskIdx))));
+					Files.newInputStream(allPartitions.get(subtaskIdx).toPath())));
 		}
 
 		@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -77,9 +77,9 @@ import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -889,8 +889,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			try {
 				File fp = File.createTempFile(appId.toString(), null);
 				fp.deleteOnExit();
-				try (FileOutputStream output = new FileOutputStream(fp);
-					ObjectOutputStream obOutput = new ObjectOutputStream(output);){
+				try (OutputStream output = Files.newOutputStream(fp.toPath());
+					ObjectOutputStream obOutput = new ObjectOutputStream(output)){
 					obOutput.writeObject(jobGraph);
 				}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -64,8 +64,6 @@ import javax.annotation.Nullable;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -73,6 +71,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -235,7 +234,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		if (yarnPropertiesLocation.exists()) {
 			LOG.info("Found Yarn properties file under {}.", yarnPropertiesLocation.getAbsolutePath());
 
-			try (InputStream is = new FileInputStream(yarnPropertiesLocation)) {
+			try (InputStream is = Files.newInputStream(yarnPropertiesLocation.toPath())) {
 				yarnPropertiesFile.load(is);
 			} catch (IOException ioe) {
 				throw new FlinkException("Could not read the Yarn properties file " + yarnPropertiesLocation +
@@ -932,7 +931,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	}
 
 	private static void writeYarnProperties(Properties properties, File propertiesFile) {
-		try (final OutputStream out = new FileOutputStream(propertiesFile)) {
+		try (final OutputStream out = Files.newOutputStream(propertiesFile.toPath())) {
 			properties.store(out, "Generated YARN properties file");
 		} catch (IOException e) {
 			throw new RuntimeException("Error writing the properties file", e);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -46,10 +46,11 @@ import org.apache.hadoop.yarn.api.ApplicationConstants;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -119,7 +120,7 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 		String jobGraphFile = configuration.getString(JOB_GRAPH_FILE_PATH, "job.graph");
 		File fp = new File(jobGraphFile);
 
-		try (FileInputStream input = new FileInputStream(fp);
+		try (InputStream input = Files.newInputStream(fp.toPath());
 			ObjectInputStream obInput = new ObjectInputStream(input)) {
 
 			return (JobGraph) obInput.readObject();


### PR DESCRIPTION
## What is the purpose of the change

Avoid using FileInputStream/FileOutputStream because they rely on finalizers (before Java 11), which create unnecessary GC load. The alternatives, Files.newInputStream, are as easy to use and don't have this issue.

## Brief change log
On the code path, the ```FileInputStream``` used by the test classes has not been modified to maintain the original appearance.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
