### PR TITLE
[FLINK-9875][runtime] Add concurrent creation of execution job vertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -174,9 +174,11 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 			timeout);
 
 		// create a co-location scheduling hint, if necessary
-		CoLocationGroup clg = jobVertex.getCoLocationGroup();
+		final CoLocationGroup clg = jobVertex.getCoLocationGroup();
 		if (clg != null) {
-			this.locationConstraint = clg.getLocationConstraint(subTaskIndex);
+			synchronized (clg) {
+				this.locationConstraint = clg.getLocationConstraint(subTaskIndex);
+			}
 		}
 		else {
 			this.locationConstraint = null;


### PR DESCRIPTION
## Add concurrent creation of execution job vertex

in some case like inputformat vertex, creation of execution job vertex is time
consuming, this pr add concurrent creation of execution job vertex to accelerate it.

## Brief change log

- `ExecutionGraph`
  - add a method `createExecutionJobVertex` to concurrent creation of execution job vertex
  - modify method `attachJobGraph` to acquire goodies from `createExecutionJobVertex`

## Verifying this change

Current tests confirm the correctness.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no, it's internal)
