### PR TITLE
[FLINK-10053] Add getParallelism API for PythonStreamExecutionEnvironment

### DIFF
--- a/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
+++ b/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
@@ -236,6 +236,15 @@ public class PythonStreamExecutionEnvironment {
 	}
 
 	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#getParallelism()}.
+	 *
+	 * @return The parallelism used by operations, unless they override that value.
+	 */
+	public int get_parallelism() {
+		return this.env.getParallelism();
+	}
+
+	/**
 	 * A thin wrapper layer over {@link StreamExecutionEnvironment#execute()}.
 	 *
 	 * @return The result of the job execution


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds getParallelism API for PythonStreamExecutionEnvironment*


## Brief change log

  - *Add getParallelism API for PythonStreamExecutionEnvironment*

## Verifying this change

TBD

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
