### PR TITLE
[FLINK-9933] Simplify taskmanager memory default values

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -84,7 +84,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
-            <td style="word-wrap: break-word;">"32768"</td>
+            <td style="word-wrap: break-word;">"32kb"</td>
             <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
         <tr>
@@ -114,12 +114,12 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.max</h5></td>
-            <td style="word-wrap: break-word;">"1073741824"</td>
+            <td style="word-wrap: break-word;">"1gb"</td>
             <td>Maximum memory size for network buffers.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.min</h5></td>
-            <td style="word-wrap: break-word;">"67108864"</td>
+            <td style="word-wrap: break-word;">"64mb"</td>
             <td>Minimum memory size for network buffers.</td>
         </tr>
         <tr>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -211,10 +211,10 @@ Previously, the number of network buffers was set manually which became a quite 
 network buffers with the following configuration parameters:
 
 - `taskmanager.network.memory.fraction`: Fraction of JVM memory to use for network buffers (DEFAULT: 0.1),
-- `taskmanager.network.memory.min`: Minimum memory size for network buffers in bytes (DEFAULT: 64 MB),
-- `taskmanager.network.memory.max`: Maximum memory size for network buffers in bytes (DEFAULT: 1 GB), and
+- `taskmanager.network.memory.min`: Minimum memory size for network buffers (DEFAULT: 64MB),
+- `taskmanager.network.memory.max`: Maximum memory size for network buffers (DEFAULT: 1GB), and
 - `taskmanager.memory.segment-size`: Size of memory buffers used by the memory manager and the
-network stack in bytes (DEFAULT: 32768 (= 32 KiBytes)).
+network stack in bytes (DEFAULT: 32KB).
 
 #### Setting the Number of Network Buffers directly
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -190,11 +190,11 @@ public class TaskManagerOptions {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Size of memory buffers used by the network stack and the memory manager (in bytes).
+	 * Size of memory buffers used by the network stack and the memory manager.
 	 */
 	public static final ConfigOption<String> MEMORY_SEGMENT_SIZE =
 			key("taskmanager.memory.segment-size")
-			.defaultValue("32768")
+			.defaultValue("32kb")
 			.withDescription("Size of memory buffers used by the network stack and the memory manager.");
 
 	/**
@@ -268,19 +268,19 @@ public class TaskManagerOptions {
 				"` and \"taskmanager.network.memory.max\" may override this fraction.");
 
 	/**
-	 * Minimum memory size for network buffers (in bytes).
+	 * Minimum memory size for network buffers.
 	 */
 	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MIN =
 			key("taskmanager.network.memory.min")
-			.defaultValue(String.valueOf(64L << 20)) // 64 MB
+			.defaultValue("64mb")
 			.withDescription("Minimum memory size for network buffers.");
 
 	/**
-	 * Maximum memory size for network buffers (in bytes).
+	 * Maximum memory size for network buffers.
 	 */
 	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MAX =
 			key("taskmanager.network.memory.max")
-			.defaultValue(String.valueOf(1024L << 20)) // 1 GB
+			.defaultValue("1gb")
 			.withDescription("Maximum memory size for network buffers.");
 
 	/**

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -184,8 +184,8 @@ rest.port: 8081
 # of network buffers" error. The default min is 64MB, teh default max is 1GB.
 # 
 # taskmanager.network.memory.fraction: 0.1
-# taskmanager.network.memory.min: 67108864
-# taskmanager.network.memory.max: 1073741824
+# taskmanager.network.memory.min: 64mb
+# taskmanager.network.memory.max: 1gb
 
 #==============================================================================
 # Flink Cluster Security Configuration

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -30,9 +30,9 @@ backup_config
 set_conf "taskmanager.heap.mb" "52" # 52Mb x 100 TMs = 5Gb total heap
 
 set_conf "taskmanager.memory.size" "8" # 8Mb
-set_conf "taskmanager.network.memory.min" "8388608" # 8Mb
-set_conf "taskmanager.network.memory.max" "8388608" # 8Mb
-set_conf "taskmanager.memory.segment-size" "8192" # 8Kb
+set_conf "taskmanager.network.memory.min" "8mb"
+set_conf "taskmanager.network.memory.max" "8mb"
+set_conf "taskmanager.memory.segment-size" "8kb"
 
 set_conf "taskmanager.network.netty.server.numThreads" "1"
 set_conf "taskmanager.network.netty.client.numThreads" "1"


### PR DESCRIPTION
## What is the purpose of the change

*This pull request simplify taskmanager memory default values*


## Brief change log

  - *Simplify taskmanager memory default values*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
