### PR TITLE
[FLINK-9236] [pom] upgrade the version of apache parent pom 

### DIFF
--- a/flink-libraries/flink-python/pom.xml
+++ b/flink-libraries/flink-python/pom.xml
@@ -48,7 +48,9 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptor>src/assembly/python.xml</descriptor>
+					<descriptors>
+						<descriptor>src/assembly/python.xml</descriptor>
+					</descriptors>
 					<finalName>python-source</finalName>
 					<appendAssemblyId>false</appendAssemblyId>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>18</version>
+		<version>20</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION

## What is the purpose of the change
This PR is for upgrading the version of Apache Parent Pom used by flink.


## Brief change log
* The version of Apache parent pom changed form 18 to 20 in pom.xml
* Modify the configuration of maven-assembly-plugin in flink-libraries/flink-python/pom.xml  because of the parameter 'descriptor' has been removed from maven-assembly-plugin:3.0.0

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
