### PR TITLE
[FLINK-9978][release] Include relative path in source release sha file

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -70,7 +70,8 @@ rsync -a \
 
 tar czf ${RELEASE_DIR}/flink-${RELEASE_VERSION}-src.tgz flink-$RELEASE_VERSION
 gpg --armor --detach-sig ${RELEASE_DIR}/flink-$RELEASE_VERSION-src.tgz
-$SHASUM ${RELEASE_DIR}/flink-$RELEASE_VERSION-src.tgz > ${RELEASE_DIR}/flink-$RELEASE_VERSION-src.tgz.sha512
+cd ${RELEASE_DIR}
+$SHASUM flink-$RELEASE_VERSION-src.tgz > flink-$RELEASE_VERSION-src.tgz.sha512
 
 cd ${CURR_DIR}
 rm -rf ${CLONE_DIR}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes an issue with the sha generation for source release artifacts. The `sha512` file contained the absolute file path to the file.

