### PR TITLE
[FLINK-9949][tests] Kill Flink processes in DB/teardown!

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -88,6 +88,7 @@
 (defn teardown-flink!
   []
   (info "Tearing down Flink")
+  (cu/grepkill! "flink")
   (meh (c/exec :rm :-rf install-dir))
   (meh (c/exec :rm :-rf (c/lit "/tmp/.yarn-properties*"))))
 


### PR DESCRIPTION
## What is the purpose of the change

*Not killing Flink processes at the end of a test, can cause interference with subsequent test runs.*

## Brief change log
  - *Kill Flink processes in `DB/teardown!`.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Ran tests in docker.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

cc: @tillrohrmann 
