### PR TITLE
[FLINK-9296] [table] Add support for non-windowed DISTINCT aggregates.

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2645,7 +2645,6 @@ The following functions are not supported yet:
 
 - Binary string operators and functions
 - System functions
-- Distinct aggregate functions like COUNT DISTINCT
 
 {% top %}
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamGroupAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamGroupAggregateRule.scala
@@ -43,19 +43,13 @@ class DataStreamGroupAggregateRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val agg: FlinkLogicalAggregate = call.rel(0).asInstanceOf[FlinkLogicalAggregate]
 
-    // check if we have distinct aggregates
-    val distinctAggs = agg.getAggCallList.exists(_.isDistinct)
-    if (distinctAggs) {
-      throw TableException("DISTINCT aggregates are currently not supported.")
-    }
-
     // check if we have grouping sets
     val groupSets = agg.getGroupSets.size() != 1 || agg.getGroupSets.get(0) != agg.getGroupSet
     if (groupSets || agg.indicator) {
       throw TableException("GROUPING SETS are currently not supported.")
     }
 
-    !distinctAggs && !groupSets && !agg.indicator
+    !groupSets && !agg.indicator
   }
 
   override def convert(rel: RelNode): RelNode = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/DistinctAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/DistinctAggregateTest.scala
@@ -72,6 +72,28 @@ class DistinctAggregateTest extends TableTestBase {
   }
 
   @Test
+  def testDistinctAggregate(): Unit = {
+    val sqlQuery = "SELECT " +
+      "  c, SUM(DISTINCT a), SUM(a), COUNT(DISTINCT b) " +
+      "FROM MyTable " +
+      "GROUP BY c "
+
+    val expected =
+      unaryNode(
+        "DataStreamGroupAggregate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "c", "a", "b")
+        ),
+        term("groupBy", "c"),
+        term("select", "c",
+          "SUM(DISTINCT a) AS EXPR$1", "SUM(a) AS EXPR$2", "COUNT(DISTINCT b) AS EXPR$3")
+      )
+    streamUtil.verifySql(sqlQuery, expected)
+  }
+
+  @Test
   def testDistinctAggregateOnTumbleWindow(): Unit = {
     val sqlQuery = "SELECT COUNT(DISTINCT a), " +
       "  SUM(a) " +


### PR DESCRIPTION
## What is the purpose of the change

- Fix a regression from 1.5 that was caused by rearranging optimization rules.
- Add tests to ensure the feature won't be broken again.

## Brief change log

- Remove DISTINCT limitation on `DataStreamAggregateRule`.
- Add plan test to ensure queries are correctly translated
- Add ITCase to ensure queries are correctly executed
- Remove outdated limitation from documentation

## Verifying this change

- Run the added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**
