### PR TITLE
[FLINK-10059] [table] Add LTRIM supported in Table API and SQL

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -2482,6 +2482,18 @@ TO_BASE64(string)
         <p>E.g., <code>TO_BASE64('hello world')</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
+    
+    <tr>
+      <td>
+        {% highlight text %}
+LTRIM(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the result string which trimmed the left spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
+        <p>E.g., <code>LTRIM(' This is a test String.')</code> returns "This is a test String.".</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -2686,6 +2686,18 @@ STRING.toBase64()
          <p>E.g., <code>'hello world'.toBase64()</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.ltrim()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the result string which trimmed the left spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
+        <p>E.g., <code>' This is a test String.'.ltrim()</code> returns "This is a test String.".</p>
+      </td>
+    </tr>
     
   </tbody>
 </table>
@@ -2876,6 +2888,18 @@ STRING.toBase64()
       <td>
         <p>Returns the base64-encoded result from <i>STRING</i>; returns NULL if <i>STRING</i> is NULL.</p>
          <p>E.g., <code>"hello world".toBase64()</code> returns "aGVsbG8gd29ybGQ=".</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.ltrim()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the result string which trimmed the left spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
+        <p>E.g., <code>' This is a test String.'.ltrim()</code> returns "This is a test String.".</p>
       </td>
     </tr>
   </tbody>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -563,6 +563,11 @@ trait ImplicitExpressionOperations {
     */
   def toBase64() = ToBase64(expr)
 
+  /**
+    * Returns the result string which trimmed the left spaces from the base string.
+    */
+  def ltrim() = LTrim(expr)
+
   // Temporal operations
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -164,6 +164,12 @@ object FunctionGenerator {
     STRING_TYPE_INFO,
     BuiltInMethods.UUID)
 
+  addSqlFunctionMethod(
+    LTRIM,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethod.LTRIM.method)
+
   // ----------------------------------------------------------------------------------------------
   // Arithmetic functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -410,3 +410,27 @@ case class ToBase64(child: Expression) extends UnaryExpression with InputTypeSpe
   override def toString: String = s"($child).toBase64"
 
 }
+
+/**
+  * Returns the result string which trimmed the left spaces from the base string.
+  */
+case class LTrim(child: Expression) extends UnaryExpression with InputTypeSpec {
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == STRING_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"Ltrim operator requires a String input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.LTRIM, child.toRexNode)
+  }
+
+  override def toString = s"($child).ltrim"
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -206,4 +206,12 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val LTRIM = new SqlFunction(
+    "LTRIM",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING)
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -205,6 +205,7 @@ object FunctionCatalog {
     "fromBase64" -> classOf[FromBase64],
     "toBase64" -> classOf[ToBase64],
     "uuid" -> classOf[UUID],
+    "ltrim" -> classOf[LTrim],
 
     // math functions
     "plus" -> classOf[Plus],
@@ -455,6 +456,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.FROM_BASE64,
     ScalarSqlFunctions.TO_BASE64,
     ScalarSqlFunctions.UUID,
+    ScalarSqlFunctions.LTRIM,
 
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -626,6 +626,33 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "-")
   }
 
+  @Test
+  def testLTrim(): Unit = {
+    testAllApis(
+      'f8.ltrim(),
+      "f8.ltrim",
+      "LTRIM(f8)",
+      "This is a test String. ")
+
+    testAllApis(
+      'f0.ltrim(),
+      "f0.ltrim",
+      "LTRIM(f0)",
+      "This is a test String.")
+
+    testAllApis(
+      "".ltrim(),
+      "''.ltrim()",
+      "LTRIM('')",
+      "")
+
+    testAllApis(
+      'f33.ltrim(),
+      "f33.ltrim",
+      "LTRIM(f33)",
+      "null")
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Math functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -149,6 +149,7 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("RPAD('hi',4,'??')", "hi??")
     testSqlApi("FROM_BASE64('aGVsbG8gd29ybGQ=')", "hello world")
     testSqlApi("TO_BASE64('hello world')", "aGVsbG8gd29ybGQ=")
+    testSqlApi("LTRIM(' This is a test String.')", "This is a test String.")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add LTRIM supported in Table API and SQL*


## Brief change log

  - *Add LTRIM supported in Table API and SQL*


## Verifying this change

This change is already covered by existing tests, such as *ScalarFunctionsTest#testLTrim*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
