### PR TITLE
[FLINK-9915] [table] Add TO_BASE64 function for table/sql API

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1848,6 +1848,17 @@ FROM_BASE64(text string)
       <td>
         <p>Returns the base string decoded with base64, if text is NULL, returns NULL. E.g. <code>FROM_BASE64('aGVsbG8gd29ybGQ=')</code> returns <code>hello world</code>.</p>
       </td>
+    </tr>  
+        
+    <tr>
+      <td>
+        {% highlight text %}
+TO_BASE64(text string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the string text encoded with BASE64, if string is null, returns null. E.g. <code>TO_BASE64('hello world')</code> returns <code>aGVsbG8gd29ybGQ=</code>.</p>
+      </td>
     </tr>
 
   </tbody>

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1853,11 +1853,11 @@ FROM_BASE64(text string)
     <tr>
       <td>
         {% highlight text %}
-TO_BASE64(text string)
+TO_BASE64(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the string text encoded with BASE64, if string is null, returns null. E.g. <code>TO_BASE64('hello world')</code> returns <code>aGVsbG8gd29ybGQ=</code>.</p>
+        <p>Returns the base64-encoded result of the input string. If the input is NULL, returns NULL. E.g. <code>TO_BASE64('hello world')</code> returns <code>aGVsbG8gd29ybGQ=</code>.</p>
       </td>
     </tr>
 

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2481,7 +2481,7 @@ STRING.rpad(len INT, pad STRING)
 STRING.fromBase64()
 {% endhighlight %}
       </td>
-      
+
       <td>
         <p>Returns the base string decoded with base64, if string is null, returns null. E.g. "aGVsbG8gd29ybGQ=".fromBase64() returns "hello world".</p>
       </td>
@@ -2495,7 +2495,7 @@ STRING.toBase64()
       </td>
 
       <td>
-        <p>Returns the string text encoded with BASE64. E.g. "hello world".toBase64() returns "aGVsbG8gd29ybGQ=".</p>
+        <p>Returns the base64-encoded result of STRING. If STRING is NULL, returns NULL. E.g. "hello world".toBase64() returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
 
@@ -4035,6 +4035,18 @@ STRING.initCap()
 
       <td>
         <p>Converts the initial letter of each word in a string to uppercase. Assumes a string containing only [A-Za-z0-9], everything else is treated as whitespace.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.toBase64()
+{% endhighlight %}
+      </td>
+
+      <td>
+        <p>Returns the base64-encoded result of STRING. If STRING is NULL, returns NULL. E.g. "hello world".toBase64() returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
 

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2474,15 +2474,28 @@ STRING.rpad(len INT, pad STRING)
         <p>Returns a string right-padded with the given pad string to a length of len characters. If the string is longer than len, the return value is shortened to len characters. E.g. "hi".rpad(4, '??') returns "hi??",  "hi".rpad(1, '??') returns "h".</p>
       </td>
     </tr>
+
     <tr>
       <td>
         {% highlight java %}
 STRING.fromBase64()
 {% endhighlight %}
       </td>
-
+      
       <td>
         <p>Returns the base string decoded with base64, if string is null, returns null. E.g. "aGVsbG8gd29ybGQ=".fromBase64() returns "hello world".</p>
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.toBase64()
+{% endhighlight %}
+      </td>
+
+      <td>
+        <p>Returns the string text encoded with BASE64. E.g. "hello world".toBase64() returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -550,7 +550,7 @@ trait ImplicitExpressionOperations {
   def fromBase64() = FromBase64(expr)
 
   /**
-    * Returns a string's representation that encoded as base64.
+    * Returns the base64-encoded result of the input string.
     */
   def toBase64() = ToBase64(expr)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -549,6 +549,11 @@ trait ImplicitExpressionOperations {
     */
   def fromBase64() = FromBase64(expr)
 
+  /**
+    * Returns a string's representation that encoded as base64.
+    */
+  def toBase64() = ToBase64(expr)
+
   // Temporal operations
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -114,4 +114,6 @@ object BuiltInMethods {
   val BIN = Types.lookupMethod(classOf[JLong], "toBinaryString", classOf[Long])
 
   val FROMBASE64 = Types.lookupMethod(classOf[ScalarFunctions], "fromBase64", classOf[String])
+
+  val TOBASE64 = Types.lookupMethod(classOf[ScalarFunctions], "toBase64", classOf[String])
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -152,6 +152,12 @@ object FunctionGenerator {
     STRING_TYPE_INFO,
     BuiltInMethods.FROMBASE64)
 
+  addSqlFunctionMethod(
+    TO_BASE64,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethods.TOBASE64)
+
   // ----------------------------------------------------------------------------------------------
   // Arithmetic functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -386,8 +386,7 @@ case class FromBase64(child: Expression) extends UnaryExpression with InputTypeS
 }
 
 /**
-  * Returns the string encoded with base64.
-  * Returns NULL If the input string is NULL.
+  * Returns the base64-encoded result of the input string.
   */
 case class ToBase64(child: Expression) extends UnaryExpression with InputTypeSpec {
 
@@ -399,7 +398,7 @@ case class ToBase64(child: Expression) extends UnaryExpression with InputTypeSpe
     if (child.resultType == STRING_TYPE_INFO) {
       ValidationSuccess
     } else {
-      ValidationFailure(s"ToBase64 operator requires String input, " +
+      ValidationFailure(s"ToBase64 operator requires a String input, " +
         s"but $child is of type ${child.resultType}")
     }
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -382,4 +382,32 @@ case class FromBase64(child: Expression) extends UnaryExpression with InputTypeS
   }
 
   override def toString: String = s"($child).fromBase64"
+
+}
+
+/**
+  * Returns the string encoded with base64.
+  * Returns NULL If the input string is NULL.
+  */
+case class ToBase64(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == STRING_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"ToBase64 operator requires String input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.TO_BASE64, children.map(_.toRexNode))
+  }
+
+  override def toString: String = s"($child).toBase64"
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -177,4 +177,13 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val TO_BASE64 = new SqlFunction(
+    "TO_BASE64",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
+    InferTypes.RETURN_TYPE,
+    OperandTypes.family(SqlTypeFamily.STRING),
+    SqlFunctionCategory.STRING
+  )
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -182,7 +182,7 @@ object ScalarSqlFunctions {
     SqlKind.OTHER_FUNCTION,
     ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
     InferTypes.RETURN_TYPE,
-    OperandTypes.family(SqlTypeFamily.STRING),
+    OperandTypes.STRING,
     SqlFunctionCategory.STRING
   )
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -202,7 +202,7 @@ object ScalarFunctions {
   def fromBase64(str: String): String = new String(Base64.decodeBase64(str))
 
   /**
-    * Returns a string's representation that encoded as base64.
+    * Returns the base64-encoded result of the input string.
     */
   def toBase64(base: String): String = Base64.encodeBase64String(base.getBytes())
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -201,4 +201,9 @@ object ScalarFunctions {
     */
   def fromBase64(str: String): String = new String(Base64.decodeBase64(str))
 
+  /**
+    * Returns a string's representation that encoded as base64.
+    */
+  def toBase64(base: String): String = Base64.encodeBase64String(base.getBytes())
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -203,6 +203,7 @@ object FunctionCatalog {
     "lpad" -> classOf[Lpad],
     "rpad" -> classOf[Rpad],
     "fromBase64" -> classOf[FromBase64],
+    "toBase64" -> classOf[ToBase64],
 
     // math functions
     "plus" -> classOf[Plus],
@@ -447,6 +448,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.SHA512,
     ScalarSqlFunctions.SHA2,
     ScalarSqlFunctions.FROM_BASE64,
+    ScalarSqlFunctions.TO_BASE64,
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,
     BasicOperatorTable.HOP,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -472,6 +472,40 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "null")
   }
 
+  @Test
+  def testToBase64(): Unit = {
+    testAllApis(
+      'f0.toBase64(),
+      "f0.toBase64()",
+      "TO_BASE64(f0)",
+      "VGhpcyBpcyBhIHRlc3QgU3RyaW5nLg==")
+
+    testAllApis(
+      'f8.toBase64(),
+      "f8.toBase64()",
+      "TO_BASE64(f8)",
+      "IFRoaXMgaXMgYSB0ZXN0IFN0cmluZy4g")
+
+    //null test
+    testAllApis(
+      'f33.toBase64(),
+      "f33.toBase64()",
+      "TO_BASE64(f33)",
+      "null")
+
+    testAllApis(
+      "".toBase64(),
+      "''.toBase64()",
+      "TO_BASE64('')",
+      "")
+
+    testAllApis(
+      'f33.toBase64(),
+      "f33.toBase64()",
+      "to_base64(f33)",
+      "null")
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Math functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -486,23 +486,17 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "TO_BASE64(f8)",
       "IFRoaXMgaXMgYSB0ZXN0IFN0cmluZy4g")
 
-    //null test
-    testAllApis(
-      'f33.toBase64(),
-      "f33.toBase64()",
-      "TO_BASE64(f33)",
-      "null")
-
     testAllApis(
       "".toBase64(),
       "''.toBase64()",
       "TO_BASE64('')",
       "")
 
+    //null test
     testAllApis(
       'f33.toBase64(),
       "f33.toBase64()",
-      "to_base64(f33)",
+      "TO_BASE64(f33)",
       "null")
   }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add TO_BASE64 function for table/sql API*

## Brief change log

  - *Add TO_BASE64 function for table/sql API*

## Verifying this change

This change added tests and can be verified as follows:

  - *ScalarFunctionsTest#testToBase64*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
