### PR TITLE
[hotfix] typo for SqlExecutionException msg

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -236,7 +236,7 @@ public class ExecutionContext<T> {
 				TableFactoryService.find(BatchTableSinkFactory.class, sinkProperties, classLoader);
 			return factory.createBatchTableSink(sinkProperties);
 		}
-		throw new SqlExecutionException("Unsupported execution type for sources.");
+		throw new SqlExecutionException("Unsupported execution type for sinks.");
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
fix typo in SqlExecutionException msg in ExecutionContext.java