### PR TITLE
[FLINK-10027] Add logging to StreamingFileSink

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.util.Preconditions;
@@ -34,11 +34,11 @@ import java.util.Objects;
 /**
  * A bucket is the directory organization of the output of the {@link StreamingFileSink}.
  *
- * <p>For each incoming  element in the {@code BucketingSink}, the user-specified
- * {@link Bucketer Bucketer} is
- * queried to see in which bucket this element should be written to.
+ * <p>For each incoming element in the {@code StreamingFileSink}, the user-specified
+ * {@link BucketAssigner Bucketer} is queried to see in which bucket this element should
+ * be written to.
  */
-@PublicEvolving
+@Internal
 public class Bucket<IN, BucketID> {
 
 	private static final String PART_PREFIX = "part";
@@ -53,57 +53,27 @@ public class Bucket<IN, BucketID> {
 
 	private final RecoverableWriter fsWriter;
 
-	private final Map<Long, List<RecoverableWriter.CommitRecoverable>> pendingPerCheckpoint = new HashMap<>();
+	private final RollingPolicy<IN, BucketID> rollingPolicy;
+
+	private final Map<Long, List<RecoverableWriter.CommitRecoverable>> pendingPartsPerCheckpoint = new HashMap<>();
 
 	private long partCounter;
 
-	private PartFileWriter<IN, BucketID> currentPart;
+	private PartFileWriter<IN, BucketID> inProgressPart;
 
-	private List<RecoverableWriter.CommitRecoverable> pending;
-
-	/**
-	 * Constructor to restore a bucket from checkpointed state.
-	 */
-	public Bucket(
-			RecoverableWriter fsWriter,
-			int subtaskIndex,
-			long initialPartCounter,
-			PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory,
-			BucketState<BucketID> bucketState) throws IOException {
-
-		this(fsWriter, subtaskIndex, bucketState.getBucketId(), bucketState.getBucketPath(), initialPartCounter, partFileFactory);
-
-		// the constructor must have already initialized the filesystem writer
-		Preconditions.checkState(fsWriter != null);
-
-		// we try to resume the previous in-progress file, if the filesystem
-		// supports such operation. If not, we just commit the file and start fresh.
-
-		final RecoverableWriter.ResumeRecoverable resumable = bucketState.getInProgress();
-		if (resumable != null) {
-			currentPart = partFileFactory.resumeFrom(
-					bucketId, fsWriter, resumable, bucketState.getCreationTime());
-		}
-
-		// we commit pending files for previous checkpoints to the last successful one
-		// (from which we are recovering from)
-		for (List<RecoverableWriter.CommitRecoverable> commitables: bucketState.getPendingPerCheckpoint().values()) {
-			for (RecoverableWriter.CommitRecoverable commitable: commitables) {
-				fsWriter.recoverForCommit(commitable).commitAfterRecovery();
-			}
-		}
-	}
+	private List<RecoverableWriter.CommitRecoverable> pendingPartsForCurrentCheckpoint;
 
 	/**
 	 * Constructor to create a new empty bucket.
 	 */
-	public Bucket(
-			RecoverableWriter fsWriter,
-			int subtaskIndex,
-			BucketID bucketId,
-			Path bucketPath,
-			long initialPartCounter,
-			PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory) {
+	private Bucket(
+			final RecoverableWriter fsWriter,
+			final int subtaskIndex,
+			final BucketID bucketId,
+			final Path bucketPath,
+			final long initialPartCounter,
+			final PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy) {
 
 		this.fsWriter = Preconditions.checkNotNull(fsWriter);
 		this.subtaskIndex = subtaskIndex;
@@ -111,117 +81,214 @@ public class Bucket<IN, BucketID> {
 		this.bucketPath = Preconditions.checkNotNull(bucketPath);
 		this.partCounter = initialPartCounter;
 		this.partFileFactory = Preconditions.checkNotNull(partFileFactory);
+		this.rollingPolicy = Preconditions.checkNotNull(rollingPolicy);
 
-		this.pending = new ArrayList<>();
+		this.pendingPartsForCurrentCheckpoint = new ArrayList<>();
 	}
 
 	/**
-	 * Gets the information available for the currently
-	 * open part file, i.e. the one we are currently writing to.
-	 *
-	 * <p>This will be null if there is no currently open part file. This
-	 * is the case when we have a new, just created bucket or a bucket
-	 * that has not received any data after the closing of its previously
-	 * open in-progress file due to the specified rolling policy.
-	 *
-	 * @return The information about the currently in-progress part file
-	 * or {@code null} if there is no open part file.
+	 * Constructor to restore a bucket from checkpointed state.
 	 */
-	public PartFileInfo<BucketID> getInProgressPartInfo() {
-		return currentPart;
+	private Bucket(
+			final RecoverableWriter fsWriter,
+			final int subtaskIndex,
+			final long initialPartCounter,
+			final PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy,
+			final BucketState<BucketID> bucketState) throws IOException {
+
+		this(
+				fsWriter,
+				subtaskIndex,
+				bucketState.getBucketId(),
+				bucketState.getBucketPath(),
+				initialPartCounter,
+				partFileFactory,
+				rollingPolicy);
+
+		restoreInProgressFile(bucketState);
+		commitRecoveredPendingFiles(bucketState);
 	}
 
-	public BucketID getBucketId() {
+	private void restoreInProgressFile(final BucketState<BucketID> state) throws IOException {
+		// we try to resume the previous in-progress file
+		if (state.hasInProgressResumableFile()) {
+			final RecoverableWriter.ResumeRecoverable resumable = state.getInProgressResumableFile();
+			inProgressPart = partFileFactory.resumeFrom(
+					bucketId, fsWriter, resumable, state.getInProgressFileCreationTime());
+		}
+	}
+
+	private void commitRecoveredPendingFiles(final BucketState<BucketID> state) throws IOException {
+
+		// we commit pending files for checkpoints that precess the last successful one, from which we are recovering
+		for (List<RecoverableWriter.CommitRecoverable> committables: state.getCommittableFilesPerCheckpoint().values()) {
+			for (RecoverableWriter.CommitRecoverable committable: committables) {
+				fsWriter.recoverForCommit(committable).commitAfterRecovery();
+			}
+		}
+	}
+
+	BucketID getBucketId() {
 		return bucketId;
 	}
 
-	public Path getBucketPath() {
+	Path getBucketPath() {
 		return bucketPath;
 	}
 
-	public long getPartCounter() {
+	long getPartCounter() {
 		return partCounter;
 	}
 
-	public boolean isActive() {
-		return currentPart != null || !pending.isEmpty() || !pendingPerCheckpoint.isEmpty();
-	}
-
-	void write(IN element, long currentTime) throws IOException {
-		Preconditions.checkState(currentPart != null, "bucket has been closed");
-		currentPart.write(element, currentTime);
-	}
-
-	void rollPartFile(final long currentTime) throws IOException {
-		closePartFile();
-		currentPart = partFileFactory.openNew(bucketId, fsWriter, getNewPartPath(), currentTime);
-		partCounter++;
+	boolean isActive() {
+		return inProgressPart != null || !pendingPartsForCurrentCheckpoint.isEmpty() || !pendingPartsPerCheckpoint.isEmpty();
 	}
 
 	void merge(final Bucket<IN, BucketID> bucket) throws IOException {
 		Preconditions.checkNotNull(bucket);
-		Preconditions.checkState(Objects.equals(bucket.getBucketPath(), bucketPath));
+		Preconditions.checkState(Objects.equals(bucket.bucketPath, bucketPath));
 
-		// there should be no pending files in the "to-merge" states.
-		Preconditions.checkState(bucket.pending.isEmpty());
-		Preconditions.checkState(bucket.pendingPerCheckpoint.isEmpty());
+		// There should be no pending files in the "to-merge" states.
+		// The reason is that:
+		// 1) the pendingPartsForCurrentCheckpoint is emptied whenever we take a snapshot (see prepareBucketForCheckpointing()).
+		//    So a snapshot, including the one we are recovering from, will never contain such files.
+		// 2) the files in pendingPartsPerCheckpoint are committed upon recovery (see commitRecoveredPendingFiles()).
 
-		RecoverableWriter.CommitRecoverable commitable = bucket.closePartFile();
-		if (commitable != null) {
-			pending.add(commitable);
+		Preconditions.checkState(bucket.pendingPartsForCurrentCheckpoint.isEmpty());
+		Preconditions.checkState(bucket.pendingPartsPerCheckpoint.isEmpty());
+
+		RecoverableWriter.CommitRecoverable committable = bucket.closePartFile();
+		if (committable != null) {
+			pendingPartsForCurrentCheckpoint.add(committable);
 		}
 	}
 
-	RecoverableWriter.CommitRecoverable closePartFile() throws IOException {
-		RecoverableWriter.CommitRecoverable commitable = null;
-		if (currentPart != null) {
-			commitable = currentPart.closeForCommit();
-			pending.add(commitable);
-			currentPart = null;
+	void write(IN element, long currentTime) throws IOException {
+		if (inProgressPart == null || rollingPolicy.shouldRollOnEvent(inProgressPart, element)) {
+			rollPartFile(currentTime);
 		}
-		return commitable;
+		inProgressPart.write(element, currentTime);
 	}
 
-	public void dispose() {
-		if (currentPart != null) {
-			currentPart.dispose();
+	private void rollPartFile(final long currentTime) throws IOException {
+		closePartFile();
+		inProgressPart = partFileFactory.openNew(bucketId, fsWriter, assembleNewPartPath(), currentTime);
+		partCounter++;
+	}
+
+	private Path assembleNewPartPath() {
+		return new Path(bucketPath, PART_PREFIX + '-' + subtaskIndex + '-' + partCounter);
+	}
+
+	private RecoverableWriter.CommitRecoverable closePartFile() throws IOException {
+		RecoverableWriter.CommitRecoverable committable = null;
+		if (inProgressPart != null) {
+			committable = inProgressPart.closeForCommit();
+			pendingPartsForCurrentCheckpoint.add(committable);
+			inProgressPart = null;
+		}
+		return committable;
+	}
+
+	void disposePartFile() {
+		if (inProgressPart != null) {
+			inProgressPart.dispose();
 		}
 	}
 
-	public void onCheckpointAcknowledgment(long checkpointId) throws IOException {
+	BucketState<BucketID> onReceptionOfCheckpoint(long checkpointId) throws IOException {
+		prepareBucketForCheckpointing(checkpointId);
+
+		RecoverableWriter.ResumeRecoverable inProgressResumable = null;
+		long inProgressFileCreationTime = Long.MAX_VALUE;
+
+		if (inProgressPart != null) {
+			inProgressResumable = inProgressPart.persist();
+			inProgressFileCreationTime = inProgressPart.getCreationTime();
+		}
+
+		return new BucketState<>(bucketId, bucketPath, inProgressFileCreationTime, inProgressResumable, pendingPartsPerCheckpoint);
+	}
+
+	private void prepareBucketForCheckpointing(long checkpointId) throws IOException {
+		if (inProgressPart != null && rollingPolicy.shouldRollOnCheckpoint(inProgressPart)) {
+			closePartFile();
+		}
+
+		if (!pendingPartsForCurrentCheckpoint.isEmpty()) {
+			pendingPartsPerCheckpoint.put(checkpointId, pendingPartsForCurrentCheckpoint);
+			pendingPartsForCurrentCheckpoint = new ArrayList<>();
+		}
+	}
+
+	void onSuccessfulCompletionOfCheckpoint(long checkpointId) throws IOException {
 		Preconditions.checkNotNull(fsWriter);
 
 		Iterator<Map.Entry<Long, List<RecoverableWriter.CommitRecoverable>>> it =
-				pendingPerCheckpoint.entrySet().iterator();
+				pendingPartsPerCheckpoint.entrySet().iterator();
 
 		while (it.hasNext()) {
 			Map.Entry<Long, List<RecoverableWriter.CommitRecoverable>> entry = it.next();
+
 			if (entry.getKey() <= checkpointId) {
-				for (RecoverableWriter.CommitRecoverable commitable : entry.getValue()) {
-					fsWriter.recoverForCommit(commitable).commit();
+				for (RecoverableWriter.CommitRecoverable committable : entry.getValue()) {
+					fsWriter.recoverForCommit(committable).commit();
 				}
 				it.remove();
 			}
 		}
 	}
 
-	public BucketState<BucketID> onCheckpoint(long checkpointId) throws IOException {
-		RecoverableWriter.ResumeRecoverable resumable = null;
-		long creationTime = Long.MAX_VALUE;
-
-		if (currentPart != null) {
-			resumable = currentPart.persist();
-			creationTime = currentPart.getCreationTime();
+	void onProcessingTime(long timestamp) throws IOException {
+		if (inProgressPart != null && rollingPolicy.shouldRollOnProcessingTime(inProgressPart, timestamp)) {
+			closePartFile();
 		}
-
-		if (!pending.isEmpty()) {
-			pendingPerCheckpoint.put(checkpointId, pending);
-			pending = new ArrayList<>();
-		}
-		return new BucketState<>(bucketId, bucketPath, creationTime, resumable, pendingPerCheckpoint);
 	}
 
-	private Path getNewPartPath() {
-		return new Path(bucketPath, PART_PREFIX + '-' + subtaskIndex + '-' + partCounter);
+	// --------------------------- Static Factory Methods -----------------------------
+
+	/**
+	 * Creates a new empty {@code Bucket}.
+	 * @param fsWriter the filesystem-specific {@link RecoverableWriter}.
+	 * @param subtaskIndex the index of the subtask creating the bucket.
+	 * @param bucketId the identifier of the bucket, as returned by the {@link BucketAssigner}.
+	 * @param bucketPath the path to where the part files for the bucket will be written to.
+	 * @param initialPartCounter the initial counter for the part files of the bucket.
+	 * @param partFileFactory the {@link PartFileWriter.PartFileFactory} the factory creating part file writers.
+	 * @param <IN> the type of input elements to the sink.
+	 * @param <BucketID> the type of the identifier of the bucket, as returned by the {@link BucketAssigner}
+	 * @return The new Bucket.
+	 */
+	static <IN, BucketID> Bucket<IN, BucketID> getNew(
+			final RecoverableWriter fsWriter,
+			final int subtaskIndex,
+			final BucketID bucketId,
+			final Path bucketPath,
+			final long initialPartCounter,
+			final PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy) {
+		return new Bucket<>(fsWriter, subtaskIndex, bucketId, bucketPath, initialPartCounter, partFileFactory, rollingPolicy);
+	}
+
+	/**
+	 * Restores a {@code Bucket} from the state included in the provided {@link BucketState}.
+	 * @param fsWriter the filesystem-specific {@link RecoverableWriter}.
+	 * @param subtaskIndex the index of the subtask creating the bucket.
+	 * @param initialPartCounter the initial counter for the part files of the bucket.
+	 * @param partFileFactory the {@link PartFileWriter.PartFileFactory} the factory creating part file writers.
+	 * @param bucketState the initial state of the restored bucket.
+	 * @param <IN> the type of input elements to the sink.
+	 * @param <BucketID> the type of the identifier of the bucket, as returned by the {@link BucketAssigner}
+	 * @return The restored Bucket.
+	 */
+	static <IN, BucketID> Bucket<IN, BucketID> restore(
+			final RecoverableWriter fsWriter,
+			final int subtaskIndex,
+			final long initialPartCounter,
+			final PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy,
+			final BucketState<BucketID> bucketState) throws IOException {
+		return new Bucket<>(fsWriter, subtaskIndex, initialPartCounter, partFileFactory, rollingPolicy, bucketState);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssigner.java
@@ -28,49 +28,45 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 /**
- * A bucketer is used with a {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink}
- * to determine the {@link org.apache.flink.streaming.api.functions.sink.filesystem.Bucket} each incoming element
+ * A BucketAssigner is used with a {@link StreamingFileSink} to determine the {@link Bucket} each incoming element
  * should be put into.
  *
  * <p>The {@code StreamingFileSink} can be writing to many buckets at a time, and it is responsible for managing
- * a set of active buckets. Whenever a new element arrives it will ask the {@code Bucketer} for the bucket the
- * element should fall in. The {@code Bucketer} can, for example, determine buckets based on system time.
+ * a set of active buckets. Whenever a new element arrives it will ask the {@code BucketAssigner} for the bucket the
+ * element should fall in. The {@code BucketAssigner} can, for example, determine buckets based on system time.
  *
  * @param <IN> The type of input elements.
- * @param <BucketID> The type of the object returned by the {@link #getBucketId(Object, Bucketer.Context)}. This has to have
+ * @param <BucketID> The type of the object returned by the {@link #getBucketId(Object, BucketAssigner.Context)}. This has to have
  *                  a correct {@link #hashCode()} and {@link #equals(Object)} method. In addition, the {@link Path}
  *                  to the created bucket will be the result of the {@link #toString()} of this method, appended to
- *                  the {@code basePath} specified in the
- *                  {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
+ *                  the {@code basePath} specified in the {@link StreamingFileSink StreamingFileSink}.
  */
 @PublicEvolving
-public interface Bucketer<IN, BucketID> extends Serializable {
+public interface BucketAssigner<IN, BucketID> extends Serializable {
 
 	/**
 	 * Returns the identifier of the bucket the provided element should be put into.
 	 * @param element The current element being processed.
-	 * @param context The {@link SinkFunction.Context context} used by the
-	 *                {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink sink}.
+	 * @param context The {@link SinkFunction.Context context} used by the {@link StreamingFileSink sink}.
 	 *
 	 * @return A string representing the identifier of the bucket the element should be put into.
-	 * This actual path to the bucket will result from the concatenation of the returned string
-	 * and the {@code base path} provided during the initialization of the
-	 * {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink sink}.
+	 * The actual path to the bucket will result from the concatenation of the returned string
+	 * and the {@code base path} provided during the initialization of the {@link StreamingFileSink sink}.
 	 */
-	BucketID getBucketId(IN element, Bucketer.Context context);
+	BucketID getBucketId(IN element, BucketAssigner.Context context);
 
 	/**
 	 * @return A {@link SimpleVersionedSerializer} capable of serializing/deserializing the elements
 	 * of type {@code BucketID}. That is the type of the objects returned by the
-	 * {@link #getBucketId(Object, Bucketer.Context)}.
+	 * {@link #getBucketId(Object, BucketAssigner.Context)}.
 	 */
 	SimpleVersionedSerializer<BucketID> getSerializer();
 
 	/**
-	 * Context that the {@link Bucketer} can use for getting additional data about
+	 * Context that the {@link BucketAssigner} can use for getting additional data about
 	 * an input record.
 	 *
-	 * <p>The context is only valid for the duration of a {@link Bucketer#getBucketId(Object, Bucketer.Context)} call.
+	 * <p>The context is only valid for the duration of a {@link BucketAssigner#getBucketId(Object, BucketAssigner.Context)} call.
 	 * Do not store the context and use afterwards!
 	 */
 	@PublicEvolving

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
@@ -37,12 +37,14 @@ interface BucketFactory<IN, BucketID> extends Serializable {
 			final BucketID bucketId,
 			final Path bucketPath,
 			final long initialPartCounter,
-			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory) throws IOException;
+			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy) throws IOException;
 
 	Bucket<IN, BucketID> restoreBucket(
 			final RecoverableWriter fsWriter,
 			final int subtaskIndex,
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final BucketState<BucketID> bucketState) throws IOException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketState.java
@@ -32,64 +32,68 @@ import java.util.Map;
  * The state of the {@link Bucket} that is to be checkpointed.
  */
 @Internal
-public class BucketState<BucketID> {
+class BucketState<BucketID> {
 
 	private final BucketID bucketId;
 
-	/**
-	 * The base path for the bucket, i.e. the directory where all the part files are stored.
-	 */
+	/** The directory where all the part files of the bucket are stored. */
 	private final Path bucketPath;
 
 	/**
-	 * The creation time of the currently open part file, or {@code Long.MAX_VALUE} if there is no open part file.
+	 * The creation time of the currently open part file,
+	 * or {@code Long.MAX_VALUE} if there is no open part file.
 	 */
-	private final long creationTime;
+	private final long inProgressFileCreationTime;
 
 	/**
-	 * A {@link RecoverableWriter.ResumeRecoverable} for the currently open part file, or null
-	 * if there is no currently open part file.
+	 * A {@link RecoverableWriter.ResumeRecoverable} for the currently open
+	 * part file, or null if there is no currently open part file.
 	 */
 	@Nullable
-	private final RecoverableWriter.ResumeRecoverable inProgress;
+	private final RecoverableWriter.ResumeRecoverable inProgressResumableFile;
 
 	/**
-	 * The {@link RecoverableWriter.CommitRecoverable files} pending to be committed, organized by checkpoint id.
+	 * The {@link RecoverableWriter.CommitRecoverable files} pending to be
+	 * committed, organized by checkpoint id.
 	 */
-	private final Map<Long, List<RecoverableWriter.CommitRecoverable>> pendingPerCheckpoint;
+	private final Map<Long, List<RecoverableWriter.CommitRecoverable>> committableFilesPerCheckpoint;
 
-	public BucketState(
+	BucketState(
 			final BucketID bucketId,
 			final Path bucketPath,
-			final long creationTime,
-			@Nullable final RecoverableWriter.ResumeRecoverable inProgress,
-			final Map<Long, List<RecoverableWriter.CommitRecoverable>> pendingPerCheckpoint
+			final long inProgressFileCreationTime,
+			@Nullable final RecoverableWriter.ResumeRecoverable inProgressResumableFile,
+			final Map<Long, List<RecoverableWriter.CommitRecoverable>> pendingCommittablesPerCheckpoint
 	) {
 		this.bucketId = Preconditions.checkNotNull(bucketId);
 		this.bucketPath = Preconditions.checkNotNull(bucketPath);
-		this.creationTime = creationTime;
-		this.inProgress = inProgress;
-		this.pendingPerCheckpoint = Preconditions.checkNotNull(pendingPerCheckpoint);
+		this.inProgressFileCreationTime = inProgressFileCreationTime;
+		this.inProgressResumableFile = inProgressResumableFile;
+		this.committableFilesPerCheckpoint = Preconditions.checkNotNull(pendingCommittablesPerCheckpoint);
 	}
 
-	public BucketID getBucketId() {
+	BucketID getBucketId() {
 		return bucketId;
 	}
 
-	public Path getBucketPath() {
+	Path getBucketPath() {
 		return bucketPath;
 	}
 
-	public long getCreationTime() {
-		return creationTime;
+	long getInProgressFileCreationTime() {
+		return inProgressFileCreationTime;
+	}
+
+	boolean hasInProgressResumableFile() {
+		return inProgressResumableFile != null;
 	}
 
 	@Nullable
-	public RecoverableWriter.ResumeRecoverable getInProgress() {
-		return inProgress;
+	RecoverableWriter.ResumeRecoverable getInProgressResumableFile() {
+		return inProgressResumableFile;
 	}
 
-	public Map<Long, List<RecoverableWriter.CommitRecoverable>> getPendingPerCheckpoint() {
-		return pendingPerCheckpoint;
+	Map<Long, List<RecoverableWriter.CommitRecoverable>> getCommittableFilesPerCheckpoint() {
+		return committableFilesPerCheckpoint;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketState.java
@@ -96,4 +96,26 @@ class BucketState<BucketID> {
 	Map<Long, List<RecoverableWriter.CommitRecoverable>> getCommittableFilesPerCheckpoint() {
 		return committableFilesPerCheckpoint;
 	}
+
+	@Override
+	public String toString() {
+		final StringBuilder strBuilder = new StringBuilder();
+
+		strBuilder
+				.append("BucketState for bucketId=").append(bucketId)
+				.append(" and bucketPath=").append(bucketPath);
+
+		if (hasInProgressResumableFile()) {
+			strBuilder.append(", has open part file created @ ").append(inProgressFileCreationTime);
+		}
+
+		if (!committableFilesPerCheckpoint.isEmpty()) {
+			strBuilder.append(", has pending files for checkpoints: {");
+			for (long checkpointId: committableFilesPerCheckpoint.keySet()) {
+				strBuilder.append(checkpointId).append(' ');
+			}
+			strBuilder.append('}');
+		}
+		return strBuilder.toString();
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -25,9 +26,6 @@ import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.util.Preconditions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -44,11 +42,10 @@ import java.util.Map;
  * this class to the lifecycle of the operator.
  *
  * @param <IN> The type of input elements.
- * @param <BucketID> The type of ids for the buckets, as returned by the {@link Bucketer}.
+ * @param <BucketID> The type of ids for the buckets, as returned by the {@link BucketAssigner}.
  */
+@Internal
 public class Buckets<IN, BucketID> {
-
-	private static final Logger LOG = LoggerFactory.getLogger(Buckets.class);
 
 	// ------------------------ configuration fields --------------------------
 
@@ -56,7 +53,7 @@ public class Buckets<IN, BucketID> {
 
 	private final BucketFactory<IN, BucketID> bucketFactory;
 
-	private final Bucketer<IN, BucketID> bucketer;
+	private final BucketAssigner<IN, BucketID> bucketAssigner;
 
 	private final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory;
 
@@ -70,33 +67,33 @@ public class Buckets<IN, BucketID> {
 
 	private final Map<BucketID, Bucket<IN, BucketID>> activeBuckets;
 
-	private long maxPartCounterUsed;
+	private long maxPartCounter;
 
-	private final RecoverableWriter fileSystemWriter;
+	private final RecoverableWriter fsWriter;
 
 	// --------------------------- State Related Fields -----------------------------
 
 	private final BucketStateSerializer<BucketID> bucketStateSerializer;
 
 	/**
-	 * A private constructor creating a new empty bucket manager.
+	 * A constructor creating a new empty bucket manager.
 	 *
 	 * @param basePath The base path for our buckets.
-	 * @param bucketer The {@link Bucketer} provided by the user.
+	 * @param bucketAssigner The {@link BucketAssigner} provided by the user.
 	 * @param bucketFactory The {@link BucketFactory} to be used to create buckets.
 	 * @param partFileWriterFactory The {@link PartFileWriter.PartFileFactory} to be used when writing data.
 	 * @param rollingPolicy The {@link RollingPolicy} as specified by the user.
 	 */
 	Buckets(
 			final Path basePath,
-			final Bucketer<IN, BucketID> bucketer,
+			final BucketAssigner<IN, BucketID> bucketAssigner,
 			final BucketFactory<IN, BucketID> bucketFactory,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final int subtaskIndex) throws IOException {
 
 		this.basePath = Preconditions.checkNotNull(basePath);
-		this.bucketer = Preconditions.checkNotNull(bucketer);
+		this.bucketAssigner = Preconditions.checkNotNull(bucketAssigner);
 		this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 		this.partFileWriterFactory = Preconditions.checkNotNull(partFileWriterFactory);
 		this.rollingPolicy = Preconditions.checkNotNull(rollingPolicy);
@@ -105,75 +102,86 @@ public class Buckets<IN, BucketID> {
 		this.activeBuckets = new HashMap<>();
 		this.bucketerContext = new Buckets.BucketerContext();
 
-		this.fileSystemWriter = FileSystem.get(basePath.toUri()).createRecoverableWriter();
+		this.fsWriter = FileSystem.get(basePath.toUri()).createRecoverableWriter();
 		this.bucketStateSerializer = new BucketStateSerializer<>(
-				fileSystemWriter.getResumeRecoverableSerializer(),
-				fileSystemWriter.getCommitRecoverableSerializer(),
-				bucketer.getSerializer()
+				fsWriter.getResumeRecoverableSerializer(),
+				fsWriter.getCommitRecoverableSerializer(),
+				bucketAssigner.getSerializer()
 		);
 
-		this.maxPartCounterUsed = 0L;
+		this.maxPartCounter = 0L;
 	}
 
 	/**
 	 * Initializes the state after recovery from a failure.
+	 *
+	 * <p>During this process:
+	 * <ol>
+	 *     <li>we set the initial value for part counter to the maximum value used before across all tasks and buckets.
+	 *     This guarantees that we do not overwrite valid data,</li>
+	 *     <li>we commit any pending files for previous checkpoints (previous to the last successful one from which we restore),</li>
+	 *     <li>we resume writing to the previous in-progress file of each bucket, and</li>
+	 *     <li>if we receive multiple states for the same bucket, we merge them.</li>
+	 * </ol>
 	 * @param bucketStates the state holding recovered state about active buckets.
 	 * @param partCounterState the state holding the max previously used part counters.
-	 * @throws Exception
+	 * @throws Exception if anything goes wrong during retrieving the state or restoring/committing of any
+	 * in-progress/pending part files
 	 */
 	void initializeState(final ListState<byte[]> bucketStates, final ListState<Long> partCounterState) throws Exception {
+		initializePartCounter(partCounterState);
+		initializeActiveBuckets(bucketStates);
+	}
 
-		// When resuming after a failure:
-		// 1) we get the max part counter used before in order to make sure that we do not overwrite valid data
-		// 2) we commit any pending files for previous checkpoints (previous to the last successful one)
-		// 3) we resume writing to the previous in-progress file of each bucket, and
-		// 4) if we receive multiple states for the same bucket, we merge them.
-
-		// get the max counter
+	private void initializePartCounter(final ListState<Long> partCounterState) throws Exception {
 		long maxCounter = 0L;
 		for (long partCounter: partCounterState.get()) {
 			maxCounter = Math.max(partCounter, maxCounter);
 		}
-		maxPartCounterUsed = maxCounter;
+		maxPartCounter = maxCounter;
+	}
 
-		// get the restored buckets
-		for (byte[] recoveredState : bucketStates.get()) {
-			final BucketState<BucketID> bucketState = SimpleVersionedSerialization.readVersionAndDeSerialize(
-					bucketStateSerializer, recoveredState);
-
-			final BucketID bucketId = bucketState.getBucketId();
-
-			LOG.info("Recovered bucket for {}", bucketId);
-
-			final Bucket<IN, BucketID> restoredBucket = bucketFactory.restoreBucket(
-					fileSystemWriter,
-					subtaskIndex,
-					maxPartCounterUsed,
-					partFileWriterFactory,
-					bucketState
-			);
-
-			final Bucket<IN, BucketID> existingBucket = activeBuckets.get(bucketId);
-			if (existingBucket == null) {
-				activeBuckets.put(bucketId, restoredBucket);
-			} else {
-				existingBucket.merge(restoredBucket);
-			}
-
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("{} idx {} restored state for bucket {}", getClass().getSimpleName(),
-						subtaskIndex, assembleBucketPath(bucketId));
-			}
+	private void initializeActiveBuckets(final ListState<byte[]> bucketStates) throws Exception {
+		for (byte[] serializedRecoveredState : bucketStates.get()) {
+			final BucketState<BucketID> recoveredState =
+					SimpleVersionedSerialization.readVersionAndDeSerialize(
+							bucketStateSerializer, serializedRecoveredState);
+			handleRestoredBucketState(recoveredState);
 		}
 	}
 
-	void publishUpToCheckpoint(long checkpointId) throws IOException {
+	private void handleRestoredBucketState(final BucketState<BucketID> recoveredState) throws Exception {
+		final BucketID bucketId = recoveredState.getBucketId();
+
+		final Bucket<IN, BucketID> restoredBucket = bucketFactory
+				.restoreBucket(
+						fsWriter,
+						subtaskIndex,
+						maxPartCounter,
+						partFileWriterFactory,
+						rollingPolicy,
+						recoveredState
+				);
+
+		updateActiveBucketId(bucketId, restoredBucket);
+	}
+
+	private void updateActiveBucketId(final BucketID bucketId, final Bucket<IN, BucketID> restoredBucket) throws IOException {
+		final Bucket<IN, BucketID> bucket = activeBuckets.get(bucketId);
+		if (bucket != null) {
+			bucket.merge(restoredBucket);
+		} else {
+			activeBuckets.put(bucketId, restoredBucket);
+		}
+	}
+
+	void commitUpToCheckpoint(final long checkpointId) throws IOException {
 		final Iterator<Map.Entry<BucketID, Bucket<IN, BucketID>>> activeBucketIt =
 				activeBuckets.entrySet().iterator();
 
 		while (activeBucketIt.hasNext()) {
-			Bucket<IN, BucketID> bucket = activeBucketIt.next().getValue();
-			bucket.onCheckpointAcknowledgment(checkpointId);
+			final Bucket<IN, BucketID> bucket = activeBucketIt.next().getValue();
+			bucket.onSuccessfulCompletionOfCheckpoint(checkpointId);
 
 			if (!bucket.isActive()) {
 				// We've dealt with all the pending files and the writer for this bucket is not currently open.
@@ -185,35 +193,32 @@ public class Buckets<IN, BucketID> {
 
 	void snapshotState(
 			final long checkpointId,
-			final ListState<byte[]> bucketStates,
-			final ListState<Long> partCounterState) throws Exception {
+			final ListState<byte[]> bucketStatesContainer,
+			final ListState<Long> partCounterStateContainer) throws Exception {
 
 		Preconditions.checkState(
-				fileSystemWriter != null && bucketStateSerializer != null,
-				"sink has not been initialized"
-		);
+				fsWriter != null && bucketStateSerializer != null,
+				"sink has not been initialized");
 
-		for (Bucket<IN, BucketID> bucket : activeBuckets.values()) {
-			final PartFileInfo<BucketID> info = bucket.getInProgressPartInfo();
-
-			if (info != null && rollingPolicy.shouldRollOnCheckpoint(info)) {
-				bucket.closePartFile();
-			}
-
-			final BucketState<BucketID> bucketState = bucket.onCheckpoint(checkpointId);
-			bucketStates.add(SimpleVersionedSerialization.writeVersionAndSerialize(bucketStateSerializer, bucketState));
-		}
-
-		partCounterState.add(maxPartCounterUsed);
+		snapshotActiveBuckets(checkpointId, bucketStatesContainer);
+		partCounterStateContainer.add(maxPartCounter);
 	}
 
-	/**
-	 * Called on every incoming element to write it to its final location.
-	 * @param value the element itself.
-	 * @param context the {@link SinkFunction.Context context} available to the sink function.
-	 * @throws Exception
-	 */
-	void onElement(IN value, SinkFunction.Context context) throws Exception {
+	private void snapshotActiveBuckets(
+			final long checkpointId,
+			final ListState<byte[]> bucketStatesContainer) throws Exception {
+
+		for (Bucket<IN, BucketID> bucket : activeBuckets.values()) {
+			final BucketState<BucketID> bucketState = bucket.onReceptionOfCheckpoint(checkpointId);
+
+			final byte[] serializedBucketState = SimpleVersionedSerialization
+					.writeVersionAndSerialize(bucketStateSerializer, bucketState);
+
+			bucketStatesContainer.add(serializedBucketState);
+		}
+	}
+
+	void onElement(final IN value, final SinkFunction.Context context) throws Exception {
 		final long currentProcessingTime = context.currentProcessingTime();
 
 		// setting the values in the bucketer context
@@ -222,79 +227,56 @@ public class Buckets<IN, BucketID> {
 				context.currentWatermark(),
 				currentProcessingTime);
 
-		final BucketID bucketId = bucketer.getBucketId(value, bucketerContext);
+		final BucketID bucketId = bucketAssigner.getBucketId(value, bucketerContext);
+		final Bucket<IN, BucketID> bucket = getOrCreateBucketForBucketId(bucketId);
+		bucket.write(value, currentProcessingTime);
 
+		// we update the global max counter here because as buckets become inactive and
+		// get removed from the list of active buckets, at the time when we want to create
+		// another part file for the bucket, if we start from 0 we may overwrite previous parts.
+
+		this.maxPartCounter = Math.max(maxPartCounter, bucket.getPartCounter());
+	}
+
+	private Bucket<IN, BucketID> getOrCreateBucketForBucketId(final BucketID bucketId) throws IOException {
 		Bucket<IN, BucketID> bucket = activeBuckets.get(bucketId);
 		if (bucket == null) {
 			final Path bucketPath = assembleBucketPath(bucketId);
 			bucket = bucketFactory.getNewBucket(
-					fileSystemWriter,
+					fsWriter,
 					subtaskIndex,
 					bucketId,
 					bucketPath,
-					maxPartCounterUsed,
-					partFileWriterFactory);
+					maxPartCounter,
+					partFileWriterFactory,
+					rollingPolicy);
 			activeBuckets.put(bucketId, bucket);
 		}
-
-		final PartFileInfo<BucketID> info = bucket.getInProgressPartInfo();
-		if (info == null || rollingPolicy.shouldRollOnEvent(info, value)) {
-
-			// info will be null if there is no currently open part file. This
-			// is the case when we have a new, just created bucket or a bucket
-			// that has not received any data after the closing of its previously
-			// open in-progress file due to the specified rolling policy.
-
-			bucket.rollPartFile(currentProcessingTime);
-		}
-		bucket.write(value, currentProcessingTime);
-
-		// we update the counter here because as buckets become inactive and
-		// get removed in the initializeState(), at the time we snapshot they
-		// may not be there to take them into account during checkpointing.
-		updateMaxPartCounter(bucket.getPartCounter());
+		return bucket;
 	}
 
 	void onProcessingTime(long timestamp) throws Exception {
 		for (Bucket<IN, BucketID> bucket : activeBuckets.values()) {
-			final PartFileInfo<BucketID> info = bucket.getInProgressPartInfo();
-			if (info != null && rollingPolicy.shouldRollOnProcessingTime(info, timestamp)) {
-				bucket.closePartFile();
-			}
+			bucket.onProcessingTime(timestamp);
 		}
 	}
 
 	void close() {
 		if (activeBuckets != null) {
-			activeBuckets.values().forEach(Bucket::dispose);
+			activeBuckets.values().forEach(Bucket::disposePartFile);
 		}
 	}
 
-	/**
-	 * Assembles the final bucket {@link Path} that will be used for the provided bucket in the
-	 * underlying filesystem.
-	 * @param bucketId the id of the bucket as returned by the {@link Bucketer}.
-	 * @return The resulting path.
-	 */
 	private Path assembleBucketPath(BucketID bucketId) {
 		return new Path(basePath, bucketId.toString());
 	}
 
 	/**
-	 * Updates the state keeping track of the maximum used part
-	 * counter across all local active buckets.
-	 * @param candidate the part counter that will potentially replace the current {@link #maxPartCounterUsed}.
-	 */
-	private void updateMaxPartCounter(long candidate) {
-		maxPartCounterUsed = Math.max(maxPartCounterUsed, candidate);
-	}
-
-	/**
-	 * The {@link Bucketer.Context} exposed to the
-	 * {@link Bucketer#getBucketId(Object, Bucketer.Context)}
+	 * The {@link BucketAssigner.Context} exposed to the
+	 * {@link BucketAssigner#getBucketId(Object, BucketAssigner.Context)}
 	 * whenever a new incoming element arrives.
 	 */
-	private static final class BucketerContext implements Bucketer.Context {
+	private static final class BucketerContext implements BucketAssigner.Context {
 
 		@Nullable
 		private Long elementTimestamp;
@@ -309,8 +291,8 @@ public class Buckets<IN, BucketID> {
 			this.currentProcessingTime = Long.MIN_VALUE;
 		}
 
-		void update(@Nullable Long element, long watermark, long processingTime) {
-			this.elementTimestamp = element;
+		void update(@Nullable Long elementTimestamp, long watermark, long processingTime) {
+			this.elementTimestamp = elementTimestamp;
 			this.currentWatermark = watermark;
 			this.currentProcessingTime = processingTime;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
@@ -66,7 +66,7 @@ final class BulkPartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID> {
 	/**
 	 * A factory that creates {@link BulkPartWriter BulkPartWriters}.
 	 * @param <IN> The type of input elements.
-	 * @param <BucketID> The type of ids for the buckets, as returned by the {@link Bucketer}.
+	 * @param <BucketID> The type of ids for the buckets, as returned by the {@link BucketAssigner}.
 	 */
 	static class Factory<IN, BucketID> implements PartFileWriter.PartFileFactory<IN, BucketID> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * A factory returning {@link Bucket buckets}.
  */
 @Internal
-class DefaultBucketFactory<IN, BucketID> implements BucketFactory<IN, BucketID> {
+class DefaultBucketFactoryImpl<IN, BucketID> implements BucketFactory<IN, BucketID> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -39,15 +39,17 @@ class DefaultBucketFactory<IN, BucketID> implements BucketFactory<IN, BucketID> 
 			final BucketID bucketId,
 			final Path bucketPath,
 			final long initialPartCounter,
-			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory) {
+			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy) {
 
-		return new Bucket<>(
+		return Bucket.getNew(
 				fsWriter,
 				subtaskIndex,
 				bucketId,
 				bucketPath,
 				initialPartCounter,
-				partFileWriterFactory);
+				partFileWriterFactory,
+				rollingPolicy);
 	}
 
 	@Override
@@ -56,13 +58,15 @@ class DefaultBucketFactory<IN, BucketID> implements BucketFactory<IN, BucketID> 
 			final int subtaskIndex,
 			final long initialPartCounter,
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileWriterFactory,
+			final RollingPolicy<IN, BucketID> rollingPolicy,
 			final BucketState<BucketID> bucketState) throws IOException {
 
-		return new Bucket<>(
+		return Bucket.restore(
 				fsWriter,
 				subtaskIndex,
 				initialPartCounter,
 				partFileWriterFactory,
+				rollingPolicy,
 				bucketState);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileInfo.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileInfo.java
@@ -32,7 +32,7 @@ public interface PartFileInfo<BucketID> {
 
 	/**
 	 * @return The bucket identifier of the current buffer, as returned by the
-	 * {@link Bucketer#getBucketId(Object, Bucketer.Context)}.
+	 * {@link BucketAssigner#getBucketId(Object, BucketAssigner.Context)}.
 	 */
 	BucketID getBucketId();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWisePartWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWisePartWriter.java
@@ -54,7 +54,7 @@ final class RowWisePartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID>
 	/**
 	 * A factory that creates {@link RowWisePartWriter RowWisePartWriters}.
 	 * @param <IN> The type of input elements.
-	 * @param <BucketID> The type of ids for the buckets, as returned by the {@link Bucketer}.
+	 * @param <BucketID> The type of ids for the buckets, as returned by the {@link BucketAssigner}.
 	 */
 	static class Factory<IN, BucketID> implements PartFileWriter.PartFileFactory<IN, BucketID> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/BasePathBucketAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/BasePathBucketAssigner.java
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.functions.sink.filesystem.bucketers;
+package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.streaming.api.functions.sink.filesystem.Bucketer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 
 /**
- * A {@link Bucketer} that does not perform any
+ * A {@link BucketAssigner} that does not perform any
  * bucketing of files. All files are written to the base path.
  */
 @PublicEvolving
-public class BasePathBucketer<T> implements Bucketer<T, String> {
+public class BasePathBucketAssigner<T> implements BucketAssigner<T, String> {
 
 	private static final long serialVersionUID = -6033643155550226022L;
 
 	@Override
-	public String getBucketId(T element, Bucketer.Context context) {
+	public String getBucketId(T element, BucketAssigner.Context context) {
 		return "";
 	}
 
@@ -44,6 +44,6 @@ public class BasePathBucketer<T> implements Bucketer<T, String> {
 
 	@Override
 	public String toString() {
-		return "BasePathBucketer";
+		return "BasePathBucketAssigner";
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssigner.java
@@ -16,17 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.functions.sink.filesystem.bucketers;
+package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.streaming.api.functions.sink.filesystem.Bucketer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * A {@link Bucketer} that assigns to buckets based on current system time.
+ * A {@link BucketAssigner} that assigns to buckets based on current system time.
  *
  *
  * <p>The {@code DateTimeBucketer} will create directories of the following form:
@@ -52,7 +52,7 @@ import java.util.Date;
  *
  */
 @PublicEvolving
-public class DateTimeBucketer<IN> implements Bucketer<IN, String> {
+public class DateTimeBucketAssigner<IN> implements BucketAssigner<IN, String> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -65,7 +65,7 @@ public class DateTimeBucketer<IN> implements Bucketer<IN, String> {
 	/**
 	 * Creates a new {@code DateTimeBucketer} with format string {@code "yyyy-MM-dd--HH"}.
 	 */
-	public DateTimeBucketer() {
+	public DateTimeBucketAssigner() {
 		this(DEFAULT_FORMAT_STRING);
 	}
 
@@ -75,12 +75,12 @@ public class DateTimeBucketer<IN> implements Bucketer<IN, String> {
 	 * @param formatString The format string that will be given to {@code SimpleDateFormat} to determine
 	 *                     the bucket path.
 	 */
-	public DateTimeBucketer(String formatString) {
+	public DateTimeBucketAssigner(String formatString) {
 		this.formatString = formatString;
 	}
 
 	@Override
-	public String getBucketId(IN element, Bucketer.Context context) {
+	public String getBucketId(IN element, BucketAssigner.Context context) {
 		if (dateFormatter == null) {
 			dateFormatter = new SimpleDateFormat(formatString);
 		}
@@ -94,8 +94,6 @@ public class DateTimeBucketer<IN> implements Bucketer<IN, String> {
 
 	@Override
 	public String toString() {
-		return "DateTimeBucketer{" +
-				"formatString='" + formatString + '\'' +
-				'}';
+		return "DateTimeBucketAssigner{formatString='" + formatString + '\'' + '}';
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/SimpleVersionedStringSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/SimpleVersionedStringSerializer.java
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.functions.sink.filesystem.bucketers;
+package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * A {@link SimpleVersionedSerializer} implementation for Strings.
  */
+@PublicEvolving
 public final class SimpleVersionedStringSerializer implements SimpleVersionedSerializer<String> {
 
 	private static final Charset CHARSET = StandardCharsets.UTF_8;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/DefaultRollingPolicy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/DefaultRollingPolicy.java
@@ -87,7 +87,10 @@ public final class DefaultRollingPolicy<IN, BucketID> implements RollingPolicy<I
 	 * To finalize it and have the actual policy, call {@code .create()}.
 	 */
 	public static DefaultRollingPolicy.PolicyBuilder create() {
-		return new DefaultRollingPolicy.PolicyBuilder();
+		return new DefaultRollingPolicy.PolicyBuilder(
+				DEFAULT_MAX_PART_SIZE,
+				DEFAULT_ROLLOVER_INTERVAL,
+				DEFAULT_INACTIVITY_INTERVAL);
 	}
 
 	/**
@@ -96,42 +99,46 @@ public final class DefaultRollingPolicy<IN, BucketID> implements RollingPolicy<I
 	@PublicEvolving
 	public static final class PolicyBuilder {
 
-		private long partSize = DEFAULT_MAX_PART_SIZE;
+		private final long partSize;
 
-		private long rolloverInterval = DEFAULT_ROLLOVER_INTERVAL;
+		private final long rolloverInterval;
 
-		private long inactivityInterval = DEFAULT_INACTIVITY_INTERVAL;
+		private final long inactivityInterval;
 
-		private PolicyBuilder() {}
+		private PolicyBuilder(
+				final long partSize,
+				final long rolloverInterval,
+				final long inactivityInterval) {
+			this.partSize = partSize;
+			this.rolloverInterval = rolloverInterval;
+			this.inactivityInterval = inactivityInterval;
+		}
 
 		/**
 		 * Sets the part size above which a part file will have to roll.
 		 * @param size the allowed part size.
 		 */
-		public DefaultRollingPolicy.PolicyBuilder withMaxPartSize(long size) {
+		public DefaultRollingPolicy.PolicyBuilder withMaxPartSize(final long size) {
 			Preconditions.checkState(size > 0L);
-			this.partSize = size;
-			return this;
+			return new PolicyBuilder(size, rolloverInterval, inactivityInterval);
 		}
 
 		/**
 		 * Sets the interval of allowed inactivity after which a part file will have to roll.
 		 * @param interval the allowed inactivity interval.
 		 */
-		public DefaultRollingPolicy.PolicyBuilder withInactivityInterval(long interval) {
+		public DefaultRollingPolicy.PolicyBuilder withInactivityInterval(final long interval) {
 			Preconditions.checkState(interval > 0L);
-			this.inactivityInterval = interval;
-			return this;
+			return new PolicyBuilder(partSize, rolloverInterval, interval);
 		}
 
 		/**
 		 * Sets the max time a part file can stay open before having to roll.
 		 * @param interval the desired rollover interval.
 		 */
-		public DefaultRollingPolicy.PolicyBuilder withRolloverInterval(long interval) {
+		public DefaultRollingPolicy.PolicyBuilder withRolloverInterval(final long interval) {
 			Preconditions.checkState(interval > 0L);
-			this.rolloverInterval = interval;
-			return this;
+			return new PolicyBuilder(partSize, interval, inactivityInterval);
 		}
 
 		/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/OnCheckpointRollingPolicy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/rollingpolicies/OnCheckpointRollingPolicy.java
@@ -18,15 +18,19 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
 import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
 
 /**
  * A {@link RollingPolicy} which rolls on every checkpoint.
  */
+@PublicEvolving
 public class OnCheckpointRollingPolicy<IN, BucketID> implements RollingPolicy<IN, BucketID> {
 
 	private static final long serialVersionUID = 1L;
+
+	private OnCheckpointRollingPolicy() {}
 
 	@Override
 	public boolean shouldRollOnCheckpoint(PartFileInfo<BucketID> partFileState) {
@@ -41,5 +45,9 @@ public class OnCheckpointRollingPolicy<IN, BucketID> implements RollingPolicy<IN
 	@Override
 	public boolean shouldRollOnProcessingTime(PartFileInfo<BucketID> partFileState, long currentTime) {
 		return false;
+	}
+
+	public static <IN, BucketID> OnCheckpointRollingPolicy<IN, BucketID> build() {
+		return new OnCheckpointRollingPolicy<>();
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketers.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -75,8 +75,8 @@ public class BucketStateSerializerTest {
 		final BucketState<String> recoveredState =  SimpleVersionedSerialization.readVersionAndDeSerialize(serializer, bytes);
 
 		Assert.assertEquals(testBucket, recoveredState.getBucketPath());
-		Assert.assertNull(recoveredState.getInProgress());
-		Assert.assertTrue(recoveredState.getPendingPerCheckpoint().isEmpty());
+		Assert.assertNull(recoveredState.getInProgressResumableFile());
+		Assert.assertTrue(recoveredState.getCommittableFilesPerCheckpoint().isEmpty());
 	}
 
 	@Test
@@ -166,7 +166,7 @@ public class BucketStateSerializerTest {
 
 		Assert.assertEquals(bucketPath, recoveredState.getBucketPath());
 
-		final Map<Long, List<RecoverableWriter.CommitRecoverable>> recoveredRecoverables = recoveredState.getPendingPerCheckpoint();
+		final Map<Long, List<RecoverableWriter.CommitRecoverable>> recoveredRecoverables = recoveredState.getCommittableFilesPerCheckpoint();
 		Assert.assertEquals(5L, recoveredRecoverables.size());
 
 		// recover and commit
@@ -238,9 +238,9 @@ public class BucketStateSerializerTest {
 		final BucketState<String> recoveredState =  SimpleVersionedSerialization.readVersionAndDeSerialize(serializer, bytes);
 
 		Assert.assertEquals(bucketPath, recoveredState.getBucketPath());
-		Assert.assertNull(recoveredState.getInProgress());
+		Assert.assertNull(recoveredState.getInProgressResumableFile());
 
-		final Map<Long, List<RecoverableWriter.CommitRecoverable>> recoveredRecoverables = recoveredState.getPendingPerCheckpoint();
+		final Map<Long, List<RecoverableWriter.CommitRecoverable>> recoveredRecoverables = recoveredState.getCommittableFilesPerCheckpoint();
 		Assert.assertEquals(5L, recoveredRecoverables.size());
 
 		// recover and commit

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketers.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -58,7 +58,7 @@ public class BucketsTest {
 
 		final Buckets<String, String> buckets = StreamingFileSink
 				.<String>forRowFormat(new Path(outDir.toURI()), new SimpleStringEncoder<>())
-				.withBucketer(new VarifyingBucketer(expectedTimestamp, expectedWatermark, expectedProcessingTime))
+				.withBucketAssigner(new VarifyingBucketer(expectedTimestamp, expectedWatermark, expectedProcessingTime))
 				.createBuckets(2);
 
 		buckets.onElement("TEST", new SinkFunction.Context() {
@@ -79,7 +79,7 @@ public class BucketsTest {
 		});
 	}
 
-	private static class VarifyingBucketer implements Bucketer<String, String> {
+	private static class VarifyingBucketer implements BucketAssigner<String, String> {
 
 		private static final long serialVersionUID = 7729086510972377578L;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -59,7 +59,7 @@ public class BulkWriterTest extends TestLogger {
 								10L,
 								new TestUtils.TupleToStringBucketer(),
 								new TestBulkWriterFactory(),
-								new DefaultBucketFactory<>())
+								new DefaultBucketFactoryImpl<>())
 		) {
 
 			testHarness.setup();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -491,8 +491,8 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 
 		OperatorSubtaskState mergedSnapshot;
 
-		final TestBucketFactory first = new TestBucketFactory();
-		final TestBucketFactory second = new TestBucketFactory();
+		final TestBucketFactoryImpl first = new TestBucketFactoryImpl();
+		final TestBucketFactoryImpl second = new TestBucketFactoryImpl();
 
 		final RollingPolicy<Tuple2<String, Integer>, String> rollingPolicy = DefaultRollingPolicy
 				.create()
@@ -526,8 +526,8 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 			);
 		}
 
-		final TestBucketFactory firstRecovered = new TestBucketFactory();
-		final TestBucketFactory secondRecovered = new TestBucketFactory();
+		final TestBucketFactoryImpl firstRecovered = new TestBucketFactoryImpl();
+		final TestBucketFactoryImpl secondRecovered = new TestBucketFactoryImpl();
 
 		try (
 				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness1 = TestUtils.createCustomRescalingTestSink(
@@ -559,7 +559,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 
 	//////////////////////			Helper Methods			//////////////////////
 
-	static class TestBucketFactory extends DefaultBucketFactory<Tuple2<String, Integer>, String> {
+	static class TestBucketFactoryImpl extends DefaultBucketFactoryImpl<Tuple2<String, Integer>, String> {
 
 		private static final long serialVersionUID = 2794824980604027930L;
 
@@ -572,7 +572,8 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 				final String bucketId,
 				final Path bucketPath,
 				final long initialPartCounter,
-				final PartFileWriter.PartFileFactory<Tuple2<String, Integer>, String> partFileWriterFactory) {
+				final PartFileWriter.PartFileFactory<Tuple2<String, Integer>, String> partFileWriterFactory,
+				final RollingPolicy<Tuple2<String, Integer>, String> rollingPolicy) {
 
 			this.initialCounter = initialPartCounter;
 
@@ -582,7 +583,8 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 					bucketId,
 					bucketPath,
 					initialPartCounter,
-					partFileWriterFactory);
+					partFileWriterFactory,
+					rollingPolicy);
 		}
 
 		@Override
@@ -591,6 +593,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 				final int subtaskIndex,
 				final long initialPartCounter,
 				final PartFileWriter.PartFileFactory<Tuple2<String, Integer>, String> partFileWriterFactory,
+				final RollingPolicy<Tuple2<String, Integer>, String> rollingPolicy,
 				final BucketState<String> bucketState) throws IOException {
 
 			this.initialCounter = initialPartCounter;
@@ -600,6 +603,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 					subtaskIndex,
 					initialPartCounter,
 					partFileWriterFactory,
+					rollingPolicy,
 					bucketState);
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
@@ -67,7 +67,7 @@ public class RollingPolicyTest {
 						new TestUtils.TupleToStringBucketer(),
 						new SimpleStringEncoder<>(),
 						rollingPolicy,
-						new DefaultBucketFactory<>())
+						new DefaultBucketFactoryImpl<>())
 		) {
 			testHarness.setup();
 			testHarness.open();
@@ -111,7 +111,7 @@ public class RollingPolicyTest {
 	public void testRollOnCheckpointPolicy() throws Exception {
 		final File outDir = TEMP_FOLDER.newFolder();
 
-		final RollingPolicy<Tuple2<String, Integer>, String> rollingPolicy = new OnCheckpointRollingPolicy<>();
+		final RollingPolicy<Tuple2<String, Integer>, String> rollingPolicy = OnCheckpointRollingPolicy.build();
 
 		try (
 				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness = TestUtils.createCustomRescalingTestSink(
@@ -122,7 +122,7 @@ public class RollingPolicyTest {
 						new TestUtils.TupleToStringBucketer(),
 						new SimpleStringEncoder<>(),
 						rollingPolicy,
-						new DefaultBucketFactory<>())
+						new DefaultBucketFactoryImpl<>())
 		) {
 			testHarness.setup();
 			testHarness.open();
@@ -246,7 +246,7 @@ public class RollingPolicyTest {
 						new TestUtils.TupleToStringBucketer(),
 						new SimpleStringEncoder<>(),
 						rollingPolicy,
-						new DefaultBucketFactory<>())
+						new DefaultBucketFactoryImpl<>())
 		) {
 			testHarness.setup();
 			testHarness.open();


### PR DESCRIPTION
## What is the purpose of the change

It introduces a big refactoring of the code of the `StreamingFileSink` and the related classes and it introduces logging.

## Brief change log

The main API change is that the `Bucketer` becomes `BucketAssigner` and also the setters in the sink Builder are renamed accordingly.

Apart from renaming, the main change is that now  the `RollingPolicy` is passed from the `Buckets` to the `Bucket`. So now the `Bucket` is responsible for checking when to roll.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicabl**e / docs / JavaDocs / not documented)
