### PR TITLE
[FLINK-10041] Extract iterators from RocksDBKeyedStateBackend (inner …

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayDataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayDataInputView.java
@@ -53,4 +53,8 @@ public class ByteArrayDataInputView extends DataInputViewStreamWrapper {
 	public void setData(@Nonnull byte[] buffer, int offset, int length) {
 		inStreamWithPos.setBuffer(buffer, offset, length);
 	}
+
+	public void setData(@Nonnull byte[] buffer) {
+		setData(buffer, 0, buffer.length);
+	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
@@ -20,8 +20,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -63,7 +61,8 @@ abstract class AbstractRocksDBAppendingState <K, N, IN, SV, OUT, S extends State
 			if (valueBytes == null) {
 				return null;
 			}
-			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(valueBytes)));
+			dataInputView.setData(valueBytes);
+			return valueSerializer.deserialize(dataInputView);
 		} catch (IOException | RocksDBException e) {
 			throw new FlinkRuntimeException("Error while retrieving data from RocksDB", e);
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -121,17 +119,15 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 			// merge the sources to the target
 			for (N source : sources) {
 				if (source != null) {
-					writeKeyWithGroupAndNamespace(
-							keyGroup, key, source,
-							keySerializationStream, keySerializationDataOutputView);
+					writeKeyWithGroupAndNamespace(keyGroup, key, source, dataOutputView);
 
-					final byte[] sourceKey = keySerializationStream.toByteArray();
+					final byte[] sourceKey = dataOutputView.toByteArray();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
 					if (valueBytes != null) {
-						ACC value = valueSerializer.deserialize(
-								new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(valueBytes)));
+						dataInputView.setData(valueBytes);
+						ACC value = valueSerializer.deserialize(dataInputView);
 
 						if (current != null) {
 							current = aggFunction.merge(current, value);
@@ -146,27 +142,25 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
 				// create the target full-binary-key
-				writeKeyWithGroupAndNamespace(
-						keyGroup, key, target,
-						keySerializationStream, keySerializationDataOutputView);
+				writeKeyWithGroupAndNamespace(keyGroup, key, target, dataOutputView);
 
-				final byte[] targetKey = keySerializationStream.toByteArray();
+				final byte[] targetKey = dataOutputView.toByteArray();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
 				if (targetValueBytes != null) {
 					// target also had a value, merge
-					ACC value = valueSerializer.deserialize(
-							new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(targetValueBytes)));
+					dataInputView.setData(targetValueBytes);
+					ACC value = valueSerializer.deserialize(dataInputView);
 
 					current = aggFunction.merge(current, value);
 				}
 
 				// serialize the resulting value
-				keySerializationStream.reset();
-				valueSerializer.serialize(current, keySerializationDataOutputView);
+				dataOutputView.reset();
+				valueSerializer.serialize(current, dataOutputView);
 
 				// write the resulting value
-				backend.db.put(columnFamily, writeOptions, targetKey, keySerializationStream.toByteArray());
+				backend.db.put(columnFamily, writeOptions, targetKey, dataOutputView.toByteArray());
 			}
 		}
 		catch (Exception e) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
@@ -18,8 +18,8 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
-import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.ByteArrayDataInputView;
+import org.apache.flink.core.memory.ByteArrayDataOutputView;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -41,13 +41,12 @@ public class RocksDBKeySerializationUtils {
 
 	public static <K> K readKey(
 		TypeSerializer<K> keySerializer,
-		ByteArrayInputStreamWithPos inputStream,
-		DataInputView inputView,
+		ByteArrayDataInputView inputView,
 		boolean ambiguousKeyPossible) throws IOException {
-		int beforeRead = inputStream.getPosition();
+		int beforeRead = inputView.getPosition();
 		K key = keySerializer.deserialize(inputView);
 		if (ambiguousKeyPossible) {
-			int length = inputStream.getPosition() - beforeRead;
+			int length = inputView.getPosition() - beforeRead;
 			readVariableIntBytes(inputView, length);
 		}
 		return key;
@@ -55,13 +54,12 @@ public class RocksDBKeySerializationUtils {
 
 	public static <N> N readNamespace(
 		TypeSerializer<N> namespaceSerializer,
-		ByteArrayInputStreamWithPos inputStream,
-		DataInputView inputView,
+		ByteArrayDataInputView inputView,
 		boolean ambiguousKeyPossible) throws IOException {
-		int beforeRead = inputStream.getPosition();
+		int beforeRead = inputView.getPosition();
 		N namespace = namespaceSerializer.deserialize(inputView);
 		if (ambiguousKeyPossible) {
-			int length = inputStream.getPosition() - beforeRead;
+			int length = inputView.getPosition() - beforeRead;
 			readVariableIntBytes(inputView, length);
 		}
 		return namespace;
@@ -70,17 +68,15 @@ public class RocksDBKeySerializationUtils {
 	public static <N> void writeNameSpace(
 		N namespace,
 		TypeSerializer<N> namespaceSerializer,
-		ByteArrayOutputStreamWithPos keySerializationStream,
-		DataOutputView keySerializationDataOutputView,
+		ByteArrayDataOutputView keySerializationDataOutputView,
 		boolean ambiguousKeyPossible) throws IOException {
 
-		int beforeWrite = keySerializationStream.getPosition();
+		int beforeWrite = keySerializationDataOutputView.getPosition();
 		namespaceSerializer.serialize(namespace, keySerializationDataOutputView);
 
 		if (ambiguousKeyPossible) {
 			//write length of namespace
-			writeLengthFrom(beforeWrite, keySerializationStream,
-				keySerializationDataOutputView);
+			writeLengthFrom(beforeWrite, keySerializationDataOutputView);
 		}
 	}
 
@@ -100,17 +96,15 @@ public class RocksDBKeySerializationUtils {
 	public static <K> void writeKey(
 		K key,
 		TypeSerializer<K> keySerializer,
-		ByteArrayOutputStreamWithPos keySerializationStream,
-		DataOutputView keySerializationDataOutputView,
+		ByteArrayDataOutputView keySerializationDataOutputView,
 		boolean ambiguousKeyPossible) throws IOException {
 		//write key
-		int beforeWrite = keySerializationStream.getPosition();
+		int beforeWrite = keySerializationDataOutputView.getPosition();
 		keySerializer.serialize(key, keySerializationDataOutputView);
 
 		if (ambiguousKeyPossible) {
 			//write size of key
-			writeLengthFrom(beforeWrite, keySerializationStream,
-				keySerializationDataOutputView);
+			writeLengthFrom(beforeWrite, keySerializationDataOutputView);
 		}
 	}
 
@@ -123,9 +117,8 @@ public class RocksDBKeySerializationUtils {
 
 	private static void writeLengthFrom(
 		int fromPosition,
-		ByteArrayOutputStreamWithPos keySerializationStream,
-		DataOutputView keySerializationDateDataOutputView) throws IOException {
-		int length = keySerializationStream.getPosition() - fromPosition;
+		ByteArrayDataOutputView keySerializationDateDataOutputView) throws IOException {
+		int length = keySerializationDateDataOutputView.getPosition() - fromPosition;
 		writeVariableIntBytes(length, keySerializationDateDataOutputView);
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * Utils for RocksDB state serialization and deserialization.
  */
-class RocksDBKeySerializationUtils {
+public class RocksDBKeySerializationUtils {
 
 	static int readKeyGroup(int keyGroupPrefixBytes, DataInputView inputView) throws IOException {
 		int keyGroup = 0;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -45,7 +45,6 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ByteArrayDataInputView;
 import org.apache.flink.core.memory.ByteArrayDataOutputView;
-import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
@@ -363,17 +362,16 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			(RegisteredKeyValueStateBackendMetaInfo<N, ?>) columnInfo.f1;
 
 		final TypeSerializer<N> namespaceSerializer = registeredKeyValueStateBackendMetaInfo.getNamespaceSerializer();
-		final ByteArrayOutputStreamWithPos namespaceOutputStream = new ByteArrayOutputStreamWithPos(8);
+		final ByteArrayDataOutputView namespaceOutputView = new ByteArrayDataOutputView(8);
 		boolean ambiguousKeyPossible = RocksDBKeySerializationUtils.isAmbiguousKeyPossible(keySerializer, namespaceSerializer);
 		final byte[] nameSpaceBytes;
 		try {
 			RocksDBKeySerializationUtils.writeNameSpace(
 				namespace,
 				namespaceSerializer,
-				namespaceOutputStream,
-				new DataOutputViewStreamWrapper(namespaceOutputStream),
+				namespaceOutputView,
 				ambiguousKeyPossible);
-			nameSpaceBytes = namespaceOutputStream.toByteArray();
+			nameSpaceBytes = namespaceOutputView.toByteArray();
 		} catch (IOException ex) {
 			throw new FlinkRuntimeException("Failed to get keys from RocksDB state backend.", ex);
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -25,15 +25,12 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.ColumnFamilyHandle;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -87,7 +84,7 @@ class RocksDBReducingState<K, N, V>
 	}
 
 	@Override
-	public V get() throws IOException {
+	public V get() {
 		return getInternal();
 	}
 
@@ -100,7 +97,7 @@ class RocksDBReducingState<K, N, V>
 	}
 
 	@Override
-	public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+	public void mergeNamespaces(N target, Collection<N> sources) {
 		if (sources == null || sources.isEmpty()) {
 			return;
 		}
@@ -116,17 +113,15 @@ class RocksDBReducingState<K, N, V>
 			for (N source : sources) {
 				if (source != null) {
 
-					writeKeyWithGroupAndNamespace(
-							keyGroup, key, source,
-							keySerializationStream, keySerializationDataOutputView);
+					writeKeyWithGroupAndNamespace(keyGroup, key, source, dataOutputView);
 
-					final byte[] sourceKey = keySerializationStream.toByteArray();
+					final byte[] sourceKey = dataOutputView.toByteArray();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
 					if (valueBytes != null) {
-						V value = valueSerializer.deserialize(
-								new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(valueBytes)));
+						dataInputView.setData(valueBytes);
+						V value = valueSerializer.deserialize(dataInputView);
 
 						if (current != null) {
 							current = reduceFunction.reduce(current, value);
@@ -141,27 +136,25 @@ class RocksDBReducingState<K, N, V>
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
 				// create the target full-binary-key
-				writeKeyWithGroupAndNamespace(
-						keyGroup, key, target,
-						keySerializationStream, keySerializationDataOutputView);
+				writeKeyWithGroupAndNamespace(keyGroup, key, target, dataOutputView);
 
-				final byte[] targetKey = keySerializationStream.toByteArray();
+				final byte[] targetKey = dataOutputView.toByteArray();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
 				if (targetValueBytes != null) {
+					dataInputView.setData(targetValueBytes);
 					// target also had a value, merge
-					V value = valueSerializer.deserialize(
-							new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(targetValueBytes)));
+					V value = valueSerializer.deserialize(dataInputView);
 
 					current = reduceFunction.reduce(current, value);
 				}
 
 				// serialize the resulting value
-				keySerializationStream.reset();
-				valueSerializer.serialize(current, keySerializationDataOutputView);
+				dataOutputView.reset();
+				valueSerializer.serialize(current, dataOutputView);
 
 				// write the resulting value
-				backend.db.put(columnFamily, writeOptions, targetKey, keySerializationStream.toByteArray());
+				backend.db.put(columnFamily, writeOptions, targetKey, dataOutputView.toByteArray());
 			}
 		}
 		catch (Exception e) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -23,8 +23,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -32,7 +30,6 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 /**
@@ -84,12 +81,13 @@ class RocksDBValueState<K, N, V>
 	public V value() {
 		try {
 			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = keySerializationStream.toByteArray();
+			byte[] key = dataOutputView.toByteArray();
 			byte[] valueBytes = backend.db.get(columnFamily, key);
 			if (valueBytes == null) {
 				return getDefaultValue();
 			}
-			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
+			dataInputView.setData(valueBytes);
+			return valueSerializer.deserialize(dataInputView);
 		} catch (IOException | RocksDBException e) {
 			throw new FlinkRuntimeException("Error while retrieving data from RocksDB.", e);
 		}
@@ -101,13 +99,13 @@ class RocksDBValueState<K, N, V>
 			clear();
 			return;
 		}
-		DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(keySerializationStream);
+
 		try {
 			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = keySerializationStream.toByteArray();
-			keySerializationStream.reset();
-			valueSerializer.serialize(value, out);
-			backend.db.put(columnFamily, writeOptions, key, keySerializationStream.toByteArray());
+			byte[] key = dataOutputView.toByteArray();
+			dataOutputView.reset();
+			valueSerializer.serialize(value, dataOutputView);
+			backend.db.put(columnFamily, writeOptions, key, dataOutputView.toByteArray());
 		} catch (Exception e) {
 			throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksSingleStateIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksSingleStateIterator.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 class RocksSingleStateIterator implements AutoCloseable {
 
 	/**
-	 * @param iterator  The #RocksIterator to wrap .
+	 * @param iterator underlying {@link RocksIteratorWrapper}
 	 * @param kvStateId Id of the K/V state to which this iterator belongs.
 	 */
 	RocksSingleStateIterator(@Nonnull RocksIteratorWrapper iterator, int kvStateId) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksSingleStateIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksSingleStateIterator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.iterator;
+
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Wraps a RocksDB iterator to cache it's current key and assigns an id for the key/value state to the iterator.
+ * Used by {@link RocksStatesPerKeyGroupMergeIterator}.
+ */
+class RocksSingleStateIterator implements AutoCloseable {
+
+	/**
+	 * @param iterator  The #RocksIterator to wrap .
+	 * @param kvStateId Id of the K/V state to which this iterator belongs.
+	 */
+	RocksSingleStateIterator(@Nonnull RocksIteratorWrapper iterator, int kvStateId) {
+		this.iterator = iterator;
+		this.currentKey = iterator.key();
+		this.kvStateId = kvStateId;
+	}
+
+	@Nonnull
+	private final RocksIteratorWrapper iterator;
+	private byte[] currentKey;
+	private final int kvStateId;
+
+	public byte[] getCurrentKey() {
+		return currentKey;
+	}
+
+	public void setCurrentKey(byte[] currentKey) {
+		this.currentKey = currentKey;
+	}
+
+	@Nonnull
+	public RocksIteratorWrapper getIterator() {
+		return iterator;
+	}
+
+	public int getKvStateId() {
+		return kvStateId;
+	}
+
+	@Override
+	public void close() {
+		IOUtils.closeQuietly(iterator);
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStateKeysIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStateKeysIterator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.iterator;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.contrib.streaming.state.RocksDBKeySerializationUtils;
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * Adapter class to bridge between {@link RocksIteratorWrapper} and {@link Iterator} to iterate over the keys. This class
+ * is not thread safe.
+ *
+ * @param <K> the type of the iterated objects, which are keys in RocksDB.
+ */
+public class RocksStateKeysIterator<K> implements Iterator<K>, AutoCloseable {
+
+	@Nonnull
+	private final RocksIteratorWrapper iterator;
+
+	@Nonnull
+	private final String state;
+
+	@Nonnull
+	private final TypeSerializer<K> keySerializer;
+
+	@Nonnull
+	private final byte[] namespaceBytes;
+
+	private final boolean ambiguousKeyPossible;
+	private final int keyGroupPrefixBytes;
+	private K nextKey;
+	private K previousKey;
+
+	public RocksStateKeysIterator(
+		@Nonnull RocksIteratorWrapper iterator,
+		@Nonnull String state,
+		@Nonnull TypeSerializer<K> keySerializer,
+		int keyGroupPrefixBytes,
+		boolean ambiguousKeyPossible,
+		@Nonnull byte[] namespaceBytes) {
+		this.iterator = iterator;
+		this.state = state;
+		this.keySerializer = keySerializer;
+		this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+		this.namespaceBytes = namespaceBytes;
+		this.nextKey = null;
+		this.previousKey = null;
+		this.ambiguousKeyPossible = ambiguousKeyPossible;
+	}
+
+	@Override
+	public boolean hasNext() {
+		try {
+			while (nextKey == null && iterator.isValid()) {
+
+				byte[] key = iterator.key();
+
+				ByteArrayInputStreamWithPos inputStream =
+					new ByteArrayInputStreamWithPos(key, keyGroupPrefixBytes, key.length - keyGroupPrefixBytes);
+
+				DataInputViewStreamWrapper dataInput = new DataInputViewStreamWrapper(inputStream);
+
+				K value = RocksDBKeySerializationUtils.readKey(
+					keySerializer,
+					inputStream,
+					dataInput,
+					ambiguousKeyPossible);
+
+				int namespaceByteStartPos = inputStream.getPosition();
+
+				if (isMatchingNameSpace(key, namespaceByteStartPos) && !Objects.equals(previousKey, value)) {
+					previousKey = value;
+					nextKey = value;
+				}
+				iterator.next();
+			}
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Failed to access state [" + state + "]", e);
+		}
+		return nextKey != null;
+	}
+
+	@Override
+	public K next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException("Failed to access state [" + state + "]");
+		}
+
+		K tmpKey = nextKey;
+		nextKey = null;
+		return tmpKey;
+	}
+
+	private boolean isMatchingNameSpace(@Nonnull byte[] key, int beginPos) {
+		final int namespaceBytesLength = namespaceBytes.length;
+		final int basicLength = namespaceBytesLength + beginPos;
+		if (key.length >= basicLength) {
+			for (int i = 0; i < namespaceBytesLength; ++i) {
+				if (key[beginPos + i] != namespaceBytes[i]) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void close() {
+		iterator.close();
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStatesPerKeyGroupMergeIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksStatesPerKeyGroupMergeIterator.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.iterator;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/**
+ * Iterator that merges multiple RocksDB iterators to partition all states into contiguous key-groups.
+ * The resulting iteration sequence is ordered by (key-group, kv-state).
+ */
+public class RocksStatesPerKeyGroupMergeIterator implements AutoCloseable {
+
+	private final PriorityQueue<RocksSingleStateIterator> heap;
+	private final int keyGroupPrefixByteCount;
+	private boolean newKeyGroup;
+	private boolean newKVState;
+	private boolean valid;
+	private RocksSingleStateIterator currentSubIterator;
+
+	private static final List<Comparator<RocksSingleStateIterator>> COMPARATORS;
+
+	static {
+		int maxBytes = 2;
+		COMPARATORS = new ArrayList<>(maxBytes);
+		for (int i = 0; i < maxBytes; ++i) {
+			final int currentBytes = i + 1;
+			COMPARATORS.add((o1, o2) -> {
+				int arrayCmpRes = compareKeyGroupsForByteArrays(
+					o1.getCurrentKey(), o2.getCurrentKey(), currentBytes);
+				return arrayCmpRes == 0 ? o1.getKvStateId() - o2.getKvStateId() : arrayCmpRes;
+			});
+		}
+	}
+
+	public RocksStatesPerKeyGroupMergeIterator(
+		List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators,
+		final int keyGroupPrefixByteCount) {
+		Preconditions.checkNotNull(kvStateIterators);
+		Preconditions.checkArgument(keyGroupPrefixByteCount >= 1);
+
+		this.keyGroupPrefixByteCount = keyGroupPrefixByteCount;
+
+		Comparator<RocksSingleStateIterator> iteratorComparator = COMPARATORS.get(keyGroupPrefixByteCount - 1);
+
+		if (kvStateIterators.size() > 0) {
+			PriorityQueue<RocksSingleStateIterator> iteratorPriorityQueue =
+				new PriorityQueue<>(kvStateIterators.size(), iteratorComparator);
+
+			for (Tuple2<RocksIteratorWrapper, Integer> rocksIteratorWithKVStateId : kvStateIterators) {
+				final RocksIteratorWrapper rocksIterator = rocksIteratorWithKVStateId.f0;
+				rocksIterator.seekToFirst();
+				if (rocksIterator.isValid()) {
+					iteratorPriorityQueue.offer(new RocksSingleStateIterator(rocksIterator, rocksIteratorWithKVStateId.f1));
+				} else {
+					IOUtils.closeQuietly(rocksIterator);
+				}
+			}
+
+			kvStateIterators.clear();
+
+			this.heap = iteratorPriorityQueue;
+			this.valid = !heap.isEmpty();
+			this.currentSubIterator = heap.poll();
+		} else {
+			// creating a PriorityQueue of size 0 results in an exception.
+			this.heap = null;
+			this.valid = false;
+		}
+
+		this.newKeyGroup = true;
+		this.newKVState = true;
+	}
+
+	/**
+	 * Advance the iterator. Should only be called if {@link #isValid()} returned true. Valid can only chance after
+	 * calls to {@link #next()}.
+	 */
+	public void next() {
+		newKeyGroup = false;
+		newKVState = false;
+
+		final RocksIteratorWrapper rocksIterator = currentSubIterator.getIterator();
+		rocksIterator.next();
+
+		byte[] oldKey = currentSubIterator.getCurrentKey();
+		if (rocksIterator.isValid()) {
+
+			currentSubIterator.setCurrentKey(rocksIterator.key());
+
+			if (isDifferentKeyGroup(oldKey, currentSubIterator.getCurrentKey())) {
+				heap.offer(currentSubIterator);
+				currentSubIterator = heap.remove();
+				newKVState = currentSubIterator.getIterator() != rocksIterator;
+				detectNewKeyGroup(oldKey);
+			}
+		} else {
+			IOUtils.closeQuietly(rocksIterator);
+
+			if (heap.isEmpty()) {
+				currentSubIterator = null;
+				valid = false;
+			} else {
+				currentSubIterator = heap.remove();
+				newKVState = true;
+				detectNewKeyGroup(oldKey);
+			}
+		}
+	}
+
+	private boolean isDifferentKeyGroup(byte[] a, byte[] b) {
+		return 0 != compareKeyGroupsForByteArrays(a, b, keyGroupPrefixByteCount);
+	}
+
+	private void detectNewKeyGroup(byte[] oldKey) {
+		if (isDifferentKeyGroup(oldKey, currentSubIterator.getCurrentKey())) {
+			newKeyGroup = true;
+		}
+	}
+
+	/**
+	 * @return key-group for the current key
+	 */
+	public int keyGroup() {
+		final byte[] currentKey = currentSubIterator.getCurrentKey();
+		int result = 0;
+		//big endian decode
+		for (int i = 0; i < keyGroupPrefixByteCount; ++i) {
+			result <<= 8;
+			result |= (currentKey[i] & 0xFF);
+		}
+		return result;
+	}
+
+	public byte[] key() {
+		return currentSubIterator.getCurrentKey();
+	}
+
+	public byte[] value() {
+		return currentSubIterator.getIterator().value();
+	}
+
+	/**
+	 * @return Id of K/V state to which the current key belongs.
+	 */
+	public int kvStateId() {
+		return currentSubIterator.getKvStateId();
+	}
+
+	/**
+	 * Indicates if current key starts a new k/v-state, i.e. belong to a different k/v-state than it's predecessor.
+	 * @return true iff the current key belong to a different k/v-state than it's predecessor.
+	 */
+	public boolean isNewKeyValueState() {
+		return newKVState;
+	}
+
+	/**
+	 * Indicates if current key starts a new key-group, i.e. belong to a different key-group than it's predecessor.
+	 * @return true iff the current key belong to a different key-group than it's predecessor.
+	 */
+	public boolean isNewKeyGroup() {
+		return newKeyGroup;
+	}
+
+	/**
+	 * Check if the iterator is still valid. Getters like {@link #key()}, {@link #value()}, etc. as well as
+	 * {@link #next()} should only be called if valid returned true. Should be checked after each call to
+	 * {@link #next()} before accessing iterator state.
+	 * @return True iff this iterator is valid.
+	 */
+	public boolean isValid() {
+		return valid;
+	}
+
+	private static int compareKeyGroupsForByteArrays(byte[] a, byte[] b, int len) {
+		for (int i = 0; i < len; ++i) {
+			int diff = (a[i] & 0xFF) - (b[i] & 0xFF);
+			if (diff != 0) {
+				return diff;
+			}
+		}
+		return 0;
+	}
+
+	@Override
+	public void close() {
+		IOUtils.closeQuietly(currentSubIterator);
+		currentSubIterator = null;
+
+		IOUtils.closeAllQuietly(heap);
+		heap.clear();
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
@@ -26,7 +26,7 @@ import org.rocksdb.RocksIterator;
 import javax.annotation.Nonnull;
 
 /**
- * Wrapper around {@link RocksIteratorWrapper} that applies a given {@link StateSnapshotTransformer} to the elements
+ * Wrapper around {@link RocksIterator} that applies a given {@link StateSnapshotTransformer} to the elements
  * during the iteration.
  */
 public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.iterator;
+
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+
+import org.rocksdb.RocksIterator;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Wrapper around {@link RocksIteratorWrapper} that applies a given {@link StateSnapshotTransformer} to the elements
+ * during the iteration.
+ */
+public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {
+
+	@Nonnull
+	private final StateSnapshotTransformer<byte[]> stateSnapshotTransformer;
+	private byte[] current;
+
+	public RocksTransformingIteratorWrapper(
+		@Nonnull RocksIterator iterator,
+		@Nonnull StateSnapshotTransformer<byte[]> stateSnapshotTransformer) {
+		super(iterator);
+		this.stateSnapshotTransformer = stateSnapshotTransformer;
+	}
+
+	@Override
+	public void seekToFirst() {
+		super.seekToFirst();
+		filterOrTransform(super::next);
+	}
+
+	@Override
+	public void seekToLast() {
+		super.seekToLast();
+		filterOrTransform(super::prev);
+	}
+
+	@Override
+	public void next() {
+		super.next();
+		filterOrTransform(super::next);
+	}
+
+	@Override
+	public void prev() {
+		super.prev();
+		filterOrTransform(super::prev);
+	}
+
+	private void filterOrTransform(@Nonnull Runnable advance) {
+		while (isValid() && (current = stateSnapshotTransformer.filterOrTransform(super.value())) == null) {
+			advance.run();
+		}
+	}
+
+	@Override
+	public byte[] value() {
+		if (!isValid()) {
+			throw new IllegalStateException("value() method cannot be called if isValid() is false");
+		}
+		return current;
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -18,9 +18,7 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
-import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ByteArrayDataOutputView;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.util.TestLogger;
@@ -114,35 +112,30 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
 			int currentGroupRangeStart = currentGroupRange.getStartKeyGroup();
 			int currentGroupRangeEnd = currentGroupRange.getEndKeyGroup();
 
+			ByteArrayDataOutputView outputView = new ByteArrayDataOutputView(32);
 			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
-				ByteArrayOutputStreamWithPos outputStreamWithPos = new ByteArrayOutputStreamWithPos(32);
-				DataOutputView outputView = new DataOutputViewStreamWrapper(outputStreamWithPos);
 				for (int j = 0; j < 100; ++j) {
-					outputStreamWithPos.reset();
+					outputView.reset();
 					RocksDBKeySerializationUtils.writeKeyGroup(i, keyGroupPrefixBytes, outputView);
 					RocksDBKeySerializationUtils.writeKey(
 						j,
 						IntSerializer.INSTANCE,
-						outputStreamWithPos,
-						new DataOutputViewStreamWrapper(outputStreamWithPos),
+						outputView,
 						false);
-					rocksDB.put(columnFamilyHandle, outputStreamWithPos.toByteArray(), String.valueOf(j).getBytes());
+					rocksDB.put(columnFamilyHandle, outputView.toByteArray(), String.valueOf(j).getBytes());
 				}
 			}
 
 			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
-				ByteArrayOutputStreamWithPos outputStreamWithPos = new ByteArrayOutputStreamWithPos(32);
-				DataOutputView outputView = new DataOutputViewStreamWrapper(outputStreamWithPos);
 				for (int j = 0; j < 100; ++j) {
-					outputStreamWithPos.reset();
+					outputView.reset();
 					RocksDBKeySerializationUtils.writeKeyGroup(i, keyGroupPrefixBytes, outputView);
 					RocksDBKeySerializationUtils.writeKey(
 						j,
 						IntSerializer.INSTANCE,
-						outputStreamWithPos,
-						new DataOutputViewStreamWrapper(outputStreamWithPos),
+						outputView,
 						false);
-					byte[] value = rocksDB.get(columnFamilyHandle, outputStreamWithPos.toByteArray());
+					byte[] value = rocksDB.get(columnFamilyHandle, outputView.toByteArray());
 					Assert.assertEquals(String.valueOf(j), new String(value));
 				}
 			}
@@ -155,19 +148,15 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
 				keyGroupPrefixBytes);
 
 			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
-				ByteArrayOutputStreamWithPos outputStreamWithPos = new ByteArrayOutputStreamWithPos(32);
-				DataOutputView outputView = new DataOutputViewStreamWrapper(outputStreamWithPos);
 				for (int j = 0; j < 100; ++j) {
-					outputStreamWithPos.reset();
+					outputView.reset();
 					RocksDBKeySerializationUtils.writeKeyGroup(i, keyGroupPrefixBytes, outputView);
 					RocksDBKeySerializationUtils.writeKey(
 						j,
 						IntSerializer.INSTANCE,
-						outputStreamWithPos,
-						new DataOutputViewStreamWrapper(outputStreamWithPos),
+						outputView,
 						false);
-					byte[] value = rocksDB.get(
-						columnFamilyHandle, outputStreamWithPos.toByteArray());
+					byte[] value = rocksDB.get(columnFamilyHandle, outputView.toByteArray());
 					if (targetGroupRange.contains(i)) {
 						Assert.assertEquals(String.valueOf(j), new String(value));
 					} else {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtilsTest.java
@@ -19,6 +19,8 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.memory.ByteArrayDataInputView;
+import org.apache.flink.core.memory.ByteArrayDataOutputView;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -61,39 +63,39 @@ public class RocksDBKeySerializationUtilsTest {
 
 	@Test
 	public void testKeySerializationAndDeserialization() throws Exception {
-		ByteArrayOutputStreamWithPos outputStream = new ByteArrayOutputStreamWithPos(8);
-		DataOutputView outputView = new DataOutputViewStreamWrapper(outputStream);
+		final ByteArrayDataOutputView outputView = new ByteArrayDataOutputView(8);
+		final ByteArrayDataInputView inputView = new ByteArrayDataInputView();
 
 		// test for key
 		for (int orgKey = 0; orgKey < 100; ++orgKey) {
-			outputStream.reset();
-			RocksDBKeySerializationUtils.writeKey(orgKey, IntSerializer.INSTANCE, outputStream, outputView, false);
-			ByteArrayInputStreamWithPos inputStream = new ByteArrayInputStreamWithPos(outputStream.toByteArray());
-			int deserializedKey = RocksDBKeySerializationUtils.readKey(IntSerializer.INSTANCE, inputStream, new DataInputViewStreamWrapper(inputStream), false);
+			outputView.reset();
+			RocksDBKeySerializationUtils.writeKey(orgKey, IntSerializer.INSTANCE, outputView, false);
+			inputView.setData(outputView.toByteArray());
+			int deserializedKey = RocksDBKeySerializationUtils.readKey(IntSerializer.INSTANCE, inputView, false);
 			Assert.assertEquals(orgKey, deserializedKey);
 
-			RocksDBKeySerializationUtils.writeKey(orgKey, IntSerializer.INSTANCE, outputStream, outputView, true);
-			inputStream = new ByteArrayInputStreamWithPos(outputStream.toByteArray());
-			deserializedKey = RocksDBKeySerializationUtils.readKey(IntSerializer.INSTANCE, inputStream, new DataInputViewStreamWrapper(inputStream), true);
+			RocksDBKeySerializationUtils.writeKey(orgKey, IntSerializer.INSTANCE, outputView, true);
+			inputView.setData(outputView.toByteArray());
+			deserializedKey = RocksDBKeySerializationUtils.readKey(IntSerializer.INSTANCE, inputView, true);
 			Assert.assertEquals(orgKey, deserializedKey);
 		}
 	}
 
 	@Test
 	public void testNamespaceSerializationAndDeserialization() throws Exception {
-		ByteArrayOutputStreamWithPos outputStream = new ByteArrayOutputStreamWithPos(8);
-		DataOutputView outputView = new DataOutputViewStreamWrapper(outputStream);
+		final ByteArrayDataOutputView outputView = new ByteArrayDataOutputView(8);
+		final ByteArrayDataInputView inputView = new ByteArrayDataInputView();
 
 		for (int orgNamespace = 0; orgNamespace < 100; ++orgNamespace) {
-			outputStream.reset();
-			RocksDBKeySerializationUtils.writeNameSpace(orgNamespace, IntSerializer.INSTANCE, outputStream, outputView, false);
-			ByteArrayInputStreamWithPos inputStream = new ByteArrayInputStreamWithPos(outputStream.toByteArray());
-			int deserializedNamepsace = RocksDBKeySerializationUtils.readNamespace(IntSerializer.INSTANCE, inputStream, new DataInputViewStreamWrapper(inputStream), false);
+			outputView.reset();
+			RocksDBKeySerializationUtils.writeNameSpace(orgNamespace, IntSerializer.INSTANCE, outputView, false);
+			inputView.setData(outputView.toByteArray());
+			int deserializedNamepsace = RocksDBKeySerializationUtils.readNamespace(IntSerializer.INSTANCE, inputView, false);
 			Assert.assertEquals(orgNamespace, deserializedNamepsace);
 
-			RocksDBKeySerializationUtils.writeNameSpace(orgNamespace, IntSerializer.INSTANCE, outputStream, outputView, true);
-			inputStream = new ByteArrayInputStreamWithPos(outputStream.toByteArray());
-			deserializedNamepsace = RocksDBKeySerializationUtils.readNamespace(IntSerializer.INSTANCE, inputStream, new DataInputViewStreamWrapper(inputStream), true);
+			RocksDBKeySerializationUtils.writeNameSpace(orgNamespace, IntSerializer.INSTANCE, outputView, true);
+			inputView.setData(outputView.toByteArray());
+			deserializedNamepsace = RocksDBKeySerializationUtils.readNamespace(IntSerializer.INSTANCE, inputView, true);
 			Assert.assertEquals(orgNamespace, deserializedNamepsace);
 		}
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysIteratorTest.java
@@ -24,8 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.contrib.streaming.state.iterator.RocksStateKeysIterator;
-import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ByteArrayDataOutputView;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -106,13 +105,12 @@ public class RocksDBRocksStateKeysIteratorTest {
 				testState.update(String.valueOf(i));
 			}
 
-			ByteArrayOutputStreamWithPos outputStream = new ByteArrayOutputStreamWithPos(8);
+			ByteArrayDataOutputView outputStream = new ByteArrayDataOutputView(8);
 			boolean ambiguousKeyPossible = RocksDBKeySerializationUtils.isAmbiguousKeyPossible(keySerializer, namespaceSerializer);
 			RocksDBKeySerializationUtils.writeNameSpace(
 				namespace,
 				namespaceSerializer,
 				outputStream,
-				new DataOutputViewStreamWrapper(outputStream),
 				ambiguousKeyPossible);
 
 			byte[] nameSpaceBytes = outputStream.toByteArray();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysIteratorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.contrib.streaming.state.iterator.RocksStateKeysIterator;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.execution.Environment;
@@ -47,7 +48,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the RocksIteratorWrapper.
  */
-public class RocksDBRocksIteratorForKeysWrapperTest {
+public class RocksDBRocksStateKeysIteratorTest {
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
@@ -119,8 +120,8 @@ public class RocksDBRocksIteratorForKeysWrapperTest {
 			try (
 				ColumnFamilyHandle handle = keyedStateBackend.getColumnFamilyHandle(testStateName);
 				RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(keyedStateBackend.db, handle);
-				RocksDBKeyedStateBackend.RocksIteratorForKeysWrapper<K> iteratorWrapper =
-					new RocksDBKeyedStateBackend.RocksIteratorForKeysWrapper<>(
+				RocksStateKeysIterator<K> iteratorWrapper =
+					new RocksStateKeysIterator<>(
 						iterator,
 						testStateName,
 						keySerializer,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.contrib.streaming.state.iterator.RocksStatesPerKeyGroupMergeIterator;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.util.IOUtils;
 
@@ -39,9 +40,9 @@ import java.util.List;
 import java.util.Random;
 
 /**
- * Tests for the RocksDBMergeIterator.
+ * Tests for the RocksStatesPerKeyGroupMergeIterator.
  */
-public class RocksDBMergeIteratorTest {
+public class RocksKeyGroupsRocksSingleStateIteratorTest {
 
 	private static final int NUM_KEY_VAL_STATES = 50;
 	private static final int MAX_NUM_KEYS = 20;
@@ -51,8 +52,8 @@ public class RocksDBMergeIteratorTest {
 
 	@Test
 	public void testEmptyMergeIterator() throws Exception {
-		RocksDBKeyedStateBackend.RocksDBMergeIterator emptyIterator =
-				new RocksDBKeyedStateBackend.RocksDBMergeIterator(Collections.emptyList(), 2);
+		RocksStatesPerKeyGroupMergeIterator emptyIterator =
+				new RocksStatesPerKeyGroupMergeIterator(Collections.emptyList(), 2);
 		Assert.assertFalse(emptyIterator.isValid());
 	}
 
@@ -111,7 +112,7 @@ public class RocksDBMergeIteratorTest {
 				++id;
 			}
 
-			try (RocksDBKeyedStateBackend.RocksDBMergeIterator mergeIterator = new RocksDBKeyedStateBackend.RocksDBMergeIterator(
+			try (RocksStatesPerKeyGroupMergeIterator mergeIterator = new RocksStatesPerKeyGroupMergeIterator(
 				rocksIteratorsWithKVStateId,
 				maxParallelism <= Byte.MAX_VALUE ? 1 : 2)) {
 


### PR DESCRIPTION
## What is the purpose of the change

`RocksDBKeyedStateBackend` has grown into a huge class with many inner classes. This PR is the first in a series of cleanups/refactoring to decompose the backend into smaller entities.

## Brief change log

Refactored all iterators into their own class files.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
