### PR TITLE
[FLINK-9294] [table] Improve type inference for UDFs with composite parameter and/or result type

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
@@ -381,6 +381,7 @@ case class AggFunctionCall(
                               .map(signatureToString)
                               .mkString(", ")}")
     } else {
+      // Add additional validation
       ValidationSuccess
     }
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ScalarFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ScalarFunction.scala
@@ -95,4 +95,9 @@ abstract class ScalarFunction extends UserDefinedFunction {
       }
     }
   }
+
+  @throws[InvalidTypesException]
+  def inferResultType(parameterTypeInfo: Array[TypeInformation[_]]): TypeInformation[_] = {
+    null
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
@@ -22,6 +22,8 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.sql._
 import org.apache.calcite.sql.`type`._
 import org.apache.calcite.sql.parser.SqlParserPos
+import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.functions.ScalarFunction
@@ -87,7 +89,8 @@ object ScalarSqlFunction {
               s"Actual: ${signatureToString(parameters)} \n" +
               s"Expected: ${signaturesToString(scalarFunction, "eval")}")
         }
-        val resultType = getResultTypeOfScalarFunction(scalarFunction, foundSignature.get)
+        val resultType = getResultTypeOfScalarFunction(
+          scalarFunction, foundSignature.get, parameters.toArray)
         typeFactory.createTypeFromTypeInfo(resultType, isNullable = true)
       }
     }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -19,8 +19,10 @@
 package org.apache.flink.table.runtime.utils;
 
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.types.Row;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Test scalar functions.
@@ -80,4 +82,21 @@ public class JavaUserDefinedScalarFunctions {
 		}
 	}
 
+	/**
+	 * Map Function.
+	 */
+	public static class JavaFunc5 extends ScalarFunction {
+		public Map<String, String> eval(Map<String, String> map) {
+			return map;
+		}
+	}
+
+	/**
+	 * Row Function.
+	 */
+	public static class JavaFunc6 extends ScalarFunction {
+		public Row eval(Row row) {
+			return Row.of(((Integer) row.getField(0)) * 2);
+		}
+	}
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/UserDefinedFunctionValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/UserDefinedFunctionValidationTest.scala
@@ -18,9 +18,9 @@
 package org.apache.flink.table.api.validation
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.expressions.utils.Func0
+import org.apache.flink.table.expressions.utils.{Func0, Func21, Func22}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.OverAgg0
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
@@ -28,7 +28,7 @@ import org.junit.Test
 class UserDefinedFunctionValidationTest extends TableTestBase {
 
   @Test
-  def testScalarFunctionOperandTypeCheck(): Unit = {
+  def testScalarSqlFunctionOperandTypeCheck(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage(
       "Given parameters of function 'func' do not match any signature. \n" +
@@ -41,7 +41,21 @@ class UserDefinedFunctionValidationTest extends TableTestBase {
   }
 
   @Test
-  def testAggregateFunctionOperandTypeCheck(): Unit = {
+  def testScalarTableFunctionOperandTypeCheck(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage(
+      "Expression org.apache.flink.table.expressions.utils.Func0$('b) " +
+        "failed on input check: Given parameters do not match any signature. \n" +
+        "Actual: (java.lang.String) \n" +
+        "Expected: (int)")
+    val util = streamTestUtil()
+    val sourceTable = util.addTable[(Int, String)]("t", 'a, 'b)
+    val resultTable = sourceTable.select(Func0('b))
+    util.verifyTable(resultTable, "n/a")
+  }
+
+  @Test
+  def testAggregateSqlFunctionOperandTypeCheck(): Unit = {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage(
       "Given parameters of function do not match any signature. \n" +
@@ -56,5 +70,37 @@ class UserDefinedFunctionValidationTest extends TableTestBase {
     util.verifySql("select agg(b, a) from t", "n/a")
   }
 
+  @Test
+  def testAggregateTableFunctionOperandTypeCheck(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage(
+      "Expression OverAgg0(ArrayBuffer('b, 'a)) failed on input check: " +
+        "Given parameters do not match any signature. \n" +
+        "Actual: (java.lang.String, java.lang.Integer) \n" +
+        "Expected: (long, int)")
+    val util = streamTestUtil()
+    val agg = new OverAgg0
+    val sourceTable = util.addTable[(Int, String)]("t", 'a, 'b)
+    val resultTable = sourceTable.select(agg('b, 'a))
+    util.verifyTable(resultTable, "n/a")
+  }
+
+  @Test
+  def userDefineMapTypeFunctionSubSchemaTypeCheck(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    val util = streamTestUtil()
+    util.addTable("t", 'a)(Types.ROW(Types.MAP(Types.INT, Types.INT)))
+    util.tableEnv.registerFunction("func", Func21)
+    util.verifySql("select func(a) from t", "n/a")
+  }
+
+  @Test
+  def userDefineRowTypeFunctionSubSchemaTypeCheck(): Unit = {
+    thrown.expect(classOf[ValidationException])
+    val util = streamTestUtil()
+    util.addTable("t", 'a)(Types.ROW(Types.ROW(Types.STRING, Types.INT)))
+    util.tableEnv.registerFunction("func", Func22)
+    util.verifySql("select func(a) from t", "n/a")
+  }
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -31,8 +31,42 @@ import org.apache.flink.table.expressions.utils.{ExpressionTestBase, _}
 import org.apache.flink.table.functions.ScalarFunction
 import org.junit.Test
 import java.lang.{Boolean => JBoolean}
+import java.util
 
 class UserDefinedScalarFunctionTest extends ExpressionTestBase {
+
+  @Test
+  def testCompositeTypeMatching(): Unit = {
+    val JavaFunc5 = new JavaFunc5
+    val JavaFunc6 = new JavaFunc6
+    // test java matching
+    testAllApis(
+      JavaFunc5('f15),
+      "JavaFunc5(f15)",
+      "JavaFunc5(f15)",
+      "{a=b}"
+    )
+    testAllApis(
+      JavaFunc6('f14),
+      "JavaFunc6(f14)",
+      "JavaFunc6(f14)",
+      "24"
+    )
+
+    // test scala matching
+    testAllApis(
+      Func21('f15),
+      "Func21(f15)",
+      "Func21(f15)",
+      "{a=b}"
+    )
+    testAllApis(
+      Func22('f16),
+      "Func22(f16)",
+      "Func22(f16)",
+      "2,aa"
+    )
+  }
 
   @Test
   def testParameters(): Unit = {
@@ -377,7 +411,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Any = {
-    val testData = new Row(15)
+    val testData = new Row(17)
     testData.setField(0, 42)
     testData.setField(1, "Test")
     testData.setField(2, null)
@@ -397,6 +431,8 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       true.asInstanceOf[JBoolean],
       Row.of(1.asInstanceOf[Integer], 2.asInstanceOf[Integer], 3.asInstanceOf[Integer]))
     )
+    testData.setField(15, util.Collections.singletonMap("a", "b"))
+    testData.setField(16, Row.of(1.asInstanceOf[Integer], "a"))
     testData
   }
 
@@ -416,7 +452,9 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Types.BYTE,
       Types.SHORT,
       Types.FLOAT,
-      Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
+      Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT)),
+      Types.MAP(Types.STRING, Types.STRING),
+      Types.ROW(Types.INT, Types.STRING)
     ).asInstanceOf[TypeInformation[Any]]
   }
 
@@ -443,11 +481,15 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func16" -> Func16,
     "Func17" -> Func17,
     "Func19" -> Func19,
+    "Func21" -> Func21,
+    "Func22" -> Func22,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,
     "JavaFunc3" -> new JavaFunc3,
     "JavaFunc4" -> new JavaFunc4,
+    "JavaFunc5" -> new JavaFunc5,
+    "JavaFunc6" -> new JavaFunc6,
     "RichFunc0" -> new RichFunc0,
     "RichFunc1" -> new RichFunc1,
     "RichFunc2" -> new RichFunc2


### PR DESCRIPTION
## What is the purpose of the change

Support more strict type checks and type inference when dealing with UDFs with composite parameter and result type. such as 
```
def func1(row: Row): Row = { // ... }
def func2(map: Map[String, String]): String[] = { // ... }
```

## Brief change log
  - Created an `inferReturnType` interface in addition to the `getReturnType`, for which, the actual `TypeInformation[_]` will be passed in for composite parameter type check and composite return type inference.
  - Changed the result type inference for ScalarFunction only in this diff -> to use `inferReturnType` results first before other interfaces.
  - Added in more composite type unit test to illustrate cases that can be automatically inferred using `TypeExtractor`. 
  - Added in more composite type validation test to demonstrate cases where inferReturnType can capture situations where results be produced from wrongly configured composite parameter type.


## Verifying this change

  - Unit tests added in `UserDefinedScalarFunctionTest`
  - Unit tests added in `UserDefinedFunctionValidationTest`
  - Integration tests added in `SqlITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
    - Changed ScalarFunction to add `inferReturnType` API as addition to `getReturnType`
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented,  shall be added once API is approved)
