### PR TITLE
[FLINK-6895][table]Add STR_TO_DATE supported in SQL

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -684,7 +684,7 @@ abstract class CodeGenerator(
         val escapedValue = StringEscapeUtils.escapeJava(
           StringEscapeUtils.unescapeJava(value.toString)
         )
-        generateNonNullLiteral(resultType, "\"" + escapedValue + "\"")
+        generateNonNullLiteral(resultType, "\"" + escapedValue + "\"", Some(escapedValue))
 
       case SYMBOL =>
         generateSymbol(value.asInstanceOf[Enum[_]])
@@ -1264,7 +1264,8 @@ abstract class CodeGenerator(
         |""".stripMargin
 
       // mark this expression as a constant literal
-      GeneratedExpression(resultTerm, ALWAYS_NULL, wrappedCode, resultType, literal = true)
+      GeneratedExpression(resultTerm, ALWAYS_NULL, wrappedCode, resultType,
+        literal = true, literalValue = Some(defaultValue))
     } else {
       throw new CodeGenException("Null literals are not allowed if nullCheck is disabled.")
     }
@@ -1272,11 +1273,12 @@ abstract class CodeGenerator(
 
   private[flink] def generateNonNullLiteral(
       literalType: TypeInformation[_],
-      literalCode: String)
+      literalCode: String,
+      literalValue: Option[Any] = None)
     : GeneratedExpression = {
 
     // mark this expression as a constant literal
-    generateTerm(literalType, literalCode).copy(literal = true)
+    generateTerm(literalType, literalCode).copy(literal = true, literalValue = literalValue)
   }
 
   private[flink] def generateSymbol(enum: Enum[_]): GeneratedExpression = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -643,12 +643,6 @@ object FunctionGenerator {
     new HashCalcCallGen("SHA-2")
   )
 
-  addSqlFunction(
-    ScalarSqlFunctions.STR_TO_DATE,
-    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
-    new StrToDateCallGen
-  )
-
   // ----------------------------------------------------------------------------------------------
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -579,6 +579,12 @@ object FunctionGenerator {
     Seq(SqlTimeTypeInfo.TIMESTAMP, STRING_TYPE_INFO),
     new DateFormatCallGen
   )
+
+  addSqlFunction(
+    ScalarSqlFunctions.STR_TO_DATE,
+    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
+    new StrToDateCallGen)
+
   addSqlFunctionMethod(
     ScalarSqlFunctions.LPAD,
     Seq(STRING_TYPE_INFO, INT_TYPE_INFO, STRING_TYPE_INFO),
@@ -635,6 +641,12 @@ object FunctionGenerator {
     ScalarSqlFunctions.SHA2,
     Seq(STRING_TYPE_INFO, INT_TYPE_INFO),
     new HashCalcCallGen("SHA-2")
+  )
+
+  addSqlFunction(
+    ScalarSqlFunctions.STR_TO_DATE,
+    Seq(STRING_TYPE_INFO, STRING_TYPE_INFO),
+    new StrToDateCallGen
   )
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/StrToDateCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/StrToDateCallGen.scala
@@ -23,6 +23,9 @@ import org.apache.flink.table.codegen.calls.CallGenerator.generateCallIfArgsNotN
 import org.apache.flink.table.codegen.{CodeGenerator, GeneratedExpression}
 import org.apache.flink.table.runtime.functions.DateTimeFunctions
 
+/**
+  * Generates StrToDate call based on the type of last operand.
+  */
 class StrToDateCallGen extends CallGenerator {
   override def generate(codeGenerator: CodeGenerator,
                         operands: Seq[GeneratedExpression]): GeneratedExpression = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/StrToDateCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/StrToDateCallGen.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen.calls
+
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo
+import org.apache.flink.table.codegen.calls.CallGenerator.generateCallIfArgsNotNull
+import org.apache.flink.table.codegen.{CodeGenerator, GeneratedExpression}
+import org.apache.flink.table.runtime.functions.DateTimeFunctions
+
+class StrToDateCallGen extends CallGenerator {
+  override def generate(codeGenerator: CodeGenerator,
+                        operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    if (operands.last.literal) {
+      generateCallIfArgsNotNull(codeGenerator.nullCheck, SqlTimeTypeInfo.DATE, operands) {
+        terms => s"""
+                    |org.apache.flink.table.runtime.functions.
+                    |DateTimeFunctions$$.MODULE$$.strToDate(${terms.head}, ${terms.last})
+              """.stripMargin
+      }
+    } else {
+      generateCallIfArgsNotNull(codeGenerator.nullCheck, SqlTimeTypeInfo.TIMESTAMP, operands) {
+        terms => s"""
+                    |org.apache.flink.table.runtime.functions.
+                    |DateTimeFunctions$$.MODULE$$.strToTimestamp(${terms.head}, ${terms.last})
+              """.stripMargin
+      }
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/generated.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/generated.scala
@@ -39,7 +39,8 @@ case class GeneratedExpression(
   nullTerm: String,
   code: String,
   resultType: TypeInformation[_],
-  literal: Boolean = false)
+  literal: Boolean = false,
+  literalValue: Option[Any] = None)
 
 object GeneratedExpression {
   val ALWAYS_NULL = "true"

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctionReturnTypes.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctionReturnTypes.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.sql
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.sql.SqlOperatorBinding
+import org.apache.calcite.sql.`type`.{SqlReturnTypeInference, SqlTypeName}
+
+/**
+  * Customized [[SqlReturnTypeInference]] for those whose [[SqlReturnTypeInference]] cannot
+  * be implemented with [[org.apache.calcite.sql.type.ReturnTypes]]
+  */
+object ScalarSqlFunctionReturnTypes {
+
+  val STR_TO_DATE: SqlReturnTypeInference = new SqlReturnTypeInference() {
+    override def inferReturnType(opBinding: SqlOperatorBinding): RelDataType = {
+      val typeFactory = opBinding.getTypeFactory
+      if (opBinding.isOperandLiteral(1, true)) {
+        typeFactory.createSqlType(SqlTypeName.DATE)
+      } else {
+        typeFactory.createSqlType(SqlTypeName.TIMESTAMP)
+      }
+    }
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.functions.sql
 
-import org.apache.calcite.sql.{SqlFunction, SqlFunctionCategory, SqlKind}
 import org.apache.calcite.sql.`type`._
+import org.apache.calcite.sql.{SqlFunction, SqlFunctionCategory, SqlKind, SqlOperatorBinding}
 
 /**
   * All built-in scalar SQL functions.
@@ -206,4 +206,11 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val STR_TO_DATE = new SqlFunction(
+    "STR_TO_DATE",
+    SqlKind.OTHER_FUNCTION,
+    ScalarSqlFunctionReturnTypes.STR_TO_DATE,
+    InferTypes.RETURN_TYPE,
+    OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING),
+    SqlFunctionCategory.TIMEDATE)
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/DateTimeFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/DateTimeFunctions.scala
@@ -17,12 +17,13 @@
  */
 package org.apache.flink.table.runtime.functions
 
-import org.joda.time.format.DateTimeFormatter
-import org.joda.time.format.DateTimeFormatterBuilder
+import org.joda.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import org.joda.time.{DateTimeZone, Days, MutableDateTime}
 
 object DateTimeFunctions {
   private val PIVOT_YEAR = 2020
 
+  private val epoch = new MutableDateTime(0, DateTimeZone.UTC)
   private val DATETIME_FORMATTER_CACHE = new ThreadLocalCache[String, DateTimeFormatter](64) {
     protected override def getNewInstance(format: String): DateTimeFormatter
     = createDateTimeFormatter(format)
@@ -31,6 +32,18 @@ object DateTimeFunctions {
   def dateFormat(ts: Long, formatString: String): String = {
     val formatter = DATETIME_FORMATTER_CACHE.get(formatString)
     formatter.print(ts)
+  }
+
+  def strToDate(str: String, formatString: String): Int = {
+    val formatter = DATETIME_FORMATTER_CACHE.get(formatString)
+    val formatDate = formatter.parseLocalDate(str).toDateTimeAtCurrentTime(DateTimeZone.UTC)
+    val days = Days.daysBetween(epoch, formatDate)
+    days.getDays
+  }
+
+  def strToTimestamp(str: String, formatString: String): Long = {
+    val formatter = DATETIME_FORMATTER_CACHE.get(formatString)
+    formatter.parseDateTime(str).getMillis
   }
 
   def createDateTimeFormatter(format: String): DateTimeFormatter = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -416,6 +416,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.CURRENT_TIMESTAMP,
     SqlStdOperatorTable.CURRENT_DATE,
     ScalarSqlFunctions.DATE_FORMAT,
+    ScalarSqlFunctions.STR_TO_DATE,
     SqlStdOperatorTable.CAST,
     SqlStdOperatorTable.EXTRACT,
     SqlStdOperatorTable.QUARTER,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DateTimeFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DateTimeFunctionTest.scala
@@ -19,12 +19,15 @@
 package org.apache.flink.table.expressions
 
 import java.sql.Timestamp
+import java.util.Date
 
 import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.ExpressionTestBase
+import org.apache.flink.table.runtime.functions.DateTimeFunctions
 import org.apache.flink.types.Row
+import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
 import org.junit.Test
 
@@ -32,6 +35,21 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   private val INSTANT = DateTime.parse("1990-01-02T03:04:05.678Z")
   private val LOCAL_ZONE = DateTimeZone.getDefault
   private val LOCAL_TIME = INSTANT.toDateTime(LOCAL_ZONE)
+
+  @Test
+  def testStrToDate(): Unit = {
+    val fmt = DateTimeFormat.forPattern("yyyy-MM-dd").withZone(LOCAL_ZONE)
+    testSqlApi("STR_TO_DATE('20170203', '%Y%m%d')", "2017-02-03")
+    testSqlApi("STR_TO_DATE('01,5,2013', '%d,%m,%Y')", "2013-05-01")
+    testSqlApi("STR_TO_DATE('20110303 am03:29:44', '%Y%m%d %p%h:%i:%s')", "2011-03-03")
+    testSqlApi("STR_TO_DATE('20110303 03:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03")
+    testSqlApi("STR_TO_DATE('20110303 14:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03")
+    testSqlApi("STR_TO_DATE('20110303 22:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03")
+    testSqlApi(
+      "STR_TO_DATE('02/03/2017', f1)",
+      fmt.parseDateTime("2017-02-03").toDateTime(DateTimeZone.UTC).toString("yyyy-MM-dd HH:mm:ss.S")
+    )
+  }
 
   @Test
   def testDateFormat(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DateTimeFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DateTimeFunctionTest.scala
@@ -39,15 +39,18 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   @Test
   def testStrToDate(): Unit = {
     val fmt = DateTimeFormat.forPattern("yyyy-MM-dd").withZone(LOCAL_ZONE)
+    testSqlApi("STR_TO_DATE('12 22:29:44', '%d %H:%i:%s')", "2000-01-12 22:29:44.0")
+    testSqlApi("STR_TO_DATE('22:29', '%H:%i')", "22:29:00")
+    testSqlApi("STR_TO_DATE('22:29:44', '%H:%i:%s')", "22:29:44")
     testSqlApi("STR_TO_DATE('20170203', '%Y%m%d')", "2017-02-03")
     testSqlApi("STR_TO_DATE('01,5,2013', '%d,%m,%Y')", "2013-05-01")
-    testSqlApi("STR_TO_DATE('20110303 am03:29:44', '%Y%m%d %p%h:%i:%s')", "2011-03-03")
-    testSqlApi("STR_TO_DATE('20110303 03:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03")
-    testSqlApi("STR_TO_DATE('20110303 14:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03")
-    testSqlApi("STR_TO_DATE('20110303 22:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03")
+    testSqlApi("STR_TO_DATE('20110303 am03:29:44', '%Y%m%d %p%h:%i:%s')", "2011-03-03 03:29:44.0")
+    testSqlApi("STR_TO_DATE('20110303 03:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03 03:29:44.0")
+    testSqlApi("STR_TO_DATE('20110303 14:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03 14:29:44.0")
+    testSqlApi("STR_TO_DATE('20110303 22:29:44', '%Y%m%d %H:%i:%s')", "2011-03-03 22:29:44.0")
     testSqlApi(
       "STR_TO_DATE('02/03/2017', f1)",
-      fmt.parseDateTime("2017-02-03").toDateTime(DateTimeZone.UTC).toString("yyyy-MM-dd HH:mm:ss.S")
+      fmt.parseLocalDateTime("2017-02-03").toString("yyyy-MM-dd HH:mm:ss.S")
     )
   }
 


### PR DESCRIPTION
## What is the purpose of the change
Add STR_TO_DATE Function supported in SQL
## Brief change log
 * STR_TO_DATE(str string, format string)  
    \-  if the format is not a literal, the return type will be timestamp, otherwise it's date.
 * Add tests in ScalarFunctionsTest.scala
 * Add docs in sql.md
## Verifying this change
 * Run unit tests in  ScalarFunctionsTest.scala
## Does this pull request potentially affect one of the following parts:
 * A new sql function
## Documentation
  * Add docs in sql.md