### PR TITLE
[FLINK-9806][docs] Add canonical link element to docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,6 +46,7 @@ download_url: "http://flink.apache.org/downloads.html"
 
 # please use a protocol relative URL here
 baseurl: //ci.apache.org/projects/flink/flink-docs-master
+stable_baseurl: //ci.apache.org/projects/flink/flink-docs-stable
 
 # Flag whether this is a stable version or not. Used for the quickstart page.
 is_stable: false

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -26,6 +26,7 @@ under the License.
     <title>Apache Flink {{ site.version_title }} Documentation: {{ page.title }}</title>
     <link rel="shortcut icon" href="{{ site.baseurl }}/page/favicon.ico" type="image/x-icon">
     <link rel="icon" href="{{ site.baseurl }}/page/favicon.ico" type="image/x-icon">
+    <link rel="canonical" href="{{ site.stable_baseurl }}{{ page.url | replace:'index.html',''}}">
 
     <!-- Bootstrap -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -14,8 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:centos7
+FROM fedora:28
 
-RUN yum install -y vim gem ruby-devel make gcc gcc-c++ python-setuptools && \
-    gem install bundler
-
+RUN set -ex; \
+  dnf install -y \
+    vim \
+    gem \
+    ruby-devel \
+    redhat-rpm-config \
+    make \
+    gcc \
+    gcc-c++ \
+    python-setuptools \
+  ; \
+  gem install bundler; \
+  dnf clean all


### PR DESCRIPTION
## What is the purpose of the change

Flink's documentation's SEO is a mess, with web searches often returning results from many Flink versions, usually with the latest not at the top.

This change adds an HTML `link` tag with `rel="canonical"` to indicate to crawlers where to find the latest version of the page, i.e. served from `//ci.apache.org/projects/flink/flink-docs-stable/`.

## Brief change log

- Update Docker image for building the docs to support the required ruby version
- Add value to the docs config file to indicate the "stable" base URL
- Add a `link` element with `rel="canonical"` to the base template so each page includes it with the appropriate value

## Notes

Once this has been merged, we should port this change to the release branches whose docs are still available.