### PR TITLE
[FLINK-9962] [FS connector] allow users to specify TimeZone in DateTimeBucketer

### DIFF
--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -70,7 +70,8 @@ stored. The sink can be further configured by specifying a custom bucketer, writ
 
 By default the bucketing sink will split by the current system time when elements arrive and will
 use the datetime pattern `"yyyy-MM-dd--HH"` to name the buckets. This pattern is passed to
-`SimpleDateFormat` with the current system time to form a bucket path. A new bucket will be created
+`SimpleDateFormat` with the current system time and JVM's default timezone to form a bucket path.
+Users can also specify a timezone for the bucketer to format bucket path. A new bucket will be created
 whenever a new date is encountered. For example, if you have a pattern that contains minutes as the
 finest granularity you will get a new bucket every minute. Each bucket is itself a directory that
 contains several part files: each parallel instance of the sink will create its own part file and
@@ -105,7 +106,7 @@ Example:
 DataStream<Tuple2<IntWritable,Text>> input = ...;
 
 BucketingSink<String> sink = new BucketingSink<String>("/base/path");
-sink.setBucketer(new DateTimeBucketer<String>("yyyy-MM-dd--HHmm"));
+sink.setBucketer(new DateTimeBucketer<String>("yyyy-MM-dd--HHmm", TimeZone.getTimeZone("UTC")));
 sink.setWriter(new SequenceFileWriter<IntWritable, Text>());
 sink.setBatchSize(1024 * 1024 * 400); // this is 400 MB,
 sink.setBatchRolloverInterval(20 * 60 * 1000); // this is 20 mins
@@ -119,7 +120,7 @@ input.addSink(sink);
 val input: DataStream[Tuple2[IntWritable, Text]] = ...
 
 val sink = new BucketingSink[String]("/base/path")
-sink.setBucketer(new DateTimeBucketer[String]("yyyy-MM-dd--HHmm"))
+sink.setBucketer(new DateTimeBucketer[String]("yyyy-MM-dd--HHmm", TimeZone.getTimeZone("UTC")))
 sink.setWriter(new SequenceFileWriter[IntWritable, Text]())
 sink.setBatchSize(1024 * 1024 * 400) // this is 400 MB,
 sink.setBatchRolloverInterval(20 * 60 * 1000); // this is 20 mins

--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -70,7 +70,7 @@ stored. The sink can be further configured by specifying a custom bucketer, writ
 
 By default the bucketing sink will split by the current system time when elements arrive and will
 use the datetime pattern `"yyyy-MM-dd--HH"` to name the buckets. This pattern is passed to
-`SimpleDateFormat` with the current system time and JVM's default timezone to form a bucket path.
+`DateTimeFormatter` with the current system time and JVM's default timezone to form a bucket path.
 Users can also specify a timezone for the bucketer to format bucket path. A new bucket will be created
 whenever a new date is encountered. For example, if you have a pattern that contains minutes as the
 finest granularity you will get a new bucket every minute. Each bucket is itself a directory that
@@ -106,7 +106,7 @@ Example:
 DataStream<Tuple2<IntWritable,Text>> input = ...;
 
 BucketingSink<String> sink = new BucketingSink<String>("/base/path");
-sink.setBucketer(new DateTimeBucketer<String>("yyyy-MM-dd--HHmm", TimeZone.getTimeZone("UTC")));
+sink.setBucketer(new DateTimeBucketer<String>("yyyy-MM-dd--HHmm", ZoneId.of("America/Los_Angeles")));
 sink.setWriter(new SequenceFileWriter<IntWritable, Text>());
 sink.setBatchSize(1024 * 1024 * 400); // this is 400 MB,
 sink.setBatchRolloverInterval(20 * 60 * 1000); // this is 20 mins
@@ -120,7 +120,7 @@ input.addSink(sink);
 val input: DataStream[Tuple2[IntWritable, Text]] = ...
 
 val sink = new BucketingSink[String]("/base/path")
-sink.setBucketer(new DateTimeBucketer[String]("yyyy-MM-dd--HHmm", TimeZone.getTimeZone("UTC")))
+sink.setBucketer(new DateTimeBucketer[String]("yyyy-MM-dd--HHmm", ZoneId.of("America/Los_Angeles")))
 sink.setWriter(new SequenceFileWriter[IntWritable, Text]())
 sink.setBatchSize(1024 * 1024 * 400) // this is 400 MB,
 sink.setBatchRolloverInterval(20 * 60 * 1000); // this is 20 mins

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
@@ -19,8 +19,8 @@
 package org.apache.flink.streaming.connectors.fs.bucketing;
 
 import org.apache.flink.streaming.connectors.fs.Clock;
-
 import org.apache.flink.util.Preconditions;
+
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * A {@link Bucketer} that assigns to buckets based on current system time.
@@ -39,7 +40,7 @@ import java.util.Date;
  *
  *
  * <p>{@link SimpleDateFormat} is used to derive a date string from the current system time and
- * the date format string. The default format string is {@code "yyyy-MM-dd--HH"} so the rolling
+ * the date format string with a timezone. The default format string is {@code "yyyy-MM-dd--HH"} so the rolling
  * files will have a granularity of hours.
  *
  *
@@ -61,26 +62,49 @@ public class DateTimeBucketer<T> implements Bucketer<T> {
 	private static final String DEFAULT_FORMAT_STRING = "yyyy-MM-dd--HH";
 
 	private final String formatString;
+	private final TimeZone timeZone;
 
 	private transient SimpleDateFormat dateFormatter;
 
 	/**
-	 * Creates a new {@code DateTimeBucketer} with format string {@code "yyyy-MM-dd--HH"}.
+	 * Creates a new {@code DateTimeBucketer} with format string {@code "yyyy-MM-dd--HH"} using JVM's default timezone.
 	 */
 	public DateTimeBucketer() {
 		this(DEFAULT_FORMAT_STRING);
 	}
 
 	/**
-	 * Creates a new {@code DateTimeBucketer} with the given date/time format string.
+	 * Creates a new {@code DateTimeBucketer} with the given date/time format string using JVM's default timezone.
 	 *
 	 * @param formatString The format string that will be given to {@code SimpleDateFormat} to determine
 	 *                     the bucket path.
 	 */
 	public DateTimeBucketer(String formatString) {
+		this(formatString, TimeZone.getDefault());
+	}
+
+	/**
+	 * Creates a new {@code DateTimeBucketer} with format string {@code "yyyy-MM-dd--HH"} using the given timezone.
+	 *
+	 * @param timeZone The timezone used to format {@code SimpleDateFormat} for bucket path.
+	 */
+	public DateTimeBucketer(TimeZone timeZone) {
+		this(DEFAULT_FORMAT_STRING, timeZone);
+	}
+
+	/**
+	 * Creates a new {@code DateTimeBucketer} with the given date/time format string using the given timezone.
+	 *
+	 * @param formatString The format string that will be given to {@code SimpleDateFormat} to determine
+	 *                     the bucket path.
+	 * @param timeZone The timezone used to format {@code SimpleDateFormat} for bucket path.
+	 */
+	public DateTimeBucketer(String formatString, TimeZone timeZone) {
 		this.formatString = formatString;
+		this.timeZone = timeZone;
 
 		this.dateFormatter = new SimpleDateFormat(formatString);
+		this.dateFormatter.setTimeZone(this.timeZone);
 	}
 
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -98,7 +122,8 @@ public class DateTimeBucketer<T> implements Bucketer<T> {
 	@Override
 	public String toString() {
 		return "DateTimeBucketer{" +
-				"formatString='" + formatString + '\'' +
-				'}';
+			"formatString='" + formatString + '\'' +
+			", timeZone=" + timeZone +
+			'}';
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketer.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.fs.bucketing;
 
 import org.apache.flink.streaming.connectors.fs.Clock;
 
+import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
@@ -100,8 +101,8 @@ public class DateTimeBucketer<T> implements Bucketer<T> {
 	 * @param zoneId The timezone used to format {@code DateTimeFormatter} for bucket path.
 	 */
 	public DateTimeBucketer(String formatString, ZoneId zoneId) {
-		this.formatString = formatString;
-		this.zoneId = zoneId;
+		this.formatString = Preconditions.checkNotNull(formatString);
+		this.zoneId = Preconditions.checkNotNull(zoneId);
 
 		this.dateTimeFormatter = DateTimeFormatter.ofPattern(this.formatString).withZone(zoneId);
 	}
@@ -109,12 +110,12 @@ public class DateTimeBucketer<T> implements Bucketer<T> {
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
 		in.defaultReadObject();
 
-		this.dateTimeFormatter = DateTimeFormatter.ofPattern(formatString);
+		this.dateTimeFormatter = DateTimeFormatter.ofPattern(formatString).withZone(zoneId);
 	}
 
 	@Override
 	public Path getBucketPath(Clock clock, Path basePath, T element) {
-		String newDateTimeString = dateTimeFormatter.format(Instant.ofEpochMilli(clock.currentTimeMillis()).atZone(zoneId).toLocalDateTime());
+		String newDateTimeString = dateTimeFormatter.format(Instant.ofEpochMilli(clock.currentTimeMillis()));
 		return new Path(basePath + "/" + newDateTimeString);
 	}
 

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketerTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketerTest.java
@@ -22,15 +22,10 @@ import org.apache.flink.streaming.connectors.fs.Clock;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.time.ZoneId;
 
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for {@link DateTimeBucketer}.

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketerTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketerTest.java
@@ -1,0 +1,49 @@
+package org.apache.flink.streaming.connectors.fs.bucketing;
+
+import org.apache.flink.streaming.connectors.fs.Clock;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests for {@link DateTimeBucketer}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(DateTimeBucketer.class)
+public class DateTimeBucketerTest {
+	private static final long TEST_TIME_IN_MILLIS = 1533363082011L;
+	private static final Path TEST_PATH = new Path("test");
+
+	@Test
+	public void testGetBucketPathWithDefaultTimezone() {
+		TimeZone utc = TimeZone.getTimeZone("UTC");
+		PowerMockito.mockStatic(TimeZone.class);
+		when(TimeZone.getDefault()).thenReturn(utc);
+
+		DateTimeBucketer bucketer = new DateTimeBucketer();
+
+		Clock clock = mock(Clock.class);
+		when(clock.currentTimeMillis()).thenReturn(TEST_TIME_IN_MILLIS);
+
+		assertEquals(new Path("test/2018-08-04--06"), bucketer.getBucketPath(clock, TEST_PATH, null));
+	}
+
+	@Test
+	public void testGetBucketPathWithSpecifiedTimezone() {
+		Clock clock = mock(Clock.class);
+		when(clock.currentTimeMillis()).thenReturn(TEST_TIME_IN_MILLIS);
+		DateTimeBucketer bucketer = new DateTimeBucketer(TimeZone.getTimeZone("PST"));
+
+		assertEquals(new Path("test/2018-08-03--23"), bucketer.getBucketPath(clock, TEST_PATH, null));
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketerTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/DateTimeBucketerTest.java
@@ -35,24 +35,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 /**
  * Tests for {@link DateTimeBucketer}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DateTimeBucketer.class)
 public class DateTimeBucketerTest {
 	private static final long TEST_TIME_IN_MILLIS = 1533363082011L;
 	private static final Path TEST_PATH = new Path("test");
 
 	private static final Clock mockedClock = new MockedClock();
-
-	@Test
-	public void testGetBucketPathWithDefaultTimezone() {
-		ZoneId utc = ZoneId.of("UTC");
-		PowerMockito.mockStatic(ZoneId.class);
-		when(ZoneId.systemDefault()).thenReturn(utc);
-
-		DateTimeBucketer bucketer = new DateTimeBucketer();
-
-		assertEquals(new Path("test/2018-08-04--06"), bucketer.getBucketPath(mockedClock, TEST_PATH, null));
-	}
 
 	@Test
 	public void testGetBucketPathWithSpecifiedTimezone() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssigner.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
+import org.apache.flink.util.Preconditions;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -98,18 +99,17 @@ public class DateTimeBucketAssigner<IN> implements BucketAssigner<IN, String> {
 	 * @param zoneId The timezone used to format {@code DateTimeFormatter} for bucket id.
 	 */
 	public DateTimeBucketAssigner(String formatString, ZoneId zoneId) {
-		this.formatString = formatString;
-		this.zoneId = zoneId;
+		this.formatString = Preconditions.checkNotNull(formatString);
+		this.zoneId = Preconditions.checkNotNull(zoneId);
 	}
 
 	@Override
 	public String getBucketId(IN element, BucketAssigner.Context context) {
 		if (dateTimeFormatter == null) {
-			dateTimeFormatter = DateTimeFormatter.ofPattern(formatString);
+			dateTimeFormatter = DateTimeFormatter.ofPattern(formatString).withZone(zoneId);
 		}
 
-		return dateTimeFormatter.format(
-			Instant.ofEpochMilli(context.currentProcessingTime()).atZone(zoneId).toLocalDateTime());
+		return dateTimeFormatter.format(Instant.ofEpochMilli(context.currentProcessingTime()));
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssigner.java
@@ -22,8 +22,9 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 /**
  * A {@link BucketAssigner} that assigns to buckets based on current system time.
@@ -37,14 +38,14 @@ import java.util.Date;
  * user provided format string.
  *
  *
- * <p>{@link SimpleDateFormat} is used to derive a date string from the current system time and
+ * <p>{@link DateTimeFormatter} is used to derive a date string from the current system time and
  * the date format string. The default format string is {@code "yyyy-MM-dd--HH"} so the rolling
  * files will have a granularity of hours.
  *
  * <p>Example:
  *
  * <pre>{@code
- *     Bucketer buck = new DateTimeBucketer("yyyy-MM-dd--HH");
+ *     BucketAssigner bucketAssigner = new DateTimeBucketAssigner("yyyy-MM-dd--HH");
  * }</pre>
  *
  * <p>This will create for example the following bucket path:
@@ -59,32 +60,56 @@ public class DateTimeBucketAssigner<IN> implements BucketAssigner<IN, String> {
 	private static final String DEFAULT_FORMAT_STRING = "yyyy-MM-dd--HH";
 
 	private final String formatString;
+	private final ZoneId zoneId;
 
-	private transient SimpleDateFormat dateFormatter;
+	private transient DateTimeFormatter dateTimeFormatter;
 
 	/**
-	 * Creates a new {@code DateTimeBucketer} with format string {@code "yyyy-MM-dd--HH"}.
+	 * Creates a new {@code DateTimeBucketAssigner} with format string {@code "yyyy-MM-dd--HH"}.
 	 */
 	public DateTimeBucketAssigner() {
 		this(DEFAULT_FORMAT_STRING);
 	}
 
 	/**
-	 * Creates a new {@code DateTimeBucketer} with the given date/time format string.
+	 * Creates a new {@code DateTimeBucketAssigner} with the given date/time format string.
 	 *
 	 * @param formatString The format string that will be given to {@code SimpleDateFormat} to determine
-	 *                     the bucket path.
+	 *                     the bucket id.
 	 */
 	public DateTimeBucketAssigner(String formatString) {
+		this(formatString, ZoneId.systemDefault());
+	}
+
+	/**
+	 * Creates a new {@code DateTimeBucketAssigner} with format string {@code "yyyy-MM-dd--HH"} using the given timezone.
+	 *
+	 * @param zoneId The timezone used to format {@code DateTimeFormatter} for bucket id.
+	 */
+	public DateTimeBucketAssigner(ZoneId zoneId) {
+		this(DEFAULT_FORMAT_STRING, zoneId);
+	}
+
+	/**
+	 * Creates a new {@code DateTimeBucketAssigner} with the given date/time format string using the given timezone.
+	 *
+	 * @param formatString The format string that will be given to {@code DateTimeFormatter} to determine
+	 *                     the bucket path.
+	 * @param zoneId The timezone used to format {@code DateTimeFormatter} for bucket id.
+	 */
+	public DateTimeBucketAssigner(String formatString, ZoneId zoneId) {
 		this.formatString = formatString;
+		this.zoneId = zoneId;
 	}
 
 	@Override
 	public String getBucketId(IN element, BucketAssigner.Context context) {
-		if (dateFormatter == null) {
-			dateFormatter = new SimpleDateFormat(formatString);
+		if (dateTimeFormatter == null) {
+			dateTimeFormatter = DateTimeFormatter.ofPattern(formatString);
 		}
-		return dateFormatter.format(new Date(context.currentProcessingTime()));
+
+		return dateTimeFormatter.format(
+			Instant.ofEpochMilli(context.currentProcessingTime()).atZone(zoneId).toLocalDateTime());
 	}
 
 	@Override
@@ -94,6 +119,9 @@ public class DateTimeBucketAssigner<IN> implements BucketAssigner<IN, String> {
 
 	@Override
 	public String toString() {
-		return "DateTimeBucketAssigner{formatString='" + formatString + '\'' + '}';
+		return "DateTimeBucketAssigner{" +
+			"formatString='" + formatString + '\'' +
+			", zoneId=" + zoneId +
+			'}';
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssignerTest.java
@@ -21,17 +21,12 @@ package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.annotation.Nullable;
 
 import java.time.ZoneId;
 
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for {@link DateTimeBucketAssigner}.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/DateTimeBucketAssignerTest.java
@@ -36,23 +36,10 @@ import static org.powermock.api.mockito.PowerMockito.when;
 /**
  * Tests for {@link DateTimeBucketAssigner}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DateTimeBucketAssigner.class)
 public class DateTimeBucketAssignerTest {
 	private static final long TEST_TIME_IN_MILLIS = 1533363082011L;
 
 	private static final MockedContext mockedContext = new MockedContext();
-
-	@Test
-	public void testGetBucketPathWithDefaultTimezone() {
-		ZoneId utc = ZoneId.of("UTC");
-		PowerMockito.mockStatic(ZoneId.class);
-		when(ZoneId.systemDefault()).thenReturn(utc);
-
-		DateTimeBucketAssigner bucketAssigner = new DateTimeBucketAssigner();
-
-		assertEquals("2018-08-04--06", bucketAssigner.getBucketId(null, mockedContext));
-	}
 
 	@Test
 	public void testGetBucketPathWithSpecifiedTimezone() {


### PR DESCRIPTION
## What is the purpose of the change

allow users to specify TimeZone in DateTimeBucketer

## Brief change log

- add TimeZone as constructor param to DateTimeBucketer
- add unit tests

## Verifying this change

This change added tests and can be verified as follows:

  - add unit tests in DateTimeBucketerTest

## Does this pull request potentially affect one of the following parts:

  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
