### PR TITLE
[hotfix] [docs] Fix ProcessWindowFunction code snippets.

### DIFF
--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -724,17 +724,19 @@ A `ProcessWindowFunction` can be defined and used like this:
 DataStream<Tuple2<String, Long>> input = ...;
 
 input
-    .keyBy(<key selector>)
-    .window(<window assigner>)
-    .process(new MyProcessWindowFunction());
+  .keyBy(t -> t.f0)
+  .timeWindow(Time.minutes(5))
+  .process(new MyProcessWindowFunction());
 
 /* ... */
 
-public class MyProcessWindowFunction extends ProcessWindowFunction<Tuple<String, Long>, String, String, TimeWindow> {
+public class MyProcessWindowFunction 
+    extends ProcessWindowFunction<Tuple2<String, Long>, String, String, TimeWindow> {
 
-  void process(String key, Context context, Iterable<Tuple<String, Long>> input, Collector<String> out) {
+  @Override
+  public void process(String key, Context context, Iterable<Tuple2<String, Long>> input, Collector<String> out) {
     long count = 0;
-    for (Tuple<String, Long> in: input) {
+    for (Tuple2<String, Long> in: input) {
       count++;
     }
     out.collect("Window: " + context.window() + "count: " + count);
@@ -749,9 +751,9 @@ public class MyProcessWindowFunction extends ProcessWindowFunction<Tuple<String,
 val input: DataStream[(String, Long)] = ...
 
 input
-    .keyBy(<key selector>)
-    .window(<window assigner>)
-    .process(new MyProcessWindowFunction())
+  .keyBy(_._1)
+  .timeWindow(Time.minutes(5))
+  .process(new MyProcessWindowFunction())
 
 /* ... */
 


### PR DESCRIPTION
## What is the purpose of the change

- Fix the code snippets for the `ProcessWindowFunction` in the documentation

## Brief change log

Problems with the examples:

- Java: Tuple does not take generic parameters (`Tuple<String, Long>`)
- Java: `process()` method must be `public`
- `MyProcessWindowFunction` expects `String` key, but no key extractor is used
- `MyProcessWindowFunction` expects `TimeWindow`, but window assigner is not defined

## Verifying this change

copy and paste code in an IDE.

## Does this pull request potentially affect one of the following parts:

No

## Documentation

Fix for the docs