### PR TITLE
[FLINK-9860][REST] fix buffer leak in FileUploadHandler

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.util.ResourceLeakDetector;
+import org.apache.flink.shaded.netty4.io.netty.util.ResourceLeakDetectorFactory;
 
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -30,6 +32,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -38,6 +42,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link FileUploadHandler}. Ensures that multipart http messages containing files and/or json are properly
@@ -49,6 +54,24 @@ public class FileUploadHandlerTest extends TestLogger {
 	public static final MultipartUploadResource MULTIPART_UPLOAD_RESOURCE = new MultipartUploadResource();
 
 	private static final ObjectMapper OBJECT_MAPPER = RestMapperUtils.getStrictObjectMapper();
+
+	private static ResourceLeakDetectorFactory previousLeakDetector;
+	private static ResourceLeakDetector.Level previousLeakDetectorLevel;
+
+	@BeforeClass
+	public static void setLeakDetector() {
+		previousLeakDetector = ResourceLeakDetectorFactory.instance();
+		previousLeakDetectorLevel = ResourceLeakDetector.getLevel();
+
+		ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+		ResourceLeakDetectorFactory.setResourceLeakDetectorFactory(new FailingResourceLeakDetectorFactory());
+	}
+
+	@AfterClass
+	public static void resetLeakDetector() {
+		ResourceLeakDetectorFactory.setResourceLeakDetectorFactory(previousLeakDetector);
+		ResourceLeakDetector.setLevel(previousLeakDetectorLevel);
+	}
 
 	@After
 	public void reset() {
@@ -220,4 +243,32 @@ public class FileUploadHandlerTest extends TestLogger {
 		}
 		MULTIPART_UPLOAD_RESOURCE.assertUploadDirectoryIsEmpty();
 	}
+
+	static class FailingResourceLeakDetectorFactory extends ResourceLeakDetectorFactory {
+		public <T> ResourceLeakDetector<T> newResourceLeakDetector(
+				Class<T> resource, int samplingInterval, long maxActive) {
+			return new FailingResourceLeakDetector<T>(resource, samplingInterval, maxActive);
+		}
+	}
+
+	static class FailingResourceLeakDetector<T> extends ResourceLeakDetector<T> {
+		FailingResourceLeakDetector(Class<?> resourceType, int samplingInterval, long maxActive) {
+			super(resourceType, samplingInterval, maxActive);
+		}
+
+		@Override
+		protected void reportTracedLeak(String resourceType, String records) {
+			super.reportTracedLeak(resourceType, records);
+			fail(String.format("LEAK: %s.release() was not called before it's garbage-collected.%s",
+				resourceType, records));
+		}
+
+		@Override
+		protected void reportUntracedLeak(String resourceType) {
+			super.reportUntracedLeak(resourceType);
+			fail(String.format("LEAK: %s.release() was not called before it's garbage-collected.",
+				resourceType));
+		}
+	}
+
 }

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -28,3 +28,5 @@ log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger
+# Resource leak detector only works with logging enabled at error level
+log4j.logger.org.apache.flink.shaded.netty4.io.netty.util.ResourceLeakDetector=ERROR, testlogger


### PR DESCRIPTION
## What is the purpose of the change

The current implementation of `FileUploadHandler` has two cases where the given message was not released or forwarded for some other handler to release.

## Brief change log

- change the use of SimpleChannelInboundHandler to auto-release objects and make sure we retain them only when needed

## Verifying this change

This change added tests and can be verified as follows:

- adapted `FileUploadHandlerTest` to use a customized (Netty) leak detector that does not only log but fails with an assertion
- enable `ERROR` logging level for `log4j.logger.org.apache.flink.shaded.netty4.io.netty.util.ResourceLeakDetector` in all unit tests in `flink-runtime` - the leak detector will otherwise not report anything

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
