### PR TITLE
[FLINK-9559] [table] The type of a union of CHAR columns of different lengths should be VARCHAR

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
@@ -48,4 +48,8 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
       super.getDefaultPrecision(typeName)
   }
 
+  // Convert return type to VARCHAR if union CHAR columns of different lengths.
+  // By default, i.e., return false, the behavior was to return a CHAR column whose length is the
+  // longest of the inputs.
+  override def shouldConvertRaggedUnionTypesToVarying(): Boolean = true
 }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -69,7 +69,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		String expected = "3,World,false,1944-12-24,12.5444444500000000\n" +
 			"2,Hello,true,1944-02-24,12.6666666650000000\n" +
 			// Calcite converts to decimals and strings with equal length
-			"1,Test ,true,1944-02-24,12.4444444444444445\n";
+			"1,Test,true,1944-02-24,12.4444444444444445\n";
 		compareResultAsText(results, expected);
 	}
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -370,14 +370,31 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "If(f9 > f8, f9 - 1, f9)",
       "9"
     )
+
+    // case when
     testSqlApi("CASE 11 WHEN 1 THEN 'a' ELSE 'b' END", "b")
     testSqlApi("CASE 2 WHEN 1 THEN 'a' ELSE 'b' END", "b")
     testSqlApi(
       "CASE 1 WHEN 1, 2 THEN '1 or 2' WHEN 2 THEN 'not possible' WHEN 3, 2 THEN '3' " +
       "ELSE 'none of the above' END",
-      "1 or 2           ")
+      "1 or 2")
+    testSqlApi(
+      "CASE 2 WHEN 1, 2 THEN '1 or 2' WHEN 2 THEN 'not possible' WHEN 3, 2 " +
+        "THEN '3' ELSE 'none of the above' END",
+      "1 or 2")
+    testSqlApi(
+      "CASE 3 WHEN 1, 2 THEN '1 or 2' WHEN 2 THEN 'not possible' WHEN 3, 2 " +
+        "THEN '3' ELSE 'none of the above' END",
+      "3")
+    testSqlApi(
+      "CASE 4 WHEN 1, 2 THEN '1 or 2' WHEN 2 THEN 'not possible' WHEN 3, 2 " +
+        "THEN '3' ELSE 'none of the above' END",
+      "none of the above")
     testSqlApi("CASE WHEN 'a'='a' THEN 1 END", "1")
     testSqlApi("CASE 2 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "bcd")
+    testSqlApi("CASE 1 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "a")
+    testSqlApi("CASE 1 WHEN 1 THEN CAST('a' AS VARCHAR(1)) WHEN 2 THEN " +
+      "CAST('bcd' AS VARCHAR(3)) END", "a")
     testSqlApi("CASE f2 WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END", "11")
     testSqlApi("CASE f7 WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END", "null")
     testSqlApi("CASE 42 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "null")


### PR DESCRIPTION

## What is the purpose of the change

Currently, if the case-when expression has two branches which return string literal, redundant white spaces will be appended to the short string literal. For example, for the sql: case 1 when 1 then 'a' when 2 then 'bcd' end, the return value will be 'a ' of CHAR(3) instead of 'a'.
This pr tries to solve the redundant white spaces problem.


## Brief change log

  - Override `shouldConvertRaggedUnionTypesToVarying` to true in `FlinkTypeSystem`, so that Calcite will return CHAR to VARCHAR when infer result type for CHAR with different length.
  - Adapt some old tests.
  - Add more tests.


## Verifying this change


This change is already covered by existing tests, such as `testValues` in `JavaSqlITCase` and `testOtherExpressions` in `ScalarOperatorsTest`.
Also add more tests in `ScalarOperatorsTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
