### PR TITLE
[FLINK-9861][tests] Add StreamingFileSink E2E test 

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
@@ -65,6 +65,4 @@ under the License.
 		</plugins>
 	</build>
 
-
-
 </project>

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
@@ -35,6 +35,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.7-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-streaming-file-sink-test</artifactId>
+	<version>1.7-SNAPSHOT</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>StreamingFileSinkSinkTestProgram</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>StreamingFileSinkProgram</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>StreamingFileSinkProgram</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+
+
+</project>

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
  * written to the file.
  *
  * <p>The sink rolls on each checkpoint, with each part file containing a sequence of integers.
- * Adding all committed part files together, and numerically sorting the contents, should 
+ * Adding all committed part files together, and numerically sorting the contents, should
  * result in a complete sequence from 0 (inclusive) to 60000 (exclusive).
  */
 public enum StreamingFileSinkProgram {

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.Bucketer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketers.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test program for the {@link StreamingFileSink}.
+ *
+ * <p>Uses a source that steadily emits a deterministic set of records over 60 seconds,
+ * after which it idles and waits for job cancellation. Every record has a unique index that is
+ * written to the file.
+ *
+ * <p>The sink rolls on each checkpoint, with each part file containing a sequence of integers.
+ * Adding all committed part files together, and numerically sorting the contents, should 
+ * result in a complete sequence from 0 (inclusive) to 60000 (exclusive).
+ */
+public enum StreamingFileSinkProgram {
+	;
+
+	public static void main(final String[] args) throws Exception {
+		final ParameterTool params = ParameterTool.fromArgs(args);
+		final String outputPath = params.getRequired("outputPath");
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		env.setParallelism(4);
+		env.enableCheckpointing(5000L);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, Time.of(10L, TimeUnit.SECONDS)));
+
+		final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
+			.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
+				PrintStream out = new PrintStream(stream);
+				out.println(element.f1);
+			})
+			.withBucketer(new KeyBucketer())
+			.withRollingPolicy(new OnCheckpointRollingPolicy<>())
+			.build();
+
+		// generate data, shuffle, sink
+		env.addSource(new Generator(10, 10, 60))
+			.keyBy(0)
+			.addSink(sink);
+
+		env.execute("StreamingFileSinkProgram");
+	}
+
+
+	/**
+	 * Use first field for buckets.
+	 */
+	public static final class KeyBucketer implements Bucketer<Tuple2<Integer, Integer>, String> {
+
+		private static final long serialVersionUID = 987325769970523326L;
+
+		@Override
+		public String getBucketId(final Tuple2<Integer, Integer> element, final Context context) {
+			return String.valueOf(element.f0);
+		}
+
+		@Override
+		public SimpleVersionedSerializer<String> getSerializer() {
+			return SimpleVersionedStringSerializer.INSTANCE;
+		}
+	}
+
+	/**
+	 * Data-generating source function.
+	 */
+	public static final class Generator implements SourceFunction<Tuple2<Integer, Integer>>, ListCheckpointed<Tuple2<Integer, Long>> {
+
+		private static final long serialVersionUID = -2819385275681175792L;
+
+		private final int numKeys;
+		private final int idlenessMs;
+		private final int durationMs;
+
+		private long ms = 0L;
+
+		private volatile int numRecordsEmitted = 0;
+		private volatile boolean canceled = false;
+
+		Generator(final int numKeys, final int idlenessMs, final int durationSeconds) {
+			this.numKeys = numKeys;
+			this.idlenessMs = idlenessMs;
+			this.durationMs = durationSeconds * 1000;
+		}
+
+		@Override
+		public void run(final SourceContext<Tuple2<Integer, Integer>> ctx) throws Exception {
+			while (ms < durationMs) {
+				synchronized (ctx.getCheckpointLock()) {
+					for (int i = 0; i < numKeys; i++) {
+						ctx.collect(Tuple2.of(i, numRecordsEmitted));
+						numRecordsEmitted++;
+					}
+					ms += idlenessMs;
+				}
+				Thread.sleep(idlenessMs);
+			}
+
+			while (!canceled) {
+				Thread.sleep(50);
+			}
+
+		}
+
+		@Override
+		public void cancel() {
+			canceled = true;
+		}
+
+		@Override
+		public List<Tuple2<Integer, Long>> snapshotState(final long checkpointId, final long timestamp) {
+			return Collections.singletonList(Tuple2.of(numRecordsEmitted, ms));
+		}
+
+		@Override
+		public void restoreState(final List<Tuple2<Integer, Long>> states) {
+			for (final Tuple2<Integer, Long> state : states) {
+				numRecordsEmitted += state.f0;
+				ms += state.f1;
+			}
+		}
+	}
+}

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
@@ -25,9 +25,9 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.filesystem.Bucketer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketers.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
@@ -65,8 +65,8 @@ public enum StreamingFileSinkProgram {
 				PrintStream out = new PrintStream(stream);
 				out.println(element.f1);
 			})
-			.withBucketer(new KeyBucketer())
-			.withRollingPolicy(new OnCheckpointRollingPolicy<>())
+			.withBucketAssigner(new KeyBucketAssigner())
+			.withRollingPolicy(OnCheckpointRollingPolicy.build())
 			.build();
 
 		// generate data, shuffle, sink
@@ -81,7 +81,7 @@ public enum StreamingFileSinkProgram {
 	/**
 	 * Use first field for buckets.
 	 */
-	public static final class KeyBucketer implements Bucketer<Tuple2<Integer, Integer>, String> {
+	public static final class KeyBucketAssigner implements BucketAssigner<Tuple2<Integer, Integer>, String> {
 
 		private static final long serialVersionUID = 987325769970523326L;
 

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -53,6 +53,7 @@ under the License.
 		<module>flink-confluent-schema-registry</module>
 		<module>flink-stream-state-ttl-test</module>
 		<module>flink-sql-client-test</module>
+		<module>flink-streaming-file-sink-test</module>
 	</modules>
 
 	<build>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -89,6 +89,7 @@ run_test "Resuming Externalized Checkpoint after terminal failure (rocks, increm
 run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
 run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh"
 run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh"
+run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh"
 run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
 
 run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false false"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -540,6 +540,16 @@ function rollback_flink_slf4j_metric_reporter() {
   rm $FLINK_DIR/lib/flink-metrics-slf4j-*.jar
 }
 
+function get_job_metric {
+  local job_id=$1
+  local metric_name=$2
+
+  local json=$(curl -s http://localhost:8081/jobs/${job_id}/metrics?get=${metric_name})
+  local metric_value=$(echo ${json} | sed -n 's/.*"value":"\(.*\)".*/\1/p')
+
+  echo ${metric_value}
+}
+
 function get_metric_processed_records {
   OPERATOR=$1
   JOB_NAME="${2:-General purpose test job}"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -110,26 +110,18 @@ wait_job_running ${JOB_ID}
 wait_num_checkpoints "${JOB_ID}" 3
 
 echo "Killing TM"
-
-# kill task manager
 kill_random_taskmanager
 
 echo "Starting TM"
-
-# start task manager again
 "$FLINK_DIR/bin/taskmanager.sh" start
 
 wait_for_restart 0
 
 echo "Killing 2 TMs"
-
-# kill two task managers again shortly after
 kill_random_taskmanager
 kill_random_taskmanager
 
 echo "Starting 2 TMs"
-
-# start task manager again and let job finish
 "$FLINK_DIR/bin/taskmanager.sh" start
 "$FLINK_DIR/bin/taskmanager.sh" start
 
@@ -153,7 +145,7 @@ cancel_job "${JOB_ID}"
 
 wait_job_terminal_state "${JOB_ID}" "CANCELED"
 
-# get all lines in part files
+# get all lines in part files and sort them numerically
 find "${OUTPUT_PATH}" -type f \( -iname "part-*" \) -exec cat {} + | sort -g > "${TEST_DATA_DIR}/complete_result"
 
 check_result_hash "File Streaming Sink" "$TEST_DATA_DIR/complete_result" "6727342fdd3aae2129e61fc8f433fb6f"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-streaming-file-sink-test/target/StreamingFileSinkProgram.jar"
+
+OUTPUT_PATH="$TEST_DATA_DIR/out"
+
+function get_num_output_files {
+    local num_files=$(find ${OUTPUT_PATH} -type f | wc -l)
+    echo ${num_files}
+}
+
+function wait_for_restart {
+    local base_num_restarts=$1
+
+    local current_num_restarts=${base_num_restarts}
+    local expected_num_restarts=$((current_num_restarts + 1))
+
+    echo "Waiting for restart to happen"
+    while ! [[ ${current_num_restarts} -eq ${expected_num_restarts} ]]; do
+        sleep 5
+        current_num_restarts=$(get_job_metric ${JOB_ID} "fullRestarts")
+        if [[ -z ${current_num_restarts} ]]; then
+            current_num_restarts=${base_num_restarts}
+        fi
+    done
+}
+
+###################################
+# Wait a specific number of successful checkpoints
+# to have happened
+#
+# Globals:
+#   None
+# Arguments:
+#   $1: the job id
+#   $2: the number of expected successful checkpoints
+#   $3: timeout in seconds
+# Returns:
+#   None
+###################################
+function wait_for_number_of_checkpoints {
+    local job_id=$1
+    local expected_num_checkpoints=$2
+    local timeout=$3
+    local count=0
+
+    echo "Starting to wait for completion of ${expected_num_checkpoints} checkpoints"
+    while (($(get_completed_number_of_checkpoints ${job_id}) < ${expected_num_checkpoints})); do
+
+        if [[ ${count} -gt ${timeout} ]]; then
+            echo "A timeout occurred waiting for successful checkpoints"
+            exit 1
+        else
+            ((count+=2))
+        fi
+
+        local current_num_checkpoints=$(get_completed_number_of_checkpoints ${job_id})
+        echo "${current_num_checkpoints}/${expected_num_checkpoints} completed checkpoints"
+        sleep 2
+    done
+}
+
+function get_completed_number_of_checkpoints {
+    local job_id=$1
+    local json_res=$(curl -s http://localhost:8081/jobs/${job_id}/checkpoints)
+
+    echo ${json_res}    | # {"counts":{"restored":0,"total":25,"in_progress":1,"completed":24,"failed":0} ...
+        cut -d ":" -f 6 | # 24,"failed"
+        sed 's/,.*//'     # 24
+}
+
+backup_config
+start_cluster
+
+"${FLINK_DIR}/bin/taskmanager.sh" start
+"${FLINK_DIR}/bin/taskmanager.sh" start
+"${FLINK_DIR}/bin/taskmanager.sh" start
+
+echo "Submitting job."
+CLIENT_OUTPUT=$("$FLINK_DIR/bin/flink" run -d "${TEST_PROGRAM_JAR}" --outputPath "${OUTPUT_PATH}")
+JOB_ID=$(echo "${CLIENT_OUTPUT}" | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+if [[ -z $JOB_ID ]]; then
+    echo "Job could not be submitted."
+    echo "${CLIENT_OUTPUT}"
+    exit 1
+fi
+
+wait_job_running ${JOB_ID}
+
+wait_num_checkpoints "${JOB_ID}" 3
+
+echo "Killing TM"
+
+# kill task manager
+kill_random_taskmanager
+
+echo "Starting TM"
+
+# start task manager again
+"$FLINK_DIR/bin/taskmanager.sh" start
+
+wait_for_restart 0
+
+echo "Killing 2 TMs"
+
+# kill two task managers again shortly after
+kill_random_taskmanager
+kill_random_taskmanager
+
+echo "Starting 2 TMs"
+
+# start task manager again and let job finish
+"$FLINK_DIR/bin/taskmanager.sh" start
+"$FLINK_DIR/bin/taskmanager.sh" start
+
+wait_for_restart 1
+
+echo "Waiting until no new files are being created"
+OLD_COUNT=0
+NEW_COUNT=$(get_num_output_files)
+while ! [[ ${OLD_COUNT} -eq ${NEW_COUNT} ]]; do
+    echo "More output files were created. previous=${OLD_COUNT} now=${NEW_COUNT}"
+    # so long as there is data to process new files should be created for each checkpoint
+    CURRENT_NUM_CHECKPOINTS=$(get_completed_number_of_checkpoints ${JOB_ID})
+    EXPECTED_NUM_CHECKPOINTS=$((CURRENT_NUM_CHECKPOINTS + 1))
+    wait_for_number_of_checkpoints ${JOB_ID} ${EXPECTED_NUM_CHECKPOINTS} 60
+
+    OLD_COUNT=${NEW_COUNT}
+    NEW_COUNT=$(get_num_output_files)
+done
+
+cancel_job "${JOB_ID}"
+
+wait_job_terminal_state "${JOB_ID}" "CANCELED"
+
+# get all lines in part files
+find "${OUTPUT_PATH}" -type f \( -iname "part-*" \) -exec cat {} + | sort -g > "${TEST_DATA_DIR}/complete_result"
+
+check_result_hash "File Streaming Sink" "$TEST_DATA_DIR/complete_result" "6727342fdd3aae2129e61fc8f433fb6f"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -88,7 +88,6 @@ function get_completed_number_of_checkpoints {
         sed 's/,.*//'     # 24
 }
 
-backup_config
 start_cluster
 
 "${FLINK_DIR}/bin/taskmanager.sh" start


### PR DESCRIPTION
## What is the purpose of the change

This PR adds an end-to-end test for the streaming file sink.

The source of the test program emits 60k elements over 60 seconds, after which it idles until the job is canceled. Records are `Tuple2<Integer, Integer>`, where `f0` is a key between 0 and 9 and `f1` a sequence counter from 0 to 59999. The current sequence count is checkpointed.

The sink of the test program uses a custom encoder&bucketer, and rolls on each checkpoint.

Test behavior:

1. submit job
2. wait for some checkpoints
3. kill 1 TM
4. wait for restart
5. kill 2 TMs
6. wait for restart
7. wait until the sink no longer creates new files
8. cancel job
9. verify result

Step 2 ensures that some state is actually checkpointed, as otherwise the source could emit the entire output again. The current checkpoint count is retrieved through the REST API:

Step 3-6 induce failures. We specifically wait for restarts to ensure that the job restarts twice. The current number of restarts is retrieved through the metrics REST API.

Step 7-8 are a work-around for the behavior of checkpointing sinks for finite streams. For finite streams it usually happens that any data received between the last checkpoint and job termination is not committed. So we don't have to deal with this we let the job run until the sinks are no longer creating new files for checkpoints. Files are only created if records are received, so if no file is created by any sink we can imply that none have received a record, which should mean that there is in fact no more data to process. Generally speaking this is just an assumption, but given the checkpoint interval of 5 seconds it is highly unlikely that no records makes it to the sink in time.

Step 9 verifies the result by concatenating and sorting all committed files, which should result in the sequence [0, 60000).

If any data was lost by the sink the sequence will be interrupted. If any data was committed twice the sequence will contain a duplicate entry.

## Verifying this change

https://travis-ci.org/zentol/flink-ci/builds/411211048