### PR TITLE
[FLINK-9987][tests] Harden ClassLoader E2E test

### DIFF
--- a/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/java/org/apache/flink/streaming/tests/ClassLoaderTestProgram.java
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/java/org/apache/flink/streaming/tests/ClassLoaderTestProgram.java
@@ -50,12 +50,12 @@ public class ClassLoaderTestProgram {
 			.fromElements("Hello")
 			.map((MapFunction<String, String>) value -> {
 
-				String gitUrl;
+				String gitCommitId;
 
 				try (InputStream propFile = ClassLoaderTestProgram.class.getClassLoader().getResourceAsStream(".version.properties")) {
 					Properties properties = new Properties();
 					properties.load(propFile);
-					gitUrl = properties.getProperty("git.remote.origin.url");
+					gitCommitId = properties.getProperty("git.commit.id.abbrev");
 				}
 
 				Enumeration<URL> resources = ClassLoaderTestProgram.class.getClassLoader().getResources(
@@ -67,7 +67,7 @@ public class ClassLoaderTestProgram {
 					try (InputStream in = url.openStream()) {
 						Properties properties = new Properties();
 						properties.load(in);
-						String orderedGitUrl = properties.getProperty("git.remote.origin.url");
+						String orderedGitUrl = properties.getProperty("git.commit.id.abbrev");
 						sortedProperties.append(orderedGitUrl);
 					}
 				}
@@ -84,13 +84,13 @@ public class ClassLoaderTestProgram {
 					} catch (NoSuchMethodError e) {
 						// expected
 					}
-					return "NoSuchMethodError:" + gitUrl + ":" + sortedProperties;
+					return "NoSuchMethodError:" + gitCommitId + ":" + sortedProperties;
 				} else if (resolveOrder.equals("child-first")) {
 					String message = TaskManager.getMessage();
 					if (!message.equals("Hello, World!")) {
 						throw new RuntimeException("Wrong message from fake TaskManager.");
 					}
-					return message + ":" + gitUrl + ":" + sortedProperties;
+					return message + ":" + gitCommitId + ":" + sortedProperties;
 				} else {
 					throw new RuntimeException("Unknown resolve order: " + resolveOrder);
 				}

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/java/org/apache/flink/streaming/tests/ClassLoaderTestProgram.java
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/java/org/apache/flink/streaming/tests/ClassLoaderTestProgram.java
@@ -67,8 +67,8 @@ public class ClassLoaderTestProgram {
 					try (InputStream in = url.openStream()) {
 						Properties properties = new Properties();
 						properties.load(in);
-						String orderedGitUrl = properties.getProperty("git.commit.id.abbrev");
-						sortedProperties.append(orderedGitUrl);
+						String orderedGitCommitId = properties.getProperty("git.commit.id.abbrev");
+						sortedProperties.append(orderedGitCommitId);
 					}
 				}
 

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/resources/.version.properties
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/resources/.version.properties
@@ -1,1 +1,1 @@
-git.remote.origin.url=hello-there-42
+git.commit.id.abbrev=hello-there-42

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -18,16 +18,10 @@
 ################################################################################
 
 source "$(dirname "$0")"/common.sh
-EXIT_CODE=0
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-parent-child-classloading-test/target/ClassLoaderTestProgram.jar
 
 echo "Testing parent-first class loading"
-
-# retrieve git.remote.origin.url from .version.properties
-GIT_REMOTE_URL=`grep "git\.remote\.origin\.url" $TEST_INFRA_DIR/../../flink-runtime/src/main/resources/.version.properties \
-  |cut -d'=' -f2 \
-  |sed -e 's/\\\:/:/g'`
 
 # remove any leftover classloader settings
 sed -i -e 's/classloader.resolve-order: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
@@ -47,12 +41,12 @@ OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_pf`
 # first field: whether we found the method on TaskManager
 # result of getResource(".version.properties"), should be from the parent
 # ordered result of getResources(".version.properties"), should have parent first
-EXPECTED="NoSuchMethodError:${GIT_REMOTE_URL}:${GIT_REMOTE_URL}hello-there-42"
-if [[ "$OUTPUT" != "$EXPECTED" ]]; then
+EXPECTED="NoSuchMethodError:[0-9a-f]{6,}:[0-9a-f]{6,}hello-there-42"
+if ! [[ "$OUTPUT" =~ $EXPECTED ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  EXIT_CODE=1
+  exit 1
 fi
 
 # This verifies that Flink classes are still resolved from the parent because the default
@@ -77,12 +71,12 @@ OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_cf_pf`
 # first field: whether we found the method on TaskManager
 # result of getResource(".version.properties"), should be from the child
 # ordered result of getResources(".version.properties"), should be child first
-EXPECTED="NoSuchMethodError:hello-there-42:hello-there-42${GIT_REMOTE_URL}"
-if [[ "$OUTPUT" != "$EXPECTED" ]]; then
+EXPECTED="NoSuchMethodError:hello-there-42:hello-there-42[0-9a-f]{6,}"
+if ! [[ "$OUTPUT" =~ $EXPECTED ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  EXIT_CODE=1
+  exit 1
 fi
 
 echo "Testing child-first class loading"
@@ -106,14 +100,10 @@ OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_cf`
 # first field: whether we found the method on TaskManager
 # result of getResource(".version.properties"), should be from the child
 # ordered result of getResources(".version.properties"), should be child first
-EXPECTED="Hello, World!:hello-there-42:hello-there-42${GIT_REMOTE_URL}"
-if [[ "$OUTPUT" != "$EXPECTED" ]]; then
+EXPECTED="Hello, World!:hello-there-42:hello-there-42[0-9a-f]{6,}"
+if ! [[ "$OUTPUT" =~ $EXPECTED ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  EXIT_CODE=1
-fi
-
-if [[ ${EXIT_CODE} != 0 ]]; then
-    exit ${EXIT_CODE}
+  exit 1
 fi


### PR DESCRIPTION
## What is the purpose of the change

This PR hardens the ClassLoader end-to-end test.

## Brief change log

* retrieve commit id from `.version.properties` as the value has a well-defined format
* do not access `.version.properties` file in source of flink-runtime and match id against regex instead
  * prevents failures caused by value mismatches if the binary does not originate from the source
  * prevents failures when flink-runtime has not been built, e.g. if the tests were run in a clean repo
  * removes access outside of `flink-end-to-end-tests` which is good for maintainability
* exit early on test failure
  * same behavior as if the test was split in several files
