### PR TITLE
[FLINK-10005][DataStream API] StreamingFileSink: sets initialPartCounter=maxUsed in new Buckets

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -115,6 +115,18 @@ public class Bucket<IN, BucketID> {
 		this.pending = new ArrayList<>();
 	}
 
+	/**
+	 * Gets the information available for the currently
+	 * open part file, i.e. the one we are currently writing to.
+	 *
+	 * <p>This will be null if there is no currently open part file. This
+	 * is the case when we have a new, just created bucket or a bucket
+	 * that has not received any data after the closing of its previously
+	 * open in-progress file due to the specified rolling policy.
+	 *
+	 * @return The information about the currently in-progress part file
+	 * or {@code null} if there is no open part file.
+	 */
 	public PartFileInfo<BucketID> getInProgressPartInfo() {
 		return currentPart;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -323,7 +323,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 					Assert.assertEquals("test1@1\n", fileContents.getValue());
 				} else if (fileContents.getKey().getParentFile().getName().equals("test2")) {
 					bucketCounter++;
-					Assert.assertEquals("part-0-0", fileContents.getKey().getName());
+					Assert.assertEquals("part-0-1", fileContents.getKey().getName());
 					Assert.assertEquals("test2@1\n", fileContents.getValue());
 				} else if (fileContents.getKey().getParentFile().getName().equals("test3")) {
 					bucketCounter++;
@@ -346,11 +346,11 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 					Assert.assertEquals("test2@1\n", fileContents.getValue());
 				} else if (fileContents.getKey().getParentFile().getName().equals("test3")) {
 					bucketCounter++;
-					Assert.assertEquals("part-0-0", fileContents.getKey().getName());
+					Assert.assertEquals("part-0-2", fileContents.getKey().getName());
 					Assert.assertEquals("test3@1\n", fileContents.getValue());
 				} else if (fileContents.getKey().getParentFile().getName().equals("test4")) {
 					bucketCounter++;
-					Assert.assertEquals("part-0-0", fileContents.getKey().getName());
+					Assert.assertEquals("part-0-3", fileContents.getKey().getName());
 					Assert.assertEquals("test4@1\n", fileContents.getValue());
 				}
 			}
@@ -437,8 +437,8 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 							inProgressFilename.contains(".part-1-0.inprogress")
 						)
 				) {
-						counter++;
-				} else if (parentFilename.equals("test2") && inProgressFilename.contains(".part-1-0.inprogress")) {
+					counter++;
+				} else if (parentFilename.equals("test2") && inProgressFilename.contains(".part-1-1.inprogress")) {
 					counter++;
 				}
 			}
@@ -476,7 +476,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 						counter++;
 						Assert.assertTrue(fileContents.getValue().equals("test1@1\n") || fileContents.getValue().equals("test1@0\n"));
 					}
-				} else if (parentFilename.equals("test2") && filename.contains(".part-1-0.inprogress")) {
+				} else if (parentFilename.equals("test2") && filename.contains(".part-1-1.inprogress")) {
 					counter++;
 					Assert.assertEquals("test2@1\n", fileContents.getValue());
 				}


### PR DESCRIPTION
## What is the purpose of the change

In the `StreamingFileSink` whenever a new bucket is created, we provide it with the initial part counter to use for its part files. In addition, when a bucket has no in-progress or pending files, it is removed from the state. 

This behavior was leading to the problem:
* bucket X starts with partCounter = 0
* creates a new part file, i.e. partCounter = 1
* everything gets committed and bucket X is empty so it gets removed from the state.
* a new element comes in, and the bucket starts again with 0.

This was solved for when recovering from a failure, but not if this deletion and creation of a bucket happens in normal execution. This PR solves this issue.

## Brief change log

We change the `initialPartCounter` argument passed when creating a new bucket, to be the `max` across all local buckets. This allows to be sure that we do not ovewrite anything and also we do not need to the `blind searches` for file names in order to determine a valid part counter. The latter would not work in eventually-consistent filesystems.

## Verifying this change

Updated existing tests to cover this scenario.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
