### PR TITLE
[FLINK-10064] [table] Fix a typo in ExternalCatalogTable

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -88,7 +88,7 @@ class ExternalCatalogTable(
     * Returns whether this external table is declared as table sink.
     */
   def isTableSink: Boolean = {
-    isSource
+    isSink
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

Function **ExternalCatalogTable.IsTableSink** should return **isSink** not **isSource**, I guess it was a small typo.

## Brief change log

- ExternalCatalogTable.IsTableSink returns isSink instead of isSource

## Verifying this change

This change is a trivial typo fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
