### PR TITLE
[FLINK-9958][DataSet] Fix potential NPE for delta iteration of DataSet

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -391,6 +391,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 				// we adjust the joins / cogroups that go into the solution set here
 				for (Channel c : node.getOutgoingChannels()) {
 					DualInputPlanNode target = (DualInputPlanNode) c.getTarget();
+					target.accept(this);
 					JobVertex accessingVertex = this.vertices.get(target);
 					TaskConfig conf = new TaskConfig(accessingVertex.getConfiguration());
 					int inputNum = c == target.getInput1() ? 0 : c == target.getInput2() ? 1 : -1;
@@ -401,6 +402,14 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 					}
 					
 					// adjust the driver
+					if (conf.getDriver().equals(JoinWithSolutionSetFirstDriver.class) ||
+						conf.getDriver().equals(JoinWithSolutionSetSecondDriver.class)) {
+						continue;
+					}
+					if (conf.getDriver().equals(CoGroupWithSolutionSetFirstDriver.class) ||
+						conf.getDriver().equals(CoGroupWithSolutionSetSecondDriver.class)) {
+						continue;
+					}
 					if (conf.getDriver().equals(JoinDriver.class)) {
 						conf.setDriver(inputNum == 0 ? JoinWithSolutionSetFirstDriver.class : JoinWithSolutionSetSecondDriver.class);
 					}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/DeltaIterationTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/DeltaIterationTranslationTest.scala
@@ -39,6 +39,21 @@ import org.apache.flink.api.scala._
 class DeltaIterationTranslationTest {
 
   @Test
+  def testIterateDelta(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val ds1 = env.fromElements((1, 1), (2, 2), (3, 3)).name("ds1")
+    val ds2 = env.fromElements((1, 1), (2, 2), (3, 3)).name("ds2")
+    val result = ds1.iterateDelta(ds2, 1, Array(0)) {
+      (s, ws) =>
+        (
+          s.join(ws).where(0).equalTo(0).name("join1").map(_._1).name("map1"),
+          s.join(ws).where(0).equalTo(0).name("join2").map(_._1).name("map2")
+        )
+    }
+    result.name("result").print()
+  }
+
+  @Test
   def testCorrectTranslation(): Unit = {
     try {
       val JOB_NAME = "Test JobName"


### PR DESCRIPTION
## What is the purpose of the change

Fix potential NPE for delta iteration of DataSet


## Brief change log
  - change preVisit logic of JobGenerator 


## Verifying this change


This change added tests and can be verified as follows:

org.apache.flink.api.scala.operators.translation.DeltaIterationTranslationTest#testIterateDelta

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
