### PR TITLE
[FLINK-9888][release] Remove unsafe defaults from release scripts

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -20,11 +20,15 @@
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##
-RELEASE_VERSION=${RELEASE_VERSION:-1.3-SNAPSHOT}
 SCALA_VERSION=none
 HADOOP_VERSION=none
 SKIP_GPG=${SKIP_GPG:-false}
 MVN=${MVN:-mvn}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+    echo "RELEASE_VERSION was not set."
+    exit 1
+fi
 
 # fail immediately
 set -o errexit

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -20,10 +20,18 @@
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##
-OLD_VERSION=${OLD_VERSION:-1.2-SNAPSHOT}
-NEW_VERSION=${NEW_VERSION:-1.3-SNAPSHOT}
 RELEASE_CANDIDATE=${RELEASE_CANDIDATE:-none}
 MVN=${MVN:-mvn}
+
+if [ -z "${OLD_VERSION}" ]; then
+    echo "OLD_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${NEW_VERSION}" ]; then
+    echo "NEW_VERSION was not set."
+    exit 1
+fi
 
 # fail immediately
 set -o errexit

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -20,8 +20,12 @@
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##
-RELEASE_VERSION=${RELEASE_VERSION:-1.3-SNAPSHOT}
 MVN=${MVN:-mvn}
+
+if [ -z "${RELEASE_VERSION}" ]; then
+    echo "RELEASE_VERSION was not set."
+    exit 1
+fi
 
 # fail immediately
 set -o errexit

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -20,9 +20,17 @@
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##
-OLD_VERSION=${OLD_VERSION:-1.4-SNAPSHOT}
-NEW_VERSION=${NEW_VERSION:-1.5-SNAPSHOT}
 MVN=${MVN:-mvn}
+
+if [ -z "${OLD_VERSION}" ]; then
+    echo "OLD_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${NEW_VERSION}" ]; then
+    echo "NEW_VERSION was not set."
+    exit 1
+fi
 
 # fail immediately
 set -o errexit


### PR DESCRIPTION
## What is the purpose of the change

This PR removes several unnecessary and unsafe `*_VERSION` defaults from the release scripts.
The scripts should never be called without explicitly setting these values.
