### PR TITLE
[FLINK-9994][DataStream API] IntervalJoinOp Context#getTimestamp() returns max timestamp.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
@@ -481,13 +481,16 @@ public class IntervalJoinOperatorTest {
 				TestElem.serializer(),
 				TestElem.serializer(),
 				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+
+					private static final long serialVersionUID = 1L;
+
 					@Override
 					public void processElement(
 						TestElem left,
 						TestElem right,
 						Context ctx,
 						Collector<Tuple2<TestElem, TestElem>> out) throws Exception {
-						Assert.assertEquals(left.ts, ctx.getTimestamp());
+						Assert.assertEquals(Math.max(left.ts, right.ts), ctx.getTimestamp());
 					}
 				}
 			);


### PR DESCRIPTION
## What is the purpose of the change

Although the `Context.getTimestamp()` in the `IntervalJoinOperator` should return the max timestamp between the elements in the joined pair, it currently returns the one of the "left" element. 

This is a remain from past versions of the code, as the timestamp of the collector is correctly updated to the max timestamp between the ones in the matched pair.

## Brief change log

The main change is in the `collect(T1 left, T2 right, long leftTimestamp, long rightTimestamp)` of the `InternalJoinOperator`.

## Verifying this change

The tests that were testing this behavior were wrong and they are now fixed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
