### PR TITLE
[FLINK-8302] [table] Add SHIFT_LEFT and SHIFT_RIGHT

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1098,7 +1098,7 @@ MOD(numeric1, numeric2)
     <tr>
       <td>
         {% highlight text %}
-SHIFTLEFT(numeric1, numeric2)
+SHIFT_LEFT(numeric1, numeric2)
 {% endhighlight %}
       </td>
       <td>
@@ -1110,7 +1110,7 @@ SHIFTLEFT(numeric1, numeric2)
     <tr>
       <td>
         {% highlight text %}
-SHIFTRIGHT(numeric1, numeric2)
+SHIFT_RIGHT(numeric1, numeric2)
 {% endhighlight %}
       </td>
       <td>
@@ -1122,7 +1122,7 @@ SHIFTRIGHT(numeric1, numeric2)
     <tr>
       <td>
         {% highlight text %}
-SHIFTRIGHTUNSIGNED(numeric1, numeric2)
+SHIFT_RIGHT_UNSIGNED(numeric1, numeric2)
 {% endhighlight %}
       </td>
       <td>

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1103,6 +1103,7 @@ SHIFTLEFT(numeric1, numeric2)
       </td>
       <td>
         <p>Returns <i>numeric1</i> shifted left of <i>numeric2</i>. The result is <i>numeric1</i> << <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -1114,6 +1115,7 @@ SHIFTRIGHT(numeric1, numeric2)
       </td>
       <td>
         <p>Returns <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >> <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -1125,6 +1127,7 @@ SHIFTRIGHTUNSIGNED(numeric1, numeric2)
       </td>
       <td>
         <p>Returns unsigned <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >>> <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -1609,6 +1612,7 @@ numeric1.shiftLeft(numeric2)
       </td>
       <td>
         <p>Returns <i>numeric1</i> shifted left of <i>numeric2</i>. The result is <i>numeric1</i> << <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -1620,6 +1624,7 @@ numeric1.shiftRight(numeric2)
       </td>
       <td>
         <p>Returns <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >> <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -1631,6 +1636,7 @@ numeric1.shiftRightUnsigned(numeric2)
       </td>
       <td>
         <p>Returns unsigned <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >>> <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -2115,6 +2121,7 @@ numeric1.shiftLeft(numeric2)
       </td>
       <td>
         <p>Returns <i>numeric1</i> shifted left of <i>numeric2</i>. The result is <i>numeric1</i> << <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -2126,6 +2133,7 @@ numeric1.shiftRight(numeric2)
       </td>
       <td>
         <p>Returns <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >> <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 
@@ -2137,6 +2145,7 @@ numeric1.shiftRightUnsigned(numeric2)
       </td>
       <td>
         <p>Returns unsigned <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >>> <i>numeric2</i> </p>
+        <p>The return type is the same as <i>numeric1</i>. The semantic of the operation is the same as equivalent java operation and casts the result to the return type.</p>
       </td>
     </tr>
 

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1098,6 +1098,40 @@ MOD(numeric1, numeric2)
     <tr>
       <td>
         {% highlight text %}
+SHIFTLEFT(numeric1, numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns <i>numeric1</i> shifted left of <i>numeric2</i>. The result is <i>numeric1</i> << <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+SHIFTRIGHT(numeric1, numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >> <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+SHIFTRIGHTUNSIGNED(numeric1, numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns unsigned <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >>> <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+
+    <tr>
+      <td>
+        {% highlight text %}
 SQRT(numeric)
 {% endhighlight %}
       </td>
@@ -1570,6 +1604,40 @@ NUMERIC1 % NUMERIC2
     <tr>
       <td>
         {% highlight java %}
+numeric1.shiftLeft(numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns <i>numeric1</i> shifted left of <i>numeric2</i>. The result is <i>numeric1</i> << <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+numeric1.shiftRight(numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >> <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+numeric1.shiftRightUnsigned(numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns unsigned <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >>> <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+
+    <tr>
+      <td>
+        {% highlight java %}
 NUMERIC.sqrt()
 {% endhighlight %}
       </td>
@@ -2038,6 +2106,40 @@ NUMERIC1 % NUMERIC2
         <p>Returns the remainder (modulus) of <i>NUMERIC1</i> divided by <i>NUMERIC2</i>. The result is negative only if <i>numeric1</i> is negative.</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+numeric1.shiftLeft(numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns <i>numeric1</i> shifted left of <i>numeric2</i>. The result is <i>numeric1</i> << <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+numeric1.shiftRight(numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >> <i>numeric2</i> </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+numeric1.shiftRightUnsigned(numeric2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns unsigned <i>numeric1</i> shifted right of <i>numeric2</i>. The result is <i>numeric1</i> >>> <i>numeric2</i> </p>
+      </td>
+    </tr>
+
 
     <tr>
       <td>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -945,17 +945,17 @@ trait ImplicitExpressionOperations {
   def notBetween(lowerBound: Expression, upperBound: Expression) =
     NotBetween(expr, lowerBound, upperBound)
 
-  /*
+  /**
    * Returns the left shift value of expr. The result is expr << right.
    */
   def shiftLeft(right: Expression) = ShiftLeft(expr, right)
 
-  /*
+  /**
    * Returns the right shift value of expr. The result is expr >> right.
    */
   def shiftRight(right: Expression) = ShiftRight(expr, right)
 
-  /*
+  /**
    * Returns the unsigned right shift value of expr. The result is expr >>> right.
    */
   def shiftRightUnsigned(right: Expression) = ShiftRightUnsigned(expr, right)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -944,6 +944,21 @@ trait ImplicitExpressionOperations {
     */
   def notBetween(lowerBound: Expression, upperBound: Expression) =
     NotBetween(expr, lowerBound, upperBound)
+
+  /*
+   * Returns the left shift value of expr. The result is expr << right.
+   */
+  def shiftLeft(right: Expression) = ShiftLeft(expr, right)
+
+  /*
+   * Returns the right shift value of expr. The result is expr >> right.
+   */
+  def shiftRight(right: Expression) = ShiftRight(expr, right)
+
+  /*
+   * Returns the unsigned right shift value of expr. The result is expr >>> right.
+   */
+  def shiftRightUnsigned(right: Expression) = ShiftRightUnsigned(expr, right)
 }
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1014,6 +1014,21 @@ abstract class CodeGenerator(
       case ScalarSqlFunctions.CONCAT_WS =>
         generateConcatWs(operands)
 
+      case ScalarSqlFunctions.SHIFT_LEFT =>
+        val left = operands.head
+        val right = operands(1)
+        generateArithmeticOperator("<<", nullCheck, resultType, left, right, config)
+
+      case ScalarSqlFunctions.SHIFT_RIGHT =>
+        val left = operands.head
+        val right = operands(1)
+        generateArithmeticOperator(">>", nullCheck, resultType, left, right, config)
+
+      case ScalarSqlFunctions.SHIFT_RIGHT_UNSIGNED =>
+        val left = operands.head
+        val right = operands(1)
+        generateArithmeticOperator(">>>", nullCheck, resultType, left, right, config)
+
       case StreamRecordTimestampSqlFunction =>
         generateStreamRecordRowtimeAccess()
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/mathExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/mathExpressions.scala
@@ -493,3 +493,66 @@ case class UUID() extends LeafExpression {
     relBuilder.call(ScalarSqlFunctions.UUID)
   }
 }
+
+case class ShiftLeft(left: Expression, right: Expression) extends BinaryArithmetic  {
+  override def toString: String = s"shiftLeft($left,$right)"
+
+  private[flink] val sqlOperator = ScalarSqlFunctions.SHIFT_LEFT
+
+  override private[flink] def resultType: TypeInformation[_] = {
+    if (left.resultType == BYTE_TYPE_INFO ||
+        left.resultType == SHORT_TYPE_INFO ||
+        left.resultType == INT_TYPE_INFO) {
+      INT_TYPE_INFO
+    } else {
+      LONG_TYPE_INFO
+    }
+  }
+
+  override private[flink] def validateInput() = {
+    TypeCheckUtils.assertIntegerFamilyExpr(left.resultType, "shiftleft")
+    TypeCheckUtils.assertIntegerFamilyExpr(right.resultType, "shiftleft")
+  }
+}
+
+case class ShiftRight(left: Expression, right: Expression) extends BinaryArithmetic  {
+  override def toString: String = s"shiftRight($left,$right)"
+
+  private[flink] val sqlOperator = ScalarSqlFunctions.SHIFT_RIGHT
+
+  override private[flink] def resultType: TypeInformation[_] = {
+    if (left.resultType == BYTE_TYPE_INFO ||
+        left.resultType == SHORT_TYPE_INFO ||
+        left.resultType == INT_TYPE_INFO) {
+      INT_TYPE_INFO
+    } else {
+      LONG_TYPE_INFO
+    }
+  }
+
+  override private[flink] def validateInput() = {
+    TypeCheckUtils.assertIntegerFamilyExpr(left.resultType, "shiftright")
+    TypeCheckUtils.assertIntegerFamilyExpr(right.resultType, "shiftright")
+  }
+}
+
+case class ShiftRightUnsigned(left: Expression, right: Expression) extends BinaryArithmetic  {
+  override def toString: String = s"shiftRightUnsigned($left,$right)"
+
+  private[flink] val sqlOperator = ScalarSqlFunctions.SHIFT_RIGHT_UNSIGNED
+
+  override private[flink] def resultType: TypeInformation[_] = {
+    if (left.resultType == BYTE_TYPE_INFO ||
+        left.resultType == SHORT_TYPE_INFO ||
+        left.resultType == INT_TYPE_INFO) {
+      INT_TYPE_INFO
+    } else {
+      LONG_TYPE_INFO
+    }
+  }
+
+  override private[flink] def validateInput() = {
+    TypeCheckUtils.assertIntegerFamilyExpr(left.resultType, "shiftrightunsigned")
+    TypeCheckUtils.assertIntegerFamilyExpr(right.resultType, "shiftrightunsigned")
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/mathExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/mathExpressions.scala
@@ -499,15 +499,7 @@ case class ShiftLeft(left: Expression, right: Expression) extends BinaryArithmet
 
   private[flink] val sqlOperator = ScalarSqlFunctions.SHIFT_LEFT
 
-  override private[flink] def resultType: TypeInformation[_] = {
-    if (left.resultType == BYTE_TYPE_INFO ||
-        left.resultType == SHORT_TYPE_INFO ||
-        left.resultType == INT_TYPE_INFO) {
-      INT_TYPE_INFO
-    } else {
-      LONG_TYPE_INFO
-    }
-  }
+  override private[flink] def resultType: TypeInformation[_] = left.resultType
 
   override private[flink] def validateInput() = {
     TypeCheckUtils.assertIntegerFamilyExpr(left.resultType, "shiftleft")
@@ -520,15 +512,7 @@ case class ShiftRight(left: Expression, right: Expression) extends BinaryArithme
 
   private[flink] val sqlOperator = ScalarSqlFunctions.SHIFT_RIGHT
 
-  override private[flink] def resultType: TypeInformation[_] = {
-    if (left.resultType == BYTE_TYPE_INFO ||
-        left.resultType == SHORT_TYPE_INFO ||
-        left.resultType == INT_TYPE_INFO) {
-      INT_TYPE_INFO
-    } else {
-      LONG_TYPE_INFO
-    }
-  }
+  override private[flink] def resultType: TypeInformation[_] = left.resultType
 
   override private[flink] def validateInput() = {
     TypeCheckUtils.assertIntegerFamilyExpr(left.resultType, "shiftright")
@@ -541,15 +525,7 @@ case class ShiftRightUnsigned(left: Expression, right: Expression) extends Binar
 
   private[flink] val sqlOperator = ScalarSqlFunctions.SHIFT_RIGHT_UNSIGNED
 
-  override private[flink] def resultType: TypeInformation[_] = {
-    if (left.resultType == BYTE_TYPE_INFO ||
-        left.resultType == SHORT_TYPE_INFO ||
-        left.resultType == INT_TYPE_INFO) {
-      INT_TYPE_INFO
-    } else {
-      LONG_TYPE_INFO
-    }
-  }
+  override private[flink] def resultType: TypeInformation[_] = left.resultType
 
   override private[flink] def validateInput() = {
     TypeCheckUtils.assertIntegerFamilyExpr(left.resultType, "shiftrightunsigned")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -277,7 +277,7 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING)
 
   val SHIFT_LEFT = new SqlFunction(
-    "SHIFTLEFT",
+    "SHIFT_LEFT",
     SqlKind.OTHER,
     ReturnTypes.ARG0_NULLABLE,
     null,
@@ -285,7 +285,7 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.NUMERIC)
 
   val SHIFT_RIGHT = new SqlFunction(
-    "SHIFTRIGHT",
+    "SHIFT_RIGHT",
     SqlKind.OTHER,
     ReturnTypes.ARG0_NULLABLE,
     null,
@@ -293,7 +293,7 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.NUMERIC)
 
   val SHIFT_RIGHT_UNSIGNED = new SqlFunction(
-    "SHIFTRIGHTUNSIGNED",
+    "SHIFT_RIGHT_UNSIGNED",
     SqlKind.OTHER,
     ReturnTypes.ARG0_NULLABLE,
     null,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -276,4 +276,28 @@ object ScalarSqlFunctions {
     OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),
     SqlFunctionCategory.STRING)
 
+  val SHIFT_LEFT = new SqlFunction(
+    "SHIFTLEFT",
+    SqlKind.OTHER,
+    ReturnTypes.LEAST_RESTRICTIVE,
+    null,
+    OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER),
+    SqlFunctionCategory.NUMERIC)
+
+  val SHIFT_RIGHT = new SqlFunction(
+    "SHIFTRIGHT",
+    SqlKind.OTHER,
+    ReturnTypes.LEAST_RESTRICTIVE,
+    null,
+    OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER),
+    SqlFunctionCategory.NUMERIC)
+
+  val SHIFT_RIGHT_UNSIGNED = new SqlFunction(
+    "SHIFTRIGHTUNSIGNED",
+    SqlKind.OTHER,
+    ReturnTypes.LEAST_RESTRICTIVE,
+    null,
+    OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER),
+    SqlFunctionCategory.NUMERIC)
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -279,7 +279,7 @@ object ScalarSqlFunctions {
   val SHIFT_LEFT = new SqlFunction(
     "SHIFTLEFT",
     SqlKind.OTHER,
-    ReturnTypes.LEAST_RESTRICTIVE,
+    ReturnTypes.ARG0_NULLABLE,
     null,
     OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER),
     SqlFunctionCategory.NUMERIC)
@@ -287,7 +287,7 @@ object ScalarSqlFunctions {
   val SHIFT_RIGHT = new SqlFunction(
     "SHIFTRIGHT",
     SqlKind.OTHER,
-    ReturnTypes.LEAST_RESTRICTIVE,
+    ReturnTypes.ARG0_NULLABLE,
     null,
     OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER),
     SqlFunctionCategory.NUMERIC)
@@ -295,7 +295,7 @@ object ScalarSqlFunctions {
   val SHIFT_RIGHT_UNSIGNED = new SqlFunction(
     "SHIFTRIGHTUNSIGNED",
     SqlKind.OTHER,
-    ReturnTypes.LEAST_RESTRICTIVE,
+    ReturnTypes.ARG0_NULLABLE,
     null,
     OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER),
     SqlFunctionCategory.NUMERIC)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.validate
 
-import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes, SqlTypeTransforms}
+import org.apache.calcite.sql.`type`.{InferTypes, OperandTypes, ReturnTypes, SqlTypeTransforms}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.util.{ChainedSqlOperatorTable, ListSqlOperatorTable, ReflectiveSqlOperatorTable}
 import org.apache.calcite.sql._
@@ -250,6 +250,9 @@ object FunctionCatalog {
     "randInteger" -> classOf[RandInteger],
     "bin" -> classOf[Bin],
     "hex" -> classOf[Hex],
+    "shiftLeft" -> classOf[ShiftLeft],
+    "shiftRight" -> classOf[ShiftRight],
+    "shiftRightUnsigned" -> classOf[ShiftRightUnsigned],
 
     // temporal functions
     "extract" -> classOf[Extract],
@@ -475,6 +478,9 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.RTRIM,
     ScalarSqlFunctions.REPEAT,
     ScalarSqlFunctions.REGEXP_REPLACE,
+    ScalarSqlFunctions.SHIFT_LEFT,
+    ScalarSqlFunctions.SHIFT_RIGHT,
+    ScalarSqlFunctions.SHIFT_RIGHT_UNSIGNED,
 
     // MATCH_RECOGNIZE
     SqlStdOperatorTable.FIRST,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.validate
 
-import org.apache.calcite.sql.`type`.{InferTypes, OperandTypes, ReturnTypes, SqlTypeTransforms}
+import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes, SqlTypeTransforms}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.util.{ChainedSqlOperatorTable, ListSqlOperatorTable, ReflectiveSqlOperatorTable}
 import org.apache.calcite.sql._

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -75,6 +75,238 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
   }
 
   @Test
+  def testShiftLeft(): Unit = {
+    testAllApis(
+      3.shiftLeft(3),
+      "3.shiftLeft(3)",
+      "SHIFTLEFT(3,3)",
+      "24"
+    )
+
+    testAllApis(
+      2147483647.shiftLeft(-2147483648),
+      "2147483647.shiftLeft(-2147483648)",
+      "SHIFTLEFT(2147483647,-2147483648)",
+      "2147483647"
+    )
+
+    testAllApis(
+      -2147483648.shiftLeft(2147483647),
+      "-2147483648.shiftLeft(2147483647)",
+      "SHIFTLEFT(-2147483648,2147483647)",
+      "0"
+    )
+
+    testAllApis(
+      9223372036854775807L.shiftLeft(-2147483648),
+      "9223372036854775807L.shiftLeft(-2147483648)",
+      "SHIFTLEFT(9223372036854775807,-2147483648)",
+      "9223372036854775807"
+    )
+
+    testAllApis(
+      'f3.shiftLeft(5),
+      "f3.shiftLeft(5)",
+      "SHIFTLEFT(f3,5)",
+      "32"
+    )
+
+    testAllApis(
+      1.shiftLeft(Null(Types.INT)),
+      "1.shiftLeft(Null(INT))",
+      "SHIFTLEFT(1, CAST(NULL AS INT))",
+      "null"
+    )
+
+    testAllApis(       // test tinyint
+      'f0.shiftLeft(20),
+      "f0.shiftLeft(20)",
+      "SHIFTLEFT(CAST(1 AS TINYINT), 20)",
+      "1048576"
+    )
+
+    testAllApis(      // test smallint
+      'f1.shiftLeft(20),
+      "f1.shiftLeft(20)",
+      "SHIFTLEFT(CAST(1 AS SMALLINT), 20)",
+      "1048576"
+    )
+
+    testAllApis(      // test long
+      'f3.shiftLeft(40),
+      "f3.shiftLeft(40)",
+      "SHIFTLEFT(CAST(1 AS BIGINT), 40)",
+      "1099511627776"
+    )
+
+    //special params
+    testAllApis(
+      3.shiftLeft(-1),
+      "3.shiftLeft(-1)",
+      "SHIFTLEFT(3,-1)",
+      "-2147483648"
+    )
+
+    testAllApis(
+      4.shiftLeft(-1),
+      "4.shiftLeft(-1)",
+      "SHIFTLEFT(4,-1)",
+      "0"
+    )
+
+    testAllApis(
+      5.shiftLeft(-2),
+      "5.shiftLeft(-2)",
+      "SHIFTLEFT(5,-2)",
+      "1073741824"
+    )
+
+    testAllApis(
+      -5.shiftLeft(2),
+      "-5.shiftLeft(2)",
+      "SHIFTLEFT(-5,2)",
+      "-20"
+    )
+
+    testAllApis(
+      -7.shiftLeft(-1),
+      "-7.shiftLeft(-1)",
+      "SHIFTLEFT(-7,-1)",
+      "-2147483648"
+    )
+  }
+
+  @Test
+  def testShiftRight(): Unit = {
+    testAllApis(
+      1.shiftRight(1),
+      "1.shiftRight(1)",
+      "SHIFTRIGHT(1,1)",
+      "0"
+    )
+
+    testAllApis(
+      21.shiftRight(1),
+      "21.shiftRight(1)",
+      "SHIFTRIGHT(21,1)",
+      "10"
+    )
+
+    testAllApis(
+      2147483647.shiftRight(-2147483648),
+      "2147483647.shiftRight(-2147483648)",
+      "SHIFTRIGHT(2147483647,-2147483648)",
+      "2147483647"
+    )
+
+    testAllApis(
+      -2147483648.shiftRight(2147483647),
+      "-2147483648.shiftRight(2147483647)",
+      "SHIFTRIGHT(-2147483648,2147483647)",
+      "-1"
+    )
+
+    testAllApis(
+      123456789.shiftRight(-2147483648),
+      "123456789.shiftRight(-2147483648)",
+      "SHIFTRIGHT(123456789,-2147483648)",
+      "123456789"
+    )
+
+    testAllApis(
+      'f3.shiftRight(1),
+      "f3.shiftRight(1)",
+      "SHIFTRIGHT(f3,1)",
+      "0"
+    )
+
+    testAllApis(
+      1.shiftRight(Null(Types.INT)),
+      "1.shiftRight(Null(INT))",
+      "SHIFTRIGHT(1, CAST(NULL AS INT))",
+      "null"
+    )
+
+    val a: Byte = 7
+    testAllApis(            // test tinyint
+      a.shiftRight(1),
+      s"$a.shiftRight(1)",
+      s"SHIFTRIGHT(CAST($a AS TINYINT),1)",
+      "3"
+    )
+
+    val b: Short = 100
+    testAllApis(            // test smallint
+      b.shiftRight(1),
+      s"$b.shiftRight(1)",
+      s"SHIFTRIGHT(CAST($b AS SMALLINT),1)",
+      "50"
+    )
+
+    val c: Long = 1099511627776L
+    testAllApis(            // test long
+      c.shiftRight(30),
+      s"${c}L.shiftRight(30)",
+      s"SHIFTRIGHT(CAST($c AS BIGINT),30)",
+      "1024"
+    )
+
+    // special params
+    testAllApis(
+      32.shiftRight(-1),
+      "32.shiftRight(-1)",
+      "SHIFTRIGHT(32,-1)",
+      "0"
+    )
+
+    testAllApis(
+      -32.shiftRight(1),
+      "-32.shiftRight(1)",
+      "SHIFTRIGHT(-32,1)",
+      "-16"
+    )
+
+    testAllApis(
+      -64.shiftRight(-1),
+      "-64.shiftRight(-1)",
+      "SHIFTRIGHT(-64,-1)",
+      "-1"
+    )
+
+  }
+
+  @Test
+  def testShiftRightUnsigned(): Unit = {
+    testAllApis(
+      64.shiftRightUnsigned(3),
+      "64.shiftRightUnsigned(3)",
+      "SHIFTRIGHTUNSIGNED(64,3)",
+      "8"
+    )
+
+    testAllApis(
+      -2.shiftRightUnsigned(1),
+      "-2.shiftRightUnsigned(1)",
+      "SHIFTRIGHTUNSIGNED(-2,1)",
+      "2147483647"
+    )
+
+    testAllApis(
+      -5.shiftRightUnsigned(2),
+      "-5.shiftRightUnsigned(2)",
+      "SHIFTRIGHTUNSIGNED(-5,2)",
+      "1073741822"
+    )
+
+    testAllApis(
+      -64.shiftRightUnsigned(-1),
+      "-64.shiftRightUnsigned(-1)",
+      "SHIFTRIGHTUNSIGNED(-64,-1)",
+      "1"
+    )
+  }
+
+  @Test
   def testArithmetic(): Unit = {
 
     // math arithmetic

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -79,35 +79,35 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       3.shiftLeft(3),
       "3.shiftLeft(3)",
-      "SHIFTLEFT(3,3)",
+      "SHIFTLEFT(3, 3)",
       "24"
     )
 
     testAllApis(
       2147483647.shiftLeft(-2147483648),
       "2147483647.shiftLeft(-2147483648)",
-      "SHIFTLEFT(2147483647,-2147483648)",
+      "SHIFTLEFT(2147483647, -2147483648)",
       "2147483647"
     )
 
     testAllApis(
       -2147483648.shiftLeft(2147483647),
       "-2147483648.shiftLeft(2147483647)",
-      "SHIFTLEFT(-2147483648,2147483647)",
+      "SHIFTLEFT(-2147483648, 2147483647)",
       "0"
     )
 
     testAllApis(
       9223372036854775807L.shiftLeft(-2147483648),
       "9223372036854775807L.shiftLeft(-2147483648)",
-      "SHIFTLEFT(9223372036854775807,-2147483648)",
+      "SHIFTLEFT(9223372036854775807, -2147483648)",
       "9223372036854775807"
     )
 
     testAllApis(
       'f3.shiftLeft(5),
       "f3.shiftLeft(5)",
-      "SHIFTLEFT(f3,5)",
+      "SHIFTLEFT(f3, 5)",
       "32"
     )
 
@@ -143,36 +143,93 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       3.shiftLeft(-1),
       "3.shiftLeft(-1)",
-      "SHIFTLEFT(3,-1)",
+      "SHIFTLEFT(3, -1)",
       "-2147483648"
     )
 
     testAllApis(
       4.shiftLeft(-1),
       "4.shiftLeft(-1)",
-      "SHIFTLEFT(4,-1)",
+      "SHIFTLEFT(4, -1)",
       "0"
     )
 
     testAllApis(
       5.shiftLeft(-2),
       "5.shiftLeft(-2)",
-      "SHIFTLEFT(5,-2)",
+      "SHIFTLEFT(5, -2)",
       "1073741824"
     )
 
     testAllApis(
       -5.shiftLeft(2),
       "-5.shiftLeft(2)",
-      "SHIFTLEFT(-5,2)",
+      "SHIFTLEFT(-5, 2)",
       "-20"
     )
 
     testAllApis(
       -7.shiftLeft(-1),
       "-7.shiftLeft(-1)",
-      "SHIFTLEFT(-7,-1)",
+      "SHIFTLEFT(-7, -1)",
       "-2147483648"
+    )
+
+    //special shift test
+    testAllApis(
+      'f0.shiftLeft(9),
+      "f0.shiftLeft(9)",
+      "SHIFTLEFT(f0, 9)",
+      "0"
+    )
+
+    testAllApis(
+      'f0.shiftLeft(17),
+      "f0.shiftLeft(17)",
+      "SHIFTLEFT(f0, 17)",
+      "0"
+    )
+
+    testAllApis(
+      'f1.shiftLeft(17),
+      "f1.shiftLeft(17)",
+      "SHIFTLEFT(f1, 17)",
+      "0"
+    )
+
+    testAllApis(
+      'f1.shiftLeft(33),
+      "f1.shiftLeft(33)",
+      "SHIFTLEFT(f1, 33)",
+      "2"
+    )
+
+    testAllApis(
+      'f2.shiftLeft(17),
+      "f2.shiftLeft(17)",
+      "SHIFTLEFT(f2, 17)",
+      "131072"
+    )
+
+    testAllApis(
+      'f2.shiftLeft(33),
+      "f2.shiftLeft(33)",
+      "SHIFTLEFT(f2, 33)",
+      "2"
+    )
+
+    testAllApis(
+      'f3.shiftLeft(33),
+      "f3.shiftLeft(33)",
+      "SHIFTLEFT(f3, 33)",
+      "8589934592"
+    )
+
+    testAllApis(
+      'f3.shiftLeft(65),
+      "f3.shiftLeft(65)",
+      "SHIFTLEFT(f3, 65)",
+      "2"
     )
   }
 
@@ -229,29 +286,29 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
 
     val a: Byte = 7
     testAllApis(            // test tinyint
-      a.shiftRight(1),
-      s"$a.shiftRight(1)",
+      a.cast(Types.BYTE).shiftRight(1),
+      s"$a.cast(BYTE).shiftRight(1)",
       s"SHIFTRIGHT(CAST($a AS TINYINT),1)",
       "3"
     )
 
     val b: Short = 100
     testAllApis(            // test smallint
-      b.shiftRight(1),
-      s"$b.shiftRight(1)",
+      b.cast(Types.SHORT).shiftRight(1),
+      s"$b.cast(SHORT).shiftRight(1)",
       s"SHIFTRIGHT(CAST($b AS SMALLINT),1)",
       "50"
     )
 
     val c: Long = 1099511627776L
     testAllApis(            // test long
-      c.shiftRight(30),
-      s"${c}L.shiftRight(30)",
+      c.cast(Types.LONG).shiftRight(30),
+      s"${c}L.cast(LONG).shiftRight(30)",
       s"SHIFTRIGHT(CAST($c AS BIGINT),30)",
       "1024"
     )
 
-    // special params
+    //special params
     testAllApis(
       32.shiftRight(-1),
       "32.shiftRight(-1)",
@@ -271,6 +328,67 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "-64.shiftRight(-1)",
       "SHIFTRIGHT(-64,-1)",
       "-1"
+    )
+
+    //special shift test
+    val b1 = Byte.MinValue
+    testAllApis(
+      b1.cast(Types.BYTE).shiftRight(9),
+      s"$b1.cast(BYTE).shiftRight(9)",
+      s"SHIFTRIGHT(CAST($b1 AS TINYINT), 9)",
+      "-1"
+    )
+
+    testAllApis(
+      b1.cast(Types.BYTE).shiftRight(17),
+      s"$b1.cast(BYTE).shiftRight(17)",
+      s"SHIFTRIGHT(CAST($b1 AS TINYINT), 17)",
+      "-1"
+    )
+
+    val s1 = Short.MinValue
+    testAllApis(
+      s1.cast(Types.SHORT).shiftRight(17),
+      s"$s1.cast(SHORT).shiftRight(17)",
+      s"SHIFTRIGHT(CAST($s1 AS SMALLINT), 17)",
+      "-1"
+    )
+
+    testAllApis(
+      s1.cast(Types.SHORT).shiftRight(33),
+      s"$s1.cast(SHORT).shiftRight(33)",
+      s"SHIFTRIGHT(CAST($s1 AS SMALLINT), 33)",
+      "-16384"
+    )
+
+    val i1 = Int.MinValue
+    testAllApis(
+      i1.shiftRight(17),
+      s"$i1.shiftRight(17)",
+      s"SHIFTRIGHT($i1, 17)",
+      "-16384"
+    )
+
+    testAllApis(
+      i1.shiftRight(33),
+      s"$i1.shiftRight(33)",
+      s"SHIFTRIGHT($i1, 33)",
+      "-1073741824"
+    )
+
+    val l1 = Long.MinValue
+    testAllApis(
+      l1.cast(Types.LONG).shiftRight(33),
+      s"${l1}L.cast(LONG).shiftRight(33)",
+      s"SHIFTRIGHT(CAST($l1 AS BIGINT), 33)",
+      "-1073741824"
+    )
+
+    testAllApis(
+      l1.cast(Types.LONG).shiftRight(65),
+      s"${l1}L.cast(LONG).shiftRight(65)",
+      s"SHIFTRIGHT(CAST($l1 AS BIGINT), 65)",
+      "-4611686018427387904"
     )
 
   }
@@ -303,6 +421,67 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "-64.shiftRightUnsigned(-1)",
       "SHIFTRIGHTUNSIGNED(-64,-1)",
       "1"
+    )
+
+    //special shift test
+    val b1 = Byte.MinValue
+    testAllApis(
+      b1.cast(Types.BYTE).shiftRightUnsigned(9),
+      s"$b1.cast(BYTE).shiftRightUnsigned(9)",
+      s"SHIFTRIGHTUNSIGNED(CAST($b1 AS TINYINT), 9)",
+      "-1"
+    )
+
+    testAllApis(
+      b1.cast(Types.BYTE).shiftRightUnsigned(17),
+      s"$b1.cast(BYTE).shiftRightUnsigned(17)",
+      s"SHIFTRIGHTUNSIGNED(CAST($b1 AS TINYINT), 17)",
+      "-1"
+    )
+
+    val s1 = Short.MinValue
+    testAllApis(
+      s1.cast(Types.SHORT).shiftRightUnsigned(17),
+      s"$s1.cast(SHORT).shiftRightUnsigned(17)",
+      s"SHIFTRIGHTUNSIGNED(CAST($s1 AS SMALLINT), 17)",
+      "32767"
+    )
+
+    testAllApis(
+      s1.cast(Types.SHORT).shiftRightUnsigned(33),
+      s"$s1.cast(SHORT).shiftRightUnsigned(33)",
+      s"SHIFTRIGHTUNSIGNED(CAST($s1 AS SMALLINT), 33)",
+      "-16384"
+    )
+
+    val i1 = Int.MinValue
+    testAllApis(
+      i1.shiftRightUnsigned(17),
+      s"$i1.shiftRightUnsigned(17)",
+      s"SHIFTRIGHTUNSIGNED($i1, 17)",
+      "16384"
+    )
+
+    testAllApis(
+      i1.shiftRightUnsigned(33),
+      s"$i1.shiftRightUnsigned(33)",
+      s"SHIFTRIGHTUNSIGNED($i1, 33)",
+      "1073741824"
+    )
+
+    val l1 = Long.MinValue
+    testAllApis(
+      l1.cast(Types.LONG).shiftRightUnsigned(33),
+      s"${l1}L.cast(LONG).shiftRightUnsigned(33)",
+      s"SHIFTRIGHTUNSIGNED(CAST($l1 AS BIGINT), 33)",
+      "1073741824"
+    )
+
+    testAllApis(
+      l1.cast(Types.LONG).shiftRightUnsigned(65),
+      s"${l1}L.cast(LONG).shiftRightUnsigned(65)",
+      s"SHIFTRIGHTUNSIGNED(CAST($l1 AS BIGINT), 65)",
+      "4611686018427387904"
     )
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -79,63 +79,63 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       3.shiftLeft(3),
       "3.shiftLeft(3)",
-      "SHIFTLEFT(3, 3)",
+      "SHIFT_LEFT(3, 3)",
       "24"
     )
 
     testAllApis(
       2147483647.shiftLeft(-2147483648),
       "2147483647.shiftLeft(-2147483648)",
-      "SHIFTLEFT(2147483647, -2147483648)",
+      "SHIFT_LEFT(2147483647, -2147483648)",
       "2147483647"
     )
 
     testAllApis(
       -2147483648.shiftLeft(2147483647),
       "-2147483648.shiftLeft(2147483647)",
-      "SHIFTLEFT(-2147483648, 2147483647)",
+      "SHIFT_LEFT(-2147483648, 2147483647)",
       "0"
     )
 
     testAllApis(
       9223372036854775807L.shiftLeft(-2147483648),
       "9223372036854775807L.shiftLeft(-2147483648)",
-      "SHIFTLEFT(9223372036854775807, -2147483648)",
+      "SHIFT_LEFT(9223372036854775807, -2147483648)",
       "9223372036854775807"
     )
 
     testAllApis(
       'f3.shiftLeft(5),
       "f3.shiftLeft(5)",
-      "SHIFTLEFT(f3, 5)",
+      "SHIFT_LEFT(f3, 5)",
       "32"
     )
 
     testAllApis(
       1.shiftLeft(Null(Types.INT)),
       "1.shiftLeft(Null(INT))",
-      "SHIFTLEFT(1, CAST(NULL AS INT))",
+      "SHIFT_LEFT(1, CAST(NULL AS INT))",
       "null"
     )
 
     testAllApis(       // test tinyint
       'f0.shiftLeft(20),
       "f0.shiftLeft(20)",
-      "SHIFTLEFT(CAST(1 AS TINYINT), 20)",
+      "SHIFT_LEFT(CAST(1 AS TINYINT), 20)",
       "0"
     )
 
     testAllApis(      // test smallint
       'f1.shiftLeft(20),
       "f1.shiftLeft(20)",
-      "SHIFTLEFT(CAST(1 AS SMALLINT), 20)",
+      "SHIFT_LEFT(CAST(1 AS SMALLINT), 20)",
       "0"
     )
 
     testAllApis(      // test long
       'f3.shiftLeft(40),
       "f3.shiftLeft(40)",
-      "SHIFTLEFT(CAST(1 AS BIGINT), 40)",
+      "SHIFT_LEFT(CAST(1 AS BIGINT), 40)",
       "1099511627776"
     )
 
@@ -143,35 +143,35 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       3.shiftLeft(-1),
       "3.shiftLeft(-1)",
-      "SHIFTLEFT(3, -1)",
+      "SHIFT_LEFT(3, -1)",
       "-2147483648"
     )
 
     testAllApis(
       4.shiftLeft(-1),
       "4.shiftLeft(-1)",
-      "SHIFTLEFT(4, -1)",
+      "SHIFT_LEFT(4, -1)",
       "0"
     )
 
     testAllApis(
       5.shiftLeft(-2),
       "5.shiftLeft(-2)",
-      "SHIFTLEFT(5, -2)",
+      "SHIFT_LEFT(5, -2)",
       "1073741824"
     )
 
     testAllApis(
       -5.shiftLeft(2),
       "-5.shiftLeft(2)",
-      "SHIFTLEFT(-5, 2)",
+      "SHIFT_LEFT(-5, 2)",
       "-20"
     )
 
     testAllApis(
       -7.shiftLeft(-1),
       "-7.shiftLeft(-1)",
-      "SHIFTLEFT(-7, -1)",
+      "SHIFT_LEFT(-7, -1)",
       "-2147483648"
     )
 
@@ -179,56 +179,56 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       'f0.shiftLeft(9),
       "f0.shiftLeft(9)",
-      "SHIFTLEFT(f0, 9)",
+      "SHIFT_LEFT(f0, 9)",
       "0"
     )
 
     testAllApis(
-      'f0.shiftLeft(17),
-      "f0.shiftLeft(17)",
-      "SHIFTLEFT(f0, 17)",
-      "0"
+      'f0.shiftLeft(33),
+      "f0.shiftLeft(33)",
+      "SHIFT_LEFT(f0, 33)",
+      "2"
     )
 
     testAllApis(
       'f1.shiftLeft(17),
       "f1.shiftLeft(17)",
-      "SHIFTLEFT(f1, 17)",
+      "SHIFT_LEFT(f1, 17)",
       "0"
     )
 
     testAllApis(
       'f1.shiftLeft(33),
       "f1.shiftLeft(33)",
-      "SHIFTLEFT(f1, 33)",
+      "SHIFT_LEFT(f1, 33)",
       "2"
     )
 
     testAllApis(
       'f2.shiftLeft(17),
       "f2.shiftLeft(17)",
-      "SHIFTLEFT(f2, 17)",
+      "SHIFT_LEFT(f2, 17)",
       "131072"
     )
 
     testAllApis(
       'f2.shiftLeft(33),
       "f2.shiftLeft(33)",
-      "SHIFTLEFT(f2, 33)",
+      "SHIFT_LEFT(f2, 33)",
       "2"
     )
 
     testAllApis(
       'f3.shiftLeft(33),
       "f3.shiftLeft(33)",
-      "SHIFTLEFT(f3, 33)",
+      "SHIFT_LEFT(f3, 33)",
       "8589934592"
     )
 
     testAllApis(
       'f3.shiftLeft(65),
       "f3.shiftLeft(65)",
-      "SHIFTLEFT(f3, 65)",
+      "SHIFT_LEFT(f3, 65)",
       "2"
     )
   }
@@ -238,49 +238,49 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       1.shiftRight(1),
       "1.shiftRight(1)",
-      "SHIFTRIGHT(1,1)",
+      "SHIFT_RIGHT(1,1)",
       "0"
     )
 
     testAllApis(
       21.shiftRight(1),
       "21.shiftRight(1)",
-      "SHIFTRIGHT(21,1)",
+      "SHIFT_RIGHT(21,1)",
       "10"
     )
 
     testAllApis(
       2147483647.shiftRight(-2147483648),
       "2147483647.shiftRight(-2147483648)",
-      "SHIFTRIGHT(2147483647,-2147483648)",
+      "SHIFT_RIGHT(2147483647,-2147483648)",
       "2147483647"
     )
 
     testAllApis(
       -2147483648.shiftRight(2147483647),
       "-2147483648.shiftRight(2147483647)",
-      "SHIFTRIGHT(-2147483648,2147483647)",
+      "SHIFT_RIGHT(-2147483648,2147483647)",
       "-1"
     )
 
     testAllApis(
       123456789.shiftRight(-2147483648),
       "123456789.shiftRight(-2147483648)",
-      "SHIFTRIGHT(123456789,-2147483648)",
+      "SHIFT_RIGHT(123456789,-2147483648)",
       "123456789"
     )
 
     testAllApis(
       'f3.shiftRight(1),
       "f3.shiftRight(1)",
-      "SHIFTRIGHT(f3,1)",
+      "SHIFT_RIGHT(f3,1)",
       "0"
     )
 
     testAllApis(
       1.shiftRight(Null(Types.INT)),
       "1.shiftRight(Null(INT))",
-      "SHIFTRIGHT(1, CAST(NULL AS INT))",
+      "SHIFT_RIGHT(1, CAST(NULL AS INT))",
       "null"
     )
 
@@ -288,7 +288,7 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(            // test tinyint
       a.cast(Types.BYTE).shiftRight(1),
       s"$a.cast(BYTE).shiftRight(1)",
-      s"SHIFTRIGHT(CAST($a AS TINYINT),1)",
+      s"SHIFT_RIGHT(CAST($a AS TINYINT),1)",
       "3"
     )
 
@@ -296,7 +296,7 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(            // test smallint
       b.cast(Types.SHORT).shiftRight(1),
       s"$b.cast(SHORT).shiftRight(1)",
-      s"SHIFTRIGHT(CAST($b AS SMALLINT),1)",
+      s"SHIFT_RIGHT(CAST($b AS SMALLINT),1)",
       "50"
     )
 
@@ -304,7 +304,7 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(            // test long
       c.cast(Types.LONG).shiftRight(30),
       s"${c}L.cast(LONG).shiftRight(30)",
-      s"SHIFTRIGHT(CAST($c AS BIGINT),30)",
+      s"SHIFT_RIGHT(CAST($c AS BIGINT),30)",
       "1024"
     )
 
@@ -312,21 +312,21 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       32.shiftRight(-1),
       "32.shiftRight(-1)",
-      "SHIFTRIGHT(32,-1)",
+      "SHIFT_RIGHT(32,-1)",
       "0"
     )
 
     testAllApis(
       -32.shiftRight(1),
       "-32.shiftRight(1)",
-      "SHIFTRIGHT(-32,1)",
+      "SHIFT_RIGHT(-32,1)",
       "-16"
     )
 
     testAllApis(
       -64.shiftRight(-1),
       "-64.shiftRight(-1)",
-      "SHIFTRIGHT(-64,-1)",
+      "SHIFT_RIGHT(-64,-1)",
       "-1"
     )
 
@@ -335,29 +335,29 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       b1.cast(Types.BYTE).shiftRight(9),
       s"$b1.cast(BYTE).shiftRight(9)",
-      s"SHIFTRIGHT(CAST($b1 AS TINYINT), 9)",
+      s"SHIFT_RIGHT(CAST($b1 AS TINYINT), 9)",
       "-1"
     )
 
     testAllApis(
-      b1.cast(Types.BYTE).shiftRight(17),
-      s"$b1.cast(BYTE).shiftRight(17)",
-      s"SHIFTRIGHT(CAST($b1 AS TINYINT), 17)",
-      "-1"
+      b1.cast(Types.BYTE).shiftRight(33),
+      s"$b1.cast(BYTE).shiftRight(33)",
+      s"SHIFT_RIGHT(CAST($b1 AS TINYINT), 33)",
+      "-64"
     )
 
     val s1 = Short.MinValue
     testAllApis(
       s1.cast(Types.SHORT).shiftRight(17),
       s"$s1.cast(SHORT).shiftRight(17)",
-      s"SHIFTRIGHT(CAST($s1 AS SMALLINT), 17)",
+      s"SHIFT_RIGHT(CAST($s1 AS SMALLINT), 17)",
       "-1"
     )
 
     testAllApis(
       s1.cast(Types.SHORT).shiftRight(33),
       s"$s1.cast(SHORT).shiftRight(33)",
-      s"SHIFTRIGHT(CAST($s1 AS SMALLINT), 33)",
+      s"SHIFT_RIGHT(CAST($s1 AS SMALLINT), 33)",
       "-16384"
     )
 
@@ -365,14 +365,14 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       i1.shiftRight(17),
       s"$i1.shiftRight(17)",
-      s"SHIFTRIGHT($i1, 17)",
+      s"SHIFT_RIGHT($i1, 17)",
       "-16384"
     )
 
     testAllApis(
       i1.shiftRight(33),
       s"$i1.shiftRight(33)",
-      s"SHIFTRIGHT($i1, 33)",
+      s"SHIFT_RIGHT($i1, 33)",
       "-1073741824"
     )
 
@@ -380,14 +380,14 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       l1.cast(Types.LONG).shiftRight(33),
       s"${l1}L.cast(LONG).shiftRight(33)",
-      s"SHIFTRIGHT(CAST($l1 AS BIGINT), 33)",
+      s"SHIFT_RIGHT(CAST($l1 AS BIGINT), 33)",
       "-1073741824"
     )
 
     testAllApis(
       l1.cast(Types.LONG).shiftRight(65),
       s"${l1}L.cast(LONG).shiftRight(65)",
-      s"SHIFTRIGHT(CAST($l1 AS BIGINT), 65)",
+      s"SHIFT_RIGHT(CAST($l1 AS BIGINT), 65)",
       "-4611686018427387904"
     )
 
@@ -398,28 +398,28 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       64.shiftRightUnsigned(3),
       "64.shiftRightUnsigned(3)",
-      "SHIFTRIGHTUNSIGNED(64,3)",
+      "SHIFT_RIGHT_UNSIGNED(64,3)",
       "8"
     )
 
     testAllApis(
       -2.shiftRightUnsigned(1),
       "-2.shiftRightUnsigned(1)",
-      "SHIFTRIGHTUNSIGNED(-2,1)",
+      "SHIFT_RIGHT_UNSIGNED(-2,1)",
       "2147483647"
     )
 
     testAllApis(
       -5.shiftRightUnsigned(2),
       "-5.shiftRightUnsigned(2)",
-      "SHIFTRIGHTUNSIGNED(-5,2)",
+      "SHIFT_RIGHT_UNSIGNED(-5,2)",
       "1073741822"
     )
 
     testAllApis(
       -64.shiftRightUnsigned(-1),
       "-64.shiftRightUnsigned(-1)",
-      "SHIFTRIGHTUNSIGNED(-64,-1)",
+      "SHIFT_RIGHT_UNSIGNED(-64,-1)",
       "1"
     )
 
@@ -428,29 +428,29 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       b1.cast(Types.BYTE).shiftRightUnsigned(9),
       s"$b1.cast(BYTE).shiftRightUnsigned(9)",
-      s"SHIFTRIGHTUNSIGNED(CAST($b1 AS TINYINT), 9)",
+      s"SHIFT_RIGHT_UNSIGNED(CAST($b1 AS TINYINT), 9)",
       "-1"
     )
 
     testAllApis(
-      b1.cast(Types.BYTE).shiftRightUnsigned(17),
-      s"$b1.cast(BYTE).shiftRightUnsigned(17)",
-      s"SHIFTRIGHTUNSIGNED(CAST($b1 AS TINYINT), 17)",
-      "-1"
+      b1.cast(Types.BYTE).shiftRightUnsigned(33),
+      s"$b1.cast(BYTE).shiftRightUnsigned(33)",
+      s"SHIFT_RIGHT_UNSIGNED(CAST($b1 AS TINYINT), 33)",
+      "-64"
     )
 
     val s1 = Short.MinValue
     testAllApis(
       s1.cast(Types.SHORT).shiftRightUnsigned(17),
       s"$s1.cast(SHORT).shiftRightUnsigned(17)",
-      s"SHIFTRIGHTUNSIGNED(CAST($s1 AS SMALLINT), 17)",
+      s"SHIFT_RIGHT_UNSIGNED(CAST($s1 AS SMALLINT), 17)",
       "32767"
     )
 
     testAllApis(
       s1.cast(Types.SHORT).shiftRightUnsigned(33),
       s"$s1.cast(SHORT).shiftRightUnsigned(33)",
-      s"SHIFTRIGHTUNSIGNED(CAST($s1 AS SMALLINT), 33)",
+      s"SHIFT_RIGHT_UNSIGNED(CAST($s1 AS SMALLINT), 33)",
       "-16384"
     )
 
@@ -458,14 +458,14 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       i1.shiftRightUnsigned(17),
       s"$i1.shiftRightUnsigned(17)",
-      s"SHIFTRIGHTUNSIGNED($i1, 17)",
+      s"SHIFT_RIGHT_UNSIGNED($i1, 17)",
       "16384"
     )
 
     testAllApis(
       i1.shiftRightUnsigned(33),
       s"$i1.shiftRightUnsigned(33)",
-      s"SHIFTRIGHTUNSIGNED($i1, 33)",
+      s"SHIFT_RIGHT_UNSIGNED($i1, 33)",
       "1073741824"
     )
 
@@ -473,14 +473,14 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis(
       l1.cast(Types.LONG).shiftRightUnsigned(33),
       s"${l1}L.cast(LONG).shiftRightUnsigned(33)",
-      s"SHIFTRIGHTUNSIGNED(CAST($l1 AS BIGINT), 33)",
+      s"SHIFT_RIGHT_UNSIGNED(CAST($l1 AS BIGINT), 33)",
       "1073741824"
     )
 
     testAllApis(
       l1.cast(Types.LONG).shiftRightUnsigned(65),
       s"${l1}L.cast(LONG).shiftRightUnsigned(65)",
-      s"SHIFTRIGHTUNSIGNED(CAST($l1 AS BIGINT), 65)",
+      s"SHIFT_RIGHT_UNSIGNED(CAST($l1 AS BIGINT), 65)",
       "4611686018427387904"
     )
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -122,14 +122,14 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       'f0.shiftLeft(20),
       "f0.shiftLeft(20)",
       "SHIFTLEFT(CAST(1 AS TINYINT), 20)",
-      "1048576"
+      "0"
     )
 
     testAllApis(      // test smallint
       'f1.shiftLeft(20),
       "f1.shiftLeft(20)",
       "SHIFTLEFT(CAST(1 AS SMALLINT), 20)",
-      "1048576"
+      "0"
     )
 
     testAllApis(      // test long


### PR DESCRIPTION
## What is the purpose of the change
This PR is based on the previous closed and unfinished work https://github.com/apache/flink/pull/5202, it adds shift left and right as core scalar operators in then code gen.

The table api syntax is 21.shiftRight(1) and 21.shiftLeft(1)
The sql syntax is SHIFT_RIGHT(21,1)

## Brief change log
  - *FunctionCatalog, expressionDsl and SHIFT_RIGHT(21,1)*
  - *CodeGenerator*

## Verifying this change

This change added tests in ScalarOperatorsTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
