### PR TITLE
[FLINK-9995][tests] Improve tearing down Mesos.

### DIFF
--- a/flink-jepsen/src/jepsen/flink/mesos.clj
+++ b/flink-jepsen/src/jepsen/flink/mesos.clj
@@ -111,14 +111,20 @@
 (defn stop-master!
   [node]
   (info node "Stopping mesos master")
-  (meh (c/exec :killall :-9 :mesos-master))
-  (meh (c/exec :rm :-rf master-pidfile)))
+  (meh (cu/grepkill! :mesos-master))
+  (meh (c/exec :rm :-rf master-pidfile))
+  (meh (c/exec :rm :-rf
+               (c/lit (str log-dir "/*"))
+               (c/lit (str master-dir "/*")))))
 
 (defn stop-slave!
   [node]
   (info node "Stopping mesos slave")
-  (meh (c/exec :killall :-9 :mesos-slave))
-  (meh (c/exec :rm :-rf slave-pidfile)))
+  (meh (cu/grepkill! :mesos-slave))
+  (meh (c/exec :rm :-rf slave-pidfile))
+  (meh (c/exec :rm :-rf
+               (c/lit (str log-dir "/*"))
+               (c/lit (str slave-dir "/*")))))
 
 ;;; Marathon functions
 


### PR DESCRIPTION
## What is the purpose of the change

*Clean up Mesos logs and working directory so that we do not run out of disk space on the DB nodes while running tests.*

## Brief change log
  - Clean up logs and Mesos working directory.
  - Kill Mesos processes using `grepkill!` utility.

## Verifying this change

This change added tests and can be verified as follows:
  - *Manually ran Jepsen tests on AWS.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
