### PR TITLE
[FLINK-10051][tests][sql] Add missing depenendeices for sql client E2E test

### DIFF
--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -43,6 +43,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<!-- Used by dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
@@ -50,6 +51,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<!-- Used by dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-json</artifactId>
 			<version>${project.version}</version>
@@ -57,6 +59,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<!-- Used by dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.9_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
@@ -64,6 +67,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<!-- Used by dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
@@ -71,6 +75,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<!-- Used by dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
@@ -123,7 +128,9 @@ under the License.
 						</goals>
 						<configuration>
 							<outputDirectory>${project.build.directory}/sql-jars</outputDirectory>
-							<!-- List of currently provided SQL jars. -->
+							<!-- List of currently provided SQL jars. 
+								When extending this list please also add a dependency
+								for the respective module. -->
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -50,7 +50,7 @@ under the License.
 			This ensures that all modules we actually need (as defined by the
  			dependency-plugin configuration) are built before this module. -->
 		<dependency>
-			<!-- Used by dependency-plugin -->
+			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
@@ -58,7 +58,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<!-- Used by dependency-plugin -->
+			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-json</artifactId>
 			<version>${project.version}</version>
@@ -66,7 +66,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<!-- Used by dependency-plugin -->
+			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.9_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
@@ -74,7 +74,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<!-- Used by dependency-plugin -->
+			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
@@ -82,7 +82,7 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<!-- Used by dependency-plugin -->
+			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -42,6 +42,41 @@ under the License.
 			<artifactId>scala-compiler</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-avro</artifactId>
+			<version>${project.version}</version>
+			<classifier>sql-jar</classifier>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${project.version}</version>
+			<classifier>sql-jar</classifier>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.9_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<classifier>sql-jar</classifier>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<classifier>sql-jar</classifier>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<classifier>sql-jar</classifier>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -79,6 +79,18 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- Pick an arbitrary version here to satisfy the enforcer-plugin,
+					as we neither access nor package the kafka dependencies -->
+				<groupId>org.apache.kafka</groupId>
+				<artifactId>kafka-clients</artifactId>
+				<version>0.11.0.2</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<plugins>
 			<!-- Build toolbox jar. -->

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -42,6 +42,13 @@ under the License.
 			<artifactId>scala-compiler</artifactId>
 			<scope>provided</scope>
 		</dependency>
+
+		<!-- The following dependencies are for connector/format sql-jars that
+			we copy using the maven-dependency-plugin. When extending the test
+ 			to cover more connectors/formats, add a dependency here and an entry
+			to the dependency-plugin configuration below.
+			This ensures that all modules we actually need (as defined by the
+ 			dependency-plugin configuration) are built before this module. -->
 		<dependency>
 			<!-- Used by dependency-plugin -->
 			<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
## What is the purpose of the change

This PR adds missing dependencies to the sql-client end-to-end test.

The sql-client end-to-end test uses the dependency-plugin to copy a few jars into the /target directory. However since the module doesn't define dependencies on these jars there's no guarantee that these jars are built before the test, or even at all. This caused the tests to fail, since the kafka 0.11 connector wasn't at all and also wasn't available in the SNAPSHOT repository.

## Brief change log

add dependencies for all kafka connectors, avro and json.

## Verifying this change

flink-ci build: https://travis-ci.org/zentol/flink-ci/builds/411803521
I modified the flink version to guard against the issue being obfuscated by existing SNAPSHOT artifacts.
