### PR TITLE
[FLINK-10107] [e2e] Exclude conflicting SQL JARs from test

### DIFF
--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -153,13 +153,14 @@ under the License.
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
 								</artifactItem>
+								<!-- This SQL JAR is not used for now to avoid dependency conflicts; see FLINK-10107.
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-connector-kafka-0.9_${scala.binary.version}</artifactId>
 									<version>${project.version}</version>
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
-								</artifactItem>
+								</artifactItem>-->
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
@@ -167,13 +168,14 @@ under the License.
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
 								</artifactItem>
+								<!-- This SQL JAR is not used for now to avoid dependency conflicts; see FLINK-10107.
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
 									<version>${project.version}</version>
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
-								</artifactItem>
+								</artifactItem>-->
 							</artifactItems>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

This is a temporary solution for fixing the SQL Client end-to-end test for releases.


## Brief change log

- Do not include conflicting SQL JARs in library folder of test.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
