### PR TITLE
[FLINK-9976][streaming] Remove unnecessary generic parameters

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -186,17 +186,17 @@ public class StreamingFileSink<IN>
 
 		private static final long serialVersionUID = 1L;
 
-		private long bucketCheckInterval = 60L * 1000L;
+		private final long bucketCheckInterval;
 
 		private final Path basePath;
 
 		private final Encoder<IN> encoder;
 
-		private Bucketer<IN, BucketID> bucketer;
+		private final Bucketer<IN, BucketID> bucketer;
 
-		private RollingPolicy<IN, BucketID> rollingPolicy;
+		private final RollingPolicy<IN, BucketID> rollingPolicy;
 
-		private BucketFactory<IN, BucketID> bucketFactory = new DefaultBucketFactory<>();
+		private final BucketFactory<IN, BucketID> bucketFactory;
 
 		RowFormatBuilder(Path basePath, Encoder<IN> encoder, Bucketer<IN, BucketID> bucketer) {
 			this(basePath, encoder, bucketer, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactory<>());
@@ -263,15 +263,15 @@ public class StreamingFileSink<IN>
 
 		private static final long serialVersionUID = 1L;
 
-		private long bucketCheckInterval = 60L * 1000L;
+		private final long bucketCheckInterval;
 
 		private final Path basePath;
 
 		private final BulkWriter.Factory<IN> writerFactory;
 
-		private Bucketer<IN, BucketID> bucketer;
+		private final Bucketer<IN, BucketID> bucketer;
 
-		private BucketFactory<IN, BucketID> bucketFactory = new DefaultBucketFactory<>();
+		private final BucketFactory<IN, BucketID> bucketFactory;
 
 		BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, Bucketer<IN, BucketID> bucketer) {
 			this(basePath, writerFactory, bucketer, 60L * 1000L, new DefaultBucketFactory<>());


### PR DESCRIPTION
## What is the purpose of the change

This PR removes unnecessary generic parameter from format builder methods of the `StreamingFileSink`.
These are inconsistent with other existing methods that use the already defined bucket ID type of the builder, and as of right now would always lead to `ClassCastExceptions` if one tried to use a different type.


