### PR TITLE
[FLINK-9899][Kinesis Connector] Add comprehensive per-shard metrics to ShardConsumer

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1393,6 +1393,80 @@ Thus, in order to infer the metric identifier:
       </td>
       <td>Gauge</td>
     </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>sleepTimeMillis</td>
+      <td>stream, shardId</td>
+      <td>The number of milliseconds the consumer spends sleeping before fetching records from Kinesis.
+      A particular shard's metric can be specified by stream name and shard id.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>maxNumberOfRecordsPerFetch</td>
+      <td>stream, shardId</td>
+      <td>The maximum number of records requested by the consumer in a single getRecords call to Kinesis. If ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS
+      is set to true, this value is adaptively calculated to maximize the 2 Mbps read limits from Kinesis.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>numberOfAggregatedRecordsPerFetch</td>
+      <td>stream, shardId</td>
+      <td>The number of aggregated Kinesis records fetched by the consumer in a single getRecords call to Kinesis.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>numberOfDeggregatedRecordsPerFetch</td>
+      <td>stream, shardId</td>
+      <td>The number of deaggregated Kinesis records fetched by the consumer in a single getRecords call to Kinesis.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>averageRecordSizeBytes</td>
+      <td>stream, shardId</td>
+      <td>The average size of a Kinesis record in bytes, fetched by the consumer in a single getRecords call.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>runLoopTimeNanos</td>
+      <td>stream, shardId</td>
+      <td>The actual time taken, in nanoseconds, by the consumer in the run loop.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>loopFrequencyHz</td>
+      <td>stream, shardId</td>
+      <td> The number of calls to getRecords in one second. 
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>bytesRequestedPerFetch</td>
+      <td>stream, shardId</td>
+      <td> The bytes requested (2 Mbps / loopFrequencyHz) in a single call to getRecords.
+      A value of -1 indicates that there is no reported value for the metric, yet.
+      </td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1399,7 +1399,6 @@ Thus, in order to infer the metric identifier:
       <td>stream, shardId</td>
       <td>The number of milliseconds the consumer spends sleeping before fetching records from Kinesis.
       A particular shard's metric can be specified by stream name and shard id.
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1409,7 +1408,6 @@ Thus, in order to infer the metric identifier:
       <td>stream, shardId</td>
       <td>The maximum number of records requested by the consumer in a single getRecords call to Kinesis. If ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS
       is set to true, this value is adaptively calculated to maximize the 2 Mbps read limits from Kinesis.
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1418,7 +1416,6 @@ Thus, in order to infer the metric identifier:
       <td>numberOfAggregatedRecordsPerFetch</td>
       <td>stream, shardId</td>
       <td>The number of aggregated Kinesis records fetched by the consumer in a single getRecords call to Kinesis.
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1427,7 +1424,6 @@ Thus, in order to infer the metric identifier:
       <td>numberOfDeggregatedRecordsPerFetch</td>
       <td>stream, shardId</td>
       <td>The number of deaggregated Kinesis records fetched by the consumer in a single getRecords call to Kinesis.
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1436,7 +1432,6 @@ Thus, in order to infer the metric identifier:
       <td>averageRecordSizeBytes</td>
       <td>stream, shardId</td>
       <td>The average size of a Kinesis record in bytes, fetched by the consumer in a single getRecords call.
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1445,7 +1440,6 @@ Thus, in order to infer the metric identifier:
       <td>runLoopTimeNanos</td>
       <td>stream, shardId</td>
       <td>The actual time taken, in nanoseconds, by the consumer in the run loop.
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1454,7 +1448,6 @@ Thus, in order to infer the metric identifier:
       <td>loopFrequencyHz</td>
       <td>stream, shardId</td>
       <td> The number of calls to getRecords in one second. 
-      A value of -1 indicates that there is no reported value for the metric, yet.
       </td>
       <td>Gauge</td>
     </tr>
@@ -1463,8 +1456,6 @@ Thus, in order to infer the metric identifier:
       <td>bytesRequestedPerFetch</td>
       <td>stream, shardId</td>
       <td> The bytes requested (2 Mbps / loopFrequencyHz) in a single call to getRecords.
-      A value of -1 indicates that there is no reported value for the metric, yet.
-      </td>
       <td>Gauge</td>
     </tr>
   </tbody>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -630,7 +630,14 @@ public class KinesisDataFetcher<T> {
 				shardState.getStreamShardHandle().getShard().getShardId());
 
 		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.MILLIS_BEHIND_LATEST_GAUGE, shardMetrics::getMillisBehindLatest);
-
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.MAX_RECORDS_PER_FETCH, shardMetrics::getMaxNumberOfRecordsPerFetch);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.NUM_AGGREGATED_RECORDS_PER_FETCH, shardMetrics::getNumberOfAggregatedRecords);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.NUM_DEAGGREGATED_RECORDS_PER_FETCH, shardMetrics::getNumberOfDeaggregatedRecords);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.AVG_RECORD_SIZE_BYTES, shardMetrics::getAverageRecordSizeBytes);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.BYTES_PER_READ, shardMetrics::getBytesPerRead);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.RUNTIME_LOOP_NANOS, shardMetrics::getRunLoopTimeNanos);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.LOOP_FREQUENCY_HZ, shardMetrics::getLoopFrequencyHz);
+		streamShardMetricGroup.gauge(KinesisConsumerMetricConstants.SLEEP_TIME_MILLIS, shardMetrics::getSleepTimeMillis);
 		return shardMetrics;
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/KinesisConsumerMetricConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/KinesisConsumerMetricConstants.java
@@ -34,4 +34,13 @@ public class KinesisConsumerMetricConstants {
 	public static final String SHARD_METRICS_GROUP = "shardId";
 
 	public static final String MILLIS_BEHIND_LATEST_GAUGE = "millisBehindLatest";
+	public static final String SLEEP_TIME_MILLIS = "sleepTimeMillis";
+	public static final String MAX_RECORDS_PER_FETCH = "maxNumberOfRecordsPerFetch";
+	public static final String NUM_AGGREGATED_RECORDS_PER_FETCH = "numberOfAggregatedRecordsPerFetch";
+	public static final String NUM_DEAGGREGATED_RECORDS_PER_FETCH = "numberOfDeaggregatedRecordsPerFetch";
+	public static final String AVG_RECORD_SIZE_BYTES = "averageRecordSizeBytes";
+	public static final String RUNTIME_LOOP_NANOS = "runLoopTimeNanos";
+	public static final String LOOP_FREQUENCY_HZ = "loopFrequencyHz";
+	public static final String BYTES_PER_READ = "bytesRequestedPerFetch";
+
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
@@ -28,6 +28,14 @@ import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
 public class ShardMetricsReporter {
 
 	private volatile long millisBehindLatest = -1;
+	private volatile double loopFrequencyHz = 0.0;
+	private volatile double bytesPerRead = 0.0;
+	private volatile long runLoopTimeNanos = 0L;
+	private volatile long averageRecordSizeBytes = 0L;
+	private volatile long sleepTimeMillis = 0L;
+	private volatile int numberOfAggregatedRecords = 0;
+	private volatile int numberOfDeaggregatedRecords = 0;
+	private volatile int maxNumberOfRecordsPerFetch = 0;
 
 	public long getMillisBehindLatest() {
 		return millisBehindLatest;
@@ -35,6 +43,70 @@ public class ShardMetricsReporter {
 
 	public void setMillisBehindLatest(long millisBehindLatest) {
 		this.millisBehindLatest = millisBehindLatest;
+	}
+
+	public double getLoopFrequencyHz() {
+		return loopFrequencyHz;
+	}
+
+	public void setLoopFrequencyHz(double loopFrequencyHz) {
+		this.loopFrequencyHz = loopFrequencyHz;
+	}
+
+	public double getBytesPerRead() {
+		return bytesPerRead;
+	}
+
+	public void setBytesPerRead(double bytesPerRead) {
+		this.bytesPerRead = bytesPerRead;
+	}
+
+	public long getRunLoopTimeNanos() {
+		return runLoopTimeNanos;
+	}
+
+	public void setRunLoopTimeNanos(long runLoopTimeNanos) {
+		this.runLoopTimeNanos = runLoopTimeNanos;
+	}
+
+	public long getAverageRecordSizeBytes() {
+		return averageRecordSizeBytes;
+	}
+
+	public void setAverageRecordSizeBytes(long averageRecordSizeBytes) {
+		this.averageRecordSizeBytes = averageRecordSizeBytes;
+	}
+
+	public long getSleepTimeMillis() {
+		return sleepTimeMillis;
+	}
+
+	public void setSleepTimeMillis(long sleepTimeMillis) {
+		this.sleepTimeMillis = sleepTimeMillis;
+	}
+
+	public int getNumberOfAggregatedRecords() {
+		return numberOfAggregatedRecords;
+	}
+
+	public void setNumberOfAggregatedRecords(int numberOfAggregatedRecords) {
+		this.numberOfAggregatedRecords = numberOfAggregatedRecords;
+	}
+
+	public int getNumberOfDeaggregatedRecords() {
+		return numberOfDeaggregatedRecords;
+	}
+
+	public void setNumberOfDeaggregatedRecords(int numberOfDeaggregatedRecords) {
+		this.numberOfDeaggregatedRecords = numberOfDeaggregatedRecords;
+	}
+
+	public int getMaxNumberOfRecordsPerFetch() {
+		return maxNumberOfRecordsPerFetch;
+	}
+
+	public void setMaxNumberOfRecordsPerFetch(int maxNumberOfRecordsPerFetch) {
+		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
 	}
 
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
@@ -28,14 +28,14 @@ import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
 public class ShardMetricsReporter {
 
 	private volatile long millisBehindLatest = -1;
-	private volatile double loopFrequencyHz = 0.0;
-	private volatile double bytesPerRead = 0.0;
-	private volatile long runLoopTimeNanos = 0L;
-	private volatile long averageRecordSizeBytes = 0L;
-	private volatile long sleepTimeMillis = 0L;
-	private volatile int numberOfAggregatedRecords = 0;
-	private volatile int numberOfDeaggregatedRecords = 0;
-	private volatile int maxNumberOfRecordsPerFetch = 0;
+	private volatile double loopFrequencyHz = -1.0;
+	private volatile double bytesPerRead = -1.0;
+	private volatile long runLoopTimeNanos = -1;
+	private volatile long averageRecordSizeBytes = -1;
+	private volatile long sleepTimeMillis = -1;
+	private volatile int numberOfAggregatedRecords = -1;
+	private volatile int numberOfDeaggregatedRecords = -1;
+	private volatile int maxNumberOfRecordsPerFetch = -1;
 
 	public long getMillisBehindLatest() {
 		return millisBehindLatest;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
@@ -28,14 +28,14 @@ import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
 public class ShardMetricsReporter {
 
 	private volatile long millisBehindLatest = -1;
-	private volatile double loopFrequencyHz = -1.0;
-	private volatile double bytesPerRead = -1.0;
-	private volatile long runLoopTimeNanos = -1;
-	private volatile long averageRecordSizeBytes = -1;
-	private volatile long sleepTimeMillis = -1;
-	private volatile int numberOfAggregatedRecords = -1;
-	private volatile int numberOfDeaggregatedRecords = -1;
-	private volatile int maxNumberOfRecordsPerFetch = -1;
+	private volatile double loopFrequencyHz = 0.0;
+	private volatile double bytesPerRead = 0.0;
+	private volatile long runLoopTimeNanos = 0L;
+	private volatile long averageRecordSizeBytes = 0L;
+	private volatile long sleepTimeMillis = 0L;
+	private volatile int numberOfAggregatedRecords = 0;
+	private volatile int numberOfDeaggregatedRecords = 0;
+	private volatile int maxNumberOfRecordsPerFetch = 0;
 
 	public long getMillisBehindLatest() {
 		return millisBehindLatest;


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this change is to add metrics to the `ShardConsumer` to get more observability into the performance of the Kinesis connector, including the enhancements introduced in [FLINK-9897](https://issues.apache.org/jira/browse/FLINK-9899) . 

**Important** - https://github.com/apache/flink/pull/6408 has to be merged **before** taking out this change.

## Brief change log
All metrics are added as gauges. The following per-shard metrics are added. :
- sleepTimeMillis
- maxNumberOfRecordsPerFetch
- numberOfAggregatedRecordsPerFetch
- numberOfDeaggregatedRecordsPerFetch
- bytesRequestedPerFetch
- averageRecordSizeBytes
- runLoopTimeNanos
- loopFrequencyHz

## Verifying this change

This change is already covered by existing tests, such as: `ShardConsumerTest`, `KinesisDataFetcherTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? ( **docs** / JavaDocs / not documented)
