### PR TITLE
[FLINK-9951][build] Update scm developerConnection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ under the License.
 	<scm>
 		<url>https://github.com/apache/flink</url>
 		<connection>git@github.com:apache/flink.git</connection>
-		<developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/flink.git</developerConnection>
+		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink.git</developerConnection>
 	</scm>
 
 	<modules>


### PR DESCRIPTION
This PR updates the developerConnection to point to gitbox instead of git-wip-us.