### PR TITLE
[FLINK-10070][build] Downgrade git-commit-id-plugin

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -593,7 +593,6 @@ under the License.
 				<!-- Description: https://github.com/ktoso/maven-git-commit-id-plugin -->
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.1.5</version>
 				<executions>
 					<execution>
 						<goals>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -464,7 +464,6 @@ under the License.
 					Used to show the git ref when starting the jobManager. -->
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.1.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -478,9 +477,6 @@ under the License.
 					<skipPoms>false</skipPoms>
 					<failOnNoGitDirectory>false</failOnNoGitDirectory>
 					<generateGitPropertiesFilename>src/main/resources/.version.properties</generateGitPropertiesFilename>
-					<includeOnlyProperties>
-						<includeOnlyProperty>git.commit.*</includeOnlyProperty>
-					</includeOnlyProperties>
 					<gitDescribe>
 						<!-- don't generate the describe property -->
 						<skip>true</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -1426,6 +1426,20 @@ under the License.
 					<version>3.0.0</version>
 				</plugin>
 
+				<plugin>
+					<groupId>pl.project13.maven</groupId>
+					<artifactId>git-commit-id-plugin</artifactId>
+					<!-- Don't use 2.1.14 as it is incompatible with various maven versions --> 
+					<version>2.1.10</version>
+					<configuration>
+						<excludeProperties>
+							<excludeProperty>git.build.*</excludeProperty>
+							<excludeProperty>git.branch.*</excludeProperty>
+							<excludeProperty>git.remote.*</excludeProperty>
+						</excludeProperties>
+					</configuration>
+				</plugin>
+
 				<!-- Disable certain plugins in Eclipse -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
## What is the purpose of the change

This PR downgrades the `git-commit-id-plugin` version to 2.1.10 since 2.1.14 is incompatible with various maven versions.

I did not pick 2.1.9 since it has an issue excluding a specific property (git.build.time), and 2.2.4 is the latest release so I'm a bit wary using that.

The configuration was inverted to exclude unnecessary properties instead, as inclusions were only added in 2.1.14 .

Additionally the version and exclusions is now defined in the root `pluginManagement` section to also cover `flink-dist`.

## Verifying this change

Manually verified with maven 3.5.2 and 3.0.5.

Run `mvn process-resources -Dfast` in flink-runtime/flink-dist and ensure that only `git.commit.*` properties are included.

@twalthr @StephanEwen 

