### PR TITLE
[FLINK-10056] [test] Add JobMasterTest#testRequestNextInputSplit

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1655,4 +1655,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	RestartStrategy getRestartStrategy() {
 		return restartStrategy;
 	}
+
+	@VisibleForTesting
+	ExecutionGraph getExecutionGraph() {
+		return executionGraph;
+	}
 }


### PR DESCRIPTION
## Brief change log

Add `JobMasterTest#testRequestNextInputSplit` to make sure that `JobMaster#requestNextInputSplit` works as expected.


## Verifying this change

well, code itself is the verify.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
