### PR TITLE
[FLINK-9872][tests] Properly cancel test job

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -592,7 +592,11 @@ public class SavepointITCase extends TestLogger {
 				latch.await();
 			}
 			savepointPath = client.triggerSavepoint(jobGraph.getJobID(), null).get();
-			source.cancel();
+
+			client.cancel(jobGraph.getJobID());
+			while (!client.getJobStatus(jobGraph.getJobID()).get().isGloballyTerminalState()) {
+				Thread.sleep(100);
+			}
 
 			jobGraph = streamGraph.getJobGraph();
 			jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
@@ -602,7 +606,11 @@ public class SavepointITCase extends TestLogger {
 			for (OneShotLatch latch : iterTestRestoreWait) {
 				latch.await();
 			}
-			source.cancel();
+
+			client.cancel(jobGraph.getJobID());
+			while (!client.getJobStatus(jobGraph.getJobID()).get().isGloballyTerminalState()) {
+				Thread.sleep(100);
+			}
 		} finally {
 			if (null != savepointPath) {
 				client.disposeSavepoint(savepointPath);


### PR DESCRIPTION
## What is the purpose of the change

With this PR the jobs started in `SavepointITCase#testSavepointForJobWithIteration` are properly canceled. Previously they remained in a running state until the cluster was shut down, causing several exceptions to be logged.