### PR TITLE
[FLINK-10107] [sql-client] Relocate Flink Kafka connectors for SQL JARs

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -225,6 +225,7 @@ under the License.
 								<configuration>
 									<shadedArtifactAttached>true</shadedArtifactAttached>
 									<shadedClassifierName>sql-jar</shadedClassifierName>
+									<!-- Flink's Kafka 0.10 connector depends on Flink's Kafka 0.9 connector. -->
 									<artifactSet>
 										<includes combine.children="append">
 											<include>org.apache.kafka:*</include>
@@ -232,6 +233,11 @@ under the License.
 											<include>org.apache.flink:flink-connector-kafka-0.9_${scala.binary.version}</include>
 										</includes>
 									</artifactSet>
+									<!-- Update service files for table factories. -->
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+									</transformers>
+									<!-- Remove version-specific resources not needed by Flink's Kafka 0.10 connector. -->
 									<filters>
 										<filter>
 											<artifact>*:*</artifact>
@@ -239,11 +245,22 @@ under the License.
 												<exclude>kafka/kafka-version.properties</exclude>
 											</excludes>
 										</filter>
+										<filter>
+											<artifact>org.apache.flink:flink-connector-kafka-0.9_${scala.binary.version}</artifact>
+											<excludes>
+												<exclude>META-INF/services/org.apache.flink.table.factories.TableFactory</exclude>
+											</excludes>
+										</filter>
 									</filters>
+									<!-- Relocate all version-specific classes. -->
 									<relocations>
 										<relocation>
 											<pattern>org.apache.kafka</pattern>
 											<shadedPattern>org.apache.flink.kafka010.shaded.org.apache.kafka</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.apache.flink.streaming.connectors.kafka</pattern>
+											<shadedPattern>org.apache.flink.kafka010.shaded.org.apache.flink.streaming.connectors.kafka</shadedPattern>
 										</relocation>
 									</relocations>
 								</configuration>

--- a/flink-connectors/flink-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.11/pom.xml
@@ -234,6 +234,7 @@ under the License.
 								<configuration>
 									<shadedArtifactAttached>true</shadedArtifactAttached>
 									<shadedClassifierName>sql-jar</shadedClassifierName>
+									<!-- Flink's Kafka 0.11 connector depends on Flink's Kafka 0.9 and 0.10 connector. -->
 									<artifactSet>
 										<includes combine.children="append">
 											<include>org.apache.kafka:*</include>
@@ -242,6 +243,11 @@ under the License.
 											<include>org.apache.flink:flink-connector-kafka-0.10_${scala.binary.version}</include>
 										</includes>
 									</artifactSet>
+									<!-- Update service files for table factories. -->
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+									</transformers>
+									<!-- Remove version-specific resources not needed by Flink's Kafka 0.11 connector. -->
 									<filters>
 										<filter>
 											<artifact>*:*</artifact>
@@ -249,11 +255,28 @@ under the License.
 												<exclude>kafka/kafka-version.properties</exclude>
 											</excludes>
 										</filter>
+										<filter>
+											<artifact>org.apache.flink:flink-connector-kafka-0.9_${scala.binary.version}</artifact>
+											<excludes>
+												<exclude>META-INF/services/org.apache.flink.table.factories.TableFactory</exclude>
+											</excludes>
+										</filter>
+										<filter>
+											<artifact>org.apache.flink:flink-connector-kafka-0.10_${scala.binary.version}</artifact>
+											<excludes>
+												<exclude>META-INF/services/org.apache.flink.table.factories.TableFactory</exclude>
+											</excludes>
+										</filter>
 									</filters>
+									<!-- Relocate all version-specific classes. -->
 									<relocations>
 										<relocation>
 											<pattern>org.apache.kafka</pattern>
 											<shadedPattern>org.apache.flink.kafka011.shaded.org.apache.kafka</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.apache.flink.streaming.connectors.kafka</pattern>
+											<shadedPattern>org.apache.flink.kafka011.shaded.org.apache.flink.streaming.connectors.kafka</shadedPattern>
 										</relocation>
 									</relocations>
 								</configuration>

--- a/flink-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.9/pom.xml
@@ -219,6 +219,10 @@ under the License.
 											<include>org.apache.flink:flink-connector-kafka-base_${scala.binary.version}</include>
 										</includes>
 									</artifactSet>
+									<!-- Update service files for table factories. -->
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+									</transformers>
 									<filters>
 										<filter>
 											<artifact>*:*</artifact>
@@ -227,10 +231,15 @@ under the License.
 											</excludes>
 										</filter>
 									</filters>
+									<!-- Relocate all version-specific classes. -->
 									<relocations>
 										<relocation>
 											<pattern>org.apache.kafka</pattern>
 											<shadedPattern>org.apache.flink.kafka09.shaded.org.apache.kafka</shadedPattern>
+										</relocation>
+										<relocation>
+											<pattern>org.apache.flink.streaming.connectors.kafka</pattern>
+											<shadedPattern>org.apache.flink.kafka09.shaded.org.apache.flink.streaming.connectors.kafka</shadedPattern>
 										</relocation>
 									</relocations>
 								</configuration>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -153,14 +153,13 @@ under the License.
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
 								</artifactItem>
-								<!-- This SQL JAR is not used for now to avoid dependency conflicts; see FLINK-10107.
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-connector-kafka-0.9_${scala.binary.version}</artifactId>
 									<version>${project.version}</version>
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
-								</artifactItem>-->
+								</artifactItem>
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
@@ -168,14 +167,13 @@ under the License.
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
 								</artifactItem>
-								<!-- This SQL JAR is not used for now to avoid dependency conflicts; see FLINK-10107.
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-connector-kafka-0.11_${scala.binary.version}</artifactId>
 									<version>${project.version}</version>
 									<classifier>sql-jar</classifier>
 									<type>jar</type>
-								</artifactItem>-->
+								</artifactItem>
 							</artifactItems>
 						</configuration>
 					</execution>

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -57,6 +57,10 @@ for SQL_JAR in $SQL_JARS_DIR/*.jar; do
   rm -r $EXTRACTED_JAR/*
 done
 
+# randomize JAR list for detecting classloading issues due to JAR order
+SQL_JARS_PARAMETERS=$(find $SQL_JARS_DIR -type f | sort -R | awk '{ print "--jar \""$0"\""}' | tr '\n' ' ')
+echo "Using randomized SQL JAR list: $SQL_JARS_PARAMETERS"
+
 ################################################################################
 # Run a SQL statement
 ################################################################################
@@ -254,7 +258,7 @@ echo "Executing SQL: Kafka JSON -> Kafka Avro"
 echo "$SQL_STATEMENT_1"
 
 $FLINK_DIR/bin/sql-client.sh embedded \
-  --library $SQL_JARS_DIR \
+  $SQL_JARS_PARAMETERS \
   --jar $SQL_TOOLBOX_JAR \
   --environment $SQL_CONF \
   --update "$SQL_STATEMENT_1"
@@ -269,7 +273,7 @@ echo "Executing SQL: Kafka Avro -> Filesystem CSV"
 echo "$SQL_STATEMENT_2"
 
 $FLINK_DIR/bin/sql-client.sh embedded \
-  --library $SQL_JARS_DIR \
+  $SQL_JARS_PARAMETERS \
   --jar $SQL_TOOLBOX_JAR \
   --environment $SQL_CONF \
   --update "$SQL_STATEMENT_2"


### PR DESCRIPTION
## What is the purpose of the change

This PR enforces even more shading for SQL JARs than before. In the past, we only shaded Kafka dependencies. However, since Flink's Kafka connectors mutually depend on each other and do not use version-specific package names (e.g. for Elasticsearch we use `elasticsearch2`, `elasticsearch3`, etc.). This is the only way of avoiding dependency conflicts between different Kafka SQL JARs. The end-to-end tests has been extended to detect classloading issues in builds.


## Brief change log

- Add more relocation to Flink's Kafka SQL JARs


## Verifying this change

SQL Client end-to-end tests has been adapted to detect classloading issues earlier.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, but only for SQL JARs
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
