### PR TITLE
[FLINK-9999] [table] Add ISNUMERIC supported in Table API/SQL

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1842,6 +1842,16 @@ RPAD(text string, len integer, pad string)
     <tr>
       <td>
         {% highlight text %}
+ISNUMERIC(text string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns an Integer to indicate if the text string is a numeric value, supports some characters that are not numbers, such as plus (+), minus (-), and valid currency symbols such as the dollar sign ($), if true, returns 1, otherwise returns 0, if text is NULL, returns NULL. E.g. <code>ISNUMERIC('123.0')</code> returns <code>1</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        {% highlight text %}
 FROM_BASE64(text string)
 {% endhighlight %}
       </td>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2477,6 +2477,17 @@ STRING.rpad(len INT, pad STRING)
     <tr>
       <td>
         {% highlight java %}
+STRING.isNumeric()
+{% endhighlight %}
+      </td>
+
+      <td>
+        <p>Returns an Integer to indicate if the text string is a numeric value, supports some characters that are not numbers, such as plus (+), minus (-), and valid currency symbols such as the dollar sign ($), if true, returns 1, otherwise returns 0, if text is NULL, returns NULL. E.g. "123".isNumeric() returns 1.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        {% highlight java %}
 STRING.fromBase64()
 {% endhighlight %}
       </td>
@@ -4022,6 +4033,18 @@ STRING.initCap()
 
       <td>
         <p>Converts the initial letter of each word in a string to uppercase. Assumes a string containing only [A-Za-z0-9], everything else is treated as whitespace.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.isNumeric()
+{% endhighlight %}
+      </td>
+
+      <td>
+        <p>Returns an Integer to indicate if the text string is a numeric value, supports some characters that are not numbers, such as plus (+), minus (-), and valid currency symbols such as the dollar sign ($), if true, returns 1, otherwise returns 0, if text is NULL, returns NULL. E.g. "123".isNumeric() returns 1.</p>
       </td>
     </tr>
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -545,6 +545,11 @@ trait ImplicitExpressionOperations {
     Overlay(expr, newString, starting, length)
 
   /**
+    * Returns an Integer to indicate if the text string is a numeric value.
+    */
+  def isNumeric() = IsNumeric(expr)
+
+  /**
     * Returns the base string decoded with base64.
     */
   def fromBase64() = FromBase64(expr)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -113,5 +113,7 @@ object BuiltInMethods {
 
   val BIN = Types.lookupMethod(classOf[JLong], "toBinaryString", classOf[Long])
 
+  val ISNUMERIC = Types.lookupMethod(classOf[ScalarFunctions], "isNumeric", classOf[String])
+
   val FROMBASE64 = Types.lookupMethod(classOf[ScalarFunctions], "fromBase64", classOf[String])
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -147,6 +147,12 @@ object FunctionGenerator {
     BuiltInMethod.OVERLAY.method)
 
   addSqlFunctionMethod(
+    ISNUMERIC,
+    Seq(STRING_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethods.ISNUMERIC)
+
+  addSqlFunctionMethod(
     FROM_BASE64,
     Seq(STRING_TYPE_INFO),
     STRING_TYPE_INFO,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -358,6 +358,29 @@ case class Rpad(text: Expression, len: Expression, pad: Expression)
   }
 }
 
+case class IsNumeric(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = INT_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == STRING_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"IsNumeric operator requires a String input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.ISNUMERIC, child.toRexNode)
+  }
+
+  override def toString: String = s"($child).isNumeric"
+
+}
+
 /**
   * Returns the base string decoded with base64.
   * Returns NULL If the input string is NULL.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -167,6 +167,15 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.TIMEDATE
   )
 
+  val ISNUMERIC = new SqlFunction(
+    "ISNUMERIC",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.INTEGER,
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING
+  )
+
   val FROM_BASE64 = new SqlFunction(
     "FROM_BASE64",
     SqlKind.OTHER_FUNCTION,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -197,6 +197,17 @@ object ScalarFunctions {
   }
 
   /**
+    * Returns an Integer to indicate if the text string is a numeric value.
+    */
+  def isNumeric(str: String): Integer = {
+    if (str.matches("^(([0-9+-.$]{1})|([+-]?[$]?[0-9]*(([.]{1}[0-9]*)|([.]?[0-9]+))))$")) {
+      1
+    } else {
+      0
+    }
+  }
+
+  /**
     * Returns the base string decoded with base64.
     */
   def fromBase64(str: String): String = new String(Base64.decodeBase64(str))

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -202,6 +202,7 @@ object FunctionCatalog {
     "concat_ws" -> classOf[ConcatWs],
     "lpad" -> classOf[Lpad],
     "rpad" -> classOf[Rpad],
+    "isNumeric" -> classOf[IsNumeric],
     "fromBase64" -> classOf[FromBase64],
 
     // math functions
@@ -446,6 +447,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.SHA384,
     ScalarSqlFunctions.SHA512,
     ScalarSqlFunctions.SHA2,
+    ScalarSqlFunctions.ISNUMERIC,
     ScalarSqlFunctions.FROM_BASE64,
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -451,6 +451,63 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
+  def testIsNumeric(): Unit = {
+    testAllApis(
+      "123".isNumeric(),
+      "'123'.isNumeric",
+      "ISNUMERIC('123')",
+      "1")
+
+    testAllApis(
+      "0.123".isNumeric(),
+      "'123'.isNumeric",
+      "ISNUMERIC('0.123')",
+      "1")
+
+    testAllApis(
+      "123.0".isNumeric(),
+      "'123.0'.isNumeric",
+      "ISNUMERIC('123.0')",
+      "1")
+
+    testAllApis(
+      "123.0".isNumeric(),
+      "'123.0'.isNumeric",
+      "ISNUMERIC('123.0')",
+      "1")
+
+    testAllApis(
+      "+123.0".isNumeric(),
+      "'+123.0'.isNumeric",
+      "ISNUMERIC('+123.0')",
+      "1")
+
+    testAllApis(
+      "-0.123".isNumeric(),
+      "'-0.123'.isNumeric",
+      "ISNUMERIC('-0.123')",
+      "1")
+
+    testAllApis(
+      "0.123a".isNumeric(),
+      "'0.123a'.isNumeric",
+      "ISNUMERIC('0.123a')",
+      "0")
+
+    testAllApis(
+      "$0.123".isNumeric(),
+      "'$0.123'.isNumeric",
+      "ISNUMERIC('$0.123')",
+      "1")
+
+    testAllApis(
+      'f33.isNumeric(),
+      "f33.isNumeric",
+      "ISNUMERIC(f33)",
+      "null")
+  }
+
+  @Test
   def testFromBase64(): Unit = {
     testAllApis(
       'f35.fromBase64(),


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add ISNUMERIC supported in Table API/SQL*

## Brief change log

  - *Add ISNUMERIC supported in Table API/SQL*

## Verifying this change

This change is already covered by existing tests, such as *ScalarFunctionsTest#testIsNumeric*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
