### PR TITLE
[FLINK-9923][tests] Harden OneInputStreamTaskTest#testWatermarkMetrics

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
@@ -25,10 +25,10 @@ import org.apache.flink.metrics.Gauge;
  */
 public class WatermarkGauge implements Gauge<Long> {
 
-	private long currentWatermark = Long.MIN_VALUE;
+	private volatile long currentWatermark = Long.MIN_VALUE;
 
 	public void setCurrentWatermark(long watermark) {
-		this.currentWatermark = watermark;
+		currentWatermark = watermark;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Convert the WatermarkGauge's field currentWatermark from long to AtomicLong because
writes and reads can happen from different threads. Unfortunately, we cannot simply
make it volatile because not all JVM support atomic writes to longs.

cc @zentol.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
