### PR TITLE
[Flink-9353] Tests running per job standalone cluster with Docker & Kubernetes

### DIFF
--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -31,6 +31,10 @@ You can also run tests individually via
 $ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh your_test.sh arg1 arg2
 ```
 
+### Kubernetes test
+
+Kubernetes test (test_kubernetes_embedded_job.sh) assumes a running minikube cluster.
+
 ## Writing Tests
 
 ### Examples

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -51,6 +51,7 @@ run_test "Shaded Hadoop S3A end-to-end test" "$END_TO_END_DIR/test-scripts/test_
 run_test "Shaded Presto S3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_presto_s3.sh"
 run_test "Hadoop-free Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_hadoop_free.sh"
 run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
+run_test "Wordcount end-to-end test in docker env" "$END_TO_END_DIR/test-scripts/test_docker_embedded_job.sh"
 
 printf "\n[PASS] All tests passed\n"
 exit 0

--- a/flink-end-to-end-tests/test-scripts/container-scripts/docker-compose.test.yml
+++ b/flink-end-to-end-tests/test-scripts/container-scripts/docker-compose.test.yml
@@ -1,0 +1,30 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Extensions to flink-container/docker/docker-compose.yml that mounts volumes needed for tests
+
+version: "2.1"
+services:
+  job-cluster:
+    volumes:
+      - ${INPUT_VOLUME}:${INPUT_PATH}
+      - ${OUTPUT_VOLUME}:${OUTPUT_PATH}
+  taskmanager:
+    volumes:
+      - ${INPUT_VOLUME}:${INPUT_PATH}
+      - ${OUTPUT_VOLUME}:${OUTPUT_PATH}

--- a/flink-end-to-end-tests/test-scripts/container-scripts/job-cluster-job.yaml.template
+++ b/flink-end-to-end-tests/test-scripts/container-scripts/job-cluster-job.yaml.template
@@ -1,0 +1,46 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flink-job-cluster
+spec:
+  template:
+    metadata:
+      labels:
+        app: flink
+        component: job-cluster
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: flink-job-cluster
+        image: ${FLINK_IMAGE_NAME}
+        imagePullPolicy: Never
+        args: ["job-cluster", "--job-classname", "${FLINK_JOB}", "-Djobmanager.rpc.address=flink-job-cluster",
+               "-Dparallelism.default=${FLINK_JOB_PARALLELISM}", "-Dblob.server.port=6124", "-Dquery.server.ports=6125",
+               ${FLINK_JOB_ARGUMENTS}]
+        ports:
+        - containerPort: 6123
+          name: rpc
+        - containerPort: 6124
+          name: blob
+        - containerPort: 6125
+          name: query
+        - containerPort: 8081
+          name: ui

--- a/flink-end-to-end-tests/test-scripts/container-scripts/task-manager-deployment.yaml.template
+++ b/flink-end-to-end-tests/test-scripts/container-scripts/task-manager-deployment.yaml.template
@@ -1,0 +1,41 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: flink-task-manager
+spec:
+  replicas: ${FLINK_JOB_PARALLELISM}
+  template:
+    metadata:
+      labels:
+        app: flink
+        component: task-manager
+    spec:
+      containers:
+      - name: flink-task-manager
+        image: ${FLINK_IMAGE_NAME}
+        imagePullPolicy: Never
+        args: ["task-manager", "-Djobmanager.rpc.address=flink-job-cluster"]
+        volumeMounts:
+            - mountPath: /cache
+              name: cache-volume
+      volumes:
+      - name: cache-volume
+        emptyDir: {}

--- a/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
+DOCKER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
+
+export FLINK_JOB=org.apache.flink.examples.java.wordcount.WordCount
+export FLINK_DOCKER_IMAGE_NAME=test_docker_embedded_job
+export INPUT_VOLUME=${END_TO_END_DIR}/test-scripts/test-data
+export OUTPUT_VOLUME=${TEST_DATA_DIR}/out
+export INPUT_PATH=/data/test/input
+export OUTPUT_PATH=/data/test/output
+export FLINK_JOB_ARGUMENTS="--input ${INPUT_PATH}/words --output ${OUTPUT_PATH}/docker_wc_out"
+
+# user inside the container must be able to createto workaround in-container permissions
+mkdir -p $OUTPUT_VOLUME
+chmod 777 $OUTPUT_VOLUME
+
+cd "$DOCKER_MODULE_DIR"
+./build.sh --from-local-dist --job-jar ${FLINK_DIR}/examples/batch/WordCount.jar --image-name ${FLINK_DOCKER_IMAGE_NAME}
+cd "$END_TO_END_DIR"
+
+docker-compose -f ${DOCKER_MODULE_DIR}/docker-compose.yml -f ${DOCKER_SCRIPTS}/docker-compose.test.yml up --abort-on-container-exit --exit-code-from job-cluster &> /dev/null
+docker-compose -f ${DOCKER_MODULE_DIR}/docker-compose.yml -f ${DOCKER_SCRIPTS}/docker-compose.test.yml logs job-cluster > ${FLINK_DIR}/log/jobmanager.log
+docker-compose -f ${DOCKER_MODULE_DIR}/docker-compose.yml -f ${DOCKER_SCRIPTS}/docker-compose.test.yml logs taskmanager > ${FLINK_DIR}/log/taskmanager.log
+
+check_result_hash "WordCount" $OUTPUT_VOLUME/docker_wc_out "72a690412be8928ba239c2da967328a5"

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
+KUBERNETES_MODULE_DIR=${END_TO_END_DIR}/../flink-container/kubernetes
+CONTAINER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
+
+export FLINK_JOB=org.apache.flink.examples.java.wordcount.WordCount
+export FLINK_IMAGE_NAME=test_kubernetes_embedded_job
+export OUTPUT_VOLUME=${TEST_DATA_DIR}/out
+export OUTPUT_FILE=kubernetes_wc_out
+export FLINK_JOB_PARALLELISM=1
+export FLINK_JOB_ARGUMENTS='"--output", "/cache/kubernetes_wc_out"'
+
+function cleanup {
+    kubectl delete job flink-job-cluster
+    kubectl delete service flink-job-cluster
+    kubectl delete deployment flink-task-manager
+    rm -rf ${OUTPUT_VOLUME}
+}
+
+trap cleanup EXIT
+
+mkdir -p $OUTPUT_VOLUME
+
+eval $(minikube docker-env)
+cd "$DOCKER_MODULE_DIR"
+./build.sh --from-local-dist --job-jar ${FLINK_DIR}/examples/batch/WordCount.jar --image-name ${FLINK_IMAGE_NAME}
+cd "$END_TO_END_DIR"
+
+
+kubectl create -f ${KUBERNETES_MODULE_DIR}/job-cluster-service.yaml
+envsubst '${FLINK_IMAGE_NAME} ${FLINK_JOB} ${FLINK_JOB_PARALLELISM} ${FLINK_JOB_ARGUMENTS}' < ${CONTAINER_SCRIPTS}/job-cluster-job.yaml.template | kubectl create -f -
+envsubst '${FLINK_IMAGE_NAME} ${FLINK_JOB_PARALLELISM}' < ${CONTAINER_SCRIPTS}/task-manager-deployment.yaml.template | kubectl create -f -
+kubectl wait --for=condition=complete job/flink-job-cluster --timeout=1h
+kubectl cp `kubectl get pods | awk '/task-manager/ {print $1}'`:/cache/${OUTPUT_FILE} ${OUTPUT_VOLUME}/${OUTPUT_FILE}
+
+check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_FILE} "e682ec6622b5e83f2eb614617d5ab2cf"


### PR DESCRIPTION
## What is the purpose of the change

Tests that we can run flink jobs in a standalone per job cluster with docker images with built-in job jar.

## Verifying this change

Those are new tests. The docker-compose test should be run on travis. For the kubernetes test you need to have minikube installed and running.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no /** don't know)
  - The S3 file system connector: (yes / **no /** don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
