### PR TITLE
[FLINK-5860] [tests] Replace java.io.tmpdir with JUnit TemporaryFolder in tests

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
@@ -28,7 +28,11 @@ import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.types.IntValue;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
 
 
 public class DelimitedInputFormatSamplingTest {
@@ -68,6 +72,11 @@ public class DelimitedInputFormatSamplingTest {
 	private static final int DEFAULT_NUM_SAMPLES = 4;
 	
 	private static Configuration CONFIG;
+
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+	private static File testTempFolder;
 	
 	// ========================================================================
 	//  Setup
@@ -76,11 +85,13 @@ public class DelimitedInputFormatSamplingTest {
 	@BeforeClass
 	public static void initialize() {
 		try {
+			testTempFolder = tempFolder.newFolder();
 			// make sure we do 4 samples
 			CONFIG = TestConfigUtils.loadGlobalConf(
 				new String[] { OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES.key(),
 								OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES.key() },
-				new String[] { "4", "4" });
+				new String[] { "4", "4" },
+				testTempFolder);
 
 
 		} catch (Throwable t) {
@@ -125,7 +136,7 @@ public class DelimitedInputFormatSamplingTest {
 	@Test
 	public void testNumSamplesMultipleFiles() {
 		try {
-			final String tempFile = TestFileUtils.createTempFileDir(TEST_DATA1, TEST_DATA1, TEST_DATA1, TEST_DATA1);
+			final String tempFile = TestFileUtils.createTempFileDir(testTempFolder, TEST_DATA1, TEST_DATA1, TEST_DATA1, TEST_DATA1);
 			final Configuration conf = new Configuration();
 			
 			final TestDelimitedInputFormat format = new TestDelimitedInputFormat(CONFIG);
@@ -175,7 +186,7 @@ public class DelimitedInputFormatSamplingTest {
 	@Test
 	public void testSamplingDirectory() {
 		try {
-			final String tempFile = TestFileUtils.createTempFileDir(TEST_DATA1, TEST_DATA2);
+			final String tempFile = TestFileUtils.createTempFileDir(testTempFolder, TEST_DATA1, TEST_DATA2);
 			final Configuration conf = new Configuration();
 			
 			final TestDelimitedInputFormat format = new TestDelimitedInputFormat(CONFIG);

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/EnumerateNestedFilesTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/EnumerateNestedFilesTest.java
@@ -30,12 +30,16 @@ import org.apache.flink.types.IntValue;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-public class EnumerateNestedFilesTest { 
+public class EnumerateNestedFilesTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	protected Configuration config;
-	final String tempPath = System.getProperty("java.io.tmpdir");
 
 	private DummyFileInputFormat format;
 
@@ -81,15 +85,8 @@ public class EnumerateNestedFilesTest {
 			String firstLevelDir = TestFileUtils.randomFileName();
 			String secondLevelDir = TestFileUtils.randomFileName();
 
-			File nestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir);
-			nestedDir.mkdirs();
-			nestedDir.deleteOnExit();
-
-			File insideNestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir);
-			insideNestedDir.mkdirs();
-			insideNestedDir.deleteOnExit();
+			File insideNestedDir = tempFolder.newFolder(firstLevelDir, secondLevelDir);
+			File nestedDir = insideNestedDir.getParentFile();
 
 			// create a file in the first-level and two files in the nested dir
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), "paella");
@@ -117,15 +114,8 @@ public class EnumerateNestedFilesTest {
 			String firstLevelDir = TestFileUtils.randomFileName();
 			String secondLevelDir = TestFileUtils.randomFileName();
 
-			File nestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir);
-			nestedDir.mkdirs();
-			nestedDir.deleteOnExit();
-
-			File insideNestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir);
-			insideNestedDir.mkdirs();
-			insideNestedDir.deleteOnExit();
+			File insideNestedDir = tempFolder.newFolder(firstLevelDir, secondLevelDir);
+			File nestedDir = insideNestedDir.getParentFile();
 
 			// create a file in the first-level and two files in the nested dir
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), "paella");
@@ -154,21 +144,9 @@ public class EnumerateNestedFilesTest {
 			String secondLevelDir = TestFileUtils.randomFileName();
 			String thirdLevelDir = TestFileUtils.randomFileName();
 
-			File nestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir);
-			nestedDir.mkdirs();
-			nestedDir.deleteOnExit();
-
-			File insideNestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir);
-			insideNestedDir.mkdirs();
-			insideNestedDir.deleteOnExit();
-
-			File nestedNestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir
-					+ System.getProperty("file.separator") + thirdLevelDir);
-			nestedNestedDir.mkdirs();
-			nestedNestedDir.deleteOnExit();
+			File nestedNestedDir = tempFolder.newFolder(firstLevelDir, secondLevelDir, thirdLevelDir);
+			File insideNestedDir = nestedNestedDir.getParentFile();
+			File nestedDir = insideNestedDir.getParentFile();
 
 			// create a file in the first-level, two files in the second level and one in the third level
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), "paella");
@@ -199,23 +177,10 @@ public class EnumerateNestedFilesTest {
 			String firstNestedNestedDir = TestFileUtils.randomFileName();
 			String secondNestedNestedDir = TestFileUtils.randomFileName();
 
-			File testDir = new File(tempPath + System.getProperty("file.separator") + rootDir);
-			testDir.mkdirs();
-			testDir.deleteOnExit();
-
-			File nested = new File(testDir.getAbsolutePath() + System.getProperty("file.separator") + nestedDir);
-			nested.mkdirs();
-			nested.deleteOnExit();
-
-			File nestedNestedDir1 = new File(nested.getAbsolutePath() + System.getProperty("file.separator")
-					+ firstNestedNestedDir);
-			nestedNestedDir1.mkdirs();
-			nestedNestedDir1.deleteOnExit();
-
-			File nestedNestedDir2 = new File(nested.getAbsolutePath() + System.getProperty("file.separator")
-					+ secondNestedNestedDir);
-			nestedNestedDir2.mkdirs();
-			nestedNestedDir2.deleteOnExit();
+			File testDir = tempFolder.newFolder(rootDir);
+			tempFolder.newFolder(rootDir, nestedDir);
+			File nestedNestedDir1 = tempFolder.newFolder(rootDir, nestedDir, firstNestedNestedDir);
+			File nestedNestedDir2 = tempFolder.newFolder(rootDir, nestedDir, secondNestedNestedDir);
 
 			// create files in second level
 			TestFileUtils.createTempFileInDirectory(nestedNestedDir1.getAbsolutePath(), "paella");
@@ -240,9 +205,6 @@ public class EnumerateNestedFilesTest {
 	 */
 	@Test
 	public void testTwoNestedDirectoriesWithFilteredFilesTrue() {
-
-		String sep = System.getProperty("file.separator");
-
 		try {
 			String firstLevelDir = TestFileUtils.randomFileName();
 			String secondLevelDir = TestFileUtils.randomFileName();
@@ -250,26 +212,12 @@ public class EnumerateNestedFilesTest {
 			String secondLevelFilterDir = "_"+TestFileUtils.randomFileName();
 			String thirdLevelFilterDir = "_"+TestFileUtils.randomFileName();
 
-			File nestedDir = new File(tempPath + sep + firstLevelDir);
-			nestedDir.mkdirs();
-			nestedDir.deleteOnExit();
-
-			File insideNestedDir = new File(tempPath + sep + firstLevelDir + sep + secondLevelDir);
-			insideNestedDir.mkdirs();
-			insideNestedDir.deleteOnExit();
-			File insideNestedDirFiltered = new File(tempPath + sep + firstLevelDir + sep + secondLevelFilterDir);
-			insideNestedDirFiltered.mkdirs();
-			insideNestedDirFiltered.deleteOnExit();
-			File filteredFile = new File(tempPath + sep + firstLevelDir + sep + "_IWillBeFiltered");
-			filteredFile.createNewFile();
-			filteredFile.deleteOnExit();
-
-			File nestedNestedDir = new File(tempPath + sep + firstLevelDir + sep + secondLevelDir + sep + thirdLevelDir);
-			nestedNestedDir.mkdirs();
-			nestedNestedDir.deleteOnExit();
-			File nestedNestedDirFiltered = new File(tempPath + sep + firstLevelDir + sep + secondLevelDir + sep + thirdLevelFilterDir);
-			nestedNestedDirFiltered.mkdirs();
-			nestedNestedDirFiltered.deleteOnExit();
+			File nestedNestedDirFiltered = tempFolder.newFolder(firstLevelDir, secondLevelDir, thirdLevelDir, thirdLevelFilterDir);
+			File nestedNestedDir = nestedNestedDirFiltered.getParentFile();
+			File insideNestedDir = nestedNestedDir.getParentFile();
+			File nestedDir = insideNestedDir.getParentFile();
+			File insideNestedDirFiltered = tempFolder.newFolder(firstLevelDir, secondLevelFilterDir);
+			new File(nestedDir, "_IWillBeFiltered");
 
 			// create a file in the first-level, two files in the second level and one in the third level
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), "paella");
@@ -300,15 +248,8 @@ public class EnumerateNestedFilesTest {
 			String firstLevelDir = TestFileUtils.randomFileName();
 			String secondLevelDir = TestFileUtils.randomFileName();
 
-			File nestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir);
-			nestedDir.mkdirs();
-			nestedDir.deleteOnExit();
-
-			File insideNestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir);
-			insideNestedDir.mkdirs();
-			insideNestedDir.deleteOnExit();
+			File insideNestedDir = tempFolder.newFolder(firstLevelDir, secondLevelDir);
+			File nestedDir = insideNestedDir.getParentFile();
 
 			// create a file in the nested dir
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE);
@@ -338,22 +279,11 @@ public class EnumerateNestedFilesTest {
 			String secondLevelDir = TestFileUtils.randomFileName();
 			String secondLevelDir2 = TestFileUtils.randomFileName();
 
-			File nestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir);
-			nestedDir.mkdirs();
-			nestedDir.deleteOnExit();
+			File insideNestedDir = tempFolder.newFolder(firstLevelDir, secondLevelDir);
+			File insideNestedDir2 = tempFolder.newFolder(firstLevelDir, secondLevelDir2);
+			File nestedDir = insideNestedDir.getParentFile();
 
-			File insideNestedDir = new File(tempPath + System.getProperty("file.separator") 
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir);
-			insideNestedDir.mkdirs();
-			insideNestedDir.deleteOnExit();
-
-			File insideNestedDir2 = new File(tempPath + System.getProperty("file.separator")
-					+ firstLevelDir + System.getProperty("file.separator") + secondLevelDir2);
-			insideNestedDir2.mkdirs();
-			insideNestedDir2.deleteOnExit();
-
-			// create a file in the first-level and two files in the nested dir
+				// create a file in the first-level and two files in the nested dir
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), SIZE1);
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE2);
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE3);

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/EnumerateNestedFilesTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/EnumerateNestedFilesTest.java
@@ -217,7 +217,8 @@ public class EnumerateNestedFilesTest {
 			File insideNestedDir = nestedNestedDir.getParentFile();
 			File nestedDir = insideNestedDir.getParentFile();
 			File insideNestedDirFiltered = tempFolder.newFolder(firstLevelDir, secondLevelFilterDir);
-			new File(nestedDir, "_IWillBeFiltered");
+			File filteredFile = new File(nestedDir, "_IWillBeFiltered");
+			filteredFile.createNewFile();
 
 			// create a file in the first-level, two files in the second level and one in the third level
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), "paella");
@@ -283,7 +284,7 @@ public class EnumerateNestedFilesTest {
 			File insideNestedDir2 = tempFolder.newFolder(firstLevelDir, secondLevelDir2);
 			File nestedDir = insideNestedDir.getParentFile();
 
-				// create a file in the first-level and two files in the nested dir
+			// create a file in the first-level and two files in the nested dir
 			TestFileUtils.createTempFileInDirectory(nestedDir.getAbsolutePath(), SIZE1);
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE2);
 			TestFileUtils.createTempFileInDirectory(insideNestedDir.getAbsolutePath(), SIZE3);

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -299,7 +299,7 @@ public class FileInputFormatTest {
 			final long SIZE3 = 10;
 			final long TOTAL = SIZE1 + SIZE2 + SIZE3;
 			
-			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
+			String tempDir = TestFileUtils.createTempFileDir(temporaryFolder.newFolder(), SIZE1, SIZE2, SIZE3);
 			
 			final DummyFileInputFormat format = new DummyFileInputFormat();
 			format.setFilePath(tempDir);
@@ -455,13 +455,13 @@ public class FileInputFormatTest {
 		final long size3 = 10;
 		final long totalSize123 = size1 + size2 + size3;
 		
-		String tempDir = TestFileUtils.createTempFileDir(size1, size2, size3);
+		String tempDir = TestFileUtils.createTempFileDir(temporaryFolder.newFolder(), size1, size2, size3);
 		
 		final long size4 = 2051;
 		final long size5 = 31902;
 		final long size6 = 15;
 		final long totalSize456 = size4 + size5 + size6;
-		String tempDir2 = TestFileUtils.createTempFileDir(size4, size5, size6);
+		String tempDir2 = TestFileUtils.createTempFileDir(temporaryFolder.newFolder(), size4, size5, size6);
 
 		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
 		format.setFilePaths(tempDir, tempDir2);
@@ -532,7 +532,7 @@ public class FileInputFormatTest {
 	@Test
 	public void testFileInputSplit() {
 		try {
-			String tempFile = TestFileUtils.createTempFileDirExtension(".deflate", "some", "stupid", "meaningless", "files");
+			String tempFile = TestFileUtils.createTempFileDirExtension(temporaryFolder.newFolder(), ".deflate", "some", "stupid", "meaningless", "files");
 			final DummyFileInputFormat format = new DummyFileInputFormat();
 			format.setFilePath(tempFile);
 			format.configure(new Configuration());

--- a/flink-core/src/test/java/org/apache/flink/testutils/TestConfigUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestConfigUtils.java
@@ -31,12 +31,11 @@ import org.apache.flink.configuration.GlobalConfiguration;
  */
 public final class TestConfigUtils {
 	
-	public static Configuration loadGlobalConf(String[] keys, String[] values) throws IOException {
-		return loadGlobalConf(getConfAsString(keys, values));
+	public static Configuration loadGlobalConf(String[] keys, String[] values, File tempDir) throws IOException {
+		return loadGlobalConf(getConfAsString(keys, values), tempDir);
 	}
 	
-	public static Configuration loadGlobalConf(String contents) throws IOException {
-		final File tempDir = new File(System.getProperty("java.io.tmpdir"));
+	public static Configuration loadGlobalConf(String contents, File tempDir) throws IOException {
 		File confDir;
 		do {
 			confDir = new File(tempDir, TestFileUtils.randomFileName());

--- a/flink-core/src/test/java/org/apache/flink/testutils/TestFileUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestFileUtils.java
@@ -90,8 +90,7 @@ public class TestFileUtils {
 	
 	// ------------------------------------------------------------------------
 
-	public static String createTempFileDir(long ... bytes) throws IOException {
-		File tempDir = new File(System.getProperty("java.io.tmpdir"));
+	public static String createTempFileDir(File tempDir, long ... bytes) throws IOException {
 		File f = null;
 		do {
 			f = new File(tempDir, randomFileName());
@@ -112,12 +111,11 @@ public class TestFileUtils {
 		return f.toURI().toString();
 	}
 	
-	public static String createTempFileDir(String ... contents) throws IOException {
-		return createTempFileDirExtension(FILE_SUFFIX, contents);
+	public static String createTempFileDir(File tempDir, String ... contents) throws IOException {
+		return createTempFileDirExtension(tempDir, FILE_SUFFIX, contents);
 	}
 	
-	public static String createTempFileDirExtension(String fileExtension, String ... contents ) throws IOException {
-		File tempDir = new File(System.getProperty("java.io.tmpdir"));
+	public static String createTempFileDirExtension(File tempDir, String fileExtension, String ... contents ) throws IOException {
 		File f = null;
 		do {
 			f = new File(tempDir, randomFileName(FILE_SUFFIX));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSinkTaskTest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -60,8 +61,6 @@ public class DataSinkTaskTest extends TaskTestBase {
 
 	private static final int NETWORK_BUFFER_SIZE = 1024;
 
-	private final String tempTestFileName = getClass().getName() + "-dst_test";
-
 	@Test
 	public void testDataSinkTask() {
 		FileReader fr = null;
@@ -75,7 +74,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 
 			DataSinkTask<Record> testTask = new DataSinkTask<>(this.mockEnv);
 
-			File tempTestFile = tempFolder.newFile(tempTestFileName);
+			File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
 			super.registerFileOutputTask(MockOutputFormat.class, tempTestFile.toURI().toString());
 
 			testTask.invoke();
@@ -136,12 +135,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 
 		DataSinkTask<Record> testTask = new DataSinkTask<>(this.mockEnv);
 
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-		} catch (IOException ex) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
 		super.registerFileOutputTask(MockOutputFormat.class, tempTestFile.toURI().toString());
 
 		try {
@@ -224,12 +218,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 		super.getTaskConfig().setFilehandlesInput(0, 8);
 		super.getTaskConfig().setSpillingThresholdInput(0, 0.8f);
 
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-		} catch (IOException ex) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());;
 		super.registerFileOutputTask(MockOutputFormat.class, tempTestFile.toURI().toString());
 
 		try {
@@ -300,12 +289,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 		Configuration stubParams = new Configuration();
 		super.getTaskConfig().setStubParameters(stubParams);
 
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-		} catch (IOException ex) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
 		super.registerFileOutputTask(MockFailingOutputFormat.class, tempTestFile.toURI().toString());
 
 		boolean stubFailed = false;
@@ -345,12 +329,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 		super.getTaskConfig().setFilehandlesInput(0, 8);
 		super.getTaskConfig().setSpillingThresholdInput(0, 0.8f);
 
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-		} catch (IOException ex) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
 		super.registerFileOutputTask(MockFailingOutputFormat.class, tempTestFile.toURI().toString());
 
 		boolean stubFailed = false;
@@ -376,7 +355,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 		Configuration stubParams = new Configuration();
 		super.getTaskConfig().setStubParameters(stubParams);
 
-		File tempTestFile = tempFolder.newFile(tempTestFileName);
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
 
 		super.registerFileOutputTask(MockOutputFormat.class, tempTestFile.toURI().toString());
 
@@ -432,12 +411,7 @@ public class DataSinkTaskTest extends TaskTestBase {
 		super.getTaskConfig().setFilehandlesInput(0, 8);
 		super.getTaskConfig().setSpillingThresholdInput(0, 0.8f);
 
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-		} catch (IOException ex) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
 		super.registerFileOutputTask(MockOutputFormat.class, tempTestFile.toURI().toString());
 
 		Thread taskRunner = new Thread() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSourceTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/DataSourceTaskTest.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 
 public class DataSourceTaskTest extends TaskTestBase {
 
@@ -54,24 +55,16 @@ public class DataSourceTaskTest extends TaskTestBase {
 	private static final int NETWORK_BUFFER_SIZE = 1024;
 
 	private List<Record> outList;
-
-	private final String tempTestFileName = getClass().getName() + "-dst_test";
 	
 	@Test
-	public void testDataSourceTask() {
+	public void testDataSourceTask() throws IOException {
 		int keyCnt = 100;
 		int valCnt = 20;
 		
 		this.outList = new ArrayList<Record>();
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-			InputFilePreparator.prepareInputFile(new UniformRecordGenerator(keyCnt, valCnt, false),
-				tempTestFile, true);
-		} catch (IOException e1) {
-			System.err.println(e1);
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
+		InputFilePreparator.prepareInputFile(new UniformRecordGenerator(keyCnt, valCnt, false),
+			tempTestFile, true);
 		
 		super.initEnvironment(MEMORY_MANAGER_SIZE, NETWORK_BUFFER_SIZE);
 		super.addOutput(this.outList);
@@ -126,19 +119,14 @@ public class DataSourceTaskTest extends TaskTestBase {
 	}
 	
 	@Test
-	public void testFailingDataSourceTask() {
+	public void testFailingDataSourceTask() throws IOException {
 		int keyCnt = 20;
 		int valCnt = 10;
 		
 		this.outList = new NirvanaOutputList();
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-			InputFilePreparator.prepareInputFile(new UniformRecordGenerator(keyCnt, valCnt, false), 
-				tempTestFile, false);
-		} catch (IOException e1) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
+		InputFilePreparator.prepareInputFile(new UniformRecordGenerator(keyCnt, valCnt, false),
+			tempTestFile, false);
 
 		super.initEnvironment(MEMORY_MANAGER_SIZE, NETWORK_BUFFER_SIZE);
 		super.addOutput(this.outList);
@@ -162,20 +150,15 @@ public class DataSourceTaskTest extends TaskTestBase {
 	}
 	
 	@Test
-	public void testCancelDataSourceTask() {
+	public void testCancelDataSourceTask() throws IOException {
 		int keyCnt = 20;
 		int valCnt = 4;
 
 		super.initEnvironment(MEMORY_MANAGER_SIZE, NETWORK_BUFFER_SIZE);
 		super.addOutput(new NirvanaOutputList());
-		File tempTestFile = null;
-		try {
-			tempTestFile = tempFolder.newFile(tempTestFileName);
-			InputFilePreparator.prepareInputFile(new UniformRecordGenerator(keyCnt, valCnt, false), 
-				tempTestFile, false);
-		} catch (IOException e1) {
-			Assert.fail("Unable to set-up test input file");
-		}
+		File tempTestFile = new File(tempFolder.getRoot(), UUID.randomUUID().toString());
+		InputFilePreparator.prepareInputFile(new UniformRecordGenerator(keyCnt, valCnt, false),
+			tempTestFile, false);
 		
 		final DataSourceTask<Record> testTask = new DataSourceTask<>(this.mockEnv);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -59,7 +59,9 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -83,6 +85,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TaskExecutorITCase extends TestLogger {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	private final Time timeout = Time.seconds(10L);
 
@@ -127,7 +132,7 @@ public class TaskExecutorITCase extends TestLogger {
 			TestingUtils.infiniteTime());
 
 		final File[] taskExecutorLocalStateRootDirs =
-			new File[]{new File(System.getProperty("java.io.tmpdir"), "localRecovery")};
+			new File[]{ tempFolder.newFolder("localRecovery") };
 
 		final TaskExecutorLocalStateStoresManager taskStateManager = new TaskExecutorLocalStateStoresManager(
 			false,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -132,7 +132,7 @@ public class TaskExecutorITCase extends TestLogger {
 			TestingUtils.infiniteTime());
 
 		final File[] taskExecutorLocalStateRootDirs =
-			new File[]{ tempFolder.newFolder("localRecovery") };
+			new File[]{ new File(tempFolder.getRoot(),"localRecovery") };
 
 		final TaskExecutorLocalStateStoresManager taskStateManager = new TaskExecutorLocalStateStoresManager(
 			false,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JarFileCreatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JarFileCreatorTest.java
@@ -31,7 +31,10 @@ import org.apache.flink.runtime.util.jartestprogram.AnonymousInNonStaticMethod2;
 import org.apache.flink.runtime.util.jartestprogram.NestedAnonymousInnerClass;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,10 +45,13 @@ import java.util.zip.ZipEntry;
 
 public class JarFileCreatorTest {
 
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
 	//anonymous inner class in static method accessing a local variable in its closure.
 	@Test
 	public void TestAnonymousInnerClassTrick1() throws Exception {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(AnonymousInStaticMethod.class)
 			.createJarFile();
@@ -63,7 +69,7 @@ public class JarFileCreatorTest {
 	//anonymous inner class in non static method accessing a local variable in its closure.
 	@Test
 	public void TestAnonymousInnerClassTrick2() throws Exception {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(AnonymousInNonStaticMethod.class)
 			.createJarFile();
@@ -81,7 +87,7 @@ public class JarFileCreatorTest {
 	//anonymous inner class in non static method accessing a field of its enclosing class.
 	@Test
 	public void TestAnonymousInnerClassTrick3() throws Exception {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(AnonymousInNonStaticMethod2.class)
 			.createJarFile();
@@ -99,7 +105,7 @@ public class JarFileCreatorTest {
 	//anonymous inner class in an anonymous inner class accessing a field of the outermost enclosing class.
 	@Test
 	public void TestAnonymousInnerClassTrick4() throws Exception {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(NestedAnonymousInnerClass.class)
 			.createJarFile();
@@ -118,7 +124,7 @@ public class JarFileCreatorTest {
 	@Ignore // this is currently not supported (see FLINK-9520)
 	@Test
 	public void testFilterWithMethodReference() throws Exception {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(FilterWithMethodReference.class)
 			.createJarFile();
@@ -133,7 +139,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void testFilterWithLambda() throws Exception{
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(FilterWithLambda.class)
 			.createJarFile();
@@ -148,7 +154,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void testFilterWithIndirection() throws Exception {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(FilterWithIndirection.class)
 			.createJarFile();
@@ -167,7 +173,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestExternalClass() throws IOException {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithExternalClass.class)
 			.createJarFile();
@@ -184,7 +190,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestInnerClass() throws IOException {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithInnerClass.class)
 			.createJarFile();
@@ -201,7 +207,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestAnonymousClass() throws IOException {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithAnonymousClass.class)
 			.createJarFile();
@@ -218,7 +224,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestExtendIdentifier() throws IOException {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithExternalClass2.class)
 			.createJarFile();
@@ -236,7 +242,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestUDFPackage() throws IOException {
-		File out = new File(System.getProperty("java.io.tmpdir"), "jarcreatortest.jar");
+		File out = tempFolder.newFile("jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithInnerClass.class)
 			.addPackage("org.apache.flink.util")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JarFileCreatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JarFileCreatorTest.java
@@ -69,7 +69,7 @@ public class JarFileCreatorTest {
 	//anonymous inner class in non static method accessing a local variable in its closure.
 	@Test
 	public void TestAnonymousInnerClassTrick2() throws Exception {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(AnonymousInNonStaticMethod.class)
 			.createJarFile();
@@ -87,7 +87,7 @@ public class JarFileCreatorTest {
 	//anonymous inner class in non static method accessing a field of its enclosing class.
 	@Test
 	public void TestAnonymousInnerClassTrick3() throws Exception {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(AnonymousInNonStaticMethod2.class)
 			.createJarFile();
@@ -105,7 +105,7 @@ public class JarFileCreatorTest {
 	//anonymous inner class in an anonymous inner class accessing a field of the outermost enclosing class.
 	@Test
 	public void TestAnonymousInnerClassTrick4() throws Exception {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(NestedAnonymousInnerClass.class)
 			.createJarFile();
@@ -124,7 +124,7 @@ public class JarFileCreatorTest {
 	@Ignore // this is currently not supported (see FLINK-9520)
 	@Test
 	public void testFilterWithMethodReference() throws Exception {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(FilterWithMethodReference.class)
 			.createJarFile();
@@ -139,7 +139,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void testFilterWithLambda() throws Exception{
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(FilterWithLambda.class)
 			.createJarFile();
@@ -154,7 +154,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void testFilterWithIndirection() throws Exception {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(FilterWithIndirection.class)
 			.createJarFile();
@@ -173,7 +173,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestExternalClass() throws IOException {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithExternalClass.class)
 			.createJarFile();
@@ -190,7 +190,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestInnerClass() throws IOException {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithInnerClass.class)
 			.createJarFile();
@@ -207,7 +207,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestAnonymousClass() throws IOException {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithAnonymousClass.class)
 			.createJarFile();
@@ -224,7 +224,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestExtendIdentifier() throws IOException {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithExternalClass2.class)
 			.createJarFile();
@@ -242,7 +242,7 @@ public class JarFileCreatorTest {
 
 	@Test
 	public void TestUDFPackage() throws IOException {
-		File out = tempFolder.newFile("jarcreatortest.jar");
+		File out = new File(tempFolder.getRoot(), "jarcreatortest.jar");
 		JarFileCreator jfc = new JarFileCreator(out);
 		jfc.addClass(WordCountWithInnerClass.class)
 			.addPackage("org.apache.flink.util")

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -108,7 +108,7 @@ public class RocksDBStateBackendConfigTest {
 		rocksDbBackend.setDbStoragePaths(testDir1, testDir2);
 		assertArrayEquals(new String[] { testDir1, testDir2 }, rocksDbBackend.getDbStoragePaths());
 
-		final Environment env = getMockEnvironment(new File[] { tempFolder.newFolder() });
+		final Environment env = getMockEnvironment(tempFolder.newFolder());
 		final RocksDBKeyedStateBackend<Integer> keyedBackend = createKeyedStateBackend(rocksDbBackend, env);
 
 		try {
@@ -171,7 +171,7 @@ public class RocksDBStateBackendConfigTest {
 		final RocksDBStateBackend rocksDbBackend = new RocksDBStateBackend(tempFolder.newFolder().toURI().toString());
 		rocksDbBackend.setDbStoragePath(configuredPath);
 
-		final Environment env = getMockEnvironment(new File[] { tempFolder.newFolder() });
+		final Environment env = getMockEnvironment(tempFolder.newFolder());
 		RocksDBKeyedStateBackend<Integer> keyedBackend = createKeyedStateBackend(rocksDbBackend, env);
 
 		try {
@@ -229,11 +229,9 @@ public class RocksDBStateBackendConfigTest {
 		File dir1 = tempFolder.newFolder();
 		File dir2 = tempFolder.newFolder();
 
-		File[] tempDirs = new File[] { dir1, dir2 };
-
 		assertNull(rocksDbBackend.getDbStoragePaths());
 
-		Environment env = getMockEnvironment(tempDirs);
+		Environment env = getMockEnvironment(dir1, dir2);
 		RocksDBKeyedStateBackend<Integer> keyedBackend = (RocksDBKeyedStateBackend<Integer>) rocksDbBackend.
 				createKeyedStateBackend(
 						env,
@@ -273,7 +271,7 @@ public class RocksDBStateBackendConfigTest {
 
 			boolean hasFailure = false;
 			try {
-				Environment env = getMockEnvironment(new File[] { tempFolder.newFolder() });
+				Environment env = getMockEnvironment(tempFolder.newFolder());
 				rocksDbBackend.createKeyedStateBackend(
 						env,
 						env.getJobID(),
@@ -314,7 +312,7 @@ public class RocksDBStateBackendConfigTest {
 			rocksDbBackend.setDbStoragePaths(targetDir1.getAbsolutePath(), targetDir2.getAbsolutePath());
 
 			try {
-				Environment env = getMockEnvironment(new File[] { tempFolder.newFolder() });
+				Environment env = getMockEnvironment(tempFolder.newFolder());
 				AbstractKeyedStateBackend<Integer> keyedStateBackend = rocksDbBackend.createKeyedStateBackend(
 					env,
 					env.getJobID(),
@@ -479,7 +477,7 @@ public class RocksDBStateBackendConfigTest {
 						env.getTaskKvStateRegistry());
 	}
 
-	static Environment getMockEnvironment(File[] tempDirs) {
+	static Environment getMockEnvironment(File... tempDirs) {
 		final String[] tempDirStrings = new String[tempDirs.length];
 		for (int i = 0; i < tempDirs.length; i++) {
 			tempDirStrings[i] = tempDirs[i].getAbsolutePath();

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -40,15 +40,6 @@ import java.util.Map;
 public class CommonTestUtils {
 
 	/**
-	 * Reads the path to the directory for temporary files from the configuration and returns it.
-	 *
-	 * @return the path to the directory for temporary files
-	 */
-	public static String getTempDir() {
-		return System.getProperty("java.io.tmpdir");
-	}
-
-	/**
 	 * Creates a copy of an object via Java Serialization.
 	 *
 	 * @param original The original object.


### PR DESCRIPTION
## What is the purpose of the change

JUnit's TemporaryFolder is a better way to handle temporary folders in tests as JUnit takes care of creation and cleanup of temporary files and folders automatically.

## Brief change log

Replaced usage of `java.io.tmpdir` with `org.junit.rules.TemporaryFolder` in test files.

## Verifying this change

The change addresses the usage of `java.io.tmpdir` in test files with a suitable replacement offered by JUnit. This doesn't change the functionality or validity of the tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable