### PR TITLE
[FLINK-10000][streaming]Fix the example of CoGroupedStreams

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -68,7 +68,7 @@ import static java.util.Objects.requireNonNull;
  *
  * DataStream<T> result = one.coGroup(two)
  *     .where(new MyFirstKeySelector())
- *     .equalTo(new MyFirstKeySelector())
+ *     .equalTo(new MySecondKeySelector())
  *     .window(TumblingEventTimeWindows.of(Time.of(5, TimeUnit.SECONDS)))
  *     .apply(new MyCoGroupFunction());
  * } </pre>


### PR DESCRIPTION
## What is the purpose of the change

  - Fix the example of CoGroupedStreams.java in comments

## Brief change log
  - Fix the mistake by replace the param of equalTo, MyFirstKeySelector, with MySecondKeySelector  

## Verifying this change
  - n/a

## Does this pull request potentially affect one of the following parts:
  - n/a

## Documentation
  - n/a
