### PR TITLE
[FLINK-9963] [table] Add a string table format factory

### DIFF
--- a/flink-formats/flink-string/pom.xml
+++ b/flink-formats/flink-string/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-formats</artifactId>
+		<version>1.7-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-string</artifactId>
+	<name>flink-string</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+
+		<!-- core dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<!-- use a dedicated Scala version to not depend on it -->
+			<artifactId>flink-table_2.11</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<!-- Projects depending on this project, won't depend on flink-table. -->
+			<optional>true</optional>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<!-- use a dedicated Scala version to not depend on it -->
+			<artifactId>flink-table_2.11</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- flink-table needs Scala -->
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- Create SQL Client uber jars for releases -->
+			<id>release</id>
+			<activation>
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+								<configuration>
+									<classifier>sql-jar</classifier>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/flink-formats/flink-string/src/main/java/org.apache.flink/formats/string/StringRowDeserializationSchema.java
+++ b/flink-formats/flink-string/src/main/java/org.apache.flink/formats/string/StringRowDeserializationSchema.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.string;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Deserialization schema from String to Flink types.
+ *
+ * <p>Deserializes a <code>byte[]</code> message as a String object and reads
+ * the specified fields.
+ *
+ * <p>Failure during deserialization are forwarded as wrapped IOExceptions.
+ */
+@PublicEvolving
+public class StringRowDeserializationSchema implements DeserializationSchema<Row> {
+
+	private static final long serialVersionUID = -7539382334470617511L;
+
+	/** Type information describing the result type. */
+	private final TypeInformation<Row> typeInfo;
+
+	/** encodings of bytes. **/
+	private final String encoding;
+
+	/** Flag indicating whether to fail on null. */
+	private boolean failOnNull;
+
+	/** Flag indicating whether to fail on empty. */
+	private boolean failOnEmpty;
+
+	public StringRowDeserializationSchema(String schema, String encoding) {
+		Preconditions.checkNotNull(schema);
+		Preconditions.checkNotNull(encoding);
+		this.typeInfo = new RowTypeInfo(
+			new TypeInformation<?>[] {Types.STRING},
+			new String[] {schema}
+		);
+		this.encoding = encoding;
+	}
+
+	public StringRowDeserializationSchema setFailOnNull(boolean failOnNull) {
+		this.failOnNull = failOnNull;
+		return this;
+	}
+
+	public StringRowDeserializationSchema setFailOnEmpty(boolean failOnEmpty) {
+		this.failOnEmpty = failOnEmpty;
+		return this;
+	}
+
+	@Override
+	public Row deserialize(byte[] message) throws IOException {
+		String result = null;
+		if (message == null) {
+			if (failOnNull) {
+				throw new IOException("message can't be null");
+			}
+		} else if (message.length == 0) {
+			if (failOnEmpty) {
+				throw new IOException("message can't be empty");
+			}
+			result = "";
+		} else {
+			try {
+				result = new String(message, encoding);
+			} catch (Exception e) {
+				throw new IOException("Failed to deserialize string object.", e);
+			}
+		}
+		return Row.of(result);
+	}
+
+	@Override
+	public boolean isEndOfStream(Row nextElement) {
+		return false;
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return this.typeInfo;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final StringRowDeserializationSchema that = (StringRowDeserializationSchema) o;
+		return failOnNull == that.failOnNull && failOnEmpty == that.failOnEmpty &&
+			encoding.equals(that.encoding) && Objects.equals(typeInfo, that.typeInfo);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(typeInfo, encoding, failOnEmpty, failOnNull);
+	}
+}

--- a/flink-formats/flink-string/src/main/java/org.apache.flink/formats/string/StringRowFormatFactory.java
+++ b/flink-formats/flink-string/src/main/java/org.apache.flink/formats/string/StringRowFormatFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.string;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.FormatDescriptorValidator;
+import org.apache.flink.table.descriptors.StringValidator;
+import org.apache.flink.table.factories.DeserializationSchemaFactory;
+import org.apache.flink.table.factories.SerializationSchemaFactory;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Table format factory for providing configured instances of String-to-Row {@link SerializationSchema}
+ * and {@link DeserializationSchema}.
+ */
+public class StringRowFormatFactory implements SerializationSchemaFactory<Row>, DeserializationSchemaFactory<Row> {
+
+	@Override
+	public DeserializationSchema<Row> createDeserializationSchema(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = validateAndGetProperties(properties);
+		String schema = descriptorProperties.getString(StringValidator.FORMAT_SCHEMA);
+		boolean failOnNull = descriptorProperties.getOptionalBoolean(StringValidator.FORMAT_FAIL_ON_NULL).orElse(false);
+		boolean failOnEmpty = descriptorProperties.getOptionalBoolean(StringValidator.FORMAT_FAIL_ON_EMPTY).orElse(false);
+		String encoding = descriptorProperties.getOptionalString(StringValidator.FORMAT_ENCODING).orElse("UTF-8");
+		return new StringRowDeserializationSchema(schema, encoding)
+			.setFailOnNull(failOnNull)
+			.setFailOnEmpty(failOnEmpty);
+	}
+
+	@Override
+	public SerializationSchema<Row> createSerializationSchema(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = validateAndGetProperties(properties);
+		String encoding = descriptorProperties.getOptionalString(StringValidator.FORMAT_ENCODING).orElse("UTF-8");
+		return new StringRowSerializationSchema(encoding);
+	}
+
+	@Override
+	public boolean supportsSchemaDerivation() {
+		return true;
+	}
+
+	@Override
+	public Map<String, String> requiredContext() {
+		final Map<String, String> context = new HashMap<>();
+		context.put(FormatDescriptorValidator.FORMAT_TYPE(), StringValidator.FORMAT_TYPE_VALUE);
+		context.put(FormatDescriptorValidator.FORMAT_PROPERTY_VERSION(), "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		final List<String> properties = new ArrayList<>();
+		properties.add(StringValidator.FORMAT_FAIL_ON_EMPTY);
+		properties.add(StringValidator.FORMAT_FAIL_ON_NULL);
+		properties.add(StringValidator.FORMAT_ENCODING);
+		properties.add(StringValidator.FORMAT_SCHEMA);
+		return properties;
+	}
+
+	private static DescriptorProperties validateAndGetProperties(Map<String, String> propertiesMap) {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		descriptorProperties.putProperties(propertiesMap);
+
+		// validate
+		new StringValidator().validate(descriptorProperties);
+
+		return descriptorProperties;
+	}
+}

--- a/flink-formats/flink-string/src/main/java/org.apache.flink/formats/string/StringRowSerializationSchema.java
+++ b/flink-formats/flink-string/src/main/java/org.apache.flink/formats/string/StringRowSerializationSchema.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.string;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+
+/**
+ * Serialization schema that serializes an object of Flink types into a string bytes.
+ *
+ * <p>Serializes the input Flink object into a string and
+ * converts it into <code>byte[]</code>.
+ *
+ * <p>Result <code>byte[]</code> messages can be deserialized using {@link StringRowDeserializationSchema}.
+ */
+public class StringRowSerializationSchema implements SerializationSchema<Row> {
+
+	private final String encoding;
+
+	public StringRowSerializationSchema(String encoding) {
+		Preconditions.checkNotNull(encoding);
+		this.encoding = encoding;
+	}
+
+	@Override
+	public byte[] serialize(Row element) {
+		byte[] bytes = null;
+		if (element != null && element.getField(0) != null) {
+			try {
+				bytes = element.getField(0).toString().getBytes(encoding);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not serialize row '" + element + "'. " +
+					"Make sure that the schema matches the input.", e);
+			}
+		}
+		return bytes;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		StringRowSerializationSchema that = (StringRowSerializationSchema) o;
+		return Objects.equals(encoding, that.encoding);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(encoding);
+	}
+}

--- a/flink-formats/flink-string/src/main/java/org.apache.flink/table/descriptors/StringFormat.java
+++ b/flink-formats/flink-string/src/main/java/org.apache.flink/table/descriptors/StringFormat.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.util.Preconditions;
+
+import static org.apache.flink.table.descriptors.StringValidator.FORMAT_ENCODING;
+import static org.apache.flink.table.descriptors.StringValidator.FORMAT_FAIL_ON_EMPTY;
+import static org.apache.flink.table.descriptors.StringValidator.FORMAT_FAIL_ON_NULL;
+import static org.apache.flink.table.descriptors.StringValidator.FORMAT_SCHEMA;
+import static org.apache.flink.table.descriptors.StringValidator.FORMAT_TYPE_VALUE;
+
+/**
+ * Format descriptor for String.
+ */
+public class StringFormat extends FormatDescriptor{
+
+	private Boolean failOnNull;
+
+	private Boolean failOnEmpty;
+
+	private String schema;
+
+	private String encoding;
+
+	/**
+	 * Format descriptor for String.
+	 */
+	public StringFormat() {
+		super(FORMAT_TYPE_VALUE, 1);
+	}
+
+	/**
+	 * Sets flag whether to fail if the string is null or not.
+	 *
+	 * @param failOnNull If set to true, the operation fails if the string is null.
+	 */
+	public StringFormat setFailOnNull(Boolean failOnNull) {
+		this.failOnNull = failOnNull;
+		return this;
+	}
+
+	/**
+	 * Sets flag whether to fail if the string is empty.
+	 *
+	 * @param failOnEmpty If set to true, the operation fails if the string is empty.
+	 */
+	public StringFormat setFailOnEmpty(Boolean failOnEmpty) {
+		this.failOnEmpty = failOnEmpty;
+		return this;
+	}
+
+	public StringFormat setSchema(String schema) {
+		Preconditions.checkNotNull(schema);
+		this.schema = schema;
+		return this;
+	}
+
+	/**
+	 * Sets encoding of the string, "UTF-8" if not set.
+	 *
+	 * @param encoding encoding of the string.
+	 */
+	public StringFormat setEncoding(String encoding) {
+		this.encoding = encoding;
+		return this;
+	}
+
+	@Override
+	public void addFormatProperties(DescriptorProperties properties) {
+		if (failOnNull != null) {
+			properties.putBoolean(FORMAT_FAIL_ON_NULL, failOnNull);
+		}
+
+		if (failOnEmpty != null) {
+			properties.putBoolean(FORMAT_FAIL_ON_EMPTY, failOnEmpty);
+		}
+
+		if (schema != null) {
+			properties.putString(FORMAT_SCHEMA, schema);
+		}
+
+		if (encoding != null) {
+			properties.putString(FORMAT_ENCODING, encoding);
+		}
+	}
+
+}

--- a/flink-formats/flink-string/src/main/java/org.apache.flink/table/descriptors/StringValidator.java
+++ b/flink-formats/flink-string/src/main/java/org.apache.flink/table/descriptors/StringValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+
+/**
+ * Validator for {@link StringFormat}.
+ */
+public class StringValidator extends FormatDescriptorValidator {
+
+	public static final String FORMAT_TYPE_VALUE = "string";
+
+	public static final String FORMAT_SCHEMA = "format.schema";
+
+	public static final String FORMAT_FAIL_ON_NULL = "format.fail-on-null";
+
+	public static final String FORMAT_FAIL_ON_EMPTY = "format.fail-on-empty";
+
+	public static final String FORMAT_ENCODING = "format.encoding";
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		super.validate(properties);
+		properties.validateBoolean(FORMAT_FAIL_ON_NULL, true);
+		properties.validateBoolean(FORMAT_FAIL_ON_EMPTY, true);
+		properties.validateString(FORMAT_SCHEMA, false, 1);
+		properties.validateString(FORMAT_ENCODING, true);
+	}
+}

--- a/flink-formats/flink-string/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-formats/flink-string/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.formats.string.StringRowFormatFactory

--- a/flink-formats/flink-string/src/test/java/org/apache/flink/formats/string/StringRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-string/src/test/java/org/apache/flink/formats/string/StringRowDeserializationSchemaTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.string;
+
+import org.apache.flink.types.Row;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests for the {@link StringRowDeserializationSchema}.
+ */
+public class StringRowDeserializationSchemaTest {
+
+	@Test
+	public void testStringDeserialization() throws IOException {
+
+		String data = "Hello World";
+		byte[] bytes = data.getBytes("UTF-8");
+
+		StringRowDeserializationSchema  deserializationSchema = new StringRowDeserializationSchema(
+			"msg",
+			"utf-8"
+		);
+
+		Row deserialized = deserializationSchema.deserialize(bytes);
+
+		Assert.assertEquals(1, deserialized.getArity());
+		Assert.assertEquals(data, deserialized.getField(0));
+
+	}
+
+	@Test(expected = IOException.class)
+	public void testNullStringDeserialization() throws IOException {
+
+		StringRowDeserializationSchema  deserializationSchema = new StringRowDeserializationSchema(
+			"msg",
+			"utf-8"
+		);
+		deserializationSchema.setFailOnNull(true);
+
+		Row deserialized = deserializationSchema.deserialize(null);
+	}
+
+	@Test(expected = IOException.class)
+	public void testEmptyStringDeserialization() throws IOException {
+
+		StringRowDeserializationSchema  deserializationSchema = new StringRowDeserializationSchema(
+			"msg",
+			"utf-8"
+		);
+		deserializationSchema.setFailOnEmpty(true);
+
+		Row deserialized = deserializationSchema.deserialize(new byte[0]);
+	}
+
+	@Test
+	public void testStringDeserializationWithWrongEncoding() throws IOException {
+
+		String data = "你好世界";
+		byte[] bytes = data.getBytes("GBK");
+
+		StringRowDeserializationSchema  deserializationSchema = new StringRowDeserializationSchema(
+			"msg",
+			"UTF-8"
+		);
+
+		Row deserialized = deserializationSchema.deserialize(bytes);
+		Assert.assertEquals(1, deserialized.getArity());
+		Assert.assertNotEquals(data, deserialized.getField(0));
+	}
+
+	@Test(expected = IOException.class)
+	public void testStringDeserializationWithUnsupportedEncoding() throws IOException {
+
+		String data = "你好世界";
+		byte[] bytes = data.getBytes("GBK");
+
+		StringRowDeserializationSchema  deserializationSchema = new StringRowDeserializationSchema(
+			"msg",
+			"ddd"
+		);
+
+		Row deserialized = deserializationSchema.deserialize(bytes);
+		Assert.assertEquals(1, deserialized.getArity());
+		Assert.assertNotEquals(data, deserialized.getField(0));
+	}
+}

--- a/flink-formats/flink-string/src/test/java/org/apache/flink/formats/string/StringRowFormatFactoryTest.java
+++ b/flink-formats/flink-string/src/test/java/org/apache/flink/formats/string/StringRowFormatFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.string;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.descriptors.Descriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.StringFormat;
+import org.apache.flink.table.factories.DeserializationSchemaFactory;
+import org.apache.flink.table.factories.SerializationSchemaFactory;
+import org.apache.flink.table.factories.TableFactoryService;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link StringRowFormatFactory}.
+ */
+public class StringRowFormatFactoryTest extends TestLogger {
+
+	@Test
+	public void testSchema() {
+		final Map<String, String> properties = toMap(
+			new StringFormat()
+				.setEncoding("UTF-8")
+				.setSchema("nid")
+				.setFailOnNull(true)
+				.setFailOnEmpty(true)
+		);
+
+		testSchemaSerializationSchema(properties);
+
+		testSchemaDeserializationSchema(properties);
+	}
+
+	private void testSchemaDeserializationSchema(Map<String, String> properties) {
+		final DeserializationSchema<?> actual2 = TableFactoryService
+			.find(DeserializationSchemaFactory.class, properties)
+			.createDeserializationSchema(properties);
+		final StringRowDeserializationSchema expected2 = new StringRowDeserializationSchema("nid", "UTF-8");
+		expected2.setFailOnNull(true);
+		expected2.setFailOnEmpty(true);
+		assertEquals(expected2, actual2);
+	}
+
+	private void testSchemaSerializationSchema(Map<String, String> properties) {
+		final SerializationSchema<?> actual1 = TableFactoryService
+			.find(SerializationSchemaFactory.class, properties)
+			.createSerializationSchema(properties);
+		final SerializationSchema expected1 = new StringRowSerializationSchema("UTF-8");
+		assertEquals(expected1, actual1);
+	}
+
+	private static Map<String, String> toMap(Descriptor... desc) {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		for (Descriptor d : desc) {
+			d.addProperties(descriptorProperties);
+		}
+		return descriptorProperties.asMap();
+	}
+}

--- a/flink-formats/flink-string/src/test/java/org/apache/flink/formats/string/StringRowSerializationSchemaTest.java
+++ b/flink-formats/flink-string/src/test/java/org/apache/flink/formats/string/StringRowSerializationSchemaTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.string;
+
+import org.apache.flink.types.Row;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests for the {@link StringRowSerializationSchema}.
+ */
+public class StringRowSerializationSchemaTest {
+
+	@Test
+	public void testStringSerialization() throws IOException {
+
+		String data = "Hello World";
+		byte[] bytes = data.getBytes("UTF-8");
+
+		Row row = Row.of(data);
+		StringRowSerializationSchema serializationSchema = new StringRowSerializationSchema("UTF-8");
+
+		byte[] serializeData = serializationSchema.serialize(row);
+
+		Assert.assertArrayEquals(bytes, serializeData);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testStringSerializationWithWrongEncoding() throws IOException {
+
+		String data = "你好世界";
+		byte[] bytes = data.getBytes("GBK");
+
+		Row row = Row.of(data);
+		StringRowSerializationSchema serializationSchema = new StringRowSerializationSchema("UTF-8");
+
+		byte[] serializeData = serializationSchema.serialize(row);
+
+		Assert.assertArrayEquals(bytes, serializeData);
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testStringSerializationWithUnsupportedEncoding() throws IOException {
+
+		String data = "你好世界";
+		byte[] bytes = data.getBytes("GBK");
+
+		Row row = Row.of(data);
+		StringRowSerializationSchema serializationSchema = new StringRowSerializationSchema("ddd");
+
+		byte[] serializeData = serializationSchema.serialize(row);
+
+		Assert.assertArrayEquals(bytes, serializeData);
+	}
+
+}

--- a/flink-formats/flink-string/src/test/java/org/apache/flink/table/descriptors/StringFormatTest.java
+++ b/flink-formats/flink-string/src/test/java/org/apache/flink/table/descriptors/StringFormatTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.table.api.ValidationException;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for the {@link StringFormat} descriptor.
+ */
+public class StringFormatTest extends DescriptorTestBase {
+
+	@Test(expected = ValidationException.class)
+	public void testInvalidFailOnNull() {
+		addPropertyAndVerify(descriptors().get(0), "format.fail-on-null", "DDD");
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testInvalidFailOnEmpty() {
+		addPropertyAndVerify(descriptors().get(0), "format.fail-on-empty", "DDD");
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testMissingSchema() {
+		addPropertyAndVerify(descriptors().get(0), "format.schema", "");
+	}
+
+	@Override
+	public List<Descriptor> descriptors() {
+		Descriptor desc1 = new StringFormat().setSchema("nid");
+		Descriptor desc2 = new StringFormat().setSchema("nid").setEncoding("UTF-8");
+		Descriptor desc3 = new StringFormat().setSchema("nid").setFailOnNull(false);
+		Descriptor desc4 = new StringFormat().setSchema("nid").setFailOnEmpty(true);
+
+		return Arrays.asList(desc1, desc2, desc3, desc4);
+	}
+
+	@Override
+	public List<Map<String, String>> properties() {
+		final Map<String, String> prop1 = new HashMap<>();
+		prop1.put("format.type", "string");
+		prop1.put("format.property-version", "1");
+		prop1.put("format.schema", "nid");
+
+		final Map<String, String> prop2 = new HashMap<>();
+		prop2.put("format.type", "string");
+		prop2.put("format.property-version", "1");
+		prop2.put("format.schema", "nid");
+		prop2.put("format.encoding", "UTF-8");
+
+		final Map<String, String> prop3 = new HashMap<>();
+		prop3.put("format.type", "string");
+		prop3.put("format.property-version", "1");
+		prop3.put("format.schema", "nid");
+		prop3.put("format.fail-on-null", "false");
+
+		final Map<String, String> prop4 = new HashMap<>();
+		prop4.put("format.type", "string");
+		prop4.put("format.property-version", "1");
+		prop4.put("format.schema", "nid");
+		prop4.put("format.fail-on-empty", "true");
+
+		return Arrays.asList(prop1, prop2, prop3, prop4);
+	}
+
+	@Override
+	public DescriptorValidator validator() {
+		return new StringValidator();
+	}
+}

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -40,6 +40,7 @@ under the License.
 		<module>flink-json</module>
 		<module>flink-avro-confluent-registry</module>
 		<module>flink-parquet</module>
+		<module>flink-string</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up


### PR DESCRIPTION

## What is the purpose of the change

Add a string table format factory


## Brief change log
  - *add StringRowFormatFactory*


## Verifying this change


This change added tests and can be verified as follows:
test cases in flink-formats/flink-string


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no
## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  no
