### PR TITLE
[FLINK-10060] [table] Add RTRIM supported in Table API and SQL

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -2482,6 +2482,18 @@ TO_BASE64(string)
         <p>E.g., <code>TO_BASE64('hello world')</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+RTRIM(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the result string which trimmed the right spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
+        <p>E.g., <code>RTRIM('This is a test String. ')</code> returns "This is a test String.".</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -2677,15 +2689,15 @@ STRING.toBase64()
 
     <tr>
       <td>
-        {% highlight text %}
-RTRIM(string)
+        {% highlight java %}
+STRING.rtrim()
 {% endhighlight %}
       </td>
       <td>
         <p>Returns the result string which trimmed the right spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
-        <p>E.g., <code>RTRIM('This is a test String. ')</code> returns "This is a test String.".</p>
+        <p>E.g., <code>'This is a test String. '.rtrim()</code> returns "This is a test String.".</p>
       </td>
-    </tr>    
+    </tr>
   </tbody>
 </table>
 </div>
@@ -2875,6 +2887,18 @@ STRING.toBase64()
       <td>
         <p>Returns the base64-encoded result from <i>STRING</i>; returns NULL if <i>STRING</i> is NULL.</p>
          <p>E.g., <code>"hello world".toBase64()</code> returns "aGVsbG8gd29ybGQ=".</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.rtrim()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the result string which trimmed the right spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
+        <p>E.g., <code>'This is a test String. '.rtrim()</code> returns "This is a test String.".</p>
       </td>
     </tr>
   </tbody>

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -2674,7 +2674,18 @@ STRING.toBase64()
          <p>E.g., <code>'hello world'.toBase64()</code> returns "aGVsbG8gd29ybGQ=".</p>
       </td>
     </tr>
-    
+
+    <tr>
+      <td>
+        {% highlight text %}
+RTRIM(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the result string which trimmed the right spaces from the base string; returns NULL if <i>string</i> is NULL.</p> 
+        <p>E.g., <code>RTRIM('This is a test String. ')</code> returns "This is a test String.".</p>
+      </td>
+    </tr>    
   </tbody>
 </table>
 </div>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -563,6 +563,11 @@ trait ImplicitExpressionOperations {
     */
   def toBase64() = ToBase64(expr)
 
+  /**
+    * Returns the result string which trimmed the right spaces from the base string.
+    */
+  def rtrim() = RTrim(expr)
+
   // Temporal operations
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -164,6 +164,12 @@ object FunctionGenerator {
     STRING_TYPE_INFO,
     BuiltInMethods.UUID)
 
+  addSqlFunctionMethod(
+    RTRIM,
+    Seq(STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethod.RTRIM.method)
+
   // ----------------------------------------------------------------------------------------------
   // Arithmetic functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -410,3 +410,25 @@ case class ToBase64(child: Expression) extends UnaryExpression with InputTypeSpe
   override def toString: String = s"($child).toBase64"
 
 }
+
+case class RTrim(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (child.resultType == STRING_TYPE_INFO) {
+      ValidationSuccess
+    } else {
+      ValidationFailure(s"RTrim operator requires a String input, " +
+        s"but $child is of type ${child.resultType}")
+    }
+  }
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.RTRIM, child.toRexNode)
+  }
+
+  override def toString = s"($child).rtrim"
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -206,4 +206,12 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val RTRIM = new SqlFunction(
+    "RTRIM",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING)
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -205,6 +205,7 @@ object FunctionCatalog {
     "fromBase64" -> classOf[FromBase64],
     "toBase64" -> classOf[ToBase64],
     "uuid" -> classOf[UUID],
+    "rtrim" -> classOf[RTrim],
 
     // math functions
     "plus" -> classOf[Plus],
@@ -455,6 +456,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.FROM_BASE64,
     ScalarSqlFunctions.TO_BASE64,
     ScalarSqlFunctions.UUID,
+    ScalarSqlFunctions.RTRIM,
 
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -626,6 +626,33 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "-")
   }
 
+  @Test
+  def testRTrim(): Unit = {
+    testAllApis(
+      'f8.rtrim(),
+      "f8.rtrim",
+      "RTRIM(f8)",
+      " This is a test String.")
+
+    testAllApis(
+      'f0.rtrim(),
+      "f0.rtrim",
+      "RTRIM(f0)",
+      "This is a test String.")
+
+    testAllApis(
+      "".rtrim(),
+      "''.rtrim()",
+      "RTRIM('')",
+      "")
+
+    testAllApis(
+      'f33.rtrim(),
+      "f33.rtrim",
+      "RTRIM(f33)",
+      "null")
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Math functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -149,6 +149,7 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("RPAD('hi',4,'??')", "hi??")
     testSqlApi("FROM_BASE64('aGVsbG8gd29ybGQ=')", "hello world")
     testSqlApi("TO_BASE64('hello world')", "aGVsbG8gd29ybGQ=")
+    testSqlApi("RTRIM('This is a test String. ')", "This is a test String.")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds RTRIM supported in Table API and SQL*


## Brief change log

  - *Add RTRIM supported in Table API and SQL*

## Verifying this change

This change is already covered by existing tests, such as *ScalarFunctionsTest#testRTrim*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
