### PR TITLE
[Flink-10079] [table] Support external sink table in the INSERT INTO clause 

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -107,7 +107,7 @@ abstract class BatchTableEnvironment(
       // check for proper batch table source
       case batchTableSource: BatchTableSource[_] =>
         // check if a table (source or sink) is registered
-        Option(getTable(name)) match {
+        getTable(name) match {
 
           // table source and/or sink is registered
           case Some(table: TableSourceSinkTable[_, _]) => table.tableSourceTable match {
@@ -249,7 +249,7 @@ abstract class BatchTableEnvironment(
       case _: BatchTableSink[_] =>
 
         // check if a table (source or sink) is registered
-        Option(getTable(name)) match {
+        getTable(name) match {
 
           // table source and/or sink is registered
           case Some(table: TableSourceSinkTable[_, _]) => table.tableSinkTable match {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -126,7 +126,7 @@ abstract class StreamTableEnvironment(
         }
 
         // register
-        Option(getTable(name)) match {
+        getTable(name) match {
 
           // check if a table (source or sink) is registered
           case Some(table: TableSourceSinkTable[_, _]) => table.tableSourceTable match {
@@ -273,7 +273,7 @@ abstract class StreamTableEnvironment(
       case _: StreamTableSink[_] =>
 
         // check if a table (source or sink) is registered
-        Option(getTable(name)) match {
+        getTable(name) match {
 
           // table source and/or sink is registered
           case Some(table: TableSourceSinkTable[_, _]) => table.tableSinkTable match {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -28,7 +28,6 @@ import org.apache.calcite.plan.RelOptPlanner.CannotPlanException
 import org.apache.calcite.plan.hep.{HepMatchOrder, HepPlanner, HepProgramBuilder}
 import org.apache.calcite.plan.{RelOptPlanner, RelOptUtil, RelTraitSet}
 import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.schema.SchemaPlus
 import org.apache.calcite.schema.impl.AbstractTable
 import org.apache.calcite.sql._
@@ -56,7 +55,7 @@ import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, Tabl
 import org.apache.flink.table.plan.cost.DataSetCostFactory
 import org.apache.flink.table.plan.logical.{CatalogNode, LogicalRelNode}
 import org.apache.flink.table.plan.rules.FlinkRuleSets
-import org.apache.flink.table.plan.schema.{RelTable, RowSchema, TableSourceSinkTable}
+import org.apache.flink.table.plan.schema.{RelTable, RowSchema, TableSinkTable, TableSourceSinkTable}
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
@@ -749,44 +748,48 @@ abstract class TableEnvironment(val config: TableConfig) {
     // check that sink table exists
     if (null == sinkTableName) throw TableException("Name of TableSink must not be null.")
     if (sinkTableName.isEmpty) throw TableException("Name of TableSink must not be empty.")
-    if (!isRegistered(sinkTableName)) {
-      throw TableException(s"No table was registered under the name $sinkTableName.")
-    }
 
     getTable(sinkTableName) match {
 
       // check for registered table that wraps a sink
-      case s: TableSourceSinkTable[_, _] if s.tableSinkTable.isDefined =>
-        val tableSink = s.tableSinkTable.get.tableSink
-        // validate schema of source table and table sink
-        val srcFieldTypes = table.getSchema.getTypes
-        val sinkFieldTypes = tableSink.getFieldTypes
+      case Some(s: TableSourceSinkTable[_, _]) => s.tableSinkTable match {
 
-        if (srcFieldTypes.length != sinkFieldTypes.length ||
-          srcFieldTypes.zip(sinkFieldTypes).exists{case (srcF, snkF) => srcF != snkF}) {
+        case Some(sinkTable: TableSinkTable[_]) =>
+          val tableSink = sinkTable.tableSink
+          // validate schema of source table and table sink
+          val srcFieldTypes = table.getSchema.getTypes
+          val sinkFieldTypes = tableSink.getFieldTypes
 
-          val srcFieldNames = table.getSchema.getColumnNames
-          val sinkFieldNames = tableSink.getFieldNames
+          if (srcFieldTypes.length != sinkFieldTypes.length ||
+            srcFieldTypes.zip(sinkFieldTypes).exists { case (srcF, snkF) => srcF != snkF }) {
 
-          // format table and table sink schema strings
-          val srcSchema = srcFieldNames.zip(srcFieldTypes)
-            .map{case (n, t) => s"$n: ${t.getTypeClass.getSimpleName}"}
-            .mkString("[", ", ", "]")
-          val sinkSchema = sinkFieldNames.zip(sinkFieldTypes)
-            .map{case (n, t) => s"$n: ${t.getTypeClass.getSimpleName}"}
-            .mkString("[", ", ", "]")
+            val srcFieldNames = table.getSchema.getColumnNames
+            val sinkFieldNames = tableSink.getFieldNames
 
-          throw ValidationException(
-            s"Field types of query result and registered TableSink $sinkTableName do not match.\n" +
-              s"Query result schema: $srcSchema\n" +
-              s"TableSink schema:    $sinkSchema")
-        }
+            // format table and table sink schema strings
+            val srcSchema = srcFieldNames.zip(srcFieldTypes)
+              .map { case (n, t) => s"$n: ${t.getTypeClass.getSimpleName}" }
+              .mkString("[", ", ", "]")
+            val sinkSchema = sinkFieldNames.zip(sinkFieldTypes)
+              .map { case (n, t) => s"$n: ${t.getTypeClass.getSimpleName}" }
+              .mkString("[", ", ", "]")
 
-        // emit the table to the configured table sink
-        writeToSink(table, tableSink, conf)
+            throw ValidationException(
+              s"Field types of query result and registered TableSink " +
+                s"$sinkTableName do not match.\n" +
+                s"Query result schema: $srcSchema\n" +
+                s"TableSink schema:    $sinkSchema")
+          }
+
+          // emit the table to the configured table sink
+          writeToSink(table, tableSink, conf)
+        case _ =>
+          throw TableException(s"The table registered as $sinkTableName is not a TableSink. " +
+            s"You can only emit query results to a registered TableSink.")
+      }
+
       case _ =>
-        throw TableException(s"The table registered as $sinkTableName is not a TableSink. " +
-          s"You can only emit query results to a registered TableSink.")
+        throw TableException(s"No table was registered under the name $sinkTableName.")
     }
   }
 
@@ -820,59 +823,44 @@ abstract class TableEnvironment(val config: TableConfig) {
 
   /**
     * Checks if a table is registered under the given name.
-    * Internal and external catalogs are both checked.
     *
     * @param name The table name to check.
     * @return true, if a table is registered under the name, false otherwise.
     */
   protected[flink] def isRegistered(name: String): Boolean = {
-    var isRegistered = rootSchema.getTableNames.contains(name)
+    rootSchema.getTableNames.contains(name)
+  }
 
-    // check if the table exists in external catalogs
-    if (!isRegistered) {
-      val (externalSchema, externalTableName) = resolveExternalTable(name)
-      if (externalSchema != null) {
-        isRegistered = externalSchema.getTableNames.contains(externalTableName)
+  /**
+    * Get a table from either internal or external catalogs.
+    *
+    * @param name The name of the table.
+    * @return The table registered either internally or externally, None otherwise.
+    */
+  protected def getTable(name: String): Option[org.apache.calcite.schema.Table] = {
+    val internalTable = rootSchema.getTable(name)
+
+    if (internalTable != null) {
+      Some(internalTable)
+    } else {
+      // search external catalogs
+      def searchSubschema(schema: SchemaPlus, tableName: String):
+        org.apache.calcite.schema.Table = {
+
+        if (schema == null) {
+          return null
+        }
+
+        if (tableName.contains(".")) {
+          val Array(subcatalog, table) = tableName.split("\\.", 2)
+          searchSubschema(schema.getSubSchema(subcatalog), table)
+        } else {
+          schema.getTable(tableName)
+        }
       }
+
+      Option(searchSubschema(rootSchema, name))
     }
-
-    return isRegistered
-  }
-
-  protected def getTable(name: String): org.apache.calcite.schema.Table = {
-    var table = rootSchema.getTable(name)
-
-    // check if the table exists in external catalogs
-    if (table == null) {
-      val (externalSchema, externalTableName) = resolveExternalTable(name)
-      if (externalSchema != null) {
-        table = externalSchema.getTable(externalTableName)
-      }
-    }
-
-    return table
-  }
-
-  protected def getRowType(name: String): RelDataType = {
-    val table = getTable(name)
-    if (table != null) {
-      table.getRowType(typeFactory)
-    }
-
-    return null
-  }
-
-  protected def resolveExternalTable(name: String): (SchemaPlus, String) = {
-    var externalSchema = rootSchema
-    var externalTableName = name
-
-    while (externalTableName.contains(".")) {
-      val Array(subcatalog, table) = externalTableName.split("\\.", 2)
-      externalSchema = externalSchema.getSubSchema(subcatalog)
-      externalTableName = table
-    }
-
-    return (externalSchema, externalTableName)
   }
 
   /** Returns a unique temporary attribute name. */

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
@@ -96,7 +96,7 @@ class ExternalCatalogSchema(
 
   override def getFunctionNames: JSet[String] = JCollections.emptySet[String]
 
-  override def getTableNames: JSet[String] = JCollections.emptySet[String]
+  override def getTableNames: JSet[String] = new JLinkedHashSet(catalog.listTables())
 
   override def snapshot(v: SchemaVersion): Schema = this
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/ExternalCatalogInsertTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/ExternalCatalogInsertTest.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api
+
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.CommonTestData
+import org.apache.flink.table.utils.TableTestBase
+import org.junit.Test
+
+/**
+  * Test for inserting into tables from external catalog.
+  */
+class ExternalCatalogInsertTest extends TableTestBase {
+  private val tableBatchEnv = TableEnvironment.getTableEnvironment(
+    ExecutionEnvironment.getExecutionEnvironment)
+  private val tableStreamEnv = TableEnvironment.getTableEnvironment(
+    StreamExecutionEnvironment.getExecutionEnvironment)
+
+  @Test
+  def testBatchTableApi(): Unit = {
+    tableBatchEnv.registerExternalCatalog(
+      "test",
+      CommonTestData.getInMemoryTestCatalog(isStreaming = false))
+
+    val table1 = tableBatchEnv.scan("test", "db1", "tb1")
+    val table2 = tableBatchEnv.scan("test", "db2", "tb2")
+    table2.select('d * 2, 'e, 'g.upperCase())
+      .unionAll(table1.select('a * 2, 'b, 'c.upperCase()))
+      .insertInto("test.db3.tb3")
+  }
+
+  @Test
+  def testBatchSQL(): Unit = {
+    tableBatchEnv.registerExternalCatalog(
+      "test",
+      CommonTestData.getInMemoryTestCatalog(isStreaming = false))
+
+    val sqlInsert = "INSERT INTO `test.db3.tb3` SELECT d * 2, e, g FROM test.db2.tb2 WHERE d < 3 " +
+      "UNION ALL (SELECT a * 2, b, c FROM test.db1.tb1)"
+
+    tableBatchEnv.sqlUpdate(sqlInsert)
+  }
+
+  @Test
+  def testStreamTableApi(): Unit = {
+    var tableEnv = tableStreamEnv
+
+    tableEnv.registerExternalCatalog(
+      "test",
+      CommonTestData.getInMemoryTestCatalog(isStreaming = true))
+
+    val table1 = tableEnv.scan("test", "db1", "tb1")
+    val table2 = tableEnv.scan("test", "db2", "tb2")
+
+    table2.where("d < 3")
+      .select('d * 2, 'e, 'g.upperCase())
+      .unionAll(table1.select('a * 2, 'b, 'c.upperCase()))
+      .insertInto("test.db3.tb3")
+  }
+
+  @Test
+  def testStreamSQL(): Unit = {
+    var tableEnv = tableStreamEnv
+
+    tableEnv.registerExternalCatalog(
+      "test",
+      CommonTestData.getInMemoryTestCatalog(isStreaming = true))
+
+    val sqlInsert = "INSERT INTO `test.db3.tb3` SELECT d * 2, e, g FROM test.db2.tb2 WHERE d < 3 " +
+      "UNION ALL (SELECT a * 2, b, c FROM test.db1.tb1)"
+
+    tableEnv.sqlUpdate(sqlInsert)
+  }
+
+  @Test
+  def testTopLevelTable(): Unit = {
+    var tableEnv = tableBatchEnv
+
+    tableEnv.registerExternalCatalog(
+      "test",
+      CommonTestData.getInMemoryTestCatalog(isStreaming = false))
+
+    val table1 = tableEnv.scan("test", "tb1")
+    val table2 = tableEnv.scan("test", "db2", "tb2")
+    table2.select('d * 2, 'e, 'g.upperCase())
+      .unionAll(table1.select('a * 2, 'b, 'c.upperCase()))
+      .insertInto("test.tb3")
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
@@ -71,7 +71,7 @@ class ExternalCatalogSchemaTest extends TableTestBase {
         .filter(_.getType.equals(SqlMonikerType.SCHEMA))
         .map(_.getFullyQualifiedNames.asScala.toList).toSet
     assertTrue(Set(List(schemaName), List(schemaName, "db1"),
-      List(schemaName, "db2")) == subSchemas)
+      List(schemaName, "db2"), List(schemaName, "db3")) == subSchemas)
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
@@ -129,16 +129,39 @@ object CommonTestData {
       externalTableBuilder2.inAppendMode()
     }
 
+    val tempFilePath3 = writeToTempFile("", "csv-test3", "tmp")
+    val connDesc3 = FileSystem().path(tempFilePath3)
+    val formatDesc3 = Csv()
+      .field("x", Types.INT)
+      .field("y", Types.LONG)
+      .field("z", Types.STRING)
+      .fieldDelimiter("#")
+    val schemaDesc3 = Schema()
+      .field("x", Types.INT)
+      .field("y", Types.LONG)
+      .field("z", Types.STRING)
+    val externalTableBuilder3 = ExternalCatalogTable.builder(connDesc3)
+      .withFormat(formatDesc3)
+      .withSchema(schemaDesc3)
+
+    if (isStreaming) {
+      externalTableBuilder3.inAppendMode()
+    }
+
     val catalog = new InMemoryExternalCatalog("test")
     val db1 = new InMemoryExternalCatalog("db1")
     val db2 = new InMemoryExternalCatalog("db2")
+    val db3 = new InMemoryExternalCatalog("db3")
     catalog.createSubCatalog("db1", db1, ignoreIfExists = false)
     catalog.createSubCatalog("db2", db2, ignoreIfExists = false)
+    catalog.createSubCatalog("db3", db3, ignoreIfExists = false)
 
     // Register the table with both catalogs
     catalog.createTable("tb1", externalTableBuilder1.asTableSource(), ignoreIfExists = false)
+    catalog.createTable("tb3", externalTableBuilder3.asTableSink(), ignoreIfExists = false)
     db1.createTable("tb1", externalTableBuilder1.asTableSource(), ignoreIfExists = false)
     db2.createTable("tb2", externalTableBuilder2.asTableSource(), ignoreIfExists = false)
+    db3.createTable("tb3", externalTableBuilder3.asTableSink(), ignoreIfExists = false)
     catalog
   }
 


### PR DESCRIPTION
## What is the purpose of the change

In the documentation, there is a description: 

> Once registered in a TableEnvironment, all tables defined in a ExternalCatalog can be accessed from Table API or SQL queries by specifying their full path, such as catalog.database.table.

Currently, this is true only for source tables. For sink table (specified as **insertInto** in the Table API or SQL), the users have to explicitly register it even though it is defined in a registered ExternalCatalog, otherwise "No table was registered under the name XXX" TableException would be thrown. 

It would be better keep consistent for both source table and sink table, and the users would enjoy more convenient approach to inserting into sink tables. This pull request tries to automatically register sink table  if it is defined in any registered external catalogs.

## Brief change log

  - Try automatic registration of sink table in `TableEnvironment.insertInto()`.
  - Add unit test `ExternalCatalogInsertTest` to expose the issue.
  - Create a new external sink table in `CommonTestData.getInMemoryTestCatalog()`. 

## Verifying this change

This change added unit tests in `ExternalCatalogInsertTest` and can be verified accordingly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
