### PR TITLE
 [FLINK-9986][build] Only include commit info in .version.properties file 

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -470,7 +470,7 @@ under the License.
 					Used to show the git ref when starting the jobManager. -->
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.1.5</version>
+				<version>2.1.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -484,6 +484,9 @@ under the License.
 					<skipPoms>false</skipPoms>
 					<failOnNoGitDirectory>false</failOnNoGitDirectory>
 					<generateGitPropertiesFilename>src/main/resources/.version.properties</generateGitPropertiesFilename>
+					<includeOnlyProperties>
+						<includeOnlyProperty>git.commit.*</includeOnlyProperty>
+					</includeOnlyProperties>
 					<gitDescribe>
 						<!-- don't generate the describe property -->
 						<skip>true</skip>


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the `git-commit-id-plugin` configuration to only contain information about the actual commit, excluding information about the build, remote and branch.

This PR is based on #6442 since one of the now removed properties is still used.

## Brief change log

* bump plugin version to earliest version supporting inclusions
* modify configuration

## Verifying this change

* run `mvn package` in flink-runtime and check `src/main/resources/.version.properties`