### PR TITLE
[FLINK-9946][tests] Expose Flink version to E2E tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -36,6 +36,8 @@ export EXIT_CODE=0
 
 echo "Flink dist directory: $FLINK_DIR"
 
+FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/[[:blank:]]\+<version>\([a-zA-Z0-9\.-]\+\)<\/version>/\1/p')
+
 USE_SSL=OFF # set via set_conf_ssl(), reset via revert_default_config()
 TEST_ROOT=`pwd -P`
 TEST_INFRA_DIR="$END_TO_END_DIR/test-scripts/"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -36,7 +36,7 @@ export EXIT_CODE=0
 
 echo "Flink dist directory: $FLINK_DIR"
 
-FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\([a-zA-Z0-9\.-]\+\)<\/version>/\1/p')
+FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>/\1/p')
 
 USE_SSL=OFF # set via set_conf_ssl(), reset via revert_default_config()
 TEST_ROOT=`pwd -P`

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -36,7 +36,7 @@ export EXIT_CODE=0
 
 echo "Flink dist directory: $FLINK_DIR"
 
-FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/[[:blank:]]\+<version>\([a-zA-Z0-9\.-]\+\)<\/version>/\1/p')
+FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\([a-zA-Z0-9\.-]\+\)<\/version>/\1/p')
 
 USE_SSL=OFF # set via set_conf_ssl(), reset via revert_default_config()
 TEST_ROOT=`pwd -P`

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -46,7 +46,7 @@ ARTIFACT_VERSION=0.1
 mvn archetype:generate                                   \
     -DarchetypeGroupId=org.apache.flink                  \
     -DarchetypeArtifactId=flink-quickstart-${TEST_TYPE}  \
-    -DarchetypeVersion=1.7-SNAPSHOT                      \
+    -DarchetypeVersion=${FLINK_VERSION}                  \
     -DgroupId=org.apache.flink.quickstart                \
     -DartifactId=${ARTIFACT_ID}                          \
     -Dversion=${ARTIFACT_VERSION}                        \


### PR DESCRIPTION
## What is the purpose of the change

With this PR the flink version is determined from the `flink-end-to-end-tests` pom and exposed to test scripts. The primary purpose is to use this version in the quickstart end-to-end test to select the correct archetype version.
