### PR TITLE
[FLINK-9739] Regression in supported filesystems for RocksDB

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -535,10 +535,12 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 						path = rawPath;
 					}
 				}
-
+				if (path.equalsIgnoreCase("file")) {
+					continue;
+				}
 				pp[i] = new File(path);
 				if (!pp[i].isAbsolute()) {
-					throw new IllegalArgumentException("Relative paths are not supported");
+					throw new IllegalArgumentException("Relative paths " + path + " are not supported");
 				}
 			}
 


### PR DESCRIPTION
Like mentioned in the description and comments of the bug -
The issue https://issues.apache.org/jira/browse/FLINK-9739 is due to the refactoring of the flink Path to java Files API. Secondly the usage File.isAbsolute() throws an java.lang.IllegalArgumentException: Relative paths are not supported which should not have happened.

The reason why java.lang.IllegalArgumentException is thrown is -
The calling function is splitting the filepaths based on File.pathSeparator and in linux systems the file seperator is ':' therefore if file paths given to state.backend.rocksdb.localdir is of form file:///some/local/path then "file" and "/some/local/path" will be considered as different path and would fail in the below absolute path check.

Solution:
1. Since "state.backend.rocksdb.localdir" expects only local file path an extra check can be added to see if the path contains "file". This is the change done in this commit.

2. The other possible solution could be to revert the API change from java File to flink Path. 