### PR TITLE
[FLINK-9815][yarn][tests] Harden tests against slow job shutdowns

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -133,7 +133,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 			"@@" + CheckpointingOptions.CHECKPOINTS_DIRECTORY + "=" + fsStateHandlePath + "/checkpoints" +
 			"@@" + HighAvailabilityOptions.HA_STORAGE_PATH.key() + "=" + fsStateHandlePath + "/recovery");
 
-		ClusterClient<ApplicationId> yarnCluster = null;
+		ClusterClient<ApplicationId> yarnClusterClient = null;
 
 		final FiniteDuration timeout = new FiniteDuration(2, TimeUnit.MINUTES);
 
@@ -147,10 +147,10 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 			.createClusterSpecification();
 
 		try {
-			yarnCluster = flinkYarnClient.deploySessionCluster(clusterSpecification);
+			yarnClusterClient = flinkYarnClient.deploySessionCluster(clusterSpecification);
 
 			highAvailabilityServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(
-				yarnCluster.getFlinkConfiguration(),
+				yarnClusterClient.getFlinkConfiguration(),
 				Executors.directExecutor(),
 				HighAvailabilityServicesUtils.AddressResolution.TRY_ADDRESS_RESOLUTION);
 
@@ -201,8 +201,10 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 			}};
 		} finally {
-			if (yarnCluster != null) {
-				yarnCluster.shutdown();
+			if (yarnClusterClient != null) {
+				log.info("Shutting down the Flink Yarn application.");
+				yarnClusterClient.shutDownCluster();
+				yarnClusterClient.shutdown();
 			}
 
 			if (highAvailabilityServices != null) {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -76,12 +76,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * This base class allows to use the MiniYARNCluster.
@@ -223,13 +223,12 @@ public abstract class YarnTestBase extends TestLogger {
 		}
 
 		if (isAnyJobRunning) {
-			final Optional<ApplicationReport> runningApp = yarnClient.getApplications().stream()
+			final List<String> runningApps = yarnClient.getApplications().stream()
 				.filter(YarnTestBase::isApplicationRunning)
-				.findAny();
-			if (runningApp.isPresent()) {
-				final ApplicationReport app = runningApp.get();
-				Assert.fail("There is at least one application on the cluster that is not finished." +
-					"App " + app.getApplicationId() + " is in state " + app.getYarnApplicationState());
+				.map(app -> "App " + app.getApplicationId() + " is in state " + app.getYarnApplicationState() + '.')
+				.collect(Collectors.toList());
+			if (!runningApps.isEmpty()) {
+				Assert.fail("There is at least one application on the cluster that is not finished." + runningApps);
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR hardens the `YarnTestBase` against jobs that just don't want to shut down that quickly (i.e. within 500ms).
The maximum waiting time has been increased to 10 seconds, during which we periodically check the state of all applications.

Additionally, the failure condition from `@Before` was moved to the `@After` method.

This change will allow us to better differentiate between simple timing issues and unsuccessful job shutdowns.