### PR TITLE
[FLINK-10054] Add getMaxParallelism/setMaxParallelism API for PythonStreamExecutionEnvironment

### DIFF
--- a/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
+++ b/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
@@ -236,6 +236,27 @@ public class PythonStreamExecutionEnvironment {
 	}
 
 	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#setMaxParallelism(int)}.
+	 *
+	 * @param maxParallelism Maximum degree of parallelism to be used for the program.,
+	 *              with 0 < maxParallelism <= 2^15 - 1
+	 * @return The same {@code PythonStreamExecutionEnvironment} instance of the caller
+	 */
+	public PythonStreamExecutionEnvironment set_max_parallelism(int maxParallelism) {
+		this.env.setMaxParallelism(maxParallelism);
+		return this;
+	}
+
+	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#getMaxParallelism()}.
+	 *
+	 * @return Maximum degree of parallelism
+	 */
+	public int get_max_parallelism() {
+		return this.env.getMaxParallelism();
+	}
+
+	/**
 	 * A thin wrapper layer over {@link StreamExecutionEnvironment#execute()}.
 	 *
 	 * @return The result of the job execution


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds getMaxParallelism/setMaxParallelism API for PythonStreamExecutionEnvironment*


## Brief change log

  - *Add getMaxParallelism/setMaxParallelism API for PythonStreamExecutionEnvironment*

## Verifying this change

TBD

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
