### PR TITLE
[FLINK-9934] [table] Fix invalid field mapping by Kafka table source factory

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -50,6 +50,7 @@ import org.apache.flink.table.factories.utils.TestTableFormat;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.TableSourceUtil;
 import org.apache.flink.table.sources.tsextractors.ExistingField;
 import org.apache.flink.table.sources.wmstrategies.AscendingTimestamps;
 import org.apache.flink.types.Row;
@@ -115,7 +116,9 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 
 		final Map<String, String> fieldMapping = new HashMap<>();
 		fieldMapping.put(FRUIT_NAME, NAME);
+		fieldMapping.put(NAME, NAME);
 		fieldMapping.put(COUNT, COUNT);
+		fieldMapping.put(TIME, TIME);
 
 		final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
 		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_0), OFFSET_0);
@@ -140,6 +143,8 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 			deserializationSchema,
 			StartupMode.SPECIFIC_OFFSETS,
 			specificOffsets);
+
+		TableSourceUtil.validateTableSource(expected);
 
 		// construct table source using descriptors and table source factory
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/SchemaValidator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/SchemaValidator.scala
@@ -21,6 +21,8 @@ package org.apache.flink.table.descriptors
 import java.util
 import java.util.Optional
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.table.api.{TableException, TableSchema, ValidationException}
 import org.apache.flink.table.descriptors.DescriptorProperties.{toJava, toScala}
 import org.apache.flink.table.descriptors.RowtimeValidator._
@@ -222,22 +224,27 @@ object SchemaValidator {
 
   /**
     * Finds a table source field mapping.
+    *
+    * @param properties The properties describing a schema.
+    * @param inputType  The input type that a connector and/or format produces. This parameter
+    *                   can be used to resolve a rowtime field against an input field.
     */
   def deriveFieldMapping(
       properties: DescriptorProperties,
-      sourceSchema: Optional[TableSchema])
+      inputType: Optional[TypeInformation[_]])
     : util.Map[String, String] = {
 
     val mapping = mutable.Map[String, String]()
 
     val schema = properties.getTableSchema(SCHEMA)
 
-    // add all source fields first because rowtime might reference one of them
-    toScala(sourceSchema).map(_.getColumnNames).foreach { names =>
-      names.foreach { name =>
-        mapping.put(name, name)
-      }
+    val columnNames = toScala(inputType) match {
+      case Some(composite: CompositeType[_]) => composite.getFieldNames.toSeq
+      case _ => Seq[String]()
     }
+
+    // add all source fields first because rowtime might reference one of them
+    columnNames.foreach(name => mapping.put(name, name))
 
     // add all schema fields first for implicit mappings
     schema.getColumnNames.foreach { name =>
@@ -266,7 +273,7 @@ object SchemaValidator {
             mapping.remove(name)
           }
           // check for invalid fields
-          else if (toScala(sourceSchema).forall(s => !s.getColumnNames.contains(name))) {
+          else if (!columnNames.contains(name)) {
             throw new ValidationException(s"Could not map the schema field '$name' to a field " +
               s"from source. Please specify the source field from which it can be derived.")
           }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/SchemaValidatorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/SchemaValidatorTest.scala
@@ -67,7 +67,7 @@ class SchemaValidatorTest {
       "myField" -> "myField").asJava
     assertEquals(
       expectedMapping,
-      SchemaValidator.deriveFieldMapping(props, Optional.of(inputSchema)))
+      SchemaValidator.deriveFieldMapping(props, Optional.of(inputSchema.toRowType)))
 
     // test field format
     val formatSchema = SchemaValidator.deriveFormatFields(props)
@@ -148,7 +148,7 @@ class SchemaValidatorTest {
       "myTime" -> "myTime").asJava
     assertEquals(
       expectedMapping,
-      SchemaValidator.deriveFieldMapping(props, Optional.of(inputSchema)))
+      SchemaValidator.deriveFieldMapping(props, Optional.of(inputSchema.toRowType)))
 
     // test field format
     val formatSchema = SchemaValidator.deriveFormatFields(props)


### PR DESCRIPTION
## What is the purpose of the change

According to the `DefinedFieldMapping` interface the field mapping can also contain the input fields. However, the Kafka table source factory was calling `SchemaValidator#deriveFieldMapping` with its own schema instead of the the input type. 


## Brief change log

- Replace schema with type in `SchemaValidator#deriveFieldMapping` to avoid confusion
- Adapted tests

## Verifying this change

The `KafkaTableSourceSinkFactoryTestBase` has been extended.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
