### PR TITLE
[FLINK-9892][tests] Disable local recovery in Jepsen tests.

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -56,7 +56,7 @@
    :taskmanager.numberOfTaskSlots      taskmanager-slots
    :yarn.application-attempts          99999
    :slotmanager.taskmanager-timeout    10000
-   :state.backend.local-recovery       "true"
+   :state.backend.local-recovery       "false"
    :taskmanager.registration.timeout   "30 s"})
 
 (defn master-nodes


### PR DESCRIPTION
## What is the purpose of the change

*Until [FLINK-9635](https://issues.apache.org/jira/browse/FLINK-9635) is fixed, local recovery should be disabled in the Jepsen tests.*

## Brief change log

  - *Disable local recovery in Jepsen tests.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
