### PR TITLE
[FLINK-9988][rest] Add deprecated keys for server bind address

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -34,6 +34,7 @@ public class RestOptions {
 	public static final ConfigOption<String> BIND_ADDRESS =
 		key("rest.bind-address")
 			.noDefaultValue()
+			.withDeprecatedKeys(WebOptions.ADDRESS.key(), "jobmanager.web.address")
 			.withDescription("The address that the server binds itself.");
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR adds missing deprecated keys for `rest.bind-address`. This setting controls on which address the REST API server (and thus the Web UI) is started on. In the past this was controlled via ` WebOptions#ADDRESS`, which is now added as a deprecated key, along with `"jobmanager.web.address"` that was used before that.
