### PR TITLE
[FLINK-9878][network][ssl] add more low-level ssl options

### DIFF
--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -13,9 +13,19 @@
             <td>The comma separated list of standard SSL algorithms to be supported. Read more &#60;a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites"&#62;here&#60;/a&#62;.</td>
         </tr>
         <tr>
+            <td><h5>security.ssl.close-notify-flush-timeout</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>The timeout (in ms) for flushing the `close_notify` that was triggered by closing a channel. If the `close_notify` was not flushed in the given timeout the channel will be closed forcibly. (-1 = use system default)</td>
+        </tr>
+        <tr>
             <td><h5>security.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.handshake-timeout</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>The timeout (in ms) during SSL handshake. (-1 = use system default)</td>
         </tr>
         <tr>
             <td><h5>security.ssl.key-password</h5></td>
@@ -36,6 +46,16 @@
             <td><h5>security.ssl.protocol</h5></td>
             <td style="word-wrap: break-word;">"TLSv1.2"</td>
             <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.session-cache-size</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>The size of the cache used for storing SSL session objects. According to https://github.com/netty/netty/issues/832, you should always set this to an appropriate number to not run into a bug with stalling IO threads during garbage collection. (-1 = use system default).</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.session-timeout</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>The timeout (in ms) for the cached SSL session objects. (-1 = use system default)</td>
         </tr>
         <tr>
             <td><h5>security.ssl.truststore</h5></td>

--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -33,6 +33,10 @@ SSL can be enabled for all network communication between Flink components. SSL k
 * **akka.ssl.enabled**: SSL flag for akka based control connection between the Flink client, jobmanager and taskmanager 
 * **jobmanager.web.ssl.enabled**: Flag to enable https access to the jobmanager's web frontend
 
+### Complete List of SSL Options
+
+{% include generated/security_configuration.html %}
+
 ## Deploying Keystores and Truststores
 
 You need to have a Java Keystore generated and copied to each node in the Flink cluster. The common name or subject alternative names in the certificate should match the node's hostname and IP address. Keystores and truststores can be generated using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html). All Flink components should have read access to the keystore and truststore files.

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -160,4 +160,41 @@ public class SecurityOptions {
 		key("security.ssl.verify-hostname")
 			.defaultValue(true)
 			.withDescription("Flag to enable peer’s hostname verification during ssl handshake.");
+
+	/**
+	 * SSL session cache size.
+	 */
+	public static final ConfigOption<Integer> SSL_SESSION_CACHE_SIZE =
+		key("security.ssl.session-cache-size")
+			.defaultValue(-1)
+			.withDescription("The size of the cache used for storing SSL session objects. "
+				+ "According to https://github.com/netty/netty/issues/832, you should always set "
+				+ "this to an appropriate number to not run into a bug with stalling IO threads "
+				+ "during garbage collection. (-1 = use system default).");
+
+	/**
+	 * SSL session timeout.
+	 */
+	public static final ConfigOption<Integer> SSL_SESSION_TIMEOUT =
+		key("security.ssl.session-timeout")
+			.defaultValue(-1)
+			.withDescription("The timeout (in ms) for the cached SSL session objects. (-1 = use system default)");
+
+	/**
+	 * SSL session timeout during handshakes.
+	 */
+	public static final ConfigOption<Integer> SSL_HANDSHAKE_TIMEOUT =
+		key("security.ssl.handshake-timeout")
+			.defaultValue(-1)
+			.withDescription("The timeout (in ms) during SSL handshake. (-1 = use system default)");
+
+	/**
+	 * SSL session timeout after flushing the <tt>close_notify</tt> message.
+	 */
+	public static final ConfigOption<Integer> SSL_CLOSE_NOTIFY_FLUSH_TIMEOUT =
+		key("security.ssl.close-notify-flush-timeout")
+			.defaultValue(-1)
+			.withDescription("The timeout (in ms) for flushing the `close_notify` that was triggered by closing a " +
+				"channel. If the `close_notify` was not flushed in the given timeout the channel will be closed " +
+				"forcibly. (-1 = use system default)");
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
@@ -58,7 +58,7 @@ import org.apache.flink.shaded.netty4.io.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 
 import java.io.File;
@@ -104,7 +104,8 @@ public class MesosArtifactServer implements MesosArtifactResolver {
 
 	private final Map<Path, URL> paths = new HashMap<>();
 
-	private final SSLContext serverSSLContext;
+	@Nullable
+	private final SSLUtils.SSLContext serverSSLContext;
 
 	public MesosArtifactServer(String prefix, String serverHostname, int configuredPort, Configuration config)
 		throws Exception {
@@ -139,7 +140,7 @@ public class MesosArtifactServer implements MesosArtifactResolver {
 
 				// SSL should be the first handler in the pipeline
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
+					SSLEngine sslEngine = serverSSLContext.sslContext.createSSLEngine();
 					SSLUtils.setSSLVerAndCipherSuites(sslEngine, sslConfig);
 					sslEngine.setUseClientMode(false);
 					ch.pipeline().addLast("ssl", new SslHandler(sslEngine));

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
@@ -140,7 +140,7 @@ public class MesosArtifactServer implements MesosArtifactResolver {
 
 				// SSL should be the first handler in the pipeline
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.sslContext.createSSLEngine();
+					SSLEngine sslEngine = serverSSLContext.getSslContext().createSSLEngine();
 					SSLUtils.setSSLVerAndCipherSuites(sslEngine, sslConfig);
 					sslEngine.setUseClientMode(false);
 					ch.pipeline().addLast("ssl", new SslHandler(sslEngine));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -92,7 +92,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -130,7 +130,8 @@ public class WebRuntimeMonitor implements WebMonitor {
 	/** Service which retrieves the currently leading JobManager and opens a JobManagerGateway. */
 	private final LeaderGatewayRetriever<JobManagerGateway> retriever;
 
-	private final SSLContext serverSSLContext;
+	@Nullable
+	private final SSLUtils.SSLContext serverSSLContext;
 
 	private final CompletableFuture<String> localRestAddress = new CompletableFuture<>();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -43,7 +43,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -90,7 +90,8 @@ public class HistoryServer {
 
 	private final HistoryServerArchiveFetcher archiveFetcher;
 
-	private final SSLContext serverSSLContext;
+	@Nullable
+	private final SSLUtils.SSLContext serverSSLContext;
 	private WebFrontendBootstrap netty;
 
 	private final Object startupShutdownLock = new Object();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -40,7 +40,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandle
 
 import org.slf4j.Logger;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 
 import java.io.File;
@@ -55,7 +55,8 @@ public class WebFrontendBootstrap {
 	private final Router router;
 	private final Logger log;
 	private final File uploadDir;
-	private final SSLContext serverSSLContext;
+	@Nullable
+	private final SSLUtils.SSLContext serverSSLContext;
 	private final ServerBootstrap bootstrap;
 	private final Channel serverChannel;
 	private final String restAddress;
@@ -64,7 +65,7 @@ public class WebFrontendBootstrap {
 			Router router,
 			Logger log,
 			File directory,
-			SSLContext sslContext,
+			@Nullable SSLUtils.SSLContext sslContext,
 			String configuredAddress,
 			int configuredPort,
 			final Configuration config) throws InterruptedException, UnknownHostException {
@@ -81,7 +82,7 @@ public class WebFrontendBootstrap {
 
 				// SSL should be the first handler in the pipeline
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
+					SSLEngine sslEngine = serverSSLContext.sslContext.createSSLEngine();
 					SSLUtils.setSSLVerAndCipherSuites(sslEngine, config);
 					sslEngine.setUseClientMode(false);
 					ch.pipeline().addLast("ssl", new SslHandler(sslEngine));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -82,7 +82,7 @@ public class WebFrontendBootstrap {
 
 				// SSL should be the first handler in the pipeline
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.sslContext.createSSLEngine();
+					SSLEngine sslEngine = serverSSLContext.getSslContext().createSSLEngine();
 					SSLUtils.setSSLVerAndCipherSuites(sslEngine, config);
 					sslEngine.setUseClientMode(false);
 					ch.pipeline().addLast("ssl", new SslHandler(sslEngine));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -101,7 +101,7 @@ public final class BlobClient implements Closeable {
 
 				LOG.info("Using ssl connection to the blob server");
 
-				SSLSocket sslSocket = (SSLSocket) clientSSLContext.sslContext.getSocketFactory().createSocket(
+				SSLSocket sslSocket = (SSLSocket) clientSSLContext.getSslContext().getSocketFactory().createSocket(
 					serverAddress.getAddress(),
 					serverAddress.getPort());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 
@@ -91,7 +90,7 @@ public final class BlobClient implements Closeable {
 
 		try {
 			// Check if ssl is enabled
-			SSLContext clientSSLContext = null;
+			SSLUtils.SSLContext clientSSLContext = null;
 			if (clientConfig != null &&
 				clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
 
@@ -102,7 +101,7 @@ public final class BlobClient implements Closeable {
 
 				LOG.info("Using ssl connection to the blob server");
 
-				SSLSocket sslSocket = (SSLSocket) clientSSLContext.getSocketFactory().createSocket(
+				SSLSocket sslSocket = (SSLSocket) clientSSLContext.sslContext.getSocketFactory().createSocket(
 					serverAddress.getAddress(),
 					serverAddress.getPort());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -195,7 +195,7 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 					return new ServerSocket(port, finalBacklog);
 				} else {
 					LOG.info("Enabling ssl for the blob server");
-					return serverSSLContext.sslContext.getServerSocketFactory().createServerSocket(port, finalBacklog);
+					return serverSSLContext.getSslContext().getServerSocketFactory().createServerSocket(port, finalBacklog);
 				}
 			}
 		});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -79,7 +78,7 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 	private final ServerSocket serverSocket;
 
 	/** The SSL server context if ssl is enabled for the connections. */
-	private final SSLContext serverSSLContext;
+	private final SSLUtils.SSLContext serverSSLContext;
 
 	/** Blob Server configuration. */
 	private final Configuration blobServiceConfiguration;
@@ -196,7 +195,7 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 					return new ServerSocket(port, finalBacklog);
 				} else {
 					LOG.info("Enabling ssl for the blob server");
-					return serverSSLContext.getServerSocketFactory().createServerSocket(port, finalBacklog);
+					return serverSSLContext.sslContext.getServerSocketFactory().createServerSocket(port, finalBacklog);
 				}
 			}
 		});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -182,7 +182,7 @@ class NettyClient {
 
 				// SSL handler should be added first in the pipeline
 				if (clientSSLContext != null) {
-					SSLEngine sslEngine = clientSSLContext.sslContext.createSSLEngine(
+					SSLEngine sslEngine = clientSSLContext.getSslContext().createSSLEngine(
 						serverSocketAddress.getAddress().getCanonicalHostName(),
 						serverSocketAddress.getPort());
 					sslEngine.setUseClientMode(true);
@@ -195,11 +195,11 @@ class NettyClient {
 					}
 
 					SslHandler sslHandler = new SslHandler(sslEngine);
-					if (clientSSLContext.handshakeTimeoutMs >= 0) {
-						sslHandler.setHandshakeTimeoutMillis(clientSSLContext.handshakeTimeoutMs);
+					if (clientSSLContext.getHandshakeTimeoutMs() >= 0) {
+						sslHandler.setHandshakeTimeoutMillis(clientSSLContext.getHandshakeTimeoutMs());
 					}
-					if (clientSSLContext.closeNotifyFlushTimeoutMs >= 0) {
-						sslHandler.setCloseNotifyTimeoutMillis(clientSSLContext.closeNotifyFlushTimeoutMs);
+					if (clientSSLContext.getCloseNotifyFlushTimeoutMs() >= 0) {
+						sslHandler.setCloseNotifyTimeoutMillis(clientSSLContext.getCloseNotifyFlushTimeoutMs());
 					}
 					channel.pipeline().addLast("ssl", sslHandler);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
+import org.apache.flink.runtime.net.SSLUtils;
+
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.Bootstrap;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
@@ -34,9 +36,10 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
@@ -52,7 +55,8 @@ class NettyClient {
 
 	private Bootstrap bootstrap;
 
-	private SSLContext clientSSLContext = null;
+	@Nullable
+	private SSLUtils.SSLContext clientSSLContext = null;
 
 	NettyClient(NettyConfig config) {
 		this.config = config;
@@ -178,7 +182,7 @@ class NettyClient {
 
 				// SSL handler should be added first in the pipeline
 				if (clientSSLContext != null) {
-					SSLEngine sslEngine = clientSSLContext.createSSLEngine(
+					SSLEngine sslEngine = clientSSLContext.sslContext.createSSLEngine(
 						serverSocketAddress.getAddress().getCanonicalHostName(),
 						serverSocketAddress.getPort());
 					sslEngine.setUseClientMode(true);
@@ -190,7 +194,14 @@ class NettyClient {
 						sslEngine.setSSLParameters(newSSLParameters);
 					}
 
-					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
+					SslHandler sslHandler = new SslHandler(sslEngine);
+					if (clientSSLContext.handshakeTimeoutMs >= 0) {
+						sslHandler.setHandshakeTimeoutMillis(clientSSLContext.handshakeTimeoutMs);
+					}
+					if (clientSSLContext.closeNotifyFlushTimeoutMs >= 0) {
+						sslHandler.setCloseNotifyTimeoutMillis(clientSSLContext.closeNotifyFlushTimeoutMs);
+					}
+					channel.pipeline().addLast("ssl", sslHandler);
 				}
 				channel.pipeline().addLast(protocol.getClientChannelHandlers());
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -23,12 +23,14 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.net.SSLUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+
 import java.net.InetAddress;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -189,26 +191,13 @@ public class NettyConfig {
 		}
 	}
 
-	public SSLContext createClientSSLContext() throws Exception {
-
-		// Create SSL Context from config
-		SSLContext clientSSLContext = null;
-		if (getSSLEnabled()) {
-			clientSSLContext = SSLUtils.createSSLClientContext(config);
-		}
-
-		return clientSSLContext;
+	@Nullable
+	public SSLUtils.SSLContext createClientSSLContext() throws Exception {
+		return SSLUtils.createSSLClientContext(config);
 	}
 
-	public SSLContext createServerSSLContext() throws Exception {
-
-		// Create SSL Context from config
-		SSLContext serverSSLContext = null;
-		if (getSSLEnabled()) {
-			serverSSLContext = SSLUtils.createSSLServerContext(config);
-		}
-
-		return serverSSLContext;
+	public SSLUtils.SSLContext createServerSSLContext() throws Exception {
+		return SSLUtils.createSSLServerContext(config);
 	}
 
 	public boolean getSSLEnabled() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
+import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 
 import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -36,7 +37,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 
 import java.io.IOException;
@@ -61,7 +62,8 @@ class NettyServer {
 
 	private ChannelFuture bindFuture;
 
-	private SSLContext serverSSLContext = null;
+	@Nullable
+	private SSLUtils.SSLContext serverSSLContext = null;
 
 	private InetSocketAddress localAddress;
 
@@ -152,10 +154,17 @@ class NettyServer {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
+					SSLEngine sslEngine = serverSSLContext.sslContext.createSSLEngine();
 					config.setSSLVerAndCipherSuites(sslEngine);
 					sslEngine.setUseClientMode(false);
-					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
+					SslHandler sslHandler = new SslHandler(sslEngine);
+					if (serverSSLContext.handshakeTimeoutMs >= 0) {
+						sslHandler.setHandshakeTimeoutMillis(serverSSLContext.handshakeTimeoutMs);
+					}
+					if (serverSSLContext.closeNotifyFlushTimeoutMs >= 0) {
+						sslHandler.setCloseNotifyTimeoutMillis(serverSSLContext.closeNotifyFlushTimeoutMs);
+					}
+					channel.pipeline().addLast("ssl", sslHandler);
 				}
 
 				channel.pipeline().addLast(protocol.getServerChannelHandlers());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -154,15 +154,15 @@ class NettyServer {
 			@Override
 			public void initChannel(SocketChannel channel) throws Exception {
 				if (serverSSLContext != null) {
-					SSLEngine sslEngine = serverSSLContext.sslContext.createSSLEngine();
+					SSLEngine sslEngine = serverSSLContext.getSslContext().createSSLEngine();
 					config.setSSLVerAndCipherSuites(sslEngine);
 					sslEngine.setUseClientMode(false);
 					SslHandler sslHandler = new SslHandler(sslEngine);
-					if (serverSSLContext.handshakeTimeoutMs >= 0) {
-						sslHandler.setHandshakeTimeoutMillis(serverSSLContext.handshakeTimeoutMs);
+					if (serverSSLContext.getHandshakeTimeoutMs() >= 0) {
+						sslHandler.setHandshakeTimeoutMillis(serverSSLContext.getHandshakeTimeoutMs());
 					}
-					if (serverSSLContext.closeNotifyFlushTimeoutMs >= 0) {
-						sslHandler.setCloseNotifyTimeoutMillis(serverSSLContext.closeNotifyFlushTimeoutMs);
+					if (serverSSLContext.getCloseNotifyFlushTimeoutMs() >= 0) {
+						sslHandler.setCloseNotifyTimeoutMillis(serverSSLContext.getCloseNotifyFlushTimeoutMs());
 					}
 					channel.pipeline().addLast("ssl", sslHandler);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -113,7 +113,7 @@ public class SSLUtils {
 		checkState(sslContext != null, "%s it not enabled", SecurityOptions.SSL_ENABLED.key());
 
 		return new SSLEngineFactory(
-			sslContext,
+			sslContext.sslContext,
 			getEnabledProtocols(config),
 			getEnabledCipherSuites(config),
 			clientMode);
@@ -176,39 +176,43 @@ public class SSLUtils {
 	public static SSLContext createSSLClientContext(Configuration sslConfig) throws Exception {
 
 		Preconditions.checkNotNull(sslConfig);
-		SSLContext clientSSLContext = null;
 
-		if (getSSLEnabled(sslConfig)) {
-			LOG.debug("Creating client SSL context from configuration");
-
-			String trustStoreFilePath = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE);
-			String trustStorePassword = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
-			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
-
-			Preconditions.checkNotNull(trustStoreFilePath, SecurityOptions.SSL_TRUSTSTORE.key() + " was not configured.");
-			Preconditions.checkNotNull(trustStorePassword, SecurityOptions.SSL_TRUSTSTORE_PASSWORD.key() + " was not configured.");
-
-			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-
-			FileInputStream trustStoreFile = null;
-			try {
-				trustStoreFile = new FileInputStream(new File(trustStoreFilePath));
-				trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
-			} finally {
-				if (trustStoreFile != null) {
-					trustStoreFile.close();
-				}
-			}
-
-			TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
-				TrustManagerFactory.getDefaultAlgorithm());
-			trustManagerFactory.init(trustStore);
-
-			clientSSLContext = SSLContext.getInstance(sslProtocolVersion);
-			clientSSLContext.init(null, trustManagerFactory.getTrustManagers(), null);
+		if (!getSSLEnabled(sslConfig)) {
+			return null;
 		}
 
-		return clientSSLContext;
+		LOG.debug("Creating client SSL context from configuration");
+
+		String trustStoreFilePath = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE);
+		String trustStorePassword = sslConfig.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD);
+		String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
+		int sessionCacheSize = sslConfig.getInteger(SecurityOptions.SSL_SESSION_CACHE_SIZE);
+		int sessionTimeoutMs = sslConfig.getInteger(SecurityOptions.SSL_SESSION_TIMEOUT);
+		int handshakeTimeoutMs = sslConfig.getInteger(SecurityOptions.SSL_HANDSHAKE_TIMEOUT);
+		int closeNotifyFlushTimeoutMs = sslConfig.getInteger(SecurityOptions.SSL_CLOSE_NOTIFY_FLUSH_TIMEOUT);
+
+		Preconditions.checkNotNull(trustStoreFilePath, SecurityOptions.SSL_TRUSTSTORE.key() + " was not configured.");
+		Preconditions.checkNotNull(trustStorePassword, SecurityOptions.SSL_TRUSTSTORE_PASSWORD.key() + " was not configured.");
+
+		KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+
+		try (FileInputStream trustStoreFile = new FileInputStream(new File(trustStoreFilePath))) {
+			trustStore.load(trustStoreFile, trustStorePassword.toCharArray());
+		}
+
+		TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+			TrustManagerFactory.getDefaultAlgorithm());
+		trustManagerFactory.init(trustStore);
+
+		javax.net.ssl.SSLContext clientSSLContext = javax.net.ssl.SSLContext.getInstance(sslProtocolVersion);
+		clientSSLContext.init(null, trustManagerFactory.getTrustManagers(), null);
+		if (sessionCacheSize >= 0) {
+			clientSSLContext.getClientSessionContext().setSessionCacheSize(sessionCacheSize);
+		}
+		if (sessionTimeoutMs >= 0) {
+			clientSSLContext.getClientSessionContext().setSessionTimeout(sessionTimeoutMs / 1000);
+		}
+		return new SSLContext(clientSSLContext, handshakeTimeoutMs, closeNotifyFlushTimeoutMs);
 	}
 
 	/**
@@ -225,38 +229,65 @@ public class SSLUtils {
 	public static SSLContext createSSLServerContext(Configuration sslConfig) throws Exception {
 
 		Preconditions.checkNotNull(sslConfig);
-		SSLContext serverSSLContext = null;
 
-		if (getSSLEnabled(sslConfig)) {
-			LOG.debug("Creating server SSL context from configuration");
-
-			String keystoreFilePath = sslConfig.getString(SecurityOptions.SSL_KEYSTORE);
-
-			String keystorePassword = sslConfig.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD);
-
-			String certPassword = sslConfig.getString(SecurityOptions.SSL_KEY_PASSWORD);
-
-			String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
-
-			Preconditions.checkNotNull(keystoreFilePath, SecurityOptions.SSL_KEYSTORE.key() + " was not configured.");
-			Preconditions.checkNotNull(keystorePassword, SecurityOptions.SSL_KEYSTORE_PASSWORD.key() + " was not configured.");
-			Preconditions.checkNotNull(certPassword, SecurityOptions.SSL_KEY_PASSWORD.key() + " was not configured.");
-
-			KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-			try (FileInputStream keyStoreFile = new FileInputStream(new File(keystoreFilePath))) {
-				ks.load(keyStoreFile, keystorePassword.toCharArray());
-			}
-
-			// Set up key manager factory to use the server key store
-			KeyManagerFactory kmf = KeyManagerFactory.getInstance(
-					KeyManagerFactory.getDefaultAlgorithm());
-			kmf.init(ks, certPassword.toCharArray());
-
-			// Initialize the SSLContext
-			serverSSLContext = SSLContext.getInstance(sslProtocolVersion);
-			serverSSLContext.init(kmf.getKeyManagers(), null, null);
+		if (!getSSLEnabled(sslConfig)) {
+			return null;
 		}
 
-		return serverSSLContext;
+		LOG.debug("Creating server SSL context from configuration");
+
+		String keystoreFilePath = sslConfig.getString(SecurityOptions.SSL_KEYSTORE);
+		String keystorePassword = sslConfig.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD);
+		String certPassword = sslConfig.getString(SecurityOptions.SSL_KEY_PASSWORD);
+		String sslProtocolVersion = sslConfig.getString(SecurityOptions.SSL_PROTOCOL);
+		int sessionCacheSize = sslConfig.getInteger(SecurityOptions.SSL_SESSION_CACHE_SIZE);
+		int sessionTimeoutMs = sslConfig.getInteger(SecurityOptions.SSL_SESSION_TIMEOUT);
+		int handshakeTimeoutMs = sslConfig.getInteger(SecurityOptions.SSL_HANDSHAKE_TIMEOUT);
+		int closeNotifyFlushTimeoutMs = sslConfig.getInteger(SecurityOptions.SSL_CLOSE_NOTIFY_FLUSH_TIMEOUT);
+
+		Preconditions.checkNotNull(keystoreFilePath, SecurityOptions.SSL_KEYSTORE.key() + " was not configured.");
+		Preconditions.checkNotNull(keystorePassword, SecurityOptions.SSL_KEYSTORE_PASSWORD.key() + " was not configured.");
+		Preconditions.checkNotNull(certPassword, SecurityOptions.SSL_KEY_PASSWORD.key() + " was not configured.");
+
+		KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+		try (FileInputStream keyStoreFile = new FileInputStream(new File(keystoreFilePath))) {
+			ks.load(keyStoreFile, keystorePassword.toCharArray());
+		}
+
+		// Set up key manager factory to use the server key store
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+			KeyManagerFactory.getDefaultAlgorithm());
+		kmf.init(ks, certPassword.toCharArray());
+
+		// Initialize the SSLContext
+		javax.net.ssl.SSLContext serverSSLContext = javax.net.ssl.SSLContext.getInstance(sslProtocolVersion);
+		serverSSLContext.init(kmf.getKeyManagers(), null, null);
+		if (sessionCacheSize >= 0) {
+			serverSSLContext.getServerSessionContext().setSessionCacheSize(sessionCacheSize);
+		}
+		if (sessionTimeoutMs >= 0) {
+			serverSSLContext.getServerSessionContext().setSessionTimeout(sessionTimeoutMs / 1000);
+		}
+
+		return new SSLContext(serverSSLContext, handshakeTimeoutMs, closeNotifyFlushTimeoutMs);
+	}
+
+	/**
+	 * Wrapper around javax.net.ssl.SSLContext, adding SSL handshake and close notify timeouts
+	 * which cannot be set on the SSL context directly.
+	 */
+	public static class SSLContext {
+		public final javax.net.ssl.SSLContext sslContext;
+		public final int handshakeTimeoutMs;
+		public final int closeNotifyFlushTimeoutMs;
+
+		public SSLContext(
+				javax.net.ssl.SSLContext sslContext,
+				int handshakeTimeoutMs,
+				int closeNotifyFlushTimeoutMs) {
+			this.sslContext = sslContext;
+			this.handshakeTimeoutMs = handshakeTimeoutMs;
+			this.closeNotifyFlushTimeoutMs = closeNotifyFlushTimeoutMs;
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -113,7 +113,7 @@ public class SSLUtils {
 		checkState(sslContext != null, "%s it not enabled", SecurityOptions.SSL_ENABLED.key());
 
 		return new SSLEngineFactory(
-			sslContext.sslContext,
+			sslContext.getSslContext(),
 			getEnabledProtocols(config),
 			getEnabledCipherSuites(config),
 			clientMode);
@@ -277,9 +277,9 @@ public class SSLUtils {
 	 * which cannot be set on the SSL context directly.
 	 */
 	public static class SSLContext {
-		public final javax.net.ssl.SSLContext sslContext;
-		public final int handshakeTimeoutMs;
-		public final int closeNotifyFlushTimeoutMs;
+		private final javax.net.ssl.SSLContext sslContext;
+		private final int handshakeTimeoutMs;
+		private final int closeNotifyFlushTimeoutMs;
 
 		public SSLContext(
 				javax.net.ssl.SSLContext sslContext,
@@ -288,6 +288,18 @@ public class SSLUtils {
 			this.sslContext = sslContext;
 			this.handshakeTimeoutMs = handshakeTimeoutMs;
 			this.closeNotifyFlushTimeoutMs = closeNotifyFlushTimeoutMs;
+		}
+
+		public javax.net.ssl.SSLContext getSslContext() {
+			return sslContext;
+		}
+
+		public int getHandshakeTimeoutMs() {
+			return handshakeTimeoutMs;
+		}
+
+		public int getCloseNotifyFlushTimeoutMs() {
+			return closeNotifyFlushTimeoutMs;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -180,7 +180,7 @@ public class SSLUtilsTest {
 
 		SSLUtils.SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
 		assertNotNull(serverContext);
-		try (ServerSocket socket = serverContext.sslContext.getServerSocketFactory().createServerSocket(0)) {
+		try (ServerSocket socket = serverContext.getSslContext().getServerSocketFactory().createServerSocket(0)) {
 
 			String[] protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			String[] algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();
@@ -216,7 +216,7 @@ public class SSLUtilsTest {
 
 		SSLUtils.SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
 		assertNotNull(serverContext);
-		SSLEngine engine = serverContext.sslContext.createSSLEngine();
+		SSLEngine engine = serverContext.getSslContext().createSSLEngine();
 
 		String[] protocols = engine.getEnabledProtocols();
 		String[] algorithms = engine.getEnabledCipherSuites();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -164,9 +164,9 @@ public class RestServerEndpointITCase extends TestLogger {
 		config.setString(WebOptions.UPLOAD_DIR, temporaryFolder.newFolder().getCanonicalPath());
 
 		defaultSSLContext = SSLContext.getDefault();
-		final SSLContext sslClientContext = SSLUtils.createSSLClientContext(config);
+		final SSLUtils.SSLContext sslClientContext = SSLUtils.createSSLClientContext(config);
 		if (sslClientContext != null) {
-			SSLContext.setDefault(sslClientContext);
+			SSLContext.setDefault(sslClientContext.sslContext);
 		}
 
 		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -166,7 +166,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		defaultSSLContext = SSLContext.getDefault();
 		final SSLUtils.SSLContext sslClientContext = SSLUtils.createSSLClientContext(config);
 		if (sslClientContext != null) {
-			SSLContext.setDefault(sslClientContext.sslContext);
+			SSLContext.setDefault(sslClientContext.getSslContext());
 		}
 
 		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);


### PR DESCRIPTION
## What is the purpose of the change

This is mostly to tackle bugs like https://github.com/netty/netty/issues/832
(JDK issue during garbage collection when the SSL session cache is not limited).
We add the following low-level configuration options for the user to fine-tune
their system:

- SSL session cache size
- SSL session timeout
- SSL handshake timeout
- SSL close notify flush timeout

This is the PR for the `release-1.5` branch only - I'll create a separate one for `master` due to the changes of #6326.

## Brief change log

- add `security.ssl.session-cache-size` and `security.ssl.session-timeout` configuration parameters
-> configure these for `SSLContext`s created by `SSLUtil`
- add `security.ssl.handshake-timeout` and `security.ssl.close-notify-flush-timeout`
-> configure these in the TM-communication channels via `NettyClient` and `NettyServer`
- refactor `SSLUtils` so that we extract these configurations separately

## Verifying this change

This change added tests and can be verified as follows:

- added configuration-verification test to `NettyClientServerSslTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes** (kind-of)
  - If yes, how is the feature documented? **docs + JavaDocs**
