### PR TITLE
[FLINK-9866] Allow passing command line arguments to standalone job

### DIFF
--- a/flink-container/docker/docker-compose.yml
+++ b/flink-container/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}
     ports:
       - "8081:8081"
-    command: job-cluster --job-classname ${FLINK_JOB} -Djobmanager.rpc.address=job-cluster
+    command: job-cluster --job-classname ${FLINK_JOB} -Djobmanager.rpc.address=job-cluster ${FLINK_JOB_ARGUMENTS}
 
   taskmanager:
     image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -51,20 +51,23 @@ import javax.annotation.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * {@link JobClusterEntrypoint} which is started with a job in a predefined
  * location.
  */
 public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 
-	private  static final String[] EMPTY_ARGS = new String[0];
+	private final String[] programArguments;
 
 	@Nonnull
 	private final String jobClassName;
 
-	StandaloneJobClusterEntryPoint(Configuration configuration, @Nonnull String jobClassName) {
+	StandaloneJobClusterEntryPoint(Configuration configuration, @Nonnull String jobClassName, @Nonnull String[] programArguments) {
 		super(configuration);
-		this.jobClassName = jobClassName;
+		this.programArguments = checkNotNull(programArguments);
+		this.jobClassName = checkNotNull(jobClassName);
 	}
 
 	@Override
@@ -84,7 +87,7 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 	private PackagedProgram createPackagedProgram() throws FlinkException {
 		try {
 			final Class<?> mainClass = getClass().getClassLoader().loadClass(jobClassName);
-			return new PackagedProgram(mainClass, EMPTY_ARGS);
+			return new PackagedProgram(mainClass, programArguments);
 		} catch (ClassNotFoundException | ProgramInvocationException e) {
 			throw new FlinkException("Could not load the provied entrypoint class.", e);
 		}
@@ -148,7 +151,9 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 
 		configuration.setString(ClusterEntrypoint.EXECUTION_MODE, ExecutionMode.DETACHED.toString());
 
-		StandaloneJobClusterEntryPoint entrypoint = new StandaloneJobClusterEntryPoint(configuration, clusterConfiguration.getJobClassName());
+		StandaloneJobClusterEntryPoint entrypoint = new StandaloneJobClusterEntryPoint(configuration,
+			clusterConfiguration.getJobClassName(),
+			clusterConfiguration.getArgs());
 
 		entrypoint.startCluster();
 	}

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPointTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPointTest.java
@@ -42,11 +42,12 @@ public class StandaloneJobClusterEntryPointTest extends TestLogger {
 		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
 		final StandaloneJobClusterEntryPoint standaloneJobClusterEntryPoint = new StandaloneJobClusterEntryPoint(
 			configuration,
-			TestJob.class.getCanonicalName());
+			TestJob.class.getCanonicalName(),
+			new String[] {"--arg", "suffix"});
 
 		final JobGraph jobGraph = standaloneJobClusterEntryPoint.retrieveJobGraph(configuration);
 
-		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName())));
+		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName() + "-suffix")));
 		assertThat(jobGraph.getMaximumParallelism(), is(parallelism));
 	}
 

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/TestJob.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/TestJob.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -35,6 +36,7 @@ public class TestJob {
 		final SingleOutputStreamOperator<Integer> mapper = source.map(element -> 2 * element);
 		mapper.addSink(new DiscardingSink<>());
 
-		env.execute(TestJob.class.getCanonicalName());
+		ParameterTool parameterTool = ParameterTool.fromArgs(args);
+		env.execute(TestJob.class.getCanonicalName() + "-" + parameterTool.getRequired("arg"));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Allow passing program arguments to standalone job

## Brief change log

*(for example:)*
  - Pass parsed program arguments to StandloneJobClusterEntry
  - updated standalone-job.sh script
  - updated docker scripts


## Verifying this change

* extended org.apache.flink.container.entrypoint.StandaloneJobClusterEntryPointTest to take parameters into account

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
