### PR TITLE
[FLINK-9943] Support TaskManagerMetricQueryServicePaths msg in JobManager Actor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/AkkaJobManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/AkkaJobManagerGateway.java
@@ -47,7 +47,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 
 import scala.Option;
 import scala.reflect.ClassTag$;
@@ -266,20 +265,15 @@ public class AkkaJobManagerGateway implements JobManagerGateway {
 
 	@Override
 	public CompletableFuture<Collection<Tuple2<ResourceID, String>>> requestTaskManagerMetricQueryServicePaths(Time timeout) {
-		return requestTaskManagerInstances(timeout)
-			.thenApply(
-				(Collection<Instance> instances) ->
-					instances
-						.stream()
-						.map(
-							(Instance instance) -> {
-								final String taskManagerAddress = instance.getTaskManagerGateway().getAddress();
-								final String taskManagerMetricQuerServicePath = taskManagerAddress.substring(0, taskManagerAddress.lastIndexOf('/') + 1) +
-									MetricQueryService.METRIC_QUERY_SERVICE_NAME + '_' + instance.getTaskManagerID().getResourceIdString();
+		CompletableFuture<JobManagerMessages.TaskManagerMetricQueryServicePaths> taskManagerQueryPathsFuture =
+				FutureUtils.toJava(
+						jobManagerGateway
+								.ask(JobManagerMessages.getRequestTaskManagerMetricQueryServicePaths(), FutureUtils.toFiniteDuration(timeout))
+								.mapTo(ClassTag$.MODULE$.apply(JobManagerMessages.TaskManagerMetricQueryServicePaths.class)));
 
-								return Tuple2.of(instance.getTaskManagerID(), taskManagerMetricQuerServicePath);
-							})
-						.collect(Collectors.toList()));
+		return taskManagerQueryPathsFuture.thenApply(
+				JobManagerMessages.TaskManagerMetricQueryServicePaths::asJavaCollection
+		);
 	}
 
 	@Override

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -23,6 +23,7 @@ import java.util.UUID
 
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
+import org.apache.flink.api.java.tuple.Tuple2
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.blob.PermanentBlobKey
 import org.apache.flink.runtime.client.{JobStatusMessage, SerializedJobExecutionResult}
@@ -431,6 +432,27 @@ object JobManagerMessages {
   case class TaskManagerInstance(instance: Option[Instance])
 
   /**
+    * Requests the metric query service paths of the registered task manager.
+    */
+  case object RequestTaskManagerMetricQueryServicePaths
+
+  /**
+    * Returns the metric query service paths of the registered task manager. This is in response to
+    * [[RequestTaskManagerMetricQueryServicePaths]]
+    */
+  case class TaskManagerMetricQueryServicePaths(paths: Iterable[Tuple2[ResourceID, String]]) {
+    def asJavaIterable: java.lang.Iterable[Tuple2[ResourceID, String]] = {
+      import scala.collection.JavaConverters._
+      paths.asJava
+    }
+
+    def asJavaCollection: java.util.Collection[Tuple2[ResourceID, String]] = {
+      import scala.collection.JavaConverters._
+      paths.asJavaCollection
+    }
+  }
+
+  /**
    * Requests stack trace messages of the task manager
    *
    * @param instanceID Instance ID of the task manager
@@ -552,6 +574,10 @@ object JobManagerMessages {
 
   def getRequestRegisteredTaskManagers : AnyRef = {
     RequestRegisteredTaskManagers
+  }
+
+  def getRequestTaskManagerMetricQueryServicePaths : AnyRef = {
+    RequestTaskManagerMetricQueryServicePaths
   }
 
   def getRequestJobManagerStatus : AnyRef = {


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes metric system be exposed to external akka client fully instead of only Jobmanager's metric*


## Brief change log

  - *Add RequestTaskManagerMetricQueryServicePaths message in JobManager actor*
  - *Add RequestTaskManagerMetricQueryServicePaths and TaskManagerMetricQueryServicePaths  in JobMessages*
  - *Refactor TaskManagerMetricQueryServicePaths's requestTaskManagerMetricQueryServicePaths method *


## Verifying this change


This change added tests and can be verified as follows:

  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers,  WebRuntimeMonitor works correctly and external akka system can fetch metrics correctly*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
