### PR TITLE
[FLINK-10094][tests] Always backup config before running test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -102,8 +102,6 @@ function change_conf() {
 
 function create_ha_config() {
 
-    backup_config
-
     # clean up the dir that will be used for zookeeper storage
     # (see high-availability.zookeeper.storageDir below)
     if [ -e $TEST_DATA_DIR/recovery ]; then

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -37,6 +37,7 @@ function run_test {
     export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
     echo "TEST_DATA_DIR: $TEST_DATA_DIR"
 
+    backup_config
     start_timer
     ${command}
     exit_code="$?"

--- a/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
@@ -28,7 +28,6 @@ cp $FLINK_DIR/conf/flink-conf.yaml $FLINK_DIR/conf/flink-conf.yaml.bak
 echo "taskmanager.network.memory.min: 10485760" >> $FLINK_DIR/conf/flink-conf.yaml
 echo "taskmanager.network.memory.max: 10485760" >> $FLINK_DIR/conf/flink-conf.yaml
 
-backup_config
 set_conf_ssl
 start_cluster
 $FLINK_DIR/bin/taskmanager.sh start

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -25,8 +25,6 @@ TEST=flink-high-parallelism-iterations-test
 TEST_PROGRAM_NAME=HighParallelismIterationsTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-backup_config
-
 set_conf "taskmanager.heap.mb" "52" # 52Mb x 100 TMs = 5Gb total heap
 
 set_conf "taskmanager.memory.size" "8" # 8Mb

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -77,8 +77,7 @@ function run_local_recovery_test {
         kill JVM: ${kill_jvm}"
 
     TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
-    # Backup conf and configure for HA
-    backup_config
+    # configure for HA
     create_ha_config
 
     # Enable debug logging

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -55,7 +55,6 @@ function run_test() {
     clean_log_files
     clean_stdout_files
 
-    backup_config
     # speeds up TM loss detection
     set_conf "heartbeat.interval" "2000"
     set_conf "heartbeat.timeout" "10000"

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -37,7 +37,6 @@ else
  NUM_SLOTS=$NEW_DOP
 fi
 
-backup_config
 change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"
 setup_flink_slf4j_metric_reporter
 start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -55,7 +55,6 @@ else
   NUM_SLOTS=$NEW_DOP
 fi
 
-backup_config
 change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"
 
 if [ $STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE == 'rocks' ]; then

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -28,7 +28,6 @@ else
   NUM_SLOTS=${NEW_DOP}
 fi
 
-backup_config
 change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"
 setup_flink_slf4j_metric_reporter
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -24,7 +24,6 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-bucketing-sink-test/target/BucketingSin
 # enable DEBUG logging level to retrieve truncate length later
 sed -i -e 's/#log4j.logger.org.apache.flink=INFO/log4j.logger.org.apache.flink=DEBUG/g' $FLINK_DIR/conf/log4j.properties
 
-backup_config
 set_conf_ssl
 start_cluster
 $FLINK_DIR/bin/taskmanager.sh start


### PR DESCRIPTION
## What is the purpose of the change

With this PR the test runner is responsible for backing up `flink-conf.yaml` and not individual tests.
This makes the tests more stable as tests can no longer leak configuration changes to other tests.

/cc @florianschmidt1994 

## Brief change log

* remove all usages of `backup_config` in individual tests
* call `backup_config` in `test-runner-common.sh#run_test`