### PR TITLE
[FLINK-10012] Add setStreamTimeCharacteristic/getStreamTimeCharacteristic for Python API

### DIFF
--- a/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
+++ b/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.python.api.datastream.PythonDataStream;
@@ -199,6 +200,24 @@ public class PythonStreamExecutionEnvironment {
 	 */
 	public PythonDataStream socket_text_stream(String host, int port) {
 		return new PythonDataStream<>(env.socketTextStream(host, port).map(new AdapterMap<String>()));
+	}
+
+	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#setStreamTimeCharacteristic(TimeCharacteristic)}.
+	 *
+	 * @param characteristic The time characteristic.
+	 */
+	public void set_stream_time_characteristic(TimeCharacteristic characteristic) {
+		this.env.setStreamTimeCharacteristic(characteristic);
+	}
+
+	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#getStreamTimeCharacteristic()}.
+	 *
+	 * @return The time characteristic.
+	 */
+	public TimeCharacteristic get_stream_time_characteristic() {
+		return this.env.getStreamTimeCharacteristic();
 	}
 
 	/**

--- a/flink-libraries/flink-streaming-python/src/test/java/org/apache/flink/streaming/python/api/PythonStreamBinderTest.java
+++ b/flink-libraries/flink-streaming-python/src/test/java/org/apache/flink/streaming/python/api/PythonStreamBinderTest.java
@@ -63,7 +63,7 @@ public class PythonStreamBinderTest extends AbstractTestBase {
 
 	@Test
 	public void testProgram() throws Exception {
-		Path testEntryPoint = new Path(getBaseTestPythonDir(), "examples/word_count.py");
+		Path testEntryPoint = new Path(getBaseTestPythonDir(), "run_all_tests.py");
 		List<String> testFiles = findTestFiles();
 
 		Preconditions.checkState(testFiles.size() > 0, "No test files were found in {}.", getBaseTestPythonDir());

--- a/flink-libraries/flink-streaming-python/src/test/java/org/apache/flink/streaming/python/api/PythonStreamExecutionEnvironmentTest.java
+++ b/flink-libraries/flink-streaming-python/src/test/java/org/apache/flink/streaming/python/api/PythonStreamExecutionEnvironmentTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.python.api;
+
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.python.api.environment.PythonEnvironmentFactory;
+import org.apache.flink.streaming.python.api.environment.PythonStreamExecutionEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link PythonStreamExecutionEnvironment}.
+ */
+public class PythonStreamExecutionEnvironmentTest extends AbstractTestBase {
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_DIR = new TemporaryFolder();
+
+	@Test
+	public void testGetAndSetTimeCharacteristic() throws Exception {
+		PythonEnvironmentFactory envFactory = new PythonEnvironmentFactory(TEMP_DIR.newFolder().getAbsolutePath(), "testPlan");
+		PythonStreamExecutionEnvironment env = envFactory.get_execution_environment();
+
+		env.set_stream_time_characteristic(TimeCharacteristic.EventTime);
+		assertEquals(TimeCharacteristic.EventTime, env.get_stream_time_characteristic());
+
+		env.set_stream_time_characteristic(TimeCharacteristic.ProcessingTime);
+		assertEquals(TimeCharacteristic.ProcessingTime, env.get_stream_time_characteristic());
+	}
+
+}

--- a/flink-libraries/flink-streaming-python/src/test/python/org/apache/flink/streaming/python/api/test_stream_execution_env.py
+++ b/flink-libraries/flink-streaming-python/src/test/python/org/apache/flink/streaming/python/api/test_stream_execution_env.py
@@ -1,0 +1,30 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from org.apache.flink.streaming.api import TimeCharacteristic
+
+class Main:
+    def run(self, flink):
+        env = flink.get_execution_environment()
+        env.set_stream_time_characteristic(TimeCharacteristic.IngestionTime)
+
+        if env.get_stream_time_characteristic() != TimeCharacteristic.IngestionTime:
+            raise Exception('expected time characteristic : ' + TimeCharacteristic.IngestionTime +
+                            ' actual time characteristic : ' + env.get_stream_time_characteristic())
+
+def main(flink):
+    Main().run(flink)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports setStreamTimeCharacteristic/getStreamTimeCharacteristic  for Python API*

## Brief change log

  - *Support setStreamTimeCharacteristic and getStreamTimeCharacteristic  for Python API*

## Verifying this change

This change is tested with `PythonStreamExecutionEnvironmentTest#testGetAndSetTimeCharacteristic`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
