### PR TITLE
[FLINK-10055] incorrect in-progress file suffix in BucketingSink's java doc

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -1001,7 +1001,7 @@ public class BucketingSink<T>
 	}
 
 	/**
-	 * Sets the suffix of in-progress part files. The default is {@code "in-progress"}.
+	 * Sets the suffix of in-progress part files. The default is {@code ".in-progress"}.
 	 */
 	public BucketingSink<T> setInProgressSuffix(String inProgressSuffix) {
 		this.inProgressSuffix = inProgressSuffix;


### PR DESCRIPTION
## What is the purpose of the change


## Brief change log

Similar to the java doc of `setPendingSuffix()` and `setValidLengthSuffix()`, the java doc of `setInProgressSuffix()` should have a `.` in `The default is {@code ".in-progress"}.`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

none 

## Documentation

  - Does this pull request introduce a new feature? (no)
