### PR TITLE
[FLINK-9975][hadoop] also shade Hadoop's io.netty dependency

### DIFF
--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -121,6 +121,7 @@ under the License.
 									<include>com.google.code.findbugs:*</include>
 									<include>asm:asm</include>
 									<include>io.netty:netty:*</include>
+									<include>io.netty:netty-all:*</include>
 									<include>org.apache.curator:*</include>
 									<include>org.apache.hadoop:*</include>
 									<include>org.htrace:htrace-core</include>
@@ -151,6 +152,10 @@ under the License.
 								<relocation>
 									<pattern>org.jboss.netty</pattern>
 									<shadedPattern>org.apache.flink.hadoop.shaded.org.jboss.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.hadoop.shaded.io.netty</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.apache.curator</pattern>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -227,6 +227,10 @@ under the License.
 									<pattern>org.jboss.netty</pattern>
 									<shadedPattern>org.apache.flink.hadoop.shaded.org.jboss.netty</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.hadoop.shaded.io.netty</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

This is to prevent user code from clashing on Netty which we relocated in the hadoop jars using its old namespace: `org.jboss.netty`. Hadoop >= 2.7, however, upgraded Netty and relies on the new package: `io.netty`.

## Brief change log

- relocate `io.netty` to `org.apache.flink.hadoop.shaded.io.netty`

## Verifying this change

This change is already covered by existing tests, such as the yarn, hdfs, and end-to-end tests.
- I also verified the jars in the `lib/` folder contain the same dependencies (for hadoop 2.8.3) except the relocated `io.netty`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no (modifies relocation, though!)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
