### PR TITLE
[FLINK-9927] [Documentation] Change .print() to .output() in Python Streaming example

### DIFF
--- a/docs/dev/stream/python.md
+++ b/docs/dev/stream/python.md
@@ -104,7 +104,7 @@ def main(factory):
         .key_by(Selector()) \
         .time_window(milliseconds(50)) \
         .reduce(Sum()) \
-        .print()
+        .output()
     env.execute()
 
 {% endhighlight %}


### PR DESCRIPTION
The method .print() doesn't exist, it should be .output()

## What is the purpose of the change

Correct the final line of the pipeline example in the python streaming example. There is no such method as .print(), it should say .output().

This is a documentation change only, no code is touched.

## Brief change log

- change one line of the [streaming program example](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/python.html#streaming-program-example) code.

## Verifying this change

This change is a trivial documentation change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
