### PR TITLE
[FLINK-9970] [table] Add ASCII/CHR function for table/sql API

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -2524,6 +2524,33 @@ REPEAT(string, integer)
     <tr>
       <td>
         {% highlight text %}
+ASCII(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the ASCII code value of the <i>string</i>.</p> 
+        <p>The return type is <i>INTEGER</i>.</p>
+        <p>E.g. <code>ASCII('THIS')</code> returns 84.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+CHR(integer)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns a character corresponding to the input <i>integer</i> ASCII code.</p> 
+        <p><b>Note:</b> If the input <i>integer</i> exceeding the range (1 - 255), returns NULL.</p>
+        <p>The return type is <i>STRING</i>.</p>
+        <p>E.g. <code>CHR(65)</code> returns "A".</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
 REGEXP_REPLACE(string1, string2, string3)
 {% endhighlight %}
       </td>
@@ -2781,6 +2808,33 @@ STRING.repeat(INT)
       <td>
         <p>Returns a string that repeats the base <i>STRING</i> <i>INT</i> times.</p> 
         <p>E.g., <code>'This is a test String.'.repeat(2)</code> returns "This is a test String.This is a test String.".</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.ascii()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the ASCII code value of the <i>STRING</i>.</p> 
+        <p>The return type is <i>INTEGER</i>.</p>
+        <p>E.g. <code>'THIS'.ascii()</code> returns 84.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+INTEGER.chr()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns a character corresponding to the input <i>INTEGER</i> ASCII code.</p> 
+        <p><b>Note:</b> If the input <i>INTEGER</i> exceeding the range (1 - 255), returns NULL.</p>
+        <p>The return type is <i>STRING</i>.</p>
+        <p>E.g. <code>65.chr()</code> returns "A".</p>
       </td>
     </tr>    
 
@@ -3045,6 +3099,33 @@ STRING.repeat(INT)
       <td>
         <p>Returns a string that repeats the base <i>STRING</i> <i>INT</i> times.</p> 
         <p>E.g., <code>"This is a test String.".repeat(2)</code> returns "This is a test String.This is a test String.".</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.ascii()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the ASCII code value of the <i>STRING</i>.</p> 
+        <p>The return type is <i>INTEGER</i>.</p>
+        <p>E.g. <code>"THIS".ascii()</code> returns 84.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+INTEGER.chr()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns a character corresponding to the input <i>INTEGER</i> ASCII code.</p> 
+        <p><b>Note:</b> If the input <i>INTEGER</i> exceeding the range (1 - 255), returns NULL.</p>
+        <p>The return type is <i>STRING</i>.</p>
+        <p>E.g. <code>65.chr()</code> returns "A".</p>
       </td>
     </tr> 
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -607,6 +607,11 @@ trait ImplicitExpressionOperations {
     RegexpExtract(expr, regex, null)
 
   /**
+    * Returns the ASCII code value of the the leftmost character of the string.
+    */
+  def ascii() = Ascii(expr)
+
+  /**
     * Returns the base string decoded with base64.
     */
   def fromBase64() = FromBase64(expr)
@@ -630,6 +635,11 @@ trait ImplicitExpressionOperations {
     * Returns a string that repeats the base string n times.
     */
   def repeat(n: Expression) = Repeat(expr, n)
+
+  /**
+    * Returns a character corresponding to the input integer ASCII code.
+    */
+  def chr() = Chr(expr)
 
   // Temporal operations
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -162,6 +162,8 @@ object BuiltInMethods {
     classOf[String],
     classOf[String])
 
+  val ASCII = Types.lookupMethod(classOf[ScalarFunctions], "ascii", classOf[String])
+
   val FROMBASE64 = Types.lookupMethod(classOf[ScalarFunctions], "fromBase64", classOf[String])
 
   val TOBASE64 = Types.lookupMethod(classOf[ScalarFunctions], "toBase64", classOf[String])
@@ -176,4 +178,7 @@ object BuiltInMethods {
     "repeat",
     classOf[String],
     classOf[Int])
+
+  val CHR = Types.lookupMethod(classOf[ScalarFunctions], "chr", classOf[Long])
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -172,6 +172,12 @@ object FunctionGenerator {
     BuiltInMethods.REGEXP_EXTRACT_WITHOUT_INDEX)
 
   addSqlFunctionMethod(
+    ASCII,
+    Seq(STRING_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethods.ASCII)
+
+  addSqlFunctionMethod(
     FROM_BASE64,
     Seq(STRING_TYPE_INFO),
     STRING_TYPE_INFO,
@@ -206,6 +212,12 @@ object FunctionGenerator {
     Seq(STRING_TYPE_INFO, INT_TYPE_INFO),
     STRING_TYPE_INFO,
     BuiltInMethods.REPEAT)
+
+  addSqlFunctionMethod(
+    CHR,
+    Seq(LONG_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethods.CHR)
 
   // ----------------------------------------------------------------------------------------------
   // Arithmetic functions

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -422,6 +422,31 @@ object RegexpExtract {
 }
 
 /**
+  * Returns the ASCII code value value of the leftmost character of the string str.
+  */
+case class Ascii(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = INT_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == STRING_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"Ascii operator requires a String input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.ASCII, child.toRexNode)
+  }
+
+  override def toString: String = s"($child).ascii"
+}
+
+/**
   * Returns the base string decoded with base64.
   * Returns NULL If the input string is NULL.
   */
@@ -573,4 +598,29 @@ case class Replace(str: Expression,
   override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
     relBuilder.call(SqlStdOperatorTable.REPLACE, children.map(_.toRexNode))
   }
+}
+
+/**
+  * Returns a character corresponding to the input integer ASCII code.
+  */
+case class Chr(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(LONG_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == LONG_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"Chr operator requires a Long input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder) = {
+    relBuilder.call(ScalarSqlFunctions.CHR, child.toRexNode)
+  }
+
+  override def toString = s"chr($child)"
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -233,6 +233,15 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val ASCII = new SqlFunction(
+    "ASCII",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.explicit(SqlTypeName.INTEGER),
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING
+  )
+
   val FROM_BASE64 = new SqlFunction(
     "FROM_BASE64",
     SqlKind.OTHER_FUNCTION,
@@ -275,5 +284,14 @@ object ScalarSqlFunctions {
     InferTypes.RETURN_TYPE,
     OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),
     SqlFunctionCategory.STRING)
+
+  val CHR = new SqlFunction(
+    "CHR",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
+    InferTypes.RETURN_TYPE,
+    OperandTypes.NUMERIC,
+    SqlFunctionCategory.STRING
+  )
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -26,6 +26,8 @@ import java.util.regex.Pattern
 import org.apache.commons.codec.binary.{Base64, Hex}
 import org.apache.commons.lang3.StringUtils
 
+import org.apache.flink.shaded.guava18.com.google.common.base.CharMatcher
+
 import scala.annotation.varargs
 
 /**
@@ -267,6 +269,21 @@ object ScalarFunctions {
   }
 
   /**
+    * Returns the ASCII code value of the leftmost character of the string str.
+    */
+  def ascii(str: String): Integer = {
+    if (str == null || str.equals("")) {
+      0
+    } else {
+      if (CharMatcher.ASCII.matches(str.charAt(0))) {
+        str.charAt(0).toByte.toInt
+      } else {
+        0
+      }
+    }
+  }
+
+  /**
     * Returns the base string decoded with base64.
     */
   def fromBase64(str: String): String =
@@ -298,5 +315,16 @@ object ScalarFunctions {
     * Returns a string that repeats the base string n times.
     */
   def repeat(base: String, n: Int): String = StringUtils.repeat(base, n)
+
+  /**
+    * Returns a character corresponding to the input integer ASCII code.
+    */
+  def chr(ascii: Long): String = {
+    if (ascii == null || ascii < 0 || ascii > 255) {
+      return null
+    }
+
+    return ascii.toChar.toString
+  }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -204,6 +204,7 @@ object FunctionCatalog {
     "lpad" -> classOf[Lpad],
     "rpad" -> classOf[Rpad],
     "regexpExtract" -> classOf[RegexpExtract],
+    "ascii" -> classOf[Ascii],
     "fromBase64" -> classOf[FromBase64],
     "toBase64" -> classOf[ToBase64],
     "uuid" -> classOf[UUID],
@@ -211,6 +212,7 @@ object FunctionCatalog {
     "rtrim" -> classOf[RTrim],
     "repeat" -> classOf[Repeat],
     "regexpReplace" -> classOf[RegexpReplace],
+    "chr" -> classOf[Chr],
 
     // math functions
     "plus" -> classOf[Plus],
@@ -468,6 +470,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.SHA512,
     ScalarSqlFunctions.SHA2,
     ScalarSqlFunctions.REGEXP_EXTRACT,
+    ScalarSqlFunctions.ASCII,
     ScalarSqlFunctions.FROM_BASE64,
     ScalarSqlFunctions.TO_BASE64,
     ScalarSqlFunctions.UUID,
@@ -475,6 +478,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.RTRIM,
     ScalarSqlFunctions.REPEAT,
     ScalarSqlFunctions.REGEXP_REPLACE,
+    ScalarSqlFunctions.CHR,
 
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -700,6 +700,39 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
+  def testAscii(): Unit = {
+    testAllApis(
+      'f0.ascii(),
+      "f0.ascii()",
+      "ASCII(f0)",
+      "84")
+
+    testAllApis(
+      'f35.ascii(),
+      "f35.ascii()",
+      "ASCII(f35)",
+      "97")
+
+    testAllApis(
+      "".ascii(),
+      "''.ascii()",
+      "ASCII('')",
+      "0")
+
+    testAllApis(
+      'f33.ascii(),
+      "f33.ascii()",
+      "ASCII(f33)",
+      "null")
+
+    testAllApis(
+      "我".ascii(),
+      "'我'.ascii()",
+      "ASCII('我')",
+      "0")
+  }
+
+  @Test
   def testFromBase64(): Unit = {
     testAllApis(
       'f35.fromBase64(),
@@ -887,6 +920,51 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "''.repeat(1)",
       "REPEAT('', 2)",
       "")
+  }
+
+  @Test
+  def testChr(): Unit = {
+    testAllApis(
+      'f14.chr(),
+      "f14.chr()",
+      "CHR(f14)",
+      "null")
+
+    testAllApis(
+      'f34.chr(),
+      "f34.chr()",
+      "CHR(f34)",
+      "null")
+
+    testAllApis(
+      'f36.chr(),
+      "f36.chr()",
+      "CHR(f36)",
+      "A")
+
+    testAllApis(
+      'f37.chr(),
+      "f37.chr()",
+      "CHR(f37)",
+      "ÿ")
+
+    testAllApis(
+      'f36.chr(),
+      "f36.chr()",
+      "CHR(CAST(f36 AS SMALLINT))",
+      "A")
+
+    testAllApis(
+      'f36.chr(),
+      "f36.chr()",
+      "CHR(CAST(f36 AS TINYINT))",
+      "A")
+
+    testAllApis(
+      'f36.chr(),
+      "f36.chr()",
+      "CHR(CAST(f36 AS BIGINT))",
+      "A")
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -160,6 +160,8 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("REGEXP_REPLACE('foobar', 'oo|ar', '')", "fb")
     testSqlApi("REPLACE('hello world', 'world', 'flink')", "hello flink")
     testSqlApi("REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)", "bar")
+    testSqlApi("ASCII('This is a test String.')", "84")
+    testSqlApi("CHR(65)", "A")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ScalarTypesTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ScalarTypesTestBase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.types.Row
 class ScalarTypesTestBase extends ExpressionTestBase {
 
   def testData: Row = {
-    val testData = new Row(36)
+    val testData = new Row(38)
     testData.setField(0, "This is a test String.")
     testData.setField(1, true)
     testData.setField(2, 42.toByte)
@@ -65,6 +65,8 @@ class ScalarTypesTestBase extends ExpressionTestBase {
     testData.setField(33, null)
     testData.setField(34, 256)
     testData.setField(35, "aGVsbG8gd29ybGQ=")
+    testData.setField(36, 65)
+    testData.setField(37, 255)
     testData
   }
 
@@ -105,6 +107,8 @@ class ScalarTypesTestBase extends ExpressionTestBase {
       Types.INT,
       Types.STRING,
       Types.INT,
-      Types.STRING).asInstanceOf[TypeInformation[Any]]
+      Types.STRING,
+      Types.INT,
+      Types.INT).asInstanceOf[TypeInformation[Any]]
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds ASCII and CHR function for table/sql API*


## Brief change log

  - *Add ASCII function for table/sql API*
  - *Add CHR function for table/sql API*


## Verifying this change

This change is already covered by existing tests, such as *testAscii/testChr*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
