### PR TITLE
[FLINK-10008] [table] Improve the LOG function in Table to support bases less than 1

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -103,11 +103,13 @@ object ScalarFunctions {
     if (x <= 0.0) {
       throw new IllegalArgumentException(s"x of 'log(base, x)' must be > 0, but x = $x")
     }
-    if (base <= 1.0) {
-      throw new IllegalArgumentException(s"base of 'log(base, x)' must be > 1, but base = $base")
-    } else {
-      Math.log(x) / Math.log(base)
+    if (base == 1.0) {
+      throw new IllegalArgumentException(s"base of 'log(base, x)' can not be 1")
     }
+    if (base <= 0.0) {
+      throw new IllegalArgumentException(s"base of 'log(base, x)' must be > 0, but base = $base")
+    }
+    Math.log(x) / Math.log(base)
   }
 
   /**

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1383,6 +1383,13 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "Log(10, 100)",
       "2.0"
     )
+
+    testAllApis(
+      0.01.log(0.1),
+      "0.01.log(0.1)",
+      "LOG(cast(0.1 as double), cast(0.01 as double))",
+      "2.0"
+    )
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -31,6 +31,15 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
   // ----------------------------------------------------------------------------------------------
 
   @Test(expected = classOf[IllegalArgumentException])
+  def testInvalidLogWithZeroBase(): Unit = {
+    // invalid arithmetic argument
+    testSqlApi(
+      "LOG(0, 100)",
+      "FAIL"
+    )
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
   def testInvalidLog1(): Unit = {
     // invalid arithmetic argument
     testSqlApi(


### PR DESCRIPTION
## What is the purpose of the change

Improve the LOG function in Table to support bases less than 1

## Brief change log

change implementation of Log function


## Verifying this change


This change added tests and can be verified as follows:
new test cases of ScalarFunctionTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? no
