### PR TITLE
[FLINK-10063][tests] Use runit to supervise mesos processes.

### DIFF
--- a/flink-jepsen/docker/Dockerfile-db
+++ b/flink-jepsen/docker/Dockerfile-db
@@ -21,7 +21,7 @@ FROM debian:jessie
 RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y -t jessie-backports openjdk-8-jdk && \
-    apt-get install -y apt-utils bzip2 curl faketime iproute iptables iputils-ping less libzip2 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo sysvinit sysvinit-core sysvinit-utils tar unzip vim wget
+    apt-get install -y apt-utils bzip2 curl faketime iproute iptables iputils-ping less libzip2 logrotate man man-db net-tools ntpdate psmisc python rsyslog runit sudo sysvinit sysvinit-core sysvinit-utils tar unzip vim wget
 
 RUN apt-get update && \
     apt-get -y install openssh-server && \
@@ -35,5 +35,12 @@ RUN mkdir -p /root/.ssh/ && \
     chmod 600 /root/.ssh/authorized_keys && \
     cat /root/id_rsa.pub >> /root/.ssh/authorized_keys
 
+COPY sshd-run /etc/sv/service/sshd/run
+RUN chmod +x /etc/sv/service/sshd/run && \
+    ln -sf /etc/sv/service/sshd /etc/service
+
 EXPOSE 22
-CMD exec /usr/sbin/sshd -D
+
+# Start runit process supervisor which will bring up sshd.
+# In our tests we can use runit to supervise more processes, e.g., Mesos.
+CMD runsvdir -P /etc/service /dev/null > /dev/null

--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -97,7 +97,7 @@
   (if (cu/exists? log-dir) (cu/ls-full log-dir) []))
 
 (defn flink-db
-  [test]
+  []
   (reify db/DB
     (setup! [_ test node]
       (c/su
@@ -131,7 +131,7 @@
   []
   (let [zk (zk/db deb-zookeeper-package)
         hadoop (hadoop/db hadoop-dist-url)
-        flink (flink-db test)]
+        flink (flink-db)]
     (combined-db [hadoop zk flink])))
 
 (defn exec-flink!
@@ -192,7 +192,7 @@
   (let [zk (zk/db deb-zookeeper-package)
         hadoop (hadoop/db hadoop-dist-url)
         mesos (mesos/db deb-mesos-package deb-marathon-package)
-        flink (flink-db test)]
+        flink (flink-db)]
     (combined-db [hadoop zk mesos flink])))
 
 (defn submit-job-with-retry!

--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -209,24 +209,25 @@
     (let [r (fu/retry (fn []
                         (http/post
                           (str (mesos/marathon-base-url test) "/v2/apps")
-                          {:form-params  {:id   "flink"
-                                          :cmd  (str "HADOOP_CLASSPATH=`" hadoop/install-dir "/bin/hadoop classpath` "
-                                                     "HADOOP_CONF_DIR=" hadoop/hadoop-conf-dir " "
-                                                     install-dir "/bin/mesos-appmaster.sh "
-                                                     "-Dmesos.master=" (zookeeper-uri
-                                                                         test
-                                                                         mesos/zk-namespace) " "
-                                                     "-Djobmanager.rpc.address=$(hostname -f) "
-                                                     "-Djobmanager.heap.mb=2048 "
-                                                     "-Djobmanager.rpc.port=6123 "
-                                                     "-Djobmanager.web.port=8081 "
-                                                     "-Dmesos.resourcemanager.tasks.mem=2048 "
-                                                     "-Dtaskmanager.heap.mb=2048 "
-                                                     "-Dtaskmanager.numberOfTaskSlots=2 "
-                                                     "-Dmesos.resourcemanager.tasks.cpus=1 "
-                                                     "-Drest.bind-address=$(hostname -f) ")
-                                          :cpus 1.0
-                                          :mem  2048}
+                          {:form-params  {:id                    "flink"
+                                          :cmd                   (str "HADOOP_CLASSPATH=`" hadoop/install-dir "/bin/hadoop classpath` "
+                                                                      "HADOOP_CONF_DIR=" hadoop/hadoop-conf-dir " "
+                                                                      install-dir "/bin/mesos-appmaster.sh "
+                                                                      "-Dmesos.master=" (zookeeper-uri
+                                                                                          test
+                                                                                          mesos/zk-namespace) " "
+                                                                      "-Djobmanager.rpc.address=$(hostname -f) "
+                                                                      "-Djobmanager.heap.mb=2048 "
+                                                                      "-Djobmanager.rpc.port=6123 "
+                                                                      "-Djobmanager.web.port=8081 "
+                                                                      "-Dmesos.resourcemanager.tasks.mem=2048 "
+                                                                      "-Dtaskmanager.heap.mb=2048 "
+                                                                      "-Dtaskmanager.numberOfTaskSlots=2 "
+                                                                      "-Dmesos.resourcemanager.tasks.cpus=1 "
+                                                                      "-Drest.bind-address=$(hostname -f) ")
+                                          :cpus                  1.0
+                                          :mem                   2048
+                                          :maxLaunchDelaySeconds 3}
                            :content-type :json})))]
       (info "Submitted Flink Application via Marathon" r)
       (c/on (-> test :nodes sort first)

--- a/flink-jepsen/src/jepsen/flink/mesos.clj
+++ b/flink-jepsen/src/jepsen/flink/mesos.clj
@@ -24,11 +24,35 @@
             [jepsen.os.debian :as debian]
             [jepsen.flink.zookeeper :refer [zookeeper-uri]]))
 
+;;; runit process supervisor (http://smarden.org/runit/)
+;;;
+;;; We use runit to supervise Mesos processes because Mesos uses a "fail-fast" approach to
+;;; error handling, e.g., the Mesos master will exit when it discovers it has been partitioned away
+;;; from the Zookeeper quorum.
+
+(def runit-version "2.1.2-3")
+
+(defn create-supervised-service!
+  "Registers a service with the process supervisor and starts it."
+  [service-name cmd]
+  (let [service-dir (str "/etc/sv/" service-name)
+        run-script (str service-dir "/run")]
+    (c/su
+      (c/exec :mkdir :-p service-dir)
+      (c/exec :echo (clojure.string/join "\n" ["#!/bin/sh" cmd]) :> run-script)
+      (c/exec :chmod :+x run-script)
+      (c/exec :ln :-sf service-dir (str "/etc/service/" service-name)))))
+
+(defn stop-supervised-service!
+  "Stops a service and removes it from supervision."
+  [service-name]
+  (c/su
+    (c/exec :sv :down service-name)
+    (c/exec :rm :-f (str "/etc/service/" service-name))))
+
 ;;; Mesos
 
 (def master-count 1)
-(def master-pidfile "/var/run/mesos/master.pid")
-(def slave-pidfile "/var/run/mesos/slave.pid")
 (def master-dir "/var/lib/mesos/master")
 (def slave-dir "/var/lib/mesos/slave")
 (def log-dir "/var/log/mesos")
@@ -40,8 +64,85 @@
 
 (def marathon-bin "/usr/bin/marathon")
 (def zk-marathon-namespace "marathon")
-(def marathon-pidfile "/var/run/mesos/marathon.pid")
 (def marathon-rest-port 8080)
+
+;;; Mesos functions
+
+(defn mesos-master-cmd
+  "Returns the command to run the mesos master."
+  [test node]
+  (clojure.string/join " "
+                       ["GLOG_v=1"
+                        master-bin
+                        (str "--hostname=" (name node))
+                        (str "--log_dir=" log-dir)
+                        (str "--offer_timeout=30secs")
+                        (str "--quorum=" (util/majority master-count))
+                        (str "--registry_fetch_timeout=120secs")
+                        (str "--registry_store_timeout=5secs")
+                        (str "--work_dir=" master-dir)
+                        (str "--zk=" (zookeeper-uri test zk-namespace))]))
+
+(defn mesos-slave-cmd
+  "Returns the command to run the mesos agent."
+  [test node]
+  (clojure.string/join " "
+                       ["GLOG_v=1"
+                        slave-bin
+                        (str "--hostname=" (name node))
+                        (str "--log_dir=" log-dir)
+                        (str "--master=" (zookeeper-uri test zk-namespace))
+                        (str "--recovery_timeout=30secs")
+                        (str "--work_dir=" slave-dir)]))
+
+(defn create-mesos-master-supervised-service!
+  [test node]
+  (create-supervised-service! "mesos-master"
+                              (mesos-master-cmd test node)))
+
+(defn create-mesos-slave-supervised-service!
+  [test node]
+  (create-supervised-service! "mesos-slave"
+                              (mesos-slave-cmd test node)))
+
+(defn master-node?
+  "Returns a truthy value if the node should run the mesos master."
+  [test node]
+  (some #{node} (take master-count (sort (:nodes test)))))
+
+(defn start-master!
+  [test node]
+  (when (master-node? test node)
+    (info node "Starting mesos master")
+    (c/su
+      (create-mesos-master-supervised-service! test node))))
+
+(defn start-slave!
+  [test node]
+  (when-not (master-node? test node)
+    (info node "Starting mesos slave")
+    (c/su
+      (create-mesos-slave-supervised-service! test node))))
+
+(defn stop-master!
+  [test node]
+  (when (master-node? test node)
+    (info node "Stopping mesos master")
+    (stop-supervised-service! "mesos-master")
+    (meh (c/exec :rm :-rf
+                 (c/lit (str log-dir "/*"))
+                 (c/lit (str master-dir "/*"))))))
+
+(defn stop-slave!
+  [test node]
+  (when-not (master-node? test node)
+    (info node "Stopping mesos slave")
+    (stop-supervised-service! "mesos-slave")
+    (meh (c/exec :rm :-rf
+                 (c/lit (str log-dir "/*"))
+                 (c/lit (str slave-dir "/*"))))))
+
+;;; Marathon functions
 
 (defn install!
   [test node mesos-version marathon-version]
@@ -51,104 +152,41 @@
                       "keyserver.ubuntu.com"
                       "E56151BF")
     (debian/install {:mesos    mesos-version
-                     :marathon marathon-version})
+                     :marathon marathon-version
+                     :runit    runit-version})
     (c/exec :mkdir :-p "/var/run/mesos")
     (c/exec :mkdir :-p master-dir)
     (c/exec :mkdir :-p slave-dir)))
 
-;;; Mesos functions
-
-(defn start-master!
+(defn marathon-cmd
+  "Returns the command to run the marathon."
   [test node]
-  (when (some #{node} (take master-count (sort (:nodes test))))
-    (info node "Starting mesos master")
-    (c/su
-      (c/exec :start-stop-daemon
-              :--background
-              :--chdir master-dir
-              :--exec "/usr/bin/env"
-              :--make-pidfile
-              :--no-close
-              :--oknodo
-              :--pidfile master-pidfile
-              :--start
-              :--
-              "GLOG_v=1"
-              master-bin
-              (str "--hostname=" (name node))
-              (str "--log_dir=" log-dir)
-              (str "--offer_timeout=30secs")
-              (str "--quorum=" (util/majority master-count))
-              (str "--registry_fetch_timeout=120secs")
-              (str "--registry_store_timeout=5secs")
-              (str "--work_dir=" master-dir)
-              (str "--zk=" (zookeeper-uri test zk-namespace))
-              :>> (str log-dir "/master.stdout")
-              (c/lit "2>&1")))))
+  (clojure.string/join " "
+                       [marathon-bin
+                        (str "--hostname " node)
+                        (str "--master " (zookeeper-uri test zk-namespace))
+                        (str "--zk " (zookeeper-uri test zk-marathon-namespace))]))
 
-(defn start-slave!
+(defn create-marathon-supervised-service!
   [test node]
-  (when-not (some #{node} (take master-count (sort (:nodes test))))
-    (info node "Starting mesos slave")
-    (c/su
-      (c/exec :start-stop-daemon :--start
-              :--background
-              :--chdir slave-dir
-              :--exec slave-bin
-              :--make-pidfile
-              :--no-close
-              :--pidfile slave-pidfile
-              :--oknodo
-              :--
-              (str "--hostname=" (name node))
-              (str "--log_dir=" log-dir)
-              (str "--master=" (zookeeper-uri test zk-namespace))
-              (str "--recovery_timeout=30secs")
-              (str "--work_dir=" slave-dir)
-              :>> (str log-dir "/slave.stdout")
-              (c/lit "2>&1")))))
+  (create-supervised-service! "marathon"
+                              (marathon-cmd test node)))
 
-(defn stop-master!
-  [node]
-  (info node "Stopping mesos master")
-  (meh (cu/grepkill! :mesos-master))
-  (meh (c/exec :rm :-rf master-pidfile))
-  (meh (c/exec :rm :-rf
-               (c/lit (str log-dir "/*"))
-               (c/lit (str master-dir "/*")))))
-
-(defn stop-slave!
-  [node]
-  (info node "Stopping mesos slave")
-  (meh (cu/grepkill! :mesos-slave))
-  (meh (c/exec :rm :-rf slave-pidfile))
-  (meh (c/exec :rm :-rf
-               (c/lit (str log-dir "/*"))
-               (c/lit (str slave-dir "/*")))))
-
-;;; Marathon functions
+(defn marathon-node?
+  [test node]
+  (= node (first (sort (:nodes test)))))
 
 (defn start-marathon!
   [test node]
-  (when (= node (first (sort (:nodes test))))
+  (when (marathon-node? test node)
     (info "Start marathon")
     (c/su
-      (c/exec :start-stop-daemon :--start
-              :--background
-              :--exec marathon-bin
-              :--make-pidfile
-              :--no-close
-              :--pidfile marathon-pidfile
-              :--
-              (c/lit (str "--hostname " node))
-              (c/lit (str "--master " (zookeeper-uri test zk-namespace)))
-              (c/lit (str "--zk " (zookeeper-uri test zk-marathon-namespace)))
-              :>> (str log-dir "/marathon.stdout")
-              (c/lit "2>&1")))))
+      (create-marathon-supervised-service! test node))))
 
 (defn stop-marathon!
-  []
-  (cu/grepkill! "marathon"))
+  [test node]
+  (when (marathon-node? test node)
+    (stop-supervised-service! "marathon")))
 
 (defn marathon-base-url
   [test]
@@ -163,9 +201,9 @@
       (start-slave! test node)
       (start-marathon! test node))
     (teardown! [this test node]
-      (stop-slave! node)
-      (stop-master! node)
-      (stop-marathon!))
+      (stop-slave! test node)
+      (stop-master! test node)
+      (stop-marathon! test node))
     db/LogFiles
     (log-files [_ test node]
       (if (cu/exists? log-dir) (cu/ls-full log-dir) []))))


### PR DESCRIPTION
## What is the purpose of the change

*Use a process supervisor to automatically restart Mesos processes. This is needed because Mesos uses a "fail-fast" approach to error handling, e.g., the Mesos master will exit when it discovers it has been partitioned away from the Zookeeper quorum. Currently the some of the tests cannot pass because the Mesos processes exiting.*

cc: @igalshilman @cewood @tillrohrmann 

## Brief change log

  - *Use runit to supervise Mesos processes.*
  - *Make docker setup work.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Ran Mesos tests on docker.*
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** (in test code) / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
