### PR TITLE
[FLINK-9886] [sql-client] Build SQL jars with every build

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -203,12 +203,12 @@ under the License.
 	</dependencies>
 
 	<profiles>
+		<!-- Create SQL Client uber jars by default -->
 		<profile>
-			<!-- Create SQL Client uber jars for releases -->
-			<id>release</id>
+			<id>sql-jars</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>!skipSqlJars</name>
 				</property>
 			</activation>
 			<build>

--- a/flink-connectors/flink-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.11/pom.xml
@@ -212,12 +212,12 @@ under the License.
 	</dependencies>
 
 	<profiles>
+		<!-- Create SQL Client uber jars by default -->
 		<profile>
-			<!-- Create SQL Client uber jars for releases -->
-			<id>release</id>
+			<id>sql-jars</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>!skipSqlJars</name>
 				</property>
 			</activation>
 			<build>

--- a/flink-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.9/pom.xml
@@ -191,12 +191,12 @@ under the License.
 	</dependencies>
 
 	<profiles>
+		<!-- Create SQL Client uber jars by default -->
 		<profile>
-			<!-- Create SQL Client uber jars for releases -->
-			<id>release</id>
+			<id>sql-jars</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>!skipSqlJars</name>
 				</property>
 			</activation>
 			<build>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -109,9 +109,14 @@ under the License.
 	</dependencies>
 
 	<profiles>
+		<!-- Create SQL Client uber jars by default -->
 		<profile>
-			<!-- Create SQL Client uber jars for releases -->
-			<id>release</id>
+			<id>sql-jars</id>
+			<activation>
+				<property>
+					<name>!skipSqlJars</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -86,12 +86,12 @@ under the License.
 	</dependencies>
 
 	<profiles>
+		<!-- Create SQL Client uber jars by default -->
 		<profile>
-			<!-- Create SQL Client uber jars for releases -->
-			<id>release</id>
+			<id>sql-jars</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>!skipSqlJars</name>
 				</property>
 			</activation>
 			<build>


### PR DESCRIPTION
## What is the purpose of the change

This enables the building of the SQL jars by default. This solves a couple of issues:

- Reduces user confusion for finding SQL jars in SNAPSHOT releases
- Enables end-to-end testing

## Brief change log

- Building enabled by defaul but can be skipped with `-DskipSqlJars`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
