### PR TITLE
[FLINK-9936][mesos] Mesos resource manager unable to connect to master after failover 

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.mesos.runtime.clusterframework;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
@@ -368,8 +367,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 		}
 	}
 
-	@VisibleForTesting
-	CompletableFuture<Void> stopSupportingActorsAsync() {
+	private CompletableFuture<Void> stopSupportingActorsAsync() {
 		FiniteDuration stopTimeout = new FiniteDuration(5L, TimeUnit.SECONDS);
 
 		CompletableFuture<Boolean> stopTaskMonitorFuture = stopActor(taskMonitor, stopTimeout);

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -809,18 +809,21 @@ public class MesosResourceManagerTest extends TestLogger {
 	}
 
 	@Test
-	public void testClearStateRevokeLeadership() throws Exception {
+	public void testClearStateAfterRevokeLeadership() throws Exception {
 		new Context() {{
-			MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1).launchWorker(slave1, slave1host);
+			final MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1);
+			final MesosWorkerStore.Worker worker2 = MesosWorkerStore.Worker.newWorker(task2).launchWorker(slave1, slave1host);
+			final MesosWorkerStore.Worker worker3 = MesosWorkerStore.Worker.newWorker(task3).launchWorker(slave1, slave1host).releaseWorker();
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
-			when(rmServices.workerStore.recoverWorkers()).thenReturn(Collections.singletonList(worker1)).thenReturn(Collections.emptyList());
+			when(rmServices.workerStore.recoverWorkers()).thenReturn(Arrays.asList(worker1, worker2, worker3)).thenReturn(Collections.emptyList());
 
 			startResourceManager();
 			rmServices.rmLeaderElectionService.notLeader();
 			rmServices.grantLeadership();
 
-			//resourceManager.stateCleared.await(5, TimeUnit.SECONDS);
+			assertThat(resourceManager.workersInNew.size(), equalTo(0));
 			assertThat(resourceManager.workersInLaunch.size(), equalTo(0));
+			assertThat(resourceManager.workersBeingReturned.size(), equalTo(0));
 			verify(rmServices.schedulerDriver).stop(true);
 		}};
 	}

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -505,6 +505,7 @@ public class MesosResourceManagerTest extends TestLogger {
 		@Override
 		public void close() throws Exception {
 			rpcService.stopService().get();
+			fatalErrorHandler.rethrowError();
 		}
 	}
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -807,4 +807,21 @@ public class MesosResourceManagerTest extends TestLogger {
 			resourceManager.taskRouter.expectMsgClass(Disconnected.class);
 		}};
 	}
+
+	@Test
+	public void testClearStateRevokeLeadership() throws Exception {
+		new Context() {{
+			MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1).launchWorker(slave1, slave1host);
+			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
+			when(rmServices.workerStore.recoverWorkers()).thenReturn(Collections.singletonList(worker1)).thenReturn(Collections.emptyList());
+
+			startResourceManager();
+			rmServices.rmLeaderElectionService.notLeader();
+			rmServices.grantLeadership();
+
+			//resourceManager.stateCleared.await(5, TimeUnit.SECONDS);
+			assertThat(resourceManager.workersInLaunch.size(), equalTo(0));
+			verify(rmServices.schedulerDriver).stop(true);
+		}};
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -908,13 +908,13 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				slotManager.start(getFencingToken(), getMainThreadExecutor(), new ResourceActionsImpl());
 
 				prepareLeadershipAsync()
+					.thenRunAsync(() ->
+						// confirming the leader session ID might be blocking,
+						leaderElectionService.confirmLeaderSessionID(newLeaderSessionID), getRpcService().getExecutor())
 					.exceptionally(t -> {
 						onFatalError(t);
 						return null;
-					})
-					.thenRunAsync(() ->
-						// confirming the leader session ID might be blocking,
-						leaderElectionService.confirmLeaderSessionID(newLeaderSessionID), getRpcService().getExecutor());
+					});
 			});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -737,6 +737,9 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		clearState();
 	}
 
+	/**
+	 * Callback to clear state on leadership revocation.
+	 */
 	protected void clearState() {}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -899,6 +899,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 				setFencingToken(newResourceManagerId);
 
+				try {
+					onLeaderShipGranted();
+				} catch (Exception e) {
+					onFatalError(e);
+				}
+
 				slotManager.start(getFencingToken(), getMainThreadExecutor(), new ResourceActionsImpl());
 
 				getRpcService().execute(
@@ -918,6 +924,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				log.info("ResourceManager {} was revoked leadership. Clearing fencing token.", getAddress());
 
 				clearState();
+
+				try {
+					onLeaderShipRevoked();
+				} catch (Exception e) {
+					onFatalError(e);
+				}
 
 				setFencingToken(null);
 
@@ -945,6 +957,18 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	 * @throws ResourceManagerException which occurs during initialization and causes the resource manager to fail.
 	 */
 	protected abstract void initialize() throws ResourceManagerException;
+
+	/**
+	 * Called when leadership is granted.
+	 * @throws Exception which occurs during granting leadership and causes the resource manager to fail.
+	 */
+	protected void onLeaderShipGranted() throws Exception {}
+
+	/**
+	 * Called when leadership is revoked.
+	 * @throws Exception which occurs during revoking leadership and causes the resource manager to fail.
+	 */
+	protected void onLeaderShipRevoked() throws Exception {}
 
 	/**
 	 * The framework specific code to deregister the application. This should report the

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
@@ -67,7 +66,6 @@ public class ResourceManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testRequestTaskManagerInfo() throws Exception {
-		final Configuration configuration = new Configuration();
 		final TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
 		final SlotManager slotManager = new SlotManager(
 			rpcService.getScheduledExecutor(),


### PR DESCRIPTION
## What is the purpose of the change

*When deployed in mesos session cluster mode, the connector monitor keeps reporting unable to connect to mesos after restart. In fact, scheduler driver already connected to mesos master, but when the connected message is lost. This is because leadership is not granted yet and fence id is not set, the rpc service ignores the connected message. So we should connect to mesos master after leadership is granted.*


## Brief change log

  - *Connect to mesos master after leadership is granted but before leadership is confirmed.* 

## Verifying this change

This change added tests and can be verified as follows:

  - *MesosResourceManagerTest*
  - *Ran against Jepsen test suite.* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
