### PR TITLE
[FLINK-10020] [kinesis] Support recoverable exceptions in listShards.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -164,7 +164,7 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final double DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
-	public static final int DEFAULT_LIST_SHARDS_RETRIES = 3;
+	public static final int DEFAULT_LIST_SHARDS_RETRIES = 10;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -92,6 +92,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The power constant for exponential backoff between each describeStream attempt. */
 	public static final String STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
 
+	/** The maximum number of listShards attempts if we get a recoverable exception. */
+	public static final String LIST_SHARDS_RETRIES = "flink.list.shards.maxretries";
+
 	/** The base backoff time between each listShards attempt. */
 	public static final String LIST_SHARDS_BACKOFF_BASE = "flink.list.shards.backoff.base";
 
@@ -104,7 +107,7 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";
 
-	/** The maximum number of getRecords attempts if we get ProvisionedThroughputExceededException. */
+	/** The maximum number of getRecords attempts if we get a recoverable exception. */
 	public static final String SHARD_GETRECORDS_RETRIES = "flink.shard.getrecords.maxretries";
 
 	/** The base backoff time between getRecords attempts if we get a ProvisionedThroughputExceededException. */
@@ -160,6 +163,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final long DEFAULT_LIST_SHARDS_BACKOFF_MAX = 5000L;
 
 	public static final double DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final int DEFAULT_LIST_SHARDS_RETRIES = 3;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -28,15 +28,22 @@ import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.amazonaws.services.kinesis.model.AmazonKinesisException;
 import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
 import com.amazonaws.services.kinesis.model.ListShardsRequest;
 import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.Shard;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
@@ -54,6 +61,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -89,6 +97,37 @@ public class KinesisProxyTest {
 		final AmazonServiceException ex = new AmazonServiceException("asdf");
 		ex.setErrorType(null);
 		assertFalse(KinesisProxy.isRecoverableException(ex));
+	}
+
+	@Test
+	public void testGetRecordsRetry() throws Exception {
+		Properties kinesisConsumerConfig = new Properties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+
+		final GetRecordsResult expectedResult = new GetRecordsResult();
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[] {
+			new AmazonKinesisException("mock"),
+		};
+
+		AmazonKinesisClient mockClient = mock(AmazonKinesisClient.class);
+		Mockito.when(mockClient.getRecords(any())).thenAnswer(new Answer<GetRecordsResult>() {
+			@Override
+			public GetRecordsResult answer(InvocationOnMock invocation) throws Throwable{
+				if (retries.intValue() < retriableExceptions.length) {
+					retries.increment();
+					throw retriableExceptions[retries.intValue() - 1];
+				}
+				return expectedResult;
+			}
+		});
+
+		KinesisProxy kinesisProxy = new KinesisProxy(kinesisConsumerConfig);
+		Whitebox.getField(KinesisProxy.class, "kinesisClient").set(kinesisProxy, mockClient);
+
+		GetRecordsResult result = kinesisProxy.getRecords("fakeShardIterator", 1);
+		assertEquals(retriableExceptions.length, retries.intValue());
+		assertEquals(expectedResult, result);
 	}
 
 	@Test
@@ -149,6 +188,45 @@ public class KinesisProxyTest {
 				actualShardList,
 				containsInAnyOrder(
 						expectedStreamShard.toArray(new StreamShardHandle[actualShardList.size()])));
+	}
+
+	@Test
+	public void testGetShardListRetry() throws Exception {
+		Properties kinesisConsumerConfig = new Properties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+
+		Shard shard = new Shard();
+		shard.setShardId("fake-shard-000000000000");
+		final ListShardsResult expectedResult = new ListShardsResult();
+		expectedResult.withShards(shard);
+
+		MutableInt retries = new MutableInt();
+		final Throwable[] retriableExceptions = new Throwable[]{
+			new AmazonKinesisException("mock"),
+		};
+
+		AmazonKinesisClient mockClient = mock(AmazonKinesisClient.class);
+		Mockito.when(mockClient.listShards(any())).thenAnswer(new Answer<ListShardsResult>() {
+
+			@Override
+			public ListShardsResult answer(InvocationOnMock invocation) throws Throwable {
+				if (retries.intValue() < retriableExceptions.length) {
+					retries.increment();
+					throw retriableExceptions[retries.intValue() - 1];
+				}
+				return expectedResult;
+			}
+		});
+
+		KinesisProxy kinesisProxy = new KinesisProxy(kinesisConsumerConfig);
+		Whitebox.getField(KinesisProxy.class, "kinesisClient").set(kinesisProxy, mockClient);
+
+		HashMap<String, String> streamNames = new HashMap();
+		streamNames.put("fake-stream", null);
+		GetShardListResult result = kinesisProxy.getShardList(streamNames);
+		assertEquals(retriableExceptions.length, retries.intValue());
+		assertEquals(true, result.hasRetrievedShards());
+		assertEquals(shard.getShardId(), result.getLastSeenShardOfStream("fake-stream").getShard().getShardId());
 	}
 
 	@Test


### PR DESCRIPTION
This change fixes the retry behavior of listShards to match what getRecords already supports. Importantly this will prevent the subtask from failing on transient listShards errors that we can identify based on well known exceptions. These are recoverable and should not lead to unnecessary recovery cycles that cause downtime.

R: @glaksh100 @jgrier @tzulitai 