### PR TITLE
[FLINK-9748][release] Use dedicated directory for release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ out/
 *.iws
 tools/flink
 tools/flink-*
+tools/releasing/release

--- a/pom.xml
+++ b/pom.xml
@@ -1150,6 +1150,8 @@ under the License.
 						<!-- Tools: watchdog -->
 						<exclude>tools/artifacts/**</exclude>
 						<exclude>tools/flink*/**</exclude>
+						<!-- artifacts created during release process -->
+						<exclude>tools/releasing/release/**</exclude>
 						<!-- manually installed version on travis -->
 						<exclude>apache-maven-3.2.5/**</exclude>
 						<!-- PyCharm -->

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -44,6 +44,12 @@ else
     SHASUM="sha512sum"
 fi
 
+cd ..
+
+FLINK_DIR=`pwd`
+RELEASE_DIR=${RELEASE_DIR}/tools/releasing/release
+mkdir -p ${RELEASE_DIR}
+
 ###########################
 
 # build maven package, create Flink distribution, generate signature
@@ -65,18 +71,17 @@ make_binary_release() {
   cd flink-dist/target/flink-*-bin/
   tar czf "${dir_name}.tgz" flink-*
 
-  cp flink-*.tgz ../../../
-  cd ../../../
+  cp flink-*.tgz ${RELEASE_DIR}
+  cd ${RELEASE_DIR}
 
   # Sign sha the tgz
   if [ "$SKIP_GPG" == "false" ] ; then
     gpg --armor --detach-sig "${dir_name}.tgz"
   fi
   $SHASUM "${dir_name}.tgz" > "${dir_name}.tgz.sha512"
+
+  cd ${FLINK_DIR}
 }
-
-cd ..
-
 
 if [ "$SCALA_VERSION" == "none" ] && [ "$HADOOP_VERSION" == "none" ]; then
   make_binary_release "" "-DwithoutHadoop" "2.11"

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -45,11 +45,17 @@ fi
 
 cd ..
 
+FLINK_DIR=`pwd`
+RELEASE_DIR=${FLINK_DIR}/tools/releasing/release
+CLONE_DIR=${RELEASE_DIR}/flink-tmp-clone
+
 echo "Creating source package"
 
+mkdir -p ${RELEASE_DIR}
+
 # create a temporary git clone to ensure that we have a pristine source release
-git clone . flink-tmp-clone
-cd flink-tmp-clone
+git clone ${FLINK_DIR} ${CLONE_DIR}
+cd ${CLONE_DIR}
 
 rsync -a \
   --exclude ".git" --exclude ".gitignore" --exclude ".gitattributes" --exclude ".travis.yml" \
@@ -58,10 +64,9 @@ rsync -a \
   --exclude "docs/content" --exclude ".rubydeps" \
   . flink-$RELEASE_VERSION
 
-tar czf flink-${RELEASE_VERSION}-src.tgz flink-$RELEASE_VERSION
-gpg --armor --detach-sig flink-$RELEASE_VERSION-src.tgz
-$SHASUM flink-$RELEASE_VERSION-src.tgz > flink-$RELEASE_VERSION-src.tgz.sha512
+tar czf ${RELEASE_DIR}/flink-${RELEASE_VERSION}-src.tgz flink-$RELEASE_VERSION
+gpg --armor --detach-sig ${RELEASE_DIR}/flink-$RELEASE_VERSION-src.tgz
+$SHASUM ${RELEASE_DIR}/flink-$RELEASE_VERSION-src.tgz > ${RELEASE_DIR}/flink-$RELEASE_VERSION-src.tgz.sha512
 
-mv flink-$RELEASE_VERSION-src.* ../
-cd ..
-rm -rf flink-tmp-clone
+cd ${CURR_DIR}
+rm -rf ${CLONE_DIR}


### PR DESCRIPTION
## What is the purpose of the change

With this PR artifacts created during the release process are no longer placed in the root flink directory, but instead a dedicated directory under `/tools/releasing`.
This makes it easier to reset the repository state in case of an error, as all you have to do is remove said directory. It also prevents accidentally committing release files.
In case of success this directory will contain all release artifacts that should be uploaded.

Additionally this PR introduces variables for commonly used directories (flink root directory, release directory, flink-clone directory) and reduces usages of relative paths.

## Brief change log

* modifies source/binary release scripts to use dedicate directory for storing release artifacts
* modified rat-plugin to exclude release directory
* modified .gitignore to exclude release directory

## Verifying this change

Manually verified.

@aljoscha @tillrohrmann I'd appreciate your input.