### PR TITLE
[FLINK-9935] [table] Fix incorrect group field access in batch window combiner.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -586,7 +586,7 @@ object AggregateUtil {
       isDistinctAggs,
       isStateBackedDataViews = false,
       partialResults = true,
-      groupings,
+      groupings.indices.toArray,
       Some(aggregates.indices.map(_ + groupings.length).toArray),
       outputType.getFieldCount,
       needRetract,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/GroupWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/GroupWindowITCase.scala
@@ -97,6 +97,7 @@ class GroupWindowITCase(
     val table = env
       .fromCollection(data)
       .toTable(tEnv, 'long, 'int, 'double, 'float, 'bigdec, 'string)
+      .select('int, 'long, 'string) // keep this select to enforce that the 'string key comes last
 
     val windowedTable = table
       .window(Tumble over 5.milli on 'long as 'w)
@@ -271,6 +272,7 @@ class GroupWindowITCase(
     val table = env
       .fromCollection(data)
       .toTable(tEnv, 'long, 'int, 'double, 'float, 'bigdec, 'string)
+      .select('int, 'long, 'string) // keep this select to enforce that the 'string key comes last
 
     val windowedTable = table
       .window(Slide over 10.milli every 5.milli on 'long as 'w)


### PR DESCRIPTION
## What is the purpose of the change

Fixes an incorrect field access (on a grouping field) in the combiner for a TUMBLE or HOP group window in a batch query. The incorrect field access would typically result in a ClassCastException or lead to incorrect results.

## Brief change log

* fix the field access in the generated aggregation code.
* modify tests to fail if the field access is invalid

## Verifying this change

* the modified tests validate the correct access.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**
