### PR TITLE
[FLINK-10110][tests] Harden Kafka component shut down for E2E tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -75,6 +75,18 @@ function start_kafka_cluster {
 function stop_kafka_cluster {
   $KAFKA_DIR/bin/kafka-server-stop.sh
   $KAFKA_DIR/bin/zookeeper-server-stop.sh
+
+  PIDS=$(jps -vl | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
+
+  if [ ! -z "$PIDS" ]; then
+    kill -s TERM $PIDS
+  fi
+
+  PIDS=$(jps -vl | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $1}')
+
+  if [ ! -z "$PIDS" ]; then
+    kill -s TERM $PIDS
+  fi
 }
 
 function create_kafka_topic {

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -38,8 +38,8 @@ function test_cleanup {
   # don't call ourselves again for normal exit
   trap "" EXIT
 
-  stop_kafka_cluster
   stop_confluent_schema_registry
+  stop_kafka_cluster
 }
 
 trap test_cleanup INT


### PR DESCRIPTION
## What is the purpose of the change

Instead of only calling kafka-server-stop.sh and zookeeper-server-stop.sh which can fail
due to KAFKA-4931 we also use jps to kill the Kafka and ZooKeeper processes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
