### PR TITLE
[FLINK-9240] Avoid deprecated Akka methods

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -90,6 +90,7 @@ import java.util.concurrent.TimeUnit;
 import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
@@ -249,8 +250,8 @@ public abstract class ClusterClient<T> {
 		@Override
 		public void close() throws Exception {
 			if (isLoaded()) {
-				actorSystem.shutdown();
-				actorSystem.awaitTermination();
+				actorSystem.terminate();
+				Await.ready(actorSystem.whenTerminated(), Duration.Inf());
 				actorSystem = null;
 			}
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -67,6 +67,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
+
 /**
  * Simple and maybe stupid test to check the {@link ClusterClient} class.
  */
@@ -114,8 +117,8 @@ public class ClientTest extends TestLogger {
 	public void shutDownActorSystem() {
 		if (jobManagerSystem != null) {
 			try {
-				jobManagerSystem.shutdown();
-				jobManagerSystem.awaitTermination();
+				jobManagerSystem.terminate();
+				Await.ready(jobManagerSystem.whenTerminated(), Duration.Inf());
 			} catch (Exception e) {
 				e.printStackTrace();
 				fail(e.getMessage());

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -82,6 +82,7 @@ import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
+import static org.apache.flink.runtime.concurrent.Executors.directExecutionContext;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -386,7 +387,7 @@ public class MesosApplicationMasterRunner {
 								LOG.error("Error shutting down actor system", failure);
 							}
 						}
-					}, org.apache.flink.runtime.concurrent.Executors.directExecutionContext());
+					}, directExecutionContext());
 			}
 
 			if (futureExecutor != null) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -57,6 +57,8 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Address;
 import akka.actor.Props;
+import akka.actor.Terminated;
+import akka.dispatch.OnComplete;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
@@ -73,8 +75,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -374,11 +379,14 @@ public class MesosApplicationMasterRunner {
 			}
 
 			if (actorSystem != null) {
-				try {
-					actorSystem.shutdown();
-				} catch (Throwable tt) {
-					LOG.error("Error shutting down actor system", tt);
-				}
+				actorSystem.terminate().onComplete(
+					new OnComplete<Terminated>() {
+						public void onComplete(Throwable failure, Terminated result) {
+							if (failure != null) {
+								LOG.error("Error shutting down actor system", failure);
+							}
+						}
+					}, org.apache.flink.runtime.concurrent.Executors.directExecutionContext());
 			}
 
 			if (futureExecutor != null) {
@@ -412,7 +420,11 @@ public class MesosApplicationMasterRunner {
 		LOG.info("Mesos JobManager started");
 
 		// wait until everything is done
-		actorSystem.awaitTermination();
+		try {
+			Await.ready(actorSystem.whenTerminated(), Duration.Inf());
+		} catch (InterruptedException | TimeoutException e) {
+			LOG.error("Error shutting down actor system", e);
+		}
 
 		// if we get here, everything work out jolly all right, and we even exited smoothly
 		if (webMonitor != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/DefaultQuarantineHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/DefaultQuarantineHandler.java
@@ -25,6 +25,8 @@ import akka.actor.ActorSystem;
 import akka.actor.Address;
 import org.slf4j.Logger;
 
+import java.util.concurrent.TimeoutException;
+
 import scala.concurrent.Await;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -71,7 +73,7 @@ public class DefaultQuarantineHandler implements QuarantineHandler {
 		try {
 			// give it some time to complete the shutdown
 			Await.ready(actorSystem.whenTerminated(), timeout);
-		} catch (InterruptedException | java.util.concurrent.TimeoutException e) {
+		} catch (InterruptedException | TimeoutException e) {
 			log.error("Exception thrown when terminating the actor system", e);
 		} finally {
 			// now let's crash the JVM

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/DefaultQuarantineHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/DefaultQuarantineHandler.java
@@ -25,6 +25,7 @@ import akka.actor.ActorSystem;
 import akka.actor.Address;
 import org.slf4j.Logger;
 
+import scala.concurrent.Await;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
@@ -65,11 +66,13 @@ public class DefaultQuarantineHandler implements QuarantineHandler {
 
 	private void shutdownActorSystem(ActorSystem actorSystem) {
 		// shut the actor system down
-		actorSystem.shutdown();
+		actorSystem.terminate();
 
 		try {
 			// give it some time to complete the shutdown
-			actorSystem.awaitTermination(timeout);
+			Await.ready(actorSystem.whenTerminated(), timeout);
+		} catch (InterruptedException | java.util.concurrent.TimeoutException e) {
+			log.error("Exception thrown when terminating the actor system", e);
 		} finally {
 			// now let's crash the JVM
 			System.exit(exitCode);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
@@ -106,7 +106,7 @@ public class MemoryLogger extends Thread {
 	@Override
 	public void run() {
 		try {
-			while (running && (monitored == null || !monitored.isTerminated())) {
+			while (running && (monitored == null || !monitored.whenTerminated().isCompleted())) {
 				logger.info(getMemoryUsageStatsAsString(memoryBean));
 				logger.info(getDirectMemoryStatsAsString(directBufferBean));
 				logger.info(getMemoryPoolStatsAsString(poolBeans));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ProcessShutDownThread.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ProcessShutDownThread.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.util;
 
 import akka.actor.ActorSystem;
 import org.slf4j.Logger;
+import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
 import java.util.concurrent.TimeoutException;
@@ -67,7 +68,7 @@ public class ProcessShutDownThread extends Thread {
 	@Override
 	public void run() {
 		try {
-			actorSystem.awaitTermination(terminationTimeout);
+			Await.ready(actorSystem.whenTerminated(), terminationTimeout);
 		} catch (Exception e) {
 			if (e instanceof TimeoutException) {
 				log.error("Actor system shut down timed out.", e);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.clusterframework.messages._
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.clusterframework.{BootstrapTools, FlinkResourceManager}
+import org.apache.flink.runtime.concurrent.Executors.directExecutionContext
 import org.apache.flink.runtime.concurrent.{FutureUtils, ScheduledExecutorServiceAdapter}
 import org.apache.flink.runtime.execution.SuppressRestartsException
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders.ResolveOrder
@@ -1870,7 +1871,7 @@ class JobManager(
     context.system.terminate().onComplete {
       case scala.util.Success(_) =>
       case scala.util.Failure(t) => log.warn("Could not cleanly shut down actor system", t)
-    }(org.apache.flink.runtime.concurrent.Executors.directExecutionContext())
+    }(directExecutionContext())
   }
 
   private def instantiateMetrics(jobManagerMetricGroup: MetricGroup) : Unit = {
@@ -2294,7 +2295,7 @@ object JobManager {
         jobManagerSystem.terminate().onComplete {
           case scala.util.Success(_) =>
           case scala.util.Failure(tt) => LOG.warn("Could not cleanly shut down actor system", tt)
-        }(org.apache.flink.runtime.concurrent.Executors.directExecutionContext())
+        }(directExecutionContext())
         throw t
     }
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent._
+import scala.util.{Failure, Success}
 
 /**
  * Abstract base class for Flink's mini cluster. The mini cluster starts a
@@ -479,30 +480,30 @@ abstract class FlinkMiniCluster(
 
     if (!useSingleActorSystem) {
       taskManagerActorSystems foreach {
-        _ foreach(_.shutdown())
+        _ foreach(_.terminate())
       }
 
       resourceManagerActorSystems foreach {
-        _ foreach(_.shutdown())
+        _ foreach(_.terminate())
       }
     }
 
     jobManagerActorSystems foreach {
-      _ foreach(_.shutdown())
+      _ foreach(_.terminate())
     }
   }
 
   def awaitTermination(): Unit = {
     jobManagerActorSystems foreach {
-      _ foreach(_.awaitTermination())
+      _ foreach(s => Await.ready(s.whenTerminated, Duration.Inf))
     }
 
     resourceManagerActorSystems foreach {
-      _ foreach(_.awaitTermination())
+      _ foreach(s => Await.ready(s.whenTerminated, Duration.Inf))
     }
 
     taskManagerActorSystems foreach {
-      _ foreach(_.awaitTermination())
+      _ foreach(s => Await.ready(s.whenTerminated, Duration.Inf))
     }
   }
 
@@ -625,7 +626,10 @@ abstract class FlinkMiniCluster(
 
   def shutdownJobClientActorSystem(actorSystem: ActorSystem): Unit = {
     if(!useSingleActorSystem) {
-      actorSystem.shutdown()
+      actorSystem.terminate().onComplete {
+        case Success(_) =>
+        case Failure(t) => LOG.warn("Could not cleanly shut down the job client actor system.", t)
+      }
     }
   }
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1905,7 +1905,7 @@ object TaskManager {
         taskManagerSystem.terminate().onComplete {
           case Success(_) =>
           case Failure(tt) => LOG.warn("Could not cleanly shut down actor system", tt)
-        }(org.apache.flink.runtime.concurrent.Executors.directExecutionContext())
+        }(Executors.directExecutionContext())
         throw t
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/QuarantineMonitorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/QuarantineMonitorTest.java
@@ -43,7 +43,10 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
@@ -72,10 +75,10 @@ public class QuarantineMonitorTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void tearDown() {
+	public static void tearDown() throws InterruptedException, TimeoutException {
 		if (actorSystem1 != null) {
-			actorSystem1.shutdown();
-			actorSystem1.awaitTermination();
+			actorSystem1.terminate();
+			Await.ready(actorSystem1.whenTerminated(), Duration.Inf());
 		}
 	}
 
@@ -85,10 +88,10 @@ public class QuarantineMonitorTest extends TestLogger {
 	}
 
 	@After
-	public void tearDownTest() {
+	public void tearDownTest() throws InterruptedException, TimeoutException {
 		if (actorSystem2 != null) {
-			actorSystem2.shutdown();
-			actorSystem2.awaitTermination();
+			actorSystem2.terminate();
+			Await.ready(actorSystem2.whenTerminated(), Duration.Inf());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHAJobGraphRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHAJobGraphRecoveryITCase.java
@@ -321,11 +321,11 @@ public class JobManagerHAJobGraphRecoveryITCase extends TestLogger {
 			}
 
 			if (taskManagerSystem != null) {
-				taskManagerSystem.shutdown();
+				taskManagerSystem.terminate();
 			}
 
 			if (testSystem != null) {
-				testSystem.shutdown();
+				testSystem.terminate();
 			}
 
 			highAvailabilityServices.closeAndCleanupAllData();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessReapingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerProcessReapingTest.java
@@ -182,7 +182,7 @@ public class JobManagerProcessReapingTest extends TestLogger {
 				jmProcess.destroy();
 			}
 			if (localSystem != null) {
-				localSystem.shutdown();
+				localSystem.terminate();
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -132,6 +132,7 @@ import scala.Tuple2;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 import scala.reflect.ClassTag$;
 
@@ -940,7 +941,7 @@ public class JobManagerTest extends TestLogger {
 			assertTrue(savepointFile.exists());
 		} finally {
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystem.terminate();
 			}
 
 			if (archiver != null) {
@@ -956,7 +957,7 @@ public class JobManagerTest extends TestLogger {
 			}
 
 			if (actorSystem != null) {
-				actorSystem.awaitTermination(TESTING_TIMEOUT());
+				Await.result(actorSystem.whenTerminated(), TESTING_TIMEOUT());
 			}
 		}
 	}
@@ -1130,7 +1131,7 @@ public class JobManagerTest extends TestLogger {
 			}
 		} finally {
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystem.terminate();
 			}
 
 			if (archiver != null) {
@@ -1243,7 +1244,7 @@ public class JobManagerTest extends TestLogger {
 			assertEquals(1, targetDirectory.listFiles().length);
 		} finally {
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystem.terminate();
 			}
 
 			if (archiver != null) {
@@ -1259,7 +1260,7 @@ public class JobManagerTest extends TestLogger {
 			}
 
 			if (actorSystem != null) {
-				actorSystem.awaitTermination(TestingUtils.TESTING_TIMEOUT());
+				Await.result(actorSystem.whenTerminated(), TestingUtils.TESTING_TIMEOUT());
 			}
 		}
 	}
@@ -1416,7 +1417,7 @@ public class JobManagerTest extends TestLogger {
 			assertTrue("Unexpected response: " + response, response instanceof JobSubmitSuccess);
 		} finally {
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystem.terminate();
 			}
 
 			if (archiver != null) {
@@ -1432,7 +1433,7 @@ public class JobManagerTest extends TestLogger {
 			}
 
 			if (actorSystem != null) {
-				actorSystem.awaitTermination(TestingUtils.TESTING_TIMEOUT());
+				Await.ready(actorSystem.whenTerminated(), TestingUtils.TESTING_TIMEOUT());
 			}
 		}
 	}
@@ -1516,8 +1517,8 @@ public class JobManagerTest extends TestLogger {
 
 		} finally {
 			// cleanup the actor system and with it all of the started actors if not already terminated
-			actorSystem.shutdown();
-			actorSystem.awaitTermination();
+			actorSystem.terminate();
+			Await.ready(actorSystem.whenTerminated(), Duration.Inf());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -117,7 +117,7 @@ public class JobSubmitTest {
 	@AfterClass
 	public static void teardownJobmanager() throws Exception {
 		if (jobManagerSystem != null) {
-			jobManagerSystem.shutdown();
+			jobManagerSystem.terminate();
 		}
 
 		if (highAvailabilityServices != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
@@ -49,6 +49,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
@@ -154,11 +156,11 @@ public class TaskManagerMetricsTest extends TestLogger {
 			Assert.assertFalse(metricRegistry.isShutdown());
 
 			// shut down the actors and the actor system
-			actorSystem.shutdown();
-			actorSystem.awaitTermination();
+			actorSystem.terminate();
+			Await.result(actorSystem.whenTerminated(), Duration.Inf());
 		} finally {
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystem.terminate();
 			}
 
 			if (highAvailabilityServices != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
@@ -116,7 +116,7 @@ public class MetricQueryServiceTest extends TestLogger {
 		testActor.message = null;
 		assertEquals(0, emptyDump.serializedMetrics.length);
 
-		s.shutdown();
+		s.terminate();
 	}
 
 	private static class TestActor extends UntypedActor {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/StackTraceSampleCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/StackTraceSampleCoordinatorTest.java
@@ -66,7 +66,7 @@ public class StackTraceSampleCoordinatorTest extends TestLogger {
 	@AfterClass
 	public static void tearDown() throws Exception {
 		if (system != null) {
-			system.shutdown();
+			system.terminate();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -49,6 +49,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import scala.concurrent.Await;
+
 public class AkkaRpcActorTest extends TestLogger {
 
 	// ------------------------------------------------------------------------
@@ -259,8 +261,8 @@ public class AkkaRpcActorTest extends TestLogger {
 
 			terminationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 		} finally {
-			rpcActorSystem.shutdown();
-			rpcActorSystem.awaitTermination(FutureUtils.toFiniteDuration(timeout));
+			rpcActorSystem.terminate();
+			Await.ready(rpcActorSystem.whenTerminated(), FutureUtils.toFiniteDuration(timeout));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -62,6 +62,8 @@ import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
 
 import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.junit.Assert.assertTrue;
@@ -205,8 +207,8 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 			jobManager.tell(Kill.getInstance(), ActorRef.noSender());
 
 			// shut down the actors and the actor system
-			actorSystem.shutdown();
-			actorSystem.awaitTermination();
+			actorSystem.terminate();
+			Await.ready(actorSystem.whenTerminated(), Duration.Inf());
 			actorSystem = null;
 
 			// now that the TaskManager is shut down, the components should be shut down as well
@@ -215,9 +217,9 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 			assertTrue(memManager.isShutdown());
 		} finally {
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystem.terminate();
 
-				actorSystem.awaitTermination(TestingUtils.TESTING_TIMEOUT());
+				Await.ready(actorSystem.whenTerminated(), TestingUtils.TESTING_TIMEOUT());
 			}
 
 			highAvailabilityServices.closeAndCleanupAllData();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerProcessReapingTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerProcessReapingTestBase.java
@@ -218,7 +218,7 @@ public abstract class TaskManagerProcessReapingTestBase extends TestLogger {
 				taskManagerProcess.destroy();
 			}
 			if (jmActorSystem != null) {
-				jmActorSystem.shutdown();
+				jmActorSystem.terminate();
 			}
 			if (highAvailabilityServices != null) {
 				highAvailabilityServices.closeAndCleanupAllData();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -102,7 +102,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 	@AfterClass
 	public static void shutdownActorSystem() {
 		if (actorSystem != null) {
-			actorSystem.shutdown();
+			actorSystem.terminate();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaJobManagerRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaJobManagerRetrieverTest.java
@@ -37,9 +37,12 @@ import org.junit.Test;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
+import scala.concurrent.Await;
 
 /**
  * Test for the {@link AkkaJobManagerRetriever}.
@@ -55,10 +58,10 @@ public class AkkaJobManagerRetrieverTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardown() {
+	public static void teardown() throws InterruptedException, TimeoutException {
 		if (actorSystem != null) {
-			actorSystem.shutdown();
-			actorSystem.awaitTermination(FutureUtils.toFiniteDuration(timeout));
+			actorSystem.terminate();
+			Await.ready(actorSystem.whenTerminated(), FutureUtils.toFiniteDuration(timeout));
 
 			actorSystem = null;
 		}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerConnectionTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerConnectionTest.scala
@@ -77,7 +77,7 @@ class JobManagerConnectionTest {
         fail(e.getMessage)
     }
     finally {
-      actorSystem.shutdown()
+      actorSystem.terminate()
     }
   }
 
@@ -116,7 +116,7 @@ class JobManagerConnectionTest {
         fail(e.getMessage)
     }
     finally {
-      actorSystem.shutdown()
+      actorSystem.terminate()
     }
   }
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.testingUtils.TestingMessages.Alive
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager
 import org.apache.flink.runtime.testutils.TestingResourceManager
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -229,8 +230,8 @@ class TestingCluster(
           Await.result(stopped, TestingCluster.MAX_RESTART_DURATION)
 
           if(!singleActorSystem) {
-            jmActorSystems(index).shutdown()
-            jmActorSystems(index).awaitTermination()
+            jmActorSystems(index).terminate()
+            Await.ready(jmActorSystems(index).whenTerminated, Duration.Inf)
           }
 
           val newJobManagerActorSystem = if(!singleActorSystem) {
@@ -274,8 +275,8 @@ class TestingCluster(
         Await.result(stopped, TestingCluster.MAX_RESTART_DURATION)
 
         if(!singleActorSystem) {
-          tmActorSystems(index).shutdown()
-          tmActorSystems(index).awaitTermination()
+          tmActorSystems(index).terminate()
+          Await.ready(tmActorSystems(index).whenTerminated, Duration.Inf)
         }
 
         val taskManagerActorSystem  = if(!singleActorSystem) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -94,7 +94,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import scala.Option;
 import scala.Some;
 import scala.Tuple2;
+import scala.concurrent.Await;
 import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.runtime.messages.JobManagerMessages.SubmitJob;
@@ -425,8 +427,8 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 				miniCluster.awaitTermination();
 			}
 
-			system.shutdown();
-			system.awaitTermination();
+			system.terminate();
+			Await.ready(system.whenTerminated(), Duration.Inf());
 
 			testingServer.stop();
 			testingServer.close();

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -38,8 +38,11 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
+import scala.concurrent.Await;
 import scala.concurrent.ExecutionContext$;
+import scala.concurrent.duration.Duration;
 import scala.concurrent.forkjoin.ForkJoinPool;
 import scala.concurrent.impl.ExecutionContextImpl;
 
@@ -62,7 +65,7 @@ public class LocalFlinkMiniClusterITCase extends TestLogger {
 	};
 
 	@Test
-	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() {
+	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() throws InterruptedException, TimeoutException {
 
 		final ActorSystem system = ActorSystem.create("Testkit", AkkaUtils.getDefaultAkkaConfig());
 		LocalFlinkMiniCluster miniCluster = null;
@@ -117,7 +120,7 @@ public class LocalFlinkMiniClusterITCase extends TestLogger {
 			}
 
 			JavaTestKit.shutdownActorSystem(system);
-			system.awaitTermination();
+			Await.ready(system.whenTerminated(), Duration.Inf());
 		}
 
 		// shut down the global execution context, to make sure it does not affect this testing

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -81,6 +81,7 @@ import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
+import static org.apache.flink.runtime.concurrent.Executors.directExecutionContext;
 import static org.apache.flink.yarn.Utils.require;
 
 /**
@@ -413,7 +414,7 @@ public class YarnApplicationMasterRunner {
 								LOG.error("Error shutting down actor system", failure);
 							}
 						}
-					}, org.apache.flink.runtime.concurrent.Executors.directExecutionContext());
+					}, directExecutionContext());
 			}
 
 			futureExecutor.shutdownNow();


### PR DESCRIPTION
## What is the purpose of the change

This PR replaces the Akka methods that were deprecated in Akka 2.4 with their respective non-deprecated alternatives. Since [Akka 2.5 is backwards binary compatible with 2.4](https://doc.akka.io/docs/akka/2.5/common/binary-compatibility-rules.html) (except the deprecated methods, which were removed in 2.5), this change would allow Flink users to use Akka 2.5, without resorting to dependency shading to avoid classpath conflicts with Flink's use of Akka 2.4. Moreover, this change would facilitate the upgrade to Akka 2.5 in Flink itself, should the Flink team decide to do so down the road.


## Brief change log

- Replaced `ActorSystem.awaitTermination()` with `Await.ready(system.whenTerminated, Duration.Inf)`
- Replaced `ActorSystem.awaitTermination(timeout)` with `Await.ready(system.whenTerminated, timeout)`
- Replaced `ActorSystem.isTerminated` with `ActorSystem.whenTerminated.isCompleted`
- Replaced `ActorSystem.shutdown()` with `ActorSystem.terminate()`


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
