### PR TITLE
[FLINK-5750] Incorrect translation of n-ary Union

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -19,10 +19,8 @@
 package org.apache.flink.table.calcite
 
 import java.util
-import java.util.Properties
 
 import com.google.common.collect.ImmutableList
-import org.apache.calcite.config.{CalciteConnectionConfig, CalciteConnectionConfigImpl, CalciteConnectionProperty}
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.plan.RelOptTable.ViewExpander
 import org.apache.calcite.plan._

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetUnionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetUnionRule.scala
@@ -26,6 +26,8 @@ import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.dataset.DataSetUnion
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalUnion
 
+import scala.collection.JavaConverters._
+
 class DataSetUnionRule
   extends ConverterRule(
     classOf[FlinkLogicalUnion],
@@ -46,14 +48,17 @@ class DataSetUnionRule
   def convert(rel: RelNode): RelNode = {
     val union: FlinkLogicalUnion = rel.asInstanceOf[FlinkLogicalUnion]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASET)
-    val convLeft: RelNode = RelOptRule.convert(union.getInput(0), FlinkConventions.DATASET)
-    val convRight: RelNode = RelOptRule.convert(union.getInput(1), FlinkConventions.DATASET)
+
+    val newInputs = union
+      .getInputs
+      .asScala
+      .map(input => RelOptRule.convert(input, FlinkConventions.DATASET))
+      .asJava
 
     new DataSetUnion(
       rel.getCluster,
       traitSet,
-      convLeft,
-      convRight,
+      newInputs,
       rel.getRowType)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamUnionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamUnionRule.scala
@@ -26,6 +26,8 @@ import org.apache.flink.table.plan.nodes.datastream.DataStreamUnion
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalUnion
 import org.apache.flink.table.plan.schema.RowSchema
 
+import scala.collection.JavaConverters._
+
 class DataStreamUnionRule
   extends ConverterRule(
     classOf[FlinkLogicalUnion],
@@ -37,14 +39,17 @@ class DataStreamUnionRule
   def convert(rel: RelNode): RelNode = {
     val union: FlinkLogicalUnion = rel.asInstanceOf[FlinkLogicalUnion]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASTREAM)
-    val convLeft: RelNode = RelOptRule.convert(union.getInput(0), FlinkConventions.DATASTREAM)
-    val convRight: RelNode = RelOptRule.convert(union.getInput(1), FlinkConventions.DATASTREAM)
+
+    val newInputs = union
+      .getInputs
+      .asScala
+      .map(input => RelOptRule.convert(input, FlinkConventions.DATASTREAM))
+      .asJava
 
     new DataStreamUnion(
       rel.getCluster,
       traitSet,
-      convLeft,
-      convRight,
+      newInputs,
       new RowSchema(rel.getRowType))
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/ExternalCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/ExternalCatalogTest.scala
@@ -59,6 +59,7 @@ class ExternalCatalogTest extends TableTestBase {
         sourceBatchTableNode(table1Path, table1ProjectedFields),
         term("select", "*(a, 2) AS _c0", "b", "UPPER(c) AS _c2")
       ),
+      term("all", "true"),
       term("union", "_c0", "e", "_c2")
     )
 
@@ -86,6 +87,7 @@ class ExternalCatalogTest extends TableTestBase {
         sourceBatchTableNode(table1Path, table1ProjectedFields),
         term("select", "*(a, 2) AS EXPR$0", "b", "c")
       ),
+      term("all", "true"),
       term("union", "EXPR$0", "e", "g"))
 
     util.verifySql(sqlQuery, expected)
@@ -118,6 +120,7 @@ class ExternalCatalogTest extends TableTestBase {
         sourceStreamTableNode(table1Path, table1ProjectedFields),
         term("select", "*(a, 2) AS _c0", "b", "UPPER(c) AS _c2")
       ),
+      term("all", "true"),
       term("union all", "_c0", "e", "_c2")
     )
 
@@ -145,6 +148,7 @@ class ExternalCatalogTest extends TableTestBase {
         sourceStreamTableNode(table1Path, table1ProjectedFields),
         term("select", "*(a, 2) AS EXPR$0", "b", "c")
       ),
+      term("all", "true"),
       term("union all", "EXPR$0", "e", "g"))
 
     util.verifySql(sqlQuery, expected)
@@ -175,6 +179,7 @@ class ExternalCatalogTest extends TableTestBase {
         sourceBatchTableNode(table1TopLevelPath, table1ProjectedFields),
         term("select", "*(a, 2) AS _c0", "b", "UPPER(c) AS _c2")
       ),
+      term("all", "true"),
       term("union", "_c0", "e", "_c2")
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
@@ -60,6 +60,7 @@ class TableSourceTest extends TableTestBase {
         "table2",
         Array("name", "id", "amount", "price"),
         "'amount > 2"),
+      term("all", "true"),
       term("union", "name, id, amount, price")
     )
     util.verifyTable(result, expected)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/GroupingSetsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/GroupingSetsTest.scala
@@ -56,6 +56,7 @@ class GroupingSetsTest extends TableTestBase {
         ),
         term("select", "null AS b", "c", "a", "2 AS g")
       ),
+      term("all", "true"),
       term("union", "b", "c", "a", "g")
     )
 
@@ -130,12 +131,15 @@ class GroupingSetsTest extends TableTestBase {
           "DataSetUnion",
           group1,
           group2,
+          term("all", "true"),
           term("union", "b", "c", "a", "g", "gb", "gc", "gib", "gic", "gid")
         ),
         group3,
+        term("all", "true"),
         term("union", "b", "c", "a", "g", "gb", "gc", "gib", "gic", "gid")
       ),
       group4,
+      term("all", "true"),
       term("union", "b", "c", "a", "g", "gb", "gc", "gib", "gic", "gid")
     )
 
@@ -195,9 +199,11 @@ class GroupingSetsTest extends TableTestBase {
         "DataSetUnion",
         group1,
         group2,
+        term("all", "true"),
         term("union", "b", "c", "a", "g", "gb", "gc", "gib", "gic", "gid")
       ),
       group3,
+      term("all", "true"),
       term("union", "b", "c", "a", "g", "gb", "gc", "gib", "gic", "gid")
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
@@ -18,13 +18,13 @@
 
 package org.apache.flink.table.api.batch.sql
 
-import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
+import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
-import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil._
 import org.junit.{Ignore, Test}
 
 class SetOperatorsTest extends TableTestBase {
@@ -190,6 +190,7 @@ class SetOperatorsTest extends TableTestBase {
         batchTableNode(0),
         term("select", "CASE(>(c, 0), b, null) AS EXPR$0")
       ),
+      term("all", "true"),
       term("union", "a")
     )
 
@@ -219,9 +220,43 @@ class SetOperatorsTest extends TableTestBase {
         batchTableNode(0),
         term("select", "b")
       ),
+      term("all", "true"),
       term("union", "a")
     )
 
     util.verifyJavaSql("SELECT a FROM A UNION ALL SELECT b FROM A", expected)
+  }
+
+  @Test
+  def testValuesWithCast(): Unit = {
+    val util = batchTestUtil()
+
+    val expected = naryNode(
+      "DataSetUnion",
+      List(
+        unaryNode("DataSetCalc",
+          values("DataSetValues",
+            tuples(List("0")),
+            "values=[ZERO]"),
+          term("select", "1 AS EXPR$0, 1 AS EXPR$1")),
+        unaryNode("DataSetCalc",
+          values("DataSetValues",
+            tuples(List("0")),
+            "values=[ZERO]"),
+          term("select", "2 AS EXPR$0, 2 AS EXPR$1")),
+        unaryNode("DataSetCalc",
+          values("DataSetValues",
+            tuples(List("0")),
+            "values=[ZERO]"),
+          term("select", "3 AS EXPR$0, 3 AS EXPR$1"))
+      ),
+      term("all", "true"),
+      term("union", "EXPR$0, EXPR$1")
+    )
+
+    util.verifySql(
+      "VALUES (1, cast(1 as BIGINT) ),(2, cast(2 as BIGINT)),(3, cast(3 as BIGINT))",
+      expected
+    )
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
@@ -102,6 +102,7 @@ class SetOperatorsTest extends TableTestBase {
         batchTableNode(0),
         term("select", "CASE(>(c, 0), b, null) AS _c0")
       ),
+      term("all", "true"),
       term("union", "a")
     )
 
@@ -130,6 +131,7 @@ class SetOperatorsTest extends TableTestBase {
         batchTableNode(0),
         term("select", "b")
       ),
+      term("all", "true"),
       term("union", "a")
     )
 
@@ -165,6 +167,7 @@ class SetOperatorsTest extends TableTestBase {
             term("select", "a", "b", "c"),
             term("where", ">(a, 0)")
           ),
+          term("all", "true"),
           term("union", "a", "b", "c")
         ),
         term("groupBy", "b"),
@@ -238,6 +241,7 @@ class SetOperatorsTest extends TableTestBase {
         batchTableNode(1),
         term("select", "b", "c")
       ),
+      term("all", "true"),
       term("union", "b", "c")
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -60,6 +60,7 @@ class StreamTableEnvironmentTest extends TableTestBase {
       "DataStreamUnion",
       streamTableNode(1),
       streamTableNode(0),
+      term("all", "true"),
       term("union all", "d, e, f"))
 
     util.verifyTable(sqlTable2, expected2)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
@@ -170,4 +170,37 @@ class SetOperatorsTest extends TableTestBase {
 
     streamUtil.verifySql(sqlQuery, expected)
   }
+
+  @Test
+  def testValuesWithCast(): Unit = {
+    val util = batchTestUtil()
+
+    val expected = naryNode(
+      "DataSetUnion",
+      List(
+        unaryNode("DataSetCalc",
+          values("DataSetValues",
+            tuples(List("0")),
+            "values=[ZERO]"),
+          term("select", "1 AS EXPR$0, 1 AS EXPR$1")),
+        unaryNode("DataSetCalc",
+          values("DataSetValues",
+            tuples(List("0")),
+            "values=[ZERO]"),
+          term("select", "2 AS EXPR$0, 2 AS EXPR$1")),
+        unaryNode("DataSetCalc",
+          values("DataSetValues",
+            tuples(List("0")),
+            "values=[ZERO]"),
+          term("select", "3 AS EXPR$0, 3 AS EXPR$1"))
+      ),
+      term("all", "true"),
+      term("union", "EXPR$0, EXPR$1")
+    )
+
+    util.verifySql(
+      "VALUES (1, cast(1 as BIGINT) ),(2, cast(2 as BIGINT)),(3, cast(3 as BIGINT))",
+      expected
+    )
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
@@ -46,6 +46,7 @@ class UnionTest extends TableTestBase {
         streamTableNode(0),
         term("select", "CASE(>(c, 0), b, null) AS EXPR$0")
       ),
+      term("all", "true"),
       term("union all", "a")
     )
 
@@ -75,6 +76,7 @@ class UnionTest extends TableTestBase {
         streamTableNode(0),
         term("select", "b")
       ),
+      term("all", "true"),
       term("union all", "a")
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
@@ -55,6 +55,7 @@ class SetOperatorsTest extends TableTestBase {
               term("select", "a", "b", "c"),
               term("where", ">(a, 0)")
             ),
+            term("all", "true"),
             term("union all", "a", "b", "c")
           ),
           term("groupBy", "b"),
@@ -88,6 +89,7 @@ class SetOperatorsTest extends TableTestBase {
         streamTableNode(1),
         term("select", "b", "c")
       ),
+      term("all", "true"),
       term("union all", "b", "c")
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
@@ -221,6 +221,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         streamTableNode(0),
         term("select", "rowtime")
       ),
+      term("all", "true"),
       term("union all", "rowtime")
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
@@ -123,6 +123,22 @@ class SetOperatorsITCase(
   }
 
   @Test
+  def testValuesWithCast(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val sqlQuery = "VALUES (1, cast(1 as BIGINT) )," +
+      "(2, cast(2 as BIGINT))," +
+      "(3, cast(3 as BIGINT))"
+
+    val result = tEnv.sqlQuery(sqlQuery)
+    val results = result.toDataSet[Row].collect()
+
+    val expected = "1,1\n2,2\n3,3"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
   def testExcept(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -122,6 +122,13 @@ object TableTestUtil {
        |""".stripMargin.stripLineEnd
   }
 
+  def naryNode(node: String, inputs: List[AnyRef], term: String*): String = {
+    val strInputs = inputs.mkString("\n")
+    s"""$node(${term.mkString(", ")})
+       |$strInputs
+       |""".stripMargin.stripLineEnd
+  }
+
   def values(node: String, term: String*): String = {
     s"$node(${term.mkString(", ")})"
   }

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnion0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnion0.out
@@ -4,7 +4,7 @@ LogicalUnion(all=[true])
   LogicalTableScan(table=[[_DataSetTable_1]])
 
 == Optimized Logical Plan ==
-DataSetUnion(union=[count, word])
+DataSetUnion(all=[true], union=[count, word])
   DataSetScan(table=[[_DataSetTable_0]])
   DataSetScan(table=[[_DataSetTable_1]])
 

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnion1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnion1.out
@@ -4,7 +4,7 @@ LogicalUnion(all=[true])
   LogicalTableScan(table=[[_DataSetTable_1]])
 
 == Optimized Logical Plan ==
-DataSetUnion(union=[count, word])
+DataSetUnion(all=[true], union=[count, word])
   DataSetScan(table=[[_DataSetTable_0]])
   DataSetScan(table=[[_DataSetTable_1]])
 

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnionStream0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnionStream0.out
@@ -4,7 +4,7 @@ LogicalUnion(all=[true])
   LogicalTableScan(table=[[_DataStreamTable_1]])
 
 == Optimized Logical Plan ==
-DataStreamUnion(union all=[count, word])
+DataStreamUnion(all=[true], union all=[count, word])
   DataStreamScan(table=[[_DataStreamTable_0]])
   DataStreamScan(table=[[_DataStreamTable_1]])
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds supporting multiple inputs in DataSetUnionRule and DataStreamUnionRule*


## Brief change log

  - *DataSetUnionRule and DataStreamUnionRule should consider all inputs instead of only the 1st and 2nd*


## Verifying this change

*This change added the following test:*
- *Added unit test testValuesWithCast that validates VALUES operator with values which have to to be casted. This query will be transform to UNION of VALUES in plan optimizer since values arguments are not literal value*
- *Also added plan test for testValuesWithCast*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
