### PR TITLE
[FLINK-6968] [table] Add Queryable table sink.

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -189,7 +189,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-queryable-state-runtime_2.11</artifactId>
+			<artifactId>flink-queryable-state-runtime_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -186,6 +186,13 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-queryable-state-runtime_2.11</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/KeyedProcessFunctionWithCleanupState.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/KeyedProcessFunctionWithCleanupState.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.aggregate
 import java.lang.{Long => JLong}
 import org.apache.flink.api.common.state.{State, ValueState, ValueStateDescriptor}
 import org.apache.flink.streaming.api.TimeDomain
-import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.table.api.{StreamQueryConfig, Types}
 
 abstract class KeyedProcessFunctionWithCleanupState[K, I, O](queryConfig: StreamQueryConfig)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/QueryableStateProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/QueryableStateProcessFunction.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks.queryable
+
+import java.lang.{Boolean => JBool}
+
+import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
+import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.runtime.aggregate.KeyedProcessFunctionWithCleanupState
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+class QueryableStateProcessFunction(
+  private val namePrefix: String,
+  private val queryConfig: StreamQueryConfig,
+  private val keyNames: Array[String],
+  private val fieldNames: Array[String],
+  private val fieldTypes: Array[TypeInformation[_]])
+  extends KeyedProcessFunctionWithCleanupState[Row, JTuple2[JBool, Row], Void](queryConfig) {
+
+  @transient private var states: Array[ValueState[AnyRef]] = _
+  @transient private var nonKeyIndices: Array[Int] = _
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+
+    nonKeyIndices = fieldNames.indices
+      .filter(idx => !keyNames.contains(fieldNames(idx)))
+      .toArray
+
+    val statesBuilder = Array.newBuilder[ValueState[AnyRef]]
+
+    for (i <- nonKeyIndices) {
+      val stateDesc = new ValueStateDescriptor(fieldNames(i), fieldTypes(i))
+      stateDesc.initializeSerializerUnlessSet(getRuntimeContext.getExecutionConfig)
+      stateDesc.setQueryable(s"$namePrefix-${fieldNames(i)}")
+      statesBuilder += getRuntimeContext.getState(stateDesc).asInstanceOf[ValueState[AnyRef]]
+    }
+
+    states = statesBuilder.result()
+
+    initCleanupTimeState("QueryableStateCleanupTime")
+  }
+
+  override def processElement(
+    value: JTuple2[JBool, Row],
+    ctx: KeyedProcessFunction[Row, JTuple2[JBool, Row], Void]#Context,
+    out: Collector[Void]): Unit = {
+    if (value.f0) {
+      var i = 0
+      while (i < nonKeyIndices.length) {
+        states(i).update(value.f1.getField(nonKeyIndices(i)))
+        i += 1
+      }
+
+      val currentTime: Long = ctx.timerService().currentProcessingTime()
+      registerProcessingCleanupTimer(ctx, currentTime)
+    } else {
+      cleanupState(states: _*)
+    }
+  }
+
+  override def onTimer(
+    timestamp: Long,
+    ctx: KeyedProcessFunction[Row, JTuple2[JBool, Row], Void]#OnTimerContext,
+    out: Collector[Void]): Unit = {
+    if (needToCleanupState(timestamp)) {
+      cleanupState(states: _*)
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/QueryableTableSink.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/QueryableTableSink.scala
@@ -112,6 +112,3 @@ class QueryableTableSink(
   }
 }
 
-
-
-

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/QueryableTableSink.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/QueryableTableSink.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks.queryable
+
+import java.lang.{Boolean => JBool}
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.sinks.{TableSinkBase, UpsertStreamTableSink}
+import org.apache.flink.types.Row
+
+/**
+  * A QueryableTableSink stores table in queryable state.
+  *
+  * This class stores table in queryable state so that users can access table data without
+  * dependency on external storage.
+  *
+  * Since this is only a kv storage, currently user can only do point query against it.
+  *
+  * Example:
+  * {{{
+  *   val env = ExecutionEnvironment.getExecutionEnvironment
+  *   val tEnv = TableEnvironment.getTableEnvironment(env)
+  *
+  *   val table: Table  = ...
+  *
+  *   val queryableTableSink: QueryableTableSink = new QueryableTableSink(
+  *       "prefix",
+  *       queryConfig)
+  *
+  *   tEnv.writeToSink(table, queryableTableSink, config)
+  * }}}
+  *
+  * When program starts to run, user can access state with QueryableStateClient.
+  * {{{
+  *   val client = new QueryableStateClient(tmHostname, proxyPort)
+  *   val data = client.getKvState(
+  *       jobId,
+  *       "prefix-column1",
+  *       Row.of(1),
+  *       new RowTypeInfo(Array(TypeInfoformation.of(classOf[Int]), Array("id"))
+  *       stateDescriptor)
+  *     .get();
+  *
+  * }}}
+  *
+  *
+  * @param namePrefix
+  * @param queryConfig
+  */
+class QueryableTableSink(
+  private val namePrefix: String,
+  private val queryConfig: StreamQueryConfig)
+  extends UpsertStreamTableSink[Row]
+    with TableSinkBase[JTuple2[JBool, Row]] {
+  private var keys: Array[String] = _
+
+  override def setKeyFields(keys: Array[String]): Unit = {
+    if (keys == null) {
+      throw new IllegalArgumentException("keys can't be null!")
+    }
+    this.keys = keys
+  }
+
+  override def setIsAppendOnly(isAppendOnly: JBool): Unit = {
+    if (isAppendOnly) {
+      throw new IllegalArgumentException("A QueryableTableSink can not be used with append-only " +
+        "tables as the table would grow infinitely")
+    }
+  }
+
+  override def getRecordType: TypeInformation[Row] = new RowTypeInfo(getFieldTypes, getFieldNames)
+
+  override def emitDataStream(dataStream: DataStream[JTuple2[JBool, Row]]): Unit = {
+    val keyIndices = keys.map(getFieldNames.indexOf(_))
+    val keyTypes = keyIndices.map(getFieldTypes(_))
+
+    val keySelectorType = new RowTypeInfo(keyTypes, keys)
+
+    val processFunction = new QueryableStateProcessFunction(
+      namePrefix,
+      queryConfig,
+      keys,
+      getFieldNames,
+      getFieldTypes)
+
+    dataStream.keyBy(new RowKeySelector(keyIndices, keySelectorType))
+      .process(processFunction)
+  }
+
+  override protected def copy: TableSinkBase[JTuple2[JBool, Row]] = {
+    new QueryableTableSink(this.namePrefix, this.queryConfig)
+  }
+}
+
+
+
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/RowKeySelector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sinks/queryable/RowKeySelector.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks.queryable
+
+import java.lang.{Boolean => JBool}
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.types.Row
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+
+class RowKeySelector(
+  private val keyIndices: Array[Int],
+  @transient private val returnType: TypeInformation[Row])
+  extends KeySelector[JTuple2[JBool, Row], Row]
+    with ResultTypeQueryable[Row] {
+
+  override def getKey(value: JTuple2[JBool, Row]): Row = {
+    Row.project(value.f1, keyIndices)
+  }
+
+  override def getProducedType: TypeInformation[Row] = returnType
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sink/queryable/AutoCancellableJob.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sink/queryable/AutoCancellableJob.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sink.queryable;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A wrapper of the job graph that makes sure to cancel the job and wait for
+ * termination after the execution of every test.
+ */
+class AutoCancellableJob implements AutoCloseable {
+
+	private final ClusterClient<?> clusterClient;
+	private final JobGraph jobGraph;
+
+	private final JobID jobId;
+
+	private final Deadline deadline;
+
+	AutoCancellableJob(Deadline deadline, final ClusterClient<?> clusterClient, final StreamExecutionEnvironment env) {
+		Preconditions.checkNotNull(env);
+
+		this.clusterClient = Preconditions.checkNotNull(clusterClient);
+		this.jobGraph = env.getStreamGraph().getJobGraph();
+
+		this.jobId = Preconditions.checkNotNull(jobGraph.getJobID());
+
+		this.deadline = deadline;
+	}
+
+	JobGraph getJobGraph() {
+		return jobGraph;
+	}
+
+	JobID getJobId() {
+		return jobId;
+	}
+
+	@Override
+	public void close() throws Exception {
+		// Free cluster resources
+		clusterClient.cancel(jobId);
+		// cancel() is non-blocking so do this to make sure the job finished
+		CompletableFuture<JobStatus> jobStatusFuture = FutureUtils.retrySuccesfulWithDelay(
+			() -> clusterClient.getJobStatus(jobId),
+			Time.milliseconds(50),
+			deadline,
+			(jobStatus) -> jobStatus.equals(JobStatus.CANCELED),
+			TestingUtils.defaultScheduledExecutor());
+		assertEquals(
+			JobStatus.CANCELED,
+			jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
+	}
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sink/queryable/QueryableSinkTestBase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sink/queryable/QueryableSinkTestBase.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sink.queryable;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.QueryableStateOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.test.util.MiniClusterResource;
+import org.apache.flink.test.util.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.TestBaseUtils;
+
+import org.junit.ClassRule;
+
+/**
+ * Base class for queryable sink.
+ */
+public class QueryableSinkTestBase extends TestBaseUtils {
+	private static final int DEFAULT_PARALLELISM = 2;
+	private static final int QS_PROXY_PORT = 9084;
+
+	@ClassRule
+	public static MiniClusterResource miniClusterResource = new MiniClusterResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setConfiguration(getConfig())
+			.setNumberTaskManagers(1)
+			.setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+			.build());
+
+	public static Configuration getConfig() {
+		Configuration config = new Configuration();
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
+		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, DEFAULT_PARALLELISM);
+		config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);
+		config.setInteger(QueryableStateOptions.PROXY_NETWORK_THREADS, 1);
+		config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
+		config.setString(QueryableStateOptions.PROXY_PORT_RANGE, String.valueOf(QS_PROXY_PORT));
+		config.setString(QueryableStateOptions.SERVER_PORT_RANGE, "9089");
+		config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
+		return config;
+	}
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sink/queryable/QueryableTableSinkTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sink/queryable/QueryableTableSinkTest.scala
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sink.queryable
+
+import java.time.Duration
+import java.util.concurrent.{ExecutionException, TimeUnit}
+
+import org.apache.flink.api.common.state.ValueStateDescriptor
+import org.apache.flink.api.common.time.{Deadline, Time}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.scala._
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend
+import org.apache.flink.queryablestate.client.QueryableStateClient
+import org.apache.flink.queryablestate.exceptions.UnknownKeyOrNamespaceException
+import org.apache.flink.runtime.state.StateBackend
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment}
+import org.apache.flink.table.runtime.harness.HarnessTestBase.TestStreamQueryConfig
+import org.apache.flink.table.sinks.queryable.QueryableTableSink
+import org.apache.flink.types.Row
+import org.hamcrest.core.Is
+import org.junit.Assert._
+import org.junit.rules.{ExpectedException, TemporaryFolder}
+import org.junit.{Rule, Test}
+
+
+class QueryableTableSinkTest extends QueryableSinkTestBase {
+
+  private val queryConfig = new StreamQueryConfig()
+  queryConfig.withIdleStateRetentionTime(Time.hours(1), Time.hours(2))
+
+  val _tempFolder = new TemporaryFolder
+  @Rule
+  def tempFolder: TemporaryFolder = _tempFolder
+
+  val _expectedException = ExpectedException.none()
+  @Rule
+  def expectedException: ExpectedException = _expectedException
+
+  def getStateBackend: StateBackend = {
+    val dbPath = tempFolder.newFolder().getAbsolutePath
+    val checkpointPath = tempFolder.newFolder().toURI.toString
+    val backend = new RocksDBStateBackend(checkpointPath)
+    backend.setDbStoragePath(dbPath)
+    backend
+  }
+
+  @Test
+  def testQueryableSink(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    //name, money
+    val data = List(("jeff", -1), ("dean", -2), ("jeff", 2), ("dean", 4))
+    val source = new TestKVListSource[String, Int](data)
+
+    // select name, sum(money) as sm from t group by name
+    val t = env.addSource(source).toTable(tEnv, 'name, 'money)
+        .groupBy("name")
+        .select("name, sum(money) as sm")
+
+    val queryableSink = new QueryableTableSink("prefix",
+      new StreamQueryConfig().withIdleStateRetentionTime(Time.minutes(1), Time.minutes(7)))
+
+    t.writeToSink(queryableSink)
+
+    val clusterClient = QueryableSinkTestBase.miniClusterResource.getClusterClient
+    val deadline = Deadline.now.plus(Duration.ofSeconds(100))
+
+    val autoCancellableJob = new AutoCancellableJob(deadline, clusterClient, env.getJavaEnv)
+    val client = new QueryableStateClient("localhost", 9084)
+
+    try {
+      val jobId = autoCancellableJob.getJobId
+      val jobGraph = autoCancellableJob.getJobGraph
+
+      clusterClient.setDetached(true)
+      clusterClient.submitJob(jobGraph, classOf[QueryableTableSinkTest].getClassLoader )
+
+      // Wait for ten seconds for processing to complete
+      Thread.sleep(10000)
+      val keyType = new RowTypeInfo(
+        Array[TypeInformation[_]](BasicTypeInfo.STRING_TYPE_INFO),
+        Array("name"))
+
+      val stateDesc = new ValueStateDescriptor[Integer]("sm", classOf[Integer])
+
+      val jeffMoney = client.getKvState(jobId, "prefix-sm", Row.of("jeff"), keyType,
+        stateDesc)
+        .get(1, TimeUnit.SECONDS)
+        .value()
+      assertEquals(1, jeffMoney)
+
+      val deanMoney = client.getKvState(jobId, "prefix-sm", Row.of("dean"), keyType,
+        stateDesc)
+        .get(1, TimeUnit.SECONDS)
+        .value()
+
+      assertEquals(2, deanMoney)
+    } finally {
+      try {
+        autoCancellableJob.close()
+      } catch {
+        case t: Throwable => log.warn("Failed to close job.", t)
+      }
+    }
+  }
+
+  @Test
+  def testCleanupState(): Unit = {
+    // Expected to throw ExecutionException, caused by UnknownKeyOrNamespaceException
+    expectedException.expect(classOf[ExecutionException])
+    expectedException.expectCause(Is.isA(classOf[UnknownKeyOrNamespaceException]))
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    //name, money
+    val data = List(("jeff", -1))
+    val source = new TestKVListSource[String, Int](data)
+
+    // select name, sum(money) as sm from t group by name
+    val t = env.addSource(source).toTable(tEnv, 'name, 'money)
+      .groupBy("name")
+      .select("name, sum(money) as sm")
+
+    val queryableSink = new QueryableTableSink("prefix",
+      new TestStreamQueryConfig(Time.milliseconds(2), Time.seconds(1)))
+
+    t.writeToSink(queryableSink)
+
+    val clusterClient = QueryableSinkTestBase.miniClusterResource.getClusterClient
+    val deadline = Deadline.now.plus(Duration.ofSeconds(100))
+
+    val autoCancellableJob = new AutoCancellableJob(deadline, clusterClient, env.getJavaEnv)
+    val client = new QueryableStateClient("localhost", 9084)
+
+    try {
+      val jobId = autoCancellableJob.getJobId
+      val jobGraph = autoCancellableJob.getJobGraph
+
+      clusterClient.setDetached(true)
+      clusterClient.submitJob(jobGraph, classOf[QueryableTableSinkTest].getClassLoader )
+
+      // Wait for ten seconds for processing to complete
+      Thread.sleep(10000)
+
+      // Now the state should already been cleaned
+      val keyType = new RowTypeInfo(
+        Array[TypeInformation[_]](BasicTypeInfo.STRING_TYPE_INFO),
+        Array("name"))
+
+      val stateDesc = new ValueStateDescriptor[Integer]("sm", classOf[Integer])
+
+      client.getKvState(jobId, "prefix-sm", Row.of("jeff"), keyType,
+        stateDesc)
+        .get(1, TimeUnit.SECONDS)
+        .value()
+    } finally {
+      try {
+        autoCancellableJob.close()
+      } catch {
+        case t: Throwable => log.warn("Failed to close job.", t)
+      }
+    }
+  }
+}
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sink/queryable/QueryableTableSinkTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sink/queryable/QueryableTableSinkTest.scala
@@ -118,6 +118,12 @@ class QueryableTableSinkTest extends QueryableSinkTestBase {
       assertEquals(2, deanMoney)
     } finally {
       try {
+        client.shutdownAndWait()
+      } catch {
+        case t: Throwable => log.warn("Failed to close client.", t)
+      }
+
+      try {
         autoCancellableJob.close()
       } catch {
         case t: Throwable => log.warn("Failed to close job.", t)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sink/queryable/TestKVListSource.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sink/queryable/TestKVListSource.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sink.queryable
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+
+class TestKVListSource[K, V](private val input: Seq[(K, V)]) extends SourceFunction[(K, V)] {
+  @volatile private var running = true
+
+  override def run(ctx: SourceFunction.SourceContext[(K, V)]): Unit = {
+    ctx.getCheckpointLock.synchronized {
+      input.foreach(ctx.collect)
+    }
+
+    while(running) {
+      Thread.sleep(1000)
+    }
+  }
+
+  override def cancel(): Unit = {
+    running = false
+  }
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.test.util;
 
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.QueryableStateOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.FileUtils;
 
 import org.junit.ClassRule;
@@ -95,4 +100,6 @@ public abstract class AbstractTestBase extends TestBaseUtils {
 	public File createAndRegisterTempFile(String fileName) throws IOException {
 		return new File(TEMPORARY_FOLDER.newFolder(), fileName);
 	}
+
+
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
@@ -18,11 +18,6 @@
 
 package org.apache.flink.test.util;
 
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.QueryableStateOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.FileUtils;
 
 import org.junit.ClassRule;
@@ -100,6 +95,4 @@ public abstract class AbstractTestBase extends TestBaseUtils {
 	public File createAndRegisterTempFile(String fileName) throws IOException {
 		return new File(TEMPORARY_FOLDER.newFolder(), fileName);
 	}
-
-
 }


### PR DESCRIPTION
## What is the purpose of the change

Streaming tables with unique key are continuously updated. For example queries with a non-windowed aggregation generate such tables. Commonly, such updating tables are emitted via an upsert table sink to an external datastore (k-v store, database) to make it accessible to applications.

## Brief change log

  - *Add a QueryableStateTableSink.*
  - *States are queryable.*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test that validates that states will be stored.*


## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
