### PR TITLE
[FLINK-9941][ScalaAPI] Flush in ScalaCsvOutputFormat before close

### DIFF
--- a/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormat.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormat.java
@@ -168,6 +168,7 @@ public class ScalaCsvOutputFormat<T extends Product> extends FileOutputFormat<T>
 	@Override
 	public void close() throws IOException {
 		if (wrt != null) {
+			this.wrt.flush();
 			this.wrt.close();
 		}
 		super.close();

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormatTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormatTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.operators;
+
+import org.apache.flink.api.common.io.FileOutputFormat;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import scala.Tuple3;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link ScalaCsvOutputFormat}.
+ */
+public class ScalaCsvOutputFormatTest {
+
+	private String path = null;
+
+	@Before
+	public void createFile() throws Exception {
+		path = File.createTempFile("csv_output_test_file", ".csv").getAbsolutePath();
+	}
+
+	@Test
+	public void testNullAllow() throws Exception {
+		final ScalaCsvOutputFormat<Tuple3<String, String, Integer>> csvOutputFormat = new ScalaCsvOutputFormat<>(new Path(path));
+		try {
+			csvOutputFormat.setWriteMode(FileSystem.WriteMode.OVERWRITE);
+			csvOutputFormat.setOutputDirectoryMode(FileOutputFormat.OutputDirectoryMode.PARONLY);
+			csvOutputFormat.setAllowNullValues(true);
+			csvOutputFormat.open(0, 1);
+			csvOutputFormat.writeRecord(new Tuple3<String, String, Integer>("One", null, 8));
+		}
+		finally {
+			csvOutputFormat.close();
+		}
+
+		java.nio.file.Path p = Paths.get(path);
+		Assert.assertTrue(Files.exists(p));
+		List<String> lines = Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8);
+		Assert.assertEquals(1, lines.size());
+		Assert.assertEquals("One,,8", lines.get(0));
+	}
+
+	@Test
+	public void testNullDisallowOnDefault() throws Exception {
+		final ScalaCsvOutputFormat<Tuple3<String, String, Integer>> csvOutputFormat = new ScalaCsvOutputFormat<>(new Path(path));
+		try {
+			csvOutputFormat.setWriteMode(FileSystem.WriteMode.OVERWRITE);
+			csvOutputFormat.setOutputDirectoryMode(FileOutputFormat.OutputDirectoryMode.PARONLY);
+			csvOutputFormat.open(0, 1);
+			try {
+				csvOutputFormat.writeRecord(new Tuple3<String, String, Integer>("One", null, 8));
+				fail("should fail with an exception");
+			} catch (RuntimeException e) {
+				// expected
+			}
+
+		}
+		finally {
+			csvOutputFormat.close();
+		}
+	}
+
+	@After
+	public void cleanUp() throws IOException {
+		Files.deleteIfExists(Paths.get(path));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
This pull request update scala api `ScalaCsvOutputFormat` to increase continuous integration stability.

## Brief change log
Add flush method before close method in ScalaCsvOutputFormat for scala API.

## Verifying this change
Add `ScalaCsvOutputFormatTest` and test passed.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / **no**)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes / **no**)
- The serializers: (yes / **no** / don't know)
- The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
- The S3 file system connector: (yes / **no** / don't know)

## Documentation
Does this pull request introduce a new feature? (yes / **no**)
If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)