### PR TITLE
[FLINK-9842][rest] Pass actual configuration to BlobClient 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -92,7 +92,8 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
 			leaderRetriever,
 			timeout,
 			responseHeaders,
-			executor);
+			executor,
+			clusterConfiguration);
 
 		if (clusterConfiguration.getBoolean(WebOptions.SUBMIT_ENABLE)) {
 			try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -62,15 +62,18 @@ public final class JobSubmitHandler extends AbstractRestHandler<DispatcherGatewa
 	private static final String FILE_TYPE_ARTIFACT = "Artifact";
 
 	private final Executor executor;
+	private final Configuration configuration;
 
 	public JobSubmitHandler(
 			CompletableFuture<String> localRestAddress,
 			GatewayRetriever<? extends DispatcherGateway> leaderRetriever,
 			Time timeout,
 			Map<String, String> headers,
-			Executor executor) {
+			Executor executor,
+			Configuration configuration) {
 		super(localRestAddress, leaderRetriever, timeout, headers, JobSubmitHeaders.getInstance());
 		this.executor = executor;
+		this.configuration = configuration;
 	}
 
 	@Override
@@ -99,7 +102,7 @@ public final class JobSubmitHandler extends AbstractRestHandler<DispatcherGatewa
 
 		Collection<Tuple2<String, Path>> artifacts = getArtifactFilesToUpload(requestBody.artifactFileNames, nameToFile);
 
-		CompletableFuture<JobGraph> finalizedJobGraphFuture = uploadJobGraphFiles(gateway, jobGraphFuture, jarFiles, artifacts);
+		CompletableFuture<JobGraph> finalizedJobGraphFuture = uploadJobGraphFiles(gateway, jobGraphFuture, jarFiles, artifacts, configuration);
 
 		CompletableFuture<Acknowledge> jobSubmissionFuture = finalizedJobGraphFuture.thenCompose(jobGraph -> gateway.submitJob(jobGraph, timeout));
 
@@ -151,13 +154,14 @@ public final class JobSubmitHandler extends AbstractRestHandler<DispatcherGatewa
 			DispatcherGateway gateway,
 			CompletableFuture<JobGraph> jobGraphFuture,
 			Collection<Path> jarFiles,
-			Collection<Tuple2<String, Path>> artifacts) {
+			Collection<Tuple2<String, Path>> artifacts,
+			Configuration configuration) {
 		CompletableFuture<Integer> blobServerPortFuture = gateway.getBlobServerPort(timeout);
 
 		return jobGraphFuture.thenCombine(blobServerPortFuture, (JobGraph jobGraph, Integer blobServerPort) -> {
 			final InetSocketAddress address = new InetSocketAddress(gateway.getHostname(), blobServerPort);
 			try {
-				ClientUtils.uploadJobGraphFiles(jobGraph, jarFiles, artifacts, () -> new BlobClient(address, new Configuration()));
+				ClientUtils.uploadJobGraphFiles(jobGraph, jarFiles, artifacts, () -> new BlobClient(address, configuration));
 			} catch (FlinkException e) {
 				throw new CompletionException(new RestHandlerException(
 					"Could not upload job files.",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.net.SSLUtilsTest;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
@@ -39,12 +40,14 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -57,15 +60,30 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Tests for the {@link JobSubmitHandler}.
  */
+@RunWith(Parameterized.class)
 public class JobSubmitHandlerTest extends TestLogger {
+
+	@Parameterized.Parameters(name = "SSL enabled: {0}")
+	public static Iterable<Boolean> data() {
+		return Arrays.asList(true, false);
+	}
 
 	@ClassRule
 	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-	private static BlobServer blobServer;
 
-	@BeforeClass
-	public static void setup() throws IOException {
-		Configuration config = new Configuration();
+	private final Configuration sslConfig;
+
+	private BlobServer blobServer;
+
+	public JobSubmitHandlerTest(boolean withSsl) {
+		this.sslConfig = withSsl
+			? SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores()
+			: new Configuration();
+	}
+
+	@Before
+	public void setup() throws IOException {
+		Configuration config = new Configuration(sslConfig);
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			TEMPORARY_FOLDER.newFolder().getAbsolutePath());
 
@@ -73,8 +91,8 @@ public class JobSubmitHandlerTest extends TestLogger {
 		blobServer.start();
 	}
 
-	@AfterClass
-	public static void teardown() throws IOException {
+	@After
+	public void teardown() throws IOException {
 		if (blobServer != null) {
 			blobServer.close();
 		}
@@ -93,7 +111,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
 			TestingUtils.defaultExecutor(),
-			new Configuration());
+			sslConfig);
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(jobGraphFile.toString(), Collections.emptyList(), Collections.emptyList());
 
@@ -125,7 +143,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
 			TestingUtils.defaultExecutor(),
-			new Configuration());
+			sslConfig);
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(jobGraphFile.getFileName().toString(), Collections.emptyList(), Collections.emptyList());
 
@@ -154,7 +172,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
 			TestingUtils.defaultExecutor(),
-			new Configuration());
+			sslConfig);
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(jobGraphFile.getFileName().toString(), Collections.emptyList(), Collections.emptyList());
 
@@ -185,7 +203,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
 			TestingUtils.defaultExecutor(),
-			new Configuration());
+			sslConfig);
 
 		final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();
 		final Path jarFile = TEMPORARY_FOLDER.newFile().toPath();
@@ -231,7 +249,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
 			TestingUtils.defaultExecutor(),
-			new Configuration());
+			sslConfig);
 
 		final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -92,7 +92,8 @@ public class JobSubmitHandlerTest extends TestLogger {
 			() -> CompletableFuture.completedFuture(mockGateway),
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
-			TestingUtils.defaultExecutor());
+			TestingUtils.defaultExecutor(),
+			new Configuration());
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(jobGraphFile.toString(), Collections.emptyList(), Collections.emptyList());
 
@@ -123,7 +124,8 @@ public class JobSubmitHandlerTest extends TestLogger {
 			() -> CompletableFuture.completedFuture(mockGateway),
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
-			TestingUtils.defaultExecutor());
+			TestingUtils.defaultExecutor(),
+			new Configuration());
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(jobGraphFile.getFileName().toString(), Collections.emptyList(), Collections.emptyList());
 
@@ -151,7 +153,8 @@ public class JobSubmitHandlerTest extends TestLogger {
 			() -> CompletableFuture.completedFuture(mockGateway),
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
-			TestingUtils.defaultExecutor());
+			TestingUtils.defaultExecutor(),
+			new Configuration());
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(jobGraphFile.getFileName().toString(), Collections.emptyList(), Collections.emptyList());
 
@@ -181,7 +184,8 @@ public class JobSubmitHandlerTest extends TestLogger {
 			() -> CompletableFuture.completedFuture(dispatcherGateway),
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
-			TestingUtils.defaultExecutor());
+			TestingUtils.defaultExecutor(),
+			new Configuration());
 
 		final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();
 		final Path jarFile = TEMPORARY_FOLDER.newFile().toPath();
@@ -226,7 +230,8 @@ public class JobSubmitHandlerTest extends TestLogger {
 			() -> CompletableFuture.completedFuture(mockGateway),
 			RpcUtils.INF_TIMEOUT,
 			Collections.emptyMap(),
-			TestingUtils.defaultExecutor());
+			TestingUtils.defaultExecutor(),
+			new Configuration());
 
 		final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();
 


### PR DESCRIPTION
## What is the purpose of the change

With this PR the `JobSubmitHandler` uses the configured ssl settings when connecting with the `BlobClient`.

## Brief change log

* pass configuration from `DispatcherEndpoint` to `JobSubmitHandler`
* pass configuration from `JobSubmitHandler` to `BlobClient`

## Verifying this change

The `JobSubmitHandlerTest` was modified to run with both ssl enabled and disabled.
Currently, the `testFileHandling` test would fail.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
