### PR TITLE
[hotfix][streaming] Fix and simplify PrintSinkFunctionTest

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.ListState;
@@ -32,16 +31,12 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.kafka.config.OffsetCommitMode;
@@ -54,6 +49,7 @@ import org.apache.flink.streaming.connectors.kafka.testutils.TestPartitionDiscov
 import org.apache.flink.streaming.connectors.kafka.testutils.TestSourceContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -743,7 +739,7 @@ public class FlinkKafkaConsumerBaseTest {
 			int totalNumSubtasks) throws Exception {
 
 		// run setup procedure in operator life cycle
-		consumer.setRuntimeContext(new MockRuntimeContext(isCheckpointingEnabled, totalNumSubtasks, subtaskIndex));
+		consumer.setRuntimeContext(new MockStreamingRuntimeContext(isCheckpointingEnabled, totalNumSubtasks, subtaskIndex));
 		consumer.initializeState(new MockFunctionInitializationContext(isRestored, new MockOperatorStateStore(restoredListState)));
 		consumer.open(new Configuration());
 	}
@@ -817,68 +813,6 @@ public class FlinkKafkaConsumerBaseTest {
 
 		private int getCommitCount() {
 			return commitCount;
-		}
-	}
-
-	private static class MockRuntimeContext extends StreamingRuntimeContext {
-
-		private final boolean isCheckpointingEnabled;
-
-		private final int numParallelSubtasks;
-		private final int subtaskIndex;
-
-		private MockRuntimeContext(
-				boolean isCheckpointingEnabled,
-				int numParallelSubtasks,
-				int subtaskIndex) {
-
-			super(
-				new MockStreamOperator(),
-				new MockEnvironmentBuilder()
-					.setTaskName("mockTask")
-					.setMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
-					.build(),
-				Collections.emptyMap());
-
-			this.isCheckpointingEnabled = isCheckpointingEnabled;
-			this.numParallelSubtasks = numParallelSubtasks;
-			this.subtaskIndex = subtaskIndex;
-		}
-
-		@Override
-		public MetricGroup getMetricGroup() {
-			return new UnregisteredMetricsGroup();
-		}
-
-		@Override
-		public boolean isCheckpointingEnabled() {
-			return isCheckpointingEnabled;
-		}
-
-		@Override
-		public int getIndexOfThisSubtask() {
-			return subtaskIndex;
-		}
-
-		@Override
-		public int getNumberOfParallelSubtasks() {
-			return numParallelSubtasks;
-		}
-
-		// ------------------------------------------------------------------------
-
-		private static class MockStreamOperator extends AbstractStreamOperator<Integer> {
-			private static final long serialVersionUID = -1153976702711944427L;
-
-			@Override
-			public ExecutionConfig getExecutionConfig() {
-				return new ExecutionConfig();
-			}
-
-			@Override
-			public OperatorID getOperatorID() {
-				return new OperatorID();
-			}
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkFunctionTest.java
@@ -20,12 +20,11 @@ package org.apache.flink.streaming.api.functions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkContextUtil;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 
 import org.junit.After;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -33,93 +32,75 @@ import java.io.PrintStream;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for the {@link org.apache.flink.streaming.api.functions.sink.PrintSinkFunction}.
+ * Tests for the {@link PrintSinkFunction}.
  */
 public class PrintSinkFunctionTest {
 
-	public PrintStream printStreamOriginal = System.out;
-	private String line = System.lineSeparator();
+	private final PrintStream originalSystemOut = System.out;
+	private final PrintStream originalSystemErr = System.err;
+
+	private final ByteArrayOutputStream arrayOutputStream = new ByteArrayOutputStream();
+	private final ByteArrayOutputStream arrayErrorStream = new ByteArrayOutputStream();
+
+	private final String line = System.lineSeparator();
+
+	@Before
+	public void setUp() {
+		System.setOut(new PrintStream(arrayOutputStream));
+		System.setErr(new PrintStream(arrayErrorStream));
+	}
+
+	@After
+	public void tearDown() {
+		if (System.out != originalSystemOut) {
+			System.out.close();
+		}
+		if (System.err != originalSystemErr) {
+			System.err.close();
+		}
+		System.setOut(originalSystemOut);
+		System.setErr(originalSystemErr);
+	}
 
 	@Test
 	public void testPrintSinkStdOut() throws Exception {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		PrintStream stream = new PrintStream(baos);
-		System.setOut(stream);
-
-		final StreamingRuntimeContext ctx = Mockito.mock(StreamingRuntimeContext.class);
-
 		PrintSinkFunction<String> printSink = new PrintSinkFunction<>();
-		printSink.setRuntimeContext(ctx);
-		try {
-			printSink.open(new Configuration());
-		} catch (Exception e) {
-			Assert.fail();
-		}
+		printSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
 		printSink.setTargetToStandardOut();
+		printSink.open(new Configuration());
+
 		printSink.invoke("hello world!", SinkContextUtil.forTimestamp(0));
 
 		assertEquals("Print to System.out", printSink.toString());
-		assertEquals("hello world!" + line, baos.toString());
-
+		assertEquals("hello world!" + line, arrayOutputStream.toString());
 		printSink.close();
-		stream.close();
 	}
 
 	@Test
 	public void testPrintSinkStdErr() throws Exception {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		PrintStream stream = new PrintStream(baos);
-		System.setOut(stream);
-
-		final StreamingRuntimeContext ctx = Mockito.mock(StreamingRuntimeContext.class);
-
 		PrintSinkFunction<String> printSink = new PrintSinkFunction<>();
-		printSink.setRuntimeContext(ctx);
-		try {
-			printSink.open(new Configuration());
-		} catch (Exception e) {
-			Assert.fail();
-		}
+		printSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
 		printSink.setTargetToStandardErr();
+		printSink.open(new Configuration());
+
 		printSink.invoke("hello world!", SinkContextUtil.forTimestamp(0));
 
 		assertEquals("Print to System.err", printSink.toString());
-		assertEquals("hello world!" + line, baos.toString());
-
+		assertEquals("hello world!" + line, arrayErrorStream.toString());
 		printSink.close();
-		stream.close();
 	}
 
 	@Test
 	public void testPrintSinkWithPrefix() throws Exception {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		PrintStream stream = new PrintStream(baos);
-		System.setOut(stream);
-
-		final StreamingRuntimeContext ctx = Mockito.mock(StreamingRuntimeContext.class);
-		Mockito.when(ctx.getNumberOfParallelSubtasks()).thenReturn(2);
-		Mockito.when(ctx.getIndexOfThisSubtask()).thenReturn(1);
-
 		PrintSinkFunction<String> printSink = new PrintSinkFunction<>();
-		printSink.setRuntimeContext(ctx);
-		try {
-			printSink.open(new Configuration());
-		} catch (Exception e) {
-			Assert.fail();
-		}
-		printSink.setTargetToStandardErr();
+		printSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 2, 1));
+		printSink.setTargetToStandardOut();
+		printSink.open(new Configuration());
+
 		printSink.invoke("hello world!", SinkContextUtil.forTimestamp(0));
 
-		assertEquals("Print to System.err", printSink.toString());
-		assertEquals("2> hello world!" + line, baos.toString());
-
+		assertEquals("Print to System.out", printSink.toString());
+		assertEquals("2> hello world!" + line, arrayOutputStream.toString());
 		printSink.close();
-		stream.close();
 	}
-
-	@After
-	public void restoreSystemOut() {
-		System.setOut(printStreamOriginal);
-	}
-
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamingRuntimeContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamingRuntimeContext.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+
+import java.util.Collections;
+
+/**
+ * Mock {@link StreamingRuntimeContext} to use in tests.
+ */
+public class MockStreamingRuntimeContext extends StreamingRuntimeContext {
+
+	private final boolean isCheckpointingEnabled;
+
+	private final int numParallelSubtasks;
+	private final int subtaskIndex;
+
+	public MockStreamingRuntimeContext(
+		boolean isCheckpointingEnabled,
+		int numParallelSubtasks,
+		int subtaskIndex) {
+
+		super(
+			new MockStreamOperator(),
+			new MockEnvironmentBuilder()
+				.setTaskName("mockTask")
+				.setMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
+				.build(),
+			Collections.emptyMap());
+
+		this.isCheckpointingEnabled = isCheckpointingEnabled;
+		this.numParallelSubtasks = numParallelSubtasks;
+		this.subtaskIndex = subtaskIndex;
+	}
+
+	@Override
+	public MetricGroup getMetricGroup() {
+		return new UnregisteredMetricsGroup();
+	}
+
+	@Override
+	public boolean isCheckpointingEnabled() {
+		return isCheckpointingEnabled;
+	}
+
+	@Override
+	public int getIndexOfThisSubtask() {
+		return subtaskIndex;
+	}
+
+	@Override
+	public int getNumberOfParallelSubtasks() {
+		return numParallelSubtasks;
+	}
+
+	private static class MockStreamOperator extends AbstractStreamOperator<Integer> {
+		private static final long serialVersionUID = -1153976702711944427L;
+
+		@Override
+		public ExecutionConfig getExecutionConfig() {
+			return new ExecutionConfig();
+		}
+
+		@Override
+		public OperatorID getOperatorID() {
+			return new OperatorID();
+		}
+	}
+}


### PR DESCRIPTION
Previously PrintSinkFunctionTest was testing incorrectly for System.err. setTargetToStandardErr was being called after opening PrintSink so it didn't have any effect.

This commit also reduce code duplication and get rids of mockito usage in this test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
