### PR TITLE
[FLINK-10065] InstantiationUtil.deserializeObject(InputStream in, ClassLoader cl, boolean isFailureTolerant) will close the inputStream

### DIFF
--- a/.akconfig
+++ b/.akconfig
@@ -1,0 +1,3 @@
+{
+  "phabricator.uri" : "https://aone.alibaba-inc.com/"
+}

--- a/.akconfig
+++ b/.akconfig
@@ -1,3 +1,0 @@
-{
-  "phabricator.uri" : "https://aone.alibaba-inc.com/"
-}

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -495,9 +495,10 @@ public final class InstantiationUtil {
 
 		final ClassLoader old = Thread.currentThread().getContextClassLoader();
 		// not using resource try to avoid AutoClosable's close() on the given stream
-		try (ObjectInputStream oois = isFailureTolerant
+		try {
+			ObjectInputStream oois = isFailureTolerant
 				? new InstantiationUtil.FailureTolerantObjectInputStream(in, cl)
-				: new InstantiationUtil.ClassLoaderObjectInputStream(in, cl)) {
+				: new InstantiationUtil.ClassLoaderObjectInputStream(in, cl);
 			Thread.currentThread().setContextClassLoader(cl);
 			return (T) oois.readObject();
 		}


### PR DESCRIPTION
## What is the purpose of the change

fix auto close InputStram in InstantiationUtil.deserializeObject

## Verifying this change
This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
