### PR TITLE
[FLINK-10025] Add getCheckpointConfig API for PythonStreamExecutionEnvironment

### DIFF
--- a/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
+++ b/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.python.api.datastream.PythonDataStream;
@@ -222,6 +223,15 @@ public class PythonStreamExecutionEnvironment {
 	public PythonStreamExecutionEnvironment enable_checkpointing(long interval, CheckpointingMode mode) {
 		this.env.enableCheckpointing(interval, mode);
 		return this;
+	}
+
+	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#getCheckpointConfig()}.
+	 *
+	 * @return The checkpoint config.
+	 */
+	public CheckpointConfig get_checkpoint_config(){
+		return this.env.getCheckpointConfig();
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add getCheckpointConfig API for PythonStreamExecutionEnvironment*

## Brief change log

  - *Add getCheckpointConfig API for PythonStreamExecutionEnvironment*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
