### PR TITLE
[FLINK-9936] Resource manager connect to mesos after leadership granted. .

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -899,6 +899,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 				setFencingToken(newResourceManagerId);
 
+				try {
+					onLeaderShipGranted();
+				} catch (Exception e) {
+					onFatalError(e);
+				}
+
 				slotManager.start(getFencingToken(), getMainThreadExecutor(), new ResourceActionsImpl());
 
 				getRpcService().execute(
@@ -918,6 +924,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				log.info("ResourceManager {} was revoked leadership. Clearing fencing token.", getAddress());
 
 				clearState();
+
+				try {
+					onLeaderShipRevoked();
+				} catch (Exception e) {
+					onFatalError(e);
+				}
 
 				setFencingToken(null);
 
@@ -945,6 +957,18 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	 * @throws ResourceManagerException which occurs during initialization and causes the resource manager to fail.
 	 */
 	protected abstract void initialize() throws ResourceManagerException;
+
+	/**
+	 * Called when leadership is granted.
+	 * @throws Exception which occurs during granting leadership and causes the resource manager to fail.
+	 */
+	protected void onLeaderShipGranted() throws Exception {}
+
+	/**
+	 * Called when leadership is revoked.
+	 * @throws Exception which occurs during revoking leadership and causes the resource manager to fail.
+	 */
+	protected void onLeaderShipRevoked() throws Exception {}
 
 	/**
 	 * The framework specific code to deregister the application. This should report the


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug in mesos resource manager which makes it unable to connect to mesos after failover.


## Brief change log

  - Add **onLeadershipGranted** callback in resource manager.
  - Add **onLeadershipRevoked** callback in resource manager.


## Verifying this change

This change added tests and can be verified as follows:

  - Manually verified the change by running a cluster on mesos, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  yes
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
