### PR TITLE
[FLINK-9996][fs] Wrap exceptions during FS creation

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/AbstractFileSystemFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/AbstractFileSystemFactory.java
@@ -51,10 +51,16 @@ public abstract class AbstractFileSystemFactory implements FileSystemFactory {
 	public FileSystem create(URI fsUri) throws IOException {
 		LOG.debug("Creating Hadoop file system (backed by " + name + ")");
 		LOG.debug("Loading Hadoop configuration for " + name);
-		org.apache.hadoop.conf.Configuration hadoopConfig = hadoopConfigLoader.getOrLoadHadoopConfig();
-		org.apache.hadoop.fs.FileSystem fs = createHadoopFileSystem();
-		fs.initialize(getInitURI(fsUri, hadoopConfig), hadoopConfig);
-		return new HadoopFileSystem(fs);
+		try {
+			org.apache.hadoop.conf.Configuration hadoopConfig = hadoopConfigLoader.getOrLoadHadoopConfig();
+			org.apache.hadoop.fs.FileSystem fs = createHadoopFileSystem();
+			fs.initialize(getInitURI(fsUri, hadoopConfig), hadoopConfig);
+			return new HadoopFileSystem(fs);
+		} catch (IOException ioe) {
+			throw ioe;
+		} catch (Exception e) {
+			throw new IOException(e.getMessage(), e);
+		}
 	}
 
 	protected abstract org.apache.hadoop.fs.FileSystem createHadoopFileSystem();


### PR DESCRIPTION
## What is the purpose of the change

This PR is a small modification to the hadoop `AbstractFileSystemFactory` too wrap all exceptions that occur during the creation of a FileSystem in a `IOException`, like we did in the past.
This behavior was modified in 7be07871c23b56547add4cd85e15b95c757f882b.

## Verifying this change

* run `PrestoS3FileSystemITCase#testConfigKeysForwarding`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes)
