### PR TITLE
[FLINK-9446][docs] Update savepoint compatibility table for 1.4

### DIFF
--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -209,6 +209,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
       <th class="text-center">1.1.x</th>
       <th class="text-center">1.2.x</th>
       <th class="text-center">1.3.x</th>
+      <th class="text-center">1.4.x</th>
       <th class="text-center">Limitations</th>
     </tr>
   </thead>
@@ -218,7 +219,8 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">The maximum parallelism of a job that was migrated from Flink 1.1.x to 1.2.x is
+          <td class="text-center"></td>
+          <td class="text-left">The maximum parallelism of a job that was migrated from Flink 1.1.x to 1.2.x+ is
           currently fixed as the parallelism of the job. This means that the parallelism can not be increased after
           migration. This limitation might be removed in a future bugfix release.</td>
     </tr>
@@ -227,12 +229,22 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">When migrating from Flink 1.2.x to Flink 1.3.x, changing parallelism at the same
-          time is not supported. Users have to first take a savepoint after migrating to Flink 1.3.x, and then change
-          parallelism.</td>
+          <td class="text-center">O</td>
+          <td class="text-left">When migrating from Flink 1.2.x to Flink 1.3.x+, changing parallelism at the same
+          time is not supported. Users have to first take a savepoint after migrating to Flink 1.3.x+, and then change
+          parallelism. Savepoints taken by the CEP library cannot be restored in 1.4.x+.</td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.3.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains scala case classes. Users have to either first upgrade to 1.3.1, or directlry to 1.4.2+.</td>
+    </tr>
+    <tr>
+          <td class="text-center"><strong>1.4.x</strong></td>
+          <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center">O</td>

--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -240,7 +240,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains scala case classes. Users have to either first upgrade to 1.3.1, or directly to 1.4.2+.</td>
+          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains scala case classes. Users have to directly migrate to 1.4.2+ instead.</td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.4.x</strong></td>

--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -240,7 +240,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains scala case classes. Users have to either first upgrade to 1.3.1, or directlry to 1.4.2+.</td>
+          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains scala case classes. Users have to either first upgrade to 1.3.1, or directly to 1.4.2+.</td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.4.x</strong></td>

--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -232,7 +232,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center">O</td>
           <td class="text-left">When migrating from Flink 1.2.x to Flink 1.3.x+, changing parallelism at the same
           time is not supported. Users have to first take a savepoint after migrating to Flink 1.3.x+, and then change
-          parallelism. Savepoints taken by the CEP library cannot be restored in 1.4.x+.</td>
+          parallelism. Savepoints created for CEP applications cannot be restored in 1.4.x+.</td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.3.x</strong></td>

--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -240,7 +240,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
           <td class="text-center"></td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
-          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains scala case classes. Users have to directly migrate to 1.4.2+ instead.</td>
+          <td class="text-left">Migrating from Flink 1.3.0 to Flink 1.4.[0,1] will fail if the savepoint contains Scala case classes. Users have to directly migrate to 1.4.2+ instead.</td>
     </tr>
     <tr>
           <td class="text-center"><strong>1.4.x</strong></td>


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the savepoint compatibility table for 1.4.

In FLINK-7461 we removed compatibility for 1.1.
In FLINK-7511 we removed CEP compatibility for 1.2.
In FLINK-8451 a compatibility issue for scala cases classes was identified.

/cc @StefanRRichter @dawidwys @aljoscha @twalthr 
