### PR TITLE
[FLINK-10122] KafkaConsumer should use partitionable state over union state if partition discovery is not active

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -643,7 +643,7 @@ public class FlinkKafkaConsumerBaseTest {
 					Collections.singletonList("dummy-topic"),
 					null,
 					(KeyedDeserializationSchema < T >) mock(KeyedDeserializationSchema.class),
-					PARTITION_DISCOVERY_DISABLED,
+					1L,
 					false);
 
 			this.testFetcher = testFetcher;
@@ -884,16 +884,16 @@ public class FlinkKafkaConsumerBaseTest {
 
 	private static class MockOperatorStateStore implements OperatorStateStore {
 
-		private final ListState<?> mockRestoredUnionListState;
+		private final ListState<?> mockListState;
 
 		private MockOperatorStateStore(ListState<?> restoredUnionListState) {
-			this.mockRestoredUnionListState = restoredUnionListState;
+			this.mockListState = restoredUnionListState;
 		}
 
 		@Override
 		@SuppressWarnings("unchecked")
 		public <S> ListState<S> getUnionListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
-			return (ListState<S>) mockRestoredUnionListState;
+			return (ListState<S>) mockListState;
 		}
 
 		@Override
@@ -914,9 +914,10 @@ public class FlinkKafkaConsumerBaseTest {
 			throw new UnsupportedOperationException();
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
-			throw new UnsupportedOperationException();
+			return (ListState<S>) mockListState;
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -920,6 +920,16 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		@Override
+		public void removeOperatorState(String name) throws Exception {
+
+		}
+
+		@Override
+		public void removeBroadcastState(String name) throws Exception {
+
+		}
+
+		@Override
 		public Set<String> getRegisteredStateNames() {
 			throw new UnsupportedOperationException();
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/OperatorStateStore.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/OperatorStateStore.java
@@ -76,6 +76,16 @@ public interface OperatorStateStore {
 	<S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor) throws Exception;
 
 	/**
+	 * Removes the operator state with the given name from the state store, if it exists.
+	 */
+	void removeOperatorState(String name) throws Exception;
+
+	/**
+	 * Removes the broadcast state with the given name from the state store, if it exists.
+	 */
+	void removeBroadcastState(String name) throws Exception;
+
+	/**
 	 * Creates (or restores) a list state. Each state is registered under a unique name.
 	 * The provided serializer is used to de/serialize the state in case of checkpointing (snapshot/restore).
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.state.OperatorStateHandle;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -36,7 +35,7 @@ public interface OperatorStateRepartitioner {
 	 * @return List with one entry per parallel subtask. Each subtask receives now one collection of states that build
 	 * of the new total state for this subtask.
 	 */
-	List<Collection<OperatorStateHandle>> repartitionState(
+	List<List<OperatorStateHandle>> repartitionState(
 			List<OperatorStateHandle> previousParallelSubtaskStates,
 			int newParallelism);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
@@ -26,11 +26,11 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Current default implementation of {@link OperatorStateRepartitioner} that redistributes state in round robin fashion.
@@ -41,7 +41,7 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 	private static final boolean OPTIMIZE_MEMORY_USE = false;
 
 	@Override
-	public List<Collection<OperatorStateHandle>> repartitionState(
+	public List<List<OperatorStateHandle>> repartitionState(
 			List<OperatorStateHandle> previousParallelSubtaskStates,
 			int newParallelism) {
 
@@ -56,7 +56,7 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 		}
 
 		// Assemble result from all merge maps
-		List<Collection<OperatorStateHandle>> result = new ArrayList<>(newParallelism);
+		List<List<OperatorStateHandle>> result = new ArrayList<>(newParallelism);
 
 		// Do the actual repartitioning for all named states
 		List<Map<StreamStateHandle, OperatorStateHandle>> mergeMapList =
@@ -93,20 +93,19 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 				continue;
 			}
 
-			for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> e :
-					psh.getStateNameToPartitionOffsets().entrySet()) {
+			final Set<Map.Entry<String, OperatorStateHandle.StateMetaInfo>> partitionOffsetEntries =
+				psh.getStateNameToPartitionOffsets().entrySet();
+
+			for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> e : partitionOffsetEntries) {
 				OperatorStateHandle.StateMetaInfo metaInfo = e.getValue();
 
 				Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>> nameToState =
 						nameToStateByMode.get(metaInfo.getDistributionMode());
 
 				List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>> stateLocations =
-						nameToState.get(e.getKey());
-
-				if (stateLocations == null) {
-					stateLocations = new ArrayList<>();
-					nameToState.put(e.getKey(), stateLocations);
-				}
+					nameToState.computeIfAbsent(
+						e.getKey(),
+						k -> new ArrayList<>(previousParallelSubtaskStates.size() * partitionOffsetEntries.size()));
 
 				stateLocations.add(new Tuple2<>(psh.getDelegateStateHandle(), e.getValue()));
 			}
@@ -203,7 +202,9 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 					Map<StreamStateHandle, OperatorStateHandle> mergeMap = mergeMapList.get(parallelOpIdx);
 					OperatorStateHandle operatorStateHandle = mergeMap.get(handleWithOffsets.f0);
 					if (operatorStateHandle == null) {
-						operatorStateHandle = new OperatorStreamStateHandle(new HashMap<>(), handleWithOffsets.f0);
+						operatorStateHandle = new OperatorStreamStateHandle(
+							new HashMap<>(distributeNameToState.size()),
+							handleWithOffsets.f0);
 						mergeMap.put(handleWithOffsets.f0, operatorStateHandle);
 					}
 					operatorStateHandle.getStateNameToPartitionOffsets().put(
@@ -229,7 +230,9 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 				for (Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo> handleWithMetaInfo : e.getValue()) {
 					OperatorStateHandle operatorStateHandle = mergeMap.get(handleWithMetaInfo.f0);
 					if (operatorStateHandle == null) {
-						operatorStateHandle = new OperatorStreamStateHandle(new HashMap<>(), handleWithMetaInfo.f0);
+						operatorStateHandle = new OperatorStreamStateHandle(
+							new HashMap<>(broadcastNameToState.size()),
+							handleWithMetaInfo.f0);
 						mergeMap.put(handleWithMetaInfo.f0, operatorStateHandle);
 					}
 					operatorStateHandle.getStateNameToPartitionOffsets().put(e.getKey(), handleWithMetaInfo.f1);
@@ -256,7 +259,9 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 
 				OperatorStateHandle operatorStateHandle = mergeMap.get(handleWithMetaInfo.f0);
 				if (operatorStateHandle == null) {
-					operatorStateHandle = new OperatorStreamStateHandle(new HashMap<>(), handleWithMetaInfo.f0);
+					operatorStateHandle = new OperatorStreamStateHandle(
+						new HashMap<>(uniformBroadcastNameToState.size()),
+						handleWithMetaInfo.f0);
 					mergeMap.put(handleWithMetaInfo.f0, operatorStateHandle);
 				}
 				operatorStateHandle.getStateNameToPartitionOffsets().put(e.getKey(), handleWithMetaInfo.f1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -24,11 +24,11 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
-import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -83,7 +83,7 @@ public class StateAssignmentOperation {
 			// find the states of all operators belonging to this task
 			List<OperatorID> operatorIDs = executionJobVertex.getOperatorIDs();
 			List<OperatorID> altOperatorIDs = executionJobVertex.getUserDefinedOperatorIDs();
-			List<OperatorState> operatorStates = new ArrayList<>();
+			List<OperatorState> operatorStates = new ArrayList<>(operatorIDs.size());
 			boolean statelessTask = true;
 			for (int x = 0; x < operatorIDs.size(); x++) {
 				OperatorID operatorID = altOperatorIDs.get(x) == null
@@ -124,7 +124,9 @@ public class StateAssignmentOperation {
 			executionJobVertex.getMaxParallelism(),
 			newParallelism);
 
-		/**
+		final int expectedNumberOfSubTasks = newParallelism * operatorIDs.size();
+
+		/*
 		 * Redistribute ManagedOperatorStates and RawOperatorStates from old parallelism to new parallelism.
 		 *
 		 * The old ManagedOperatorStates with old parallelism 3:
@@ -143,8 +145,10 @@ public class StateAssignmentOperation {
 		 * op2   state2,0	  state2,1 	   state2,2		state2,3
 		 * op3   state3,0	  state3,1 	   state3,2		state3,3
 		 */
-		Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates = new HashMap<>();
-		Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates = new HashMap<>();
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates =
+			new HashMap<>(expectedNumberOfSubTasks);
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates =
+			new HashMap<>(expectedNumberOfSubTasks);
 
 		reDistributePartitionableStates(
 			operatorStates,
@@ -153,8 +157,10 @@ public class StateAssignmentOperation {
 			newManagedOperatorStates,
 			newRawOperatorStates);
 
-		Map<OperatorInstanceID, List<KeyedStateHandle>> newManagedKeyedState = new HashMap<>();
-		Map<OperatorInstanceID, List<KeyedStateHandle>> newRawKeyedState = new HashMap<>();
+		Map<OperatorInstanceID, List<KeyedStateHandle>> newManagedKeyedState =
+			new HashMap<>(expectedNumberOfSubTasks);
+		Map<OperatorInstanceID, List<KeyedStateHandle>> newRawKeyedState =
+			new HashMap<>(expectedNumberOfSubTasks);
 
 		reDistributeKeyedStates(
 			operatorStates,
@@ -164,7 +170,7 @@ public class StateAssignmentOperation {
 			newManagedKeyedState,
 			newRawKeyedState);
 
-		/**
+		/*
 		 *  An executionJobVertex's all state handles needed to restore are something like a matrix
 		 *
 		 * 		parallelism0 parallelism1 parallelism2 parallelism3
@@ -198,7 +204,7 @@ public class StateAssignmentOperation {
 			Execution currentExecutionAttempt = executionJobVertex.getTaskVertices()[subTaskIndex]
 				.getCurrentExecutionAttempt();
 
-			TaskStateSnapshot taskState = new TaskStateSnapshot();
+			TaskStateSnapshot taskState = new TaskStateSnapshot(operatorIDs.size());
 			boolean statelessTask = true;
 
 			for (OperatorID operatorID : operatorIDs) {
@@ -276,38 +282,34 @@ public class StateAssignmentOperation {
 			for (int subTaskIndex = 0; subTaskIndex < newParallelism; subTaskIndex++) {
 				OperatorInstanceID instanceID = OperatorInstanceID.of(subTaskIndex, newOperatorIDs.get(operatorIndex));
 				if (isHeadOperator(operatorIndex, newOperatorIDs)) {
-					Tuple2<Collection<KeyedStateHandle>, Collection<KeyedStateHandle>> subKeyedStates = reAssignSubKeyedStates(
+					Tuple2<List<KeyedStateHandle>, List<KeyedStateHandle>> subKeyedStates = reAssignSubKeyedStates(
 						operatorState,
 						newKeyGroupPartitions,
 						subTaskIndex,
 						newParallelism,
 						oldParallelism);
-					newManagedKeyedState
-						.computeIfAbsent(instanceID, key -> new ArrayList<>())
-						.addAll(subKeyedStates.f0);
-					newRawKeyedState
-						.computeIfAbsent(instanceID, key -> new ArrayList<>())
-						.addAll(subKeyedStates.f1);
+					newManagedKeyedState.put(instanceID, subKeyedStates.f0);
+					newRawKeyedState.put(instanceID, subKeyedStates.f1);
 				}
 			}
 		}
 	}
 
 	// TODO rewrite based on operator id
-	private Tuple2<Collection<KeyedStateHandle>, Collection<KeyedStateHandle>> reAssignSubKeyedStates(
+	private Tuple2<List<KeyedStateHandle>, List<KeyedStateHandle>> reAssignSubKeyedStates(
 			OperatorState operatorState,
 			List<KeyGroupRange> keyGroupPartitions,
 			int subTaskIndex,
 			int newParallelism,
 			int oldParallelism) {
 
-		Collection<KeyedStateHandle> subManagedKeyedState;
-		Collection<KeyedStateHandle> subRawKeyedState;
+		List<KeyedStateHandle> subManagedKeyedState;
+		List<KeyedStateHandle> subRawKeyedState;
 
 		if (newParallelism == oldParallelism) {
 			if (operatorState.getState(subTaskIndex) != null) {
-				subManagedKeyedState = operatorState.getState(subTaskIndex).getManagedKeyedState();
-				subRawKeyedState = operatorState.getState(subTaskIndex).getRawKeyedState();
+				subManagedKeyedState = operatorState.getState(subTaskIndex).getManagedKeyedState().asList();
+				subRawKeyedState = operatorState.getState(subTaskIndex).getRawKeyedState().asList();
 			} else {
 				subManagedKeyedState = Collections.emptyList();
 				subRawKeyedState = Collections.emptyList();
@@ -336,8 +338,8 @@ public class StateAssignmentOperation {
 			"This method still depends on the order of the new and old operators");
 
 		//collect the old partitionable state
-		List<List<OperatorStateHandle>> oldManagedOperatorStates = new ArrayList<>();
-		List<List<OperatorStateHandle>> oldRawOperatorStates = new ArrayList<>();
+		List<List<OperatorStateHandle>> oldManagedOperatorStates = new ArrayList<>(oldOperatorStates.size());
+		List<List<OperatorStateHandle>> oldRawOperatorStates = new ArrayList<>(oldOperatorStates.size());
 
 		collectPartionableStates(oldOperatorStates, oldManagedOperatorStates, oldRawOperatorStates);
 
@@ -368,24 +370,29 @@ public class StateAssignmentOperation {
 			List<List<OperatorStateHandle>> rawOperatorStates) {
 
 		for (OperatorState operatorState : operatorStates) {
+
+			final int parallelism = operatorState.getParallelism();
+
 			List<OperatorStateHandle> managedOperatorState = null;
 			List<OperatorStateHandle> rawOperatorState = null;
 
-			for (int i = 0; i < operatorState.getParallelism(); i++) {
+			for (int i = 0; i < parallelism; i++) {
 				OperatorSubtaskState operatorSubtaskState = operatorState.getState(i);
 				if (operatorSubtaskState != null) {
 
+					StateObjectCollection<OperatorStateHandle> managed = operatorSubtaskState.getManagedOperatorState();
+					StateObjectCollection<OperatorStateHandle> raw = operatorSubtaskState.getRawOperatorState();
+
 					if (managedOperatorState == null) {
-						managedOperatorState = new ArrayList<>();
+						managedOperatorState = new ArrayList<>(parallelism * managed.size());
 					}
-					managedOperatorState.addAll(operatorSubtaskState.getManagedOperatorState());
+					managedOperatorState.addAll(managed);
 
 					if (rawOperatorState == null) {
-						rawOperatorState = new ArrayList<>();
+						rawOperatorState = new ArrayList<>(parallelism * raw.size());
 					}
-					rawOperatorState.addAll(operatorSubtaskState.getRawOperatorState());
+					rawOperatorState.addAll(raw);
 				}
-
 			}
 			managedOperatorStates.add(managedOperatorState);
 			rawOperatorStates.add(rawOperatorState);
@@ -404,12 +411,19 @@ public class StateAssignmentOperation {
 		OperatorState operatorState,
 		KeyGroupRange subtaskKeyGroupRange) {
 
-		List<KeyedStateHandle> subtaskKeyedStateHandles = new ArrayList<>();
+		final int parallelism = operatorState.getParallelism();
 
-		for (int i = 0; i < operatorState.getParallelism(); i++) {
+		List<KeyedStateHandle> subtaskKeyedStateHandles = null;
+
+		for (int i = 0; i < parallelism; i++) {
 			if (operatorState.getState(i) != null) {
 
 				Collection<KeyedStateHandle> keyedStateHandles = operatorState.getState(i).getManagedKeyedState();
+
+				if (subtaskKeyedStateHandles == null) {
+					subtaskKeyedStateHandles = new ArrayList<>(parallelism * keyedStateHandles.size());
+				}
+
 				extractIntersectingState(
 					keyedStateHandles,
 					subtaskKeyGroupRange,
@@ -432,11 +446,19 @@ public class StateAssignmentOperation {
 		OperatorState operatorState,
 		KeyGroupRange subtaskKeyGroupRange) {
 
-		List<KeyedStateHandle> extractedKeyedStateHandles = new ArrayList<>();
+		final int parallelism = operatorState.getParallelism();
 
-		for (int i = 0; i < operatorState.getParallelism(); i++) {
+		List<KeyedStateHandle> extractedKeyedStateHandles = null;
+
+		for (int i = 0; i < parallelism; i++) {
 			if (operatorState.getState(i) != null) {
+
 				Collection<KeyedStateHandle> rawKeyedState = operatorState.getState(i).getRawKeyedState();
+
+				if (extractedKeyedStateHandles == null) {
+					extractedKeyedStateHandles = new ArrayList<>(parallelism * rawKeyedState.size());
+				}
+
 				extractIntersectingState(
 					rawKeyedState,
 					subtaskKeyGroupRange,
@@ -565,19 +587,18 @@ public class StateAssignmentOperation {
 			List<OperatorStateHandle> chainOpParallelStates,
 			int oldParallelism,
 			int newParallelism) {
-		Map<OperatorInstanceID, List<OperatorStateHandle>> result = new HashMap<>();
 
-		List<Collection<OperatorStateHandle>> states = applyRepartitioner(
+		List<List<OperatorStateHandle>> states = applyRepartitioner(
 			opStateRepartitioner,
 			chainOpParallelStates,
 			oldParallelism,
 			newParallelism);
 
+		Map<OperatorInstanceID, List<OperatorStateHandle>> result = new HashMap<>(states.size());
+
 		for (int subtaskIndex = 0; subtaskIndex < states.size(); subtaskIndex++) {
 			checkNotNull(states.get(subtaskIndex) != null, "states.get(subtaskIndex) is null");
-			result
-				.computeIfAbsent(OperatorInstanceID.of(subtaskIndex, operatorID), key -> new ArrayList<>())
-				.addAll(states.get(subtaskIndex));
+			result.put(OperatorInstanceID.of(subtaskIndex, operatorID), states.get(subtaskIndex));
 		}
 
 		return result;
@@ -594,7 +615,7 @@ public class StateAssignmentOperation {
 	 * @return repartitioned state
 	 */
 	// TODO rewrite based on operator id
-	public static List<Collection<OperatorStateHandle>> applyRepartitioner(
+	public static List<List<OperatorStateHandle>> applyRepartitioner(
 			OperatorStateRepartitioner opStateRepartitioner,
 			List<OperatorStateHandle> chainOpParallelStates,
 			int oldParallelism,
@@ -611,7 +632,7 @@ public class StateAssignmentOperation {
 					chainOpParallelStates,
 					newParallelism);
 		} else {
-			List<Collection<OperatorStateHandle>> repackStream = new ArrayList<>(newParallelism);
+			List<List<OperatorStateHandle>> repackStream = new ArrayList<>(newParallelism);
 			for (OperatorStateHandle operatorStateHandle : chainOpParallelStates) {
 
 				if (operatorStateHandle != null) {
@@ -645,7 +666,7 @@ public class StateAssignmentOperation {
 		Collection<? extends KeyedStateHandle> keyedStateHandles,
 		KeyGroupRange subtaskKeyGroupRange) {
 
-		List<KeyedStateHandle> subtaskKeyedStateHandles = new ArrayList<>();
+		List<KeyedStateHandle> subtaskKeyedStateHandles = new ArrayList<>(keyedStateHandles.size());
 
 		for (KeyedStateHandle keyedStateHandle : keyedStateHandles) {
 			KeyedStateHandle intersectedKeyedStateHandle = keyedStateHandle.getIntersection(subtaskKeyGroupRange);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateObjectCollection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateObjectCollection.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -176,6 +177,14 @@ public class StateObjectCollection<T extends StateObject> implements Collection<
 	@Override
 	public String toString() {
 		return "StateObjectCollection{" + stateObjects + '}';
+	}
+
+	public List<T> asList() {
+		return stateObjects instanceof List ?
+			(List<T>) stateObjects :
+			stateObjects != null ?
+				new ArrayList<>(stateObjects) :
+				Collections.emptyList();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -62,7 +62,7 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	private int currentKeyGroup;
 
 	/** So that we can give out state when the user uses the same key. */
-	private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
+	protected final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
 
 	/** For caching the last accessed partitioned state. */
 	private String lastName;
@@ -319,5 +319,4 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	public boolean requiresLegacySynchronousTimerSnapshots() {
 		return false;
 	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -180,6 +180,21 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	// -------------------------------------------------------------------------------------------
 	//  State access methods
 	// -------------------------------------------------------------------------------------------
+	@Override
+	public void removeBroadcastState(String name) {
+		restoredBroadcastStateMetaInfos.remove(name);
+		if (registeredBroadcastStates.remove(name) != null) {
+			accessedBroadcastStatesByName.remove(name);
+		}
+	}
+
+	@Override
+	public void removeOperatorState(String name) {
+		restoredOperatorStateMetaInfos.remove(name);
+		if (registeredOperatorStates.remove(name) != null) {
+			accessedStatesByName.remove(name);
+		}
+	}
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -196,6 +196,20 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		}
 	}
 
+	public void deleteBroadCastState(String name) {
+		restoredBroadcastStateMetaInfos.remove(name);
+		if (registeredBroadcastStates.remove(name) != null) {
+			accessedBroadcastStatesByName.remove(name);
+		}
+	}
+
+	public void deleteOperatorState(String name) {
+		restoredOperatorStateMetaInfos.remove(name);
+		if (registeredOperatorStates.remove(name) != null) {
+			accessedStatesByName.remove(name);
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public <K, V> BroadcastState<K, V> getBroadcastState(final MapStateDescriptor<K, V> stateDescriptor) throws StateMigrationException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.util.Disposable;
 
+import javax.annotation.Nonnull;
+
 import java.util.stream.Stream;
 
 /**
@@ -103,6 +105,16 @@ public interface KeyedStateBackend<K>
 			N namespace,
 			TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<S, ?> stateDescriptor) throws Exception;
+
+	/**
+	 * Removes the operator state with the given name from the state store, if it exists.
+	 */
+	void removeKeyedState(@Nonnull String stateName) throws Exception;
+
+	/**
+	 * Removes the queue state with the given name from the state store, if it exists.
+	 */
+	void removeQueueState(@Nonnull String name) throws Exception;
 
 	@Override
 	void dispose();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityQueueSetFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PriorityQueueSetFactory.java
@@ -38,7 +38,7 @@ public interface PriorityQueueSetFactory {
 	 * @return the queue with the specified unique name.
 	 */
 	@Nonnull
-	<T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T> create(
+	<T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T> createQueueState(
 		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer);
+		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSetFactory.java
@@ -55,7 +55,7 @@ public class HeapPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
 	@Nonnull
 	@Override
-	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> HeapPriorityQueueSet<T> create(
+	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> HeapPriorityQueueSet<T> createQueueState(
 		@Nonnull String stateName,
 		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -53,10 +53,11 @@ import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.RecoverableCompletedCheckpointStore;
-import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -2741,7 +2742,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		OperatorStateHandle osh = new OperatorStreamStateHandle(metaInfoMap, new ByteStreamStateHandle("test", new byte[150]));
 
 		OperatorStateRepartitioner repartitioner = RoundRobinOperatorStateRepartitioner.INSTANCE;
-		List<Collection<OperatorStateHandle>> repartitionedStates =
+		List<List<OperatorStateHandle>> repartitionedStates =
 				repartitioner.repartitionState(Collections.singletonList(osh), 3);
 
 		Map<String, Integer> checkCounts = new HashMap<>(3);
@@ -3331,7 +3332,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		OperatorStateRepartitioner repartitioner = RoundRobinOperatorStateRepartitioner.INSTANCE;
 
-		List<Collection<OperatorStateHandle>> pshs =
+		List<List<OperatorStateHandle>> pshs =
 				repartitioner.repartitionState(previousParallelOpInstanceStates, newParallelism);
 
 		Map<StreamStateHandle, Map<String, List<Long>>> actual = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -944,6 +945,50 @@ public class OperatorStateBackendTest {
 		static MutableType of(int value) {
 			return new MutableType(value);
 		}
+	}
+
+	@Test
+	public void testDeleteBroadcastState() throws Exception {
+		final OperatorStateBackend operatorStateBackend =
+			new DefaultOperatorStateBackend(classLoader, new ExecutionConfig(), false);
+
+		MapStateDescriptor<Integer, Integer> broadcastStateDesc1 = new MapStateDescriptor<>(
+			"test-broadcast-1", IntSerializer.INSTANCE, IntSerializer.INSTANCE);
+
+		MapStateDescriptor<Integer, Integer> broadcastStateDesc2 = new MapStateDescriptor<>(
+			"test-broadcast-2", IntSerializer.INSTANCE, IntSerializer.INSTANCE);
+
+		operatorStateBackend.getBroadcastState(broadcastStateDesc1);
+		operatorStateBackend.getBroadcastState(broadcastStateDesc2);
+
+		Assert.assertEquals(2, operatorStateBackend.getRegisteredBroadcastStateNames().size());
+
+		operatorStateBackend.removeBroadcastState(broadcastStateDesc2.getName());
+		Assert.assertEquals(1, operatorStateBackend.getRegisteredBroadcastStateNames().size());
+		Assert.assertTrue(operatorStateBackend.getRegisteredBroadcastStateNames().contains(broadcastStateDesc1.getName()));
+	}
+
+	@Test
+	public void testDeleteOperatorState() throws Exception {
+		final OperatorStateBackend operatorStateBackend =
+			new DefaultOperatorStateBackend(classLoader, new ExecutionConfig(), false);
+
+		ListStateDescriptor<Integer> listStateDesc1 = new ListStateDescriptor<>("test-broadcast-1", IntSerializer.INSTANCE);
+		ListStateDescriptor<Integer> listStateDesc2 = new ListStateDescriptor<>("test-broadcast-2", IntSerializer.INSTANCE);
+
+		operatorStateBackend.getListState(listStateDesc1);
+		operatorStateBackend.getUnionListState(listStateDesc2);
+
+		Set<String> registeredStateNames = operatorStateBackend.getRegisteredStateNames();
+
+		Assert.assertEquals(2, registeredStateNames.size());
+
+		operatorStateBackend.removeOperatorState(listStateDesc1.getName());
+		Assert.assertEquals(1, registeredStateNames.size());
+		Assert.assertTrue(registeredStateNames.contains(listStateDesc2.getName()));
+
+		operatorStateBackend.removeOperatorState(listStateDesc2.getName());
+		Assert.assertEquals(0, registeredStateNames.size());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -171,6 +171,16 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	@Override
+	public void removeKeyedState(@Nonnull String stateName) {
+
+	}
+
+	@Override
+	public void removeQueueState(@Nonnull String name) {
+
+	}
+
+	@Override
 	public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
 		long checkpointId,
 		long timestamp,
@@ -229,7 +239,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@Nonnull
 	@Override
 	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T>
-	create(
+	createQueueState(
 		@Nonnull String stateName,
 		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
 		return new HeapPriorityQueueSet<>(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -85,7 +85,6 @@ import org.apache.flink.runtime.state.SnapshotStrategy;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
-import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -353,6 +352,33 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 	}
 
+	@Override
+	public void removeQueueState(@Nonnull String stateName) throws RocksDBException {
+		removeInternal(stateName);
+	}
+
+	@Override
+	public void removeKeyedState(@Nonnull String stateName) throws RocksDBException {
+		removeInternal(stateName);
+	}
+
+	private void removeInternal(@Nonnull String name) throws RocksDBException {
+		restoredKvStateMetaInfos.remove(name);
+		Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> removedStateMetaInfo = kvStateInformation.remove(name);
+		if (removedStateMetaInfo != null) {
+			if (kvStateRegistry != null) {
+				kvStateRegistry.unregisterKvState(name);
+			}
+			keyValueStatesByName.remove(name);
+			ColumnFamilyHandle removeColumnFamily = removedStateMetaInfo.f0;
+			try {
+				db.dropColumnFamily(removeColumnFamily);
+			} finally {
+				IOUtils.closeQuietly(removeColumnFamily);
+			}
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public <N> Stream<K> getKeys(String state, N namespace) {
@@ -444,10 +470,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@Nonnull
 	@Override
 	public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T>
-	create(
+	createQueueState(
 		@Nonnull String stateName,
-		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
-		return priorityQueueFactory.create(stateName, byteOrderedElementSerializer);
+		@Nonnull TypeSerializer<T> byteOrderedElementSerializer) throws Exception {
+		return priorityQueueFactory.createQueueState(stateName, byteOrderedElementSerializer);
 	}
 
 	private void cleanInstanceBasePath() {
@@ -1381,7 +1407,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(
 		@Nonnull TypeSerializer<N> namespaceSerializer,
 		@Nonnull StateDescriptor<S, SV> stateDesc,
-		@Nonnull StateSnapshotTransformFactory<SEV> snapshotTransformFactory) throws Exception {
+		@Nonnull StateSnapshotTransformer.StateSnapshotTransformFactory<SEV> snapshotTransformFactory) throws Exception {
 		StateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
 		if (stateFactory == null) {
 			String message = String.format("State %s is not supported by %s",
@@ -1396,7 +1422,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@SuppressWarnings("unchecked")
 	private <SV, SEV> StateSnapshotTransformer<SV> getStateSnapshotTransformer(
 		StateDescriptor<?, SV> stateDesc,
-		StateSnapshotTransformFactory<SEV> snapshotTransformFactory) {
+		StateSnapshotTransformer.StateSnapshotTransformFactory<SEV> snapshotTransformFactory) {
 		if (stateDesc instanceof ListStateDescriptor) {
 			Optional<StateSnapshotTransformer<SEV>> original = snapshotTransformFactory.createForDeserializedState();
 			return original.map(est -> createRocksDBListStateTransformer(stateDesc, est)).orElse(null);
@@ -2756,7 +2782,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		@Nonnull
 		@Override
 		public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> KeyGroupedInternalPriorityQueue<T>
-		create(@Nonnull String stateName, @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+		createQueueState(@Nonnull String stateName, @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
 
 			final Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> metaInfoTuple =
 				tryRegisterPriorityQueueMetaInfo(stateName, byteOrderedElementSerializer);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -729,7 +729,7 @@ public abstract class AbstractStreamOperator<OUT>
 	public <K, N> InternalTimerService<N> getInternalTimerService(
 			String name,
 			TypeSerializer<N> namespaceSerializer,
-			Triggerable<K, N> triggerable) {
+			Triggerable<K, N> triggerable) throws Exception {
 
 		checkTimerServiceInitialization();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -82,7 +82,7 @@ public class InternalTimeServiceManager<K> {
 	public <N> InternalTimerService<N> getInternalTimerService(
 		String name,
 		TimerSerializer<K, N> timerSerializer,
-		Triggerable<K, N> triggerable) {
+		Triggerable<K, N> triggerable) throws Exception {
 
 		InternalTimerServiceImpl<K, N> timerService = registerOrGetTimerService(name, timerSerializer);
 
@@ -95,7 +95,10 @@ public class InternalTimeServiceManager<K> {
 	}
 
 	@SuppressWarnings("unchecked")
-	<N> InternalTimerServiceImpl<K, N> registerOrGetTimerService(String name, TimerSerializer<K, N> timerSerializer) {
+	<N> InternalTimerServiceImpl<K, N> registerOrGetTimerService(
+		String name,
+		TimerSerializer<K, N> timerSerializer) throws Exception {
+
 		InternalTimerServiceImpl<K, N> timerService = (InternalTimerServiceImpl<K, N>) timerServices.get(name);
 		if (timerService == null) {
 
@@ -117,8 +120,8 @@ public class InternalTimeServiceManager<K> {
 
 	private <N> KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> createTimerPriorityQueue(
 		String name,
-		TimerSerializer<K, N> timerSerializer) {
-		return priorityQueueSetFactory.create(
+		TimerSerializer<K, N> timerSerializer) throws Exception {
+		return priorityQueueSetFactory.createQueueState(
 			name,
 			timerSerializer);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
@@ -79,7 +79,7 @@ public class InternalTimerServiceImplTest {
 	}
 
 	@Test
-	public void testKeyGroupStartIndexSetting() {
+	public void testKeyGroupStartIndexSetting() throws Exception {
 
 		int startKeyGroupIdx = 7;
 		int endKeyGroupIdx = 21;
@@ -101,7 +101,7 @@ public class InternalTimerServiceImplTest {
 	}
 
 	@Test
-	public void testTimerAssignmentToKeyGroups() {
+	public void testTimerAssignmentToKeyGroups() throws Exception {
 		int totalNoOfTimers = 100;
 
 		int totalNoOfKeyGroups = 100;
@@ -811,7 +811,7 @@ public class InternalTimerServiceImplTest {
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
 			KeyGroupRange keyGroupList,
-			PriorityQueueSetFactory priorityQueueSetFactory) {
+			PriorityQueueSetFactory priorityQueueSetFactory) throws Exception {
 		InternalTimerServiceImpl<Integer, String> service = createInternalTimerService(
 			keyGroupList,
 			keyContext,
@@ -892,7 +892,7 @@ public class InternalTimerServiceImplTest {
 		ProcessingTimeService processingTimeService,
 		TypeSerializer<K> keySerializer,
 		TypeSerializer<N> namespaceSerializer,
-		PriorityQueueSetFactory priorityQueueSetFactory) {
+		PriorityQueueSetFactory priorityQueueSetFactory) throws Exception {
 
 		TimerSerializer<K, N> timerSerializer = new TimerSerializer<>(keySerializer, namespaceSerializer);
 
@@ -907,8 +907,8 @@ public class InternalTimerServiceImplTest {
 	private static <K, N> KeyGroupedInternalPriorityQueue<TimerHeapInternalTimer<K, N>> createTimerQueue(
 		String name,
 		TimerSerializer<K, N> timerSerializer,
-		PriorityQueueSetFactory priorityQueueSetFactory) {
-		return priorityQueueSetFactory.create(
+		PriorityQueueSetFactory priorityQueueSetFactory) throws Exception {
+		return priorityQueueSetFactory.createQueueState(
 			name,
 			timerSerializer);
 	}


### PR DESCRIPTION
## What is the purpose of the change

KafkaConsumer store its offsets state always as union state. I think this is only required in the case that partition discovery is active. For jobs with a very high parallelism, the union state can lead to prohibitively expensive deployments. For example, a job with 2000 source and a total of 10MB checkpointed union state offsets state would have to ship ~ 2000 x 10MB = 20GB of state. With partitionable state, it would have to ship ~10MB.

For now, I would suggest to go back to partitionable state in case that partition discovery is not active. In the long run, I have some ideas for more efficient partitioning schemes that would also work for active discovery.

As an additional step to support backwards compatibility and avoid state blowup from the compatibility state, I also implemented FLINK-10121, so that operator state can be removed from the backend.

Included also a hotfix that makes state assignment on the JM more memory friendly by trying to allocate all collections with good sizes.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
