### PR TITLE
[FLINK-10058] Add getStateBackend/setStateBackend API for PythonStreamExecutionEnvironment

### DIFF
--- a/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
+++ b/flink-libraries/flink-streaming-python/src/main/java/org/apache/flink/streaming/python/api/environment/PythonStreamExecutionEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -232,6 +233,25 @@ public class PythonStreamExecutionEnvironment {
 	 */
 	public PythonStreamExecutionEnvironment set_parallelism(int parallelism) {
 		this.env.setParallelism(parallelism);
+		return this;
+	}
+
+	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#getStateBackend()}.
+	 *
+	 * @return The state backend.
+	 */
+	public StateBackend get_state_backend() {
+		return this.env.getStateBackend();
+	}
+
+	/**
+	 * A thin wrapper layer over {@link StreamExecutionEnvironment#setStateBackend(StateBackend)}.
+	 *
+	 * @return The same {@code PythonStreamExecutionEnvironment} instance of the caller
+	 */
+	public PythonStreamExecutionEnvironment set_state_backend(StateBackend stateBackend) {
+		this.env.setStateBackend(stateBackend);
 		return this;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds getStateBackend/setStateBackend API for PythonStreamExecutionEnvironment*

## Brief change log

  - *Add getStateBackend/setStateBackend API for PythonStreamExecutionEnvironment*

## Verifying this change

TBD

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
