### PR TITLE
[FLINK-10123] Use ExecutorThreadFactory instead of DefaultThreadFactory in RestServer/Client

### DIFF
--- a/docs/_includes/generated/akka_configuration.html
+++ b/docs/_includes/generated/akka_configuration.html
@@ -13,9 +13,39 @@
             <td>Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
+            <td><h5>akka.client-socket-worker-pool.pool-size-factor</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>The pool size factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the pool-size-min and pool-size-max values.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.client-socket-worker-pool.pool-size-max</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Max number of threads to cap factor-based number to.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.client-socket-worker-pool.pool-size-min</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Min number of threads to cap factor-based number to.</td>
+        </tr>
+        <tr>
             <td><h5>akka.client.timeout</h5></td>
             <td style="word-wrap: break-word;">"60 s"</td>
             <td>Timeout for all blocking calls on the client side.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.fork-join-executor.parallelism-factor</h5></td>
+            <td style="word-wrap: break-word;">2.0</td>
+            <td>The parallelism factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the parallelism-min and parallelism-max values.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.fork-join-executor.parallelism-max</h5></td>
+            <td style="word-wrap: break-word;">64</td>
+            <td>Max number of threads to cap factor-based parallelism number to.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.fork-join-executor.parallelism-min</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Min number of threads to cap factor-based parallelism number to.</td>
         </tr>
         <tr>
             <td><h5>akka.framesize</h5></td>
@@ -41,6 +71,21 @@
             <td><h5>akka.retry-gate-closed-for</h5></td>
             <td style="word-wrap: break-word;">50</td>
             <td>Milliseconds a gate should be closed for after a remote connection was disconnected.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.server-socket-worker-pool.pool-size-factor</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>The pool size factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the pool-size-min and pool-size-max values.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.server-socket-worker-pool.pool-size-max</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Max number of threads to cap factor-based number to.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.server-socket-worker-pool.pool-size-min</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Min number of threads to cap factor-based number to.</td>
         </tr>
         <tr>
             <td><h5>akka.ssl.enabled</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -194,4 +194,81 @@ public class AkkaOptions {
 		.key("akka.retry-gate-closed-for")
 		.defaultValue(50L)
 		.withDescription("Milliseconds a gate should be closed for after a remote connection was disconnected.");
+
+	// ==================================================
+	// Configurations for fork-join-executor.
+	// ==================================================
+
+	public static final ConfigOption<Double> FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR = ConfigOptions
+		.key("akka.fork-join-executor.parallelism-factor")
+		.defaultValue(2.0)
+		.withDescription(Description.builder()
+			.text("The parallelism factor is used to determine thread pool size using the" +
+				" following formula: ceil(available processors * factor). Resulting size" +
+				" is then bounded by the parallelism-min and parallelism-max values."
+			).build());
+
+	public static final ConfigOption<Integer> FORK_JOIN_EXECUTOR_PARALLELISM_MIN = ConfigOptions
+		.key("akka.fork-join-executor.parallelism-min")
+		.defaultValue(8)
+		.withDescription(Description.builder()
+			.text("Min number of threads to cap factor-based parallelism number to.").build());
+
+	public static final ConfigOption<Integer> FORK_JOIN_EXECUTOR_PARALLELISM_MAX = ConfigOptions
+		.key("akka.fork-join-executor.parallelism-max")
+		.defaultValue(64)
+		.withDescription(Description.builder()
+			.text("Max number of threads to cap factor-based parallelism number to.").build());
+
+	// ==================================================
+	// Configurations for client-socket-work-pool.
+	// ==================================================
+
+	public static final ConfigOption<Integer> CLIENT_SOCKET_WORKER_POOL_SIZE_MIN = ConfigOptions
+		.key("akka.client-socket-worker-pool.pool-size-min")
+		.defaultValue(1)
+		.withDescription(Description.builder()
+			.text("Min number of threads to cap factor-based number to.").build());
+
+	public static final ConfigOption<Integer> CLIENT_SOCKET_WORKER_POOL_SIZE_MAX = ConfigOptions
+		.key("akka.client-socket-worker-pool.pool-size-max")
+		.defaultValue(2)
+		.withDescription(Description.builder()
+			.text("Max number of threads to cap factor-based number to.").build());
+
+	public static final ConfigOption<Double> CLIENT_SOCKET_WORKER_POOL_SIZE_FACTOR = ConfigOptions
+		.key("akka.client-socket-worker-pool.pool-size-factor")
+		.defaultValue(1.0)
+		.withDescription(Description.builder()
+			.text("The pool size factor is used to determine thread pool size" +
+				" using the following formula: ceil(available processors * factor)." +
+				" Resulting size is then bounded by the pool-size-min and" +
+				" pool-size-max values."
+			).build());
+
+	// ==================================================
+	// Configurations for server-socket-work-pool.
+	// ==================================================
+
+	public static final ConfigOption<Integer> SERVER_SOCKET_WORKER_POOL_SIZE_MIN = ConfigOptions
+		.key("akka.server-socket-worker-pool.pool-size-min")
+		.defaultValue(1)
+		.withDescription(Description.builder()
+			.text("Min number of threads to cap factor-based number to.").build());
+
+	public static final ConfigOption<Integer> SERVER_SOCKET_WORKER_POOL_SIZE_MAX = ConfigOptions
+		.key("akka.server-socket-worker-pool.pool-size-max")
+		.defaultValue(2)
+		.withDescription(Description.builder()
+			.text("Max number of threads to cap factor-based number to.").build());
+
+	public static final ConfigOption<Double> SERVER_SOCKET_WORKER_POOL_SIZE_FACTOR = ConfigOptions
+		.key("akka.server-socket-worker-pool.pool-size-factor")
+		.defaultValue(1.0)
+		.withDescription(Description.builder()
+			.text("The pool size factor is used to determine thread pool size" +
+				" using the following formula: ceil(available processors * factor)." +
+				" Resulting size is then bounded by the pool-size-min and" +
+				" pool-size-max values."
+			).build());
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -104,14 +104,7 @@ public class BootstrapTools {
 		while (portsIterator.hasNext()) {
 			// first, we check if the port is available by opening a socket
 			// if the actor system fails to start on the port, we try further
-			ServerSocket availableSocket = NetUtils.createSocketFromPorts(
-				portsIterator,
-				new NetUtils.SocketFactory() {
-					@Override
-					public ServerSocket createSocket(int port) throws IOException {
-						return new ServerSocket(port);
-					}
-				});
+			ServerSocket availableSocket = NetUtils.createSocketFromPorts(portsIterator, ServerSocket::new);
 
 			int port;
 			if (availableSocket == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1655,4 +1655,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	RestartStrategy getRestartStrategy() {
 		return restartStrategy;
 	}
+
+	@VisibleForTesting
+	ExecutionGraph getExecutionGraph() {
+		return executionGraph;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.rest.util.RestConstants;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
@@ -69,7 +70,6 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.multipart.Http
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.multipart.MemoryAttribute;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
-import org.apache.flink.shaded.netty4.io.netty.util.concurrent.DefaultThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,7 +121,7 @@ public class RestClient {
 					.addLast(new ClientHandler());
 			}
 		};
-		NioEventLoopGroup group = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-client-netty"));
+		NioEventLoopGroup group = new NioEventLoopGroup(1, new ExecutorThreadFactory("flink-rest-client-netty"));
 
 		bootstrap = new Bootstrap();
 		bootstrap

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.rest.handler.router.RouterHandler;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.Preconditions;
 
@@ -43,7 +44,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocke
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCodec;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
-import org.apache.flink.shaded.netty4.io.netty.util.concurrent.DefaultThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,8 +169,8 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 				}
 			};
 
-			NioEventLoopGroup bossGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-server-netty-boss"));
-			NioEventLoopGroup workerGroup = new NioEventLoopGroup(0, new DefaultThreadFactory("flink-rest-server-netty-worker"));
+			NioEventLoopGroup bossGroup = new NioEventLoopGroup(1, new ExecutorThreadFactory("flink-rest-server-netty-boss"));
+			NioEventLoopGroup workerGroup = new NioEventLoopGroup(0, new ExecutorThreadFactory("flink-rest-server-netty-worker"));
 
 			bootstrap = new ServerBootstrap();
 			bootstrap

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -52,7 +52,7 @@ public class AkkaRpcServiceUtils {
 	private static final Logger LOG = LoggerFactory.getLogger(AkkaRpcServiceUtils.class);
 
 	private static final String AKKA_TCP = "akka.tcp";
-	private static final String AkKA_SSL_TCP = "akka.ssl.tcp";
+	private static final String AKKA_SSL_TCP = "akka.ssl.tcp";
 
 	private static final AtomicLong nextNameOffset = new AtomicLong(0L);
 
@@ -162,7 +162,7 @@ public class AkkaRpcServiceUtils {
 		checkNotNull(endpointName, "endpointName is null");
 		checkArgument(port > 0 && port <= 65535, "port must be in [1, 65535]");
 
-		final String protocolPrefix = akkaProtocol == AkkaProtocol.SSL_TCP ? AkKA_SSL_TCP : AKKA_TCP;
+		final String protocolPrefix = akkaProtocol == AkkaProtocol.SSL_TCP ? AKKA_SSL_TCP : AKKA_TCP;
 
 		if (addressResolution == AddressResolution.TRY_ADDRESS_RESOLUTION) {
 			// Fail fast if the hostname cannot be resolved

--- a/flink-runtime/src/main/scala/akka/actor/RobustActorSystem.scala
+++ b/flink-runtime/src/main/scala/akka/actor/RobustActorSystem.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.actor
+
+import java.lang.Thread.UncaughtExceptionHandler
+
+import akka.actor.ActorSystem.findClassLoader
+import akka.actor.setup.ActorSystemSetup
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.flink.runtime.util.FatalExitExceptionHandler
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * [[ActorSystemImpl]] which has a configurable [[java.lang.Thread.UncaughtExceptionHandler]].
+  */
+class RobustActorSystem(
+    name: String,
+    applicationConfig: Config,
+    classLoader: ClassLoader,
+    defaultExecutionContext: Option[ExecutionContext],
+    guardianProps: Option[Props],
+    setup: ActorSystemSetup,
+    val optionalUncaughtExceptionHandler: Option[UncaughtExceptionHandler])
+    extends ActorSystemImpl(
+      name,
+      applicationConfig,
+      classLoader,
+      defaultExecutionContext,
+      guardianProps,
+      setup) {
+
+  override protected def uncaughtExceptionHandler: Thread.UncaughtExceptionHandler =
+    optionalUncaughtExceptionHandler.getOrElse(super.uncaughtExceptionHandler)
+}
+
+object RobustActorSystem {
+  def create(name: String, applicationConfig: Config): RobustActorSystem = {
+    apply(name, ActorSystemSetup.create(BootstrapSetup(None, Option(applicationConfig), None)))
+  }
+
+  def create(
+      name: String,
+      applicationConfig: Config,
+      uncaughtExceptionHandler: UncaughtExceptionHandler): RobustActorSystem = {
+    apply(
+      name,
+      ActorSystemSetup.create(BootstrapSetup(None, Option(applicationConfig), None)),
+      uncaughtExceptionHandler
+    )
+  }
+
+  def apply(name: String, setup: ActorSystemSetup): RobustActorSystem = {
+    internalApply(name, setup, Some(FatalExitExceptionHandler.INSTANCE))
+  }
+
+  def apply(
+      name: String,
+      setup: ActorSystemSetup,
+      uncaughtExceptionHandler: UncaughtExceptionHandler): RobustActorSystem = {
+    internalApply(name, setup, Some(uncaughtExceptionHandler))
+  }
+
+  def internalApply(
+      name: String,
+      setup: ActorSystemSetup,
+      uncaughtExceptionHandler: Option[UncaughtExceptionHandler]): RobustActorSystem = {
+    val bootstrapSettings = setup.get[BootstrapSetup]
+    val cl = bootstrapSettings.flatMap(_.classLoader).getOrElse(findClassLoader())
+    val appConfig = bootstrapSettings.flatMap(_.config).getOrElse(ConfigFactory.load(cl))
+    val defaultEC = bootstrapSettings.flatMap(_.defaultExecutionContext)
+
+    new RobustActorSystem(
+      name,
+      appConfig,
+      cl,
+      defaultEC,
+      None,
+      setup,
+      uncaughtExceptionHandler).start()
+  }
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -103,7 +103,7 @@ object AkkaUtils {
   def createActorSystem(akkaConfig: Config): ActorSystem = {
     // Initialize slf4j as logger of Akka's Netty instead of java.util.logging (FLINK-1650)
     InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory)
-    new RobustActorSystem("flink", akkaConfig)
+    RobustActorSystem.create("flink", akkaConfig)
   }
 
   /**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -103,7 +103,7 @@ object AkkaUtils {
   def createActorSystem(akkaConfig: Config): ActorSystem = {
     // Initialize slf4j as logger of Akka's Netty instead of java.util.logging (FLINK-1650)
     InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory)
-    ActorSystem.create("flink", akkaConfig)
+    new RobustActorSystem("flink", akkaConfig)
   }
 
   /**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.net.SSLUtils
 import org.apache.flink.util.NetUtils
 import org.jboss.netty.channel.ChannelException
 import org.jboss.netty.logging.{InternalLoggerFactory, Slf4JLoggerFactory}
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
 import scala.concurrent._
@@ -44,9 +44,9 @@ import scala.language.postfixOps
  * actor systems resides in this class.
  */
 object AkkaUtils {
-  val LOG = LoggerFactory.getLogger(AkkaUtils.getClass)
+  val LOG: Logger = LoggerFactory.getLogger(AkkaUtils.getClass)
 
-  val INF_TIMEOUT = 21474835 seconds
+  val INF_TIMEOUT: FiniteDuration = 21474835 seconds
 
   /**
    * Creates a local actor system without remoting.
@@ -124,7 +124,9 @@ object AkkaUtils {
     * @param port to bind against
     * @return A remote Akka config
     */
-  def getAkkaConfig(configuration: Configuration, hostname: String, port: Int): Config = {
+  def getAkkaConfig(configuration: Configuration,
+                    hostname: String,
+                    port: Int): Config = {
     getAkkaConfig(configuration, Some((hostname, port)))
   }
 
@@ -203,6 +205,24 @@ object AkkaUtils {
     val supervisorStrategy = classOf[StoppingSupervisorWithoutLoggingActorKilledExceptionStrategy]
       .getCanonicalName
 
+    val forkJoinExecutorParallelismFactor =
+      configuration.getDouble(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR)
+
+    val forkJoinExecutorParallelismMin =
+      configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MIN)
+
+    val forkJoinExecutorParallelismMax =
+      configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MAX)
+
+    val forkJoinExecutorConfig =
+      s"""
+         | fork-join-executor {
+         |   parallelism-factor = $forkJoinExecutorParallelismFactor
+         |   parallelism-min = $forkJoinExecutorParallelismMin
+         |   parallelism-max = $forkJoinExecutorParallelismMax
+         | }
+       """.stripMargin
+
     val config =
       s"""
         |akka {
@@ -230,9 +250,7 @@ object AkkaUtils {
         |   default-dispatcher {
         |     throughput = $akkaThroughput
         |
-        |     fork-join-executor {
-        |       parallelism-factor = 2.0
-        |     }
+        |   $forkJoinExecutorConfig
         |   }
         | }
         |}
@@ -263,7 +281,7 @@ object AkkaUtils {
   private def validateHeartbeat(pauseParamName: String,
                                 pauseValue: String,
                                 intervalParamName: String,
-                                intervalValue: String) = {
+                                intervalValue: String): Unit = {
     if (Duration.apply(pauseValue).lteq(Duration.apply(intervalValue))) {
       throw new IllegalConfigurationException(
         "%s [%s] must greater then %s [%s]",
@@ -367,6 +385,25 @@ object AkkaUtils {
     val akkaSSLAlgorithmsString = configuration.getString(SecurityOptions.SSL_ALGORITHMS)
     val akkaSSLAlgorithms = akkaSSLAlgorithmsString.split(",").toList.mkString("[", ",", "]")
 
+    val clientSocketWorkerPoolPoolSizeMin =
+      configuration.getInteger(AkkaOptions.CLIENT_SOCKET_WORKER_POOL_SIZE_MIN)
+
+    val clientSocketWorkerPoolPoolSizeMax =
+      configuration.getInteger(AkkaOptions.CLIENT_SOCKET_WORKER_POOL_SIZE_MAX)
+
+    val clientSocketWorkerPoolPoolSizeFactor =
+      configuration.getDouble(AkkaOptions.CLIENT_SOCKET_WORKER_POOL_SIZE_FACTOR)
+
+    val serverSocketWorkerPoolPoolSizeMin =
+      configuration.getInteger(AkkaOptions.SERVER_SOCKET_WORKER_POOL_SIZE_MIN)
+
+    val serverSocketWorkerPoolPoolSizeMax =
+      configuration.getInteger(AkkaOptions.SERVER_SOCKET_WORKER_POOL_SIZE_MAX)
+
+    val serverSocketWorkerPoolPoolSizeFactor =
+      configuration.getDouble(AkkaOptions.SERVER_SOCKET_WORKER_POOL_SIZE_FACTOR)
+
+
     val configString =
       s"""
          |akka {
@@ -397,6 +434,18 @@ object AkkaUtils {
          |        connection-timeout = $akkaTCPTimeout
          |        maximum-frame-size = $akkaFramesize
          |        tcp-nodelay = on
+         |
+         |        client-socket-worker-pool {
+         |          pool-size-min = $clientSocketWorkerPoolPoolSizeMin
+         |          pool-size-max = $clientSocketWorkerPoolPoolSizeMax
+         |          pool-size-factor = $clientSocketWorkerPoolPoolSizeFactor
+         |        }
+         |
+         |        server-socket-worker-pool {
+         |          pool-size-min = $serverSocketWorkerPoolPoolSizeMin
+         |          pool-size-max = $serverSocketWorkerPoolPoolSizeMax
+         |          pool-size-factor = $serverSocketWorkerPoolPoolSizeFactor
+         |        }
          |      }
          |    }
          |
@@ -790,7 +839,7 @@ object AkkaUtils {
           retryOnBindException(fn, stopCond)
         }
       case scala.util.Failure(x: Exception) => x.getCause match {
-        case c: ChannelException =>
+        case _: ChannelException =>
           if (stopCond) {
             scala.util.Failure(new RuntimeException(
               "Unable to do further retries starting the actor system"))

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -2143,7 +2143,6 @@ object JobManager {
       configuration: Configuration,
       externalHostname: String,
       port: Int): ActorSystem = {
-
     // Bring up the job manager actor system first, bind it to the given address.
     val jobManagerSystem = BootstrapTools.startActorSystem(
       configuration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
@@ -26,6 +26,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Kill;
 import akka.actor.Props;
+import akka.actor.RobustActorSystem;
 import akka.testkit.JavaTestKit;
 import akka.testkit.TestActorRef;
 import org.junit.AfterClass;
@@ -46,7 +47,7 @@ public class FlinkUntypedActorTest {
 
 	@BeforeClass
 	public static void setup() {
-		actorSystem = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
+		actorSystem = new RobustActorSystem("TestingActorSystem", TestingUtils.testConfig());
 	}
 
 	@AfterClass

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.akka;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.RequiresLeaderSessionID;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -41,13 +42,13 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link FlinkUntypedActor}.
  */
-public class FlinkUntypedActorTest {
+public class FlinkUntypedActorTest extends TestLogger {
 
 	private static ActorSystem actorSystem;
 
 	@BeforeClass
 	public static void setup() {
-		actorSystem = new RobustActorSystem("TestingActorSystem", TestingUtils.testConfig());
+		actorSystem = RobustActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
 	}
 
 	@AfterClass

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.instance;
 
 import akka.actor.ActorSystem;
+import akka.actor.RobustActorSystem;
 import akka.testkit.JavaTestKit;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -55,7 +56,7 @@ public class InstanceManagerTest{
 
 	@BeforeClass
 	public static void setup(){
-		system = ActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
+		system = new RobustActorSystem("TestingActorSystem", TestingUtils.testConfig());
 	}
 
 	@AfterClass

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -48,7 +49,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link org.apache.flink.runtime.instance.InstanceManager}.
  */
-public class InstanceManagerTest{
+public class InstanceManagerTest extends TestLogger {
 
 	static ActorSystem system;
 
@@ -56,7 +57,7 @@ public class InstanceManagerTest{
 
 	@BeforeClass
 	public static void setup(){
-		system = new RobustActorSystem("TestingActorSystem", TestingUtils.testConfig());
+		system = RobustActorSystem.create("TestingActorSystem", TestingUtils.testConfig());
 	}
 
 	@AfterClass

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -47,6 +47,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
+import akka.actor.RobustActorSystem;
 import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
@@ -78,7 +79,7 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 
 	@BeforeClass
 	public static void setup() throws Exception {
-		actorSystem = ActorSystem.create("TestingActorSystem");
+		actorSystem = new RobustActorSystem("TestingActorSystem", TestingUtils.getDefaultTestingActorSystemConfig());
 		testingServer = new TestingServer();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -33,8 +33,6 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.jobmanager.StandaloneSubmittedJobGraphStore;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
-import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
-import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.testingUtils.TestingJobManager;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
@@ -79,7 +77,7 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 
 	@BeforeClass
 	public static void setup() throws Exception {
-		actorSystem = new RobustActorSystem("TestingActorSystem", TestingUtils.getDefaultTestingActorSystemConfig());
+		actorSystem = RobustActorSystem.create("TestingActorSystem", TestingUtils.getDefaultTestingActorSystemConfig());
 		testingServer = new TestingServer();
 	}
 

--- a/flink-runtime/src/test/scala/akka/actor/RobustActorSystemTest.scala
+++ b/flink-runtime/src/test/scala/akka/actor/RobustActorSystemTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.actor
+
+import java.lang.Thread.UncaughtExceptionHandler
+
+import org.apache.flink.runtime.akka.AkkaUtils
+import org.junit.{After, Before, Test}
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitSuite
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, Promise}
+import scala.util.Success
+
+class RobustActorSystemTest extends JUnitSuite with Matchers {
+
+  var robustActorSystem: RobustActorSystem = null
+  var testingUncaughtExceptionHandler: TestingUncaughtExceptionHandler = null
+
+  @Before
+  def setup(): Unit = {
+    testingUncaughtExceptionHandler = new TestingUncaughtExceptionHandler
+    robustActorSystem = RobustActorSystem.create(
+      "testSystem",
+      AkkaUtils.testDispatcherConfig,
+      testingUncaughtExceptionHandler)
+  }
+
+  @After
+  def teardown(): Unit = {
+    robustActorSystem.terminate()
+    testingUncaughtExceptionHandler = null;
+  }
+
+  @Test
+  def testUncaughtExceptionHandler(): Unit = {
+    val error = new UnknownError("Foobar")
+
+    Future {
+      throw error
+    }(robustActorSystem.dispatcher)
+
+    val caughtException = Await.result(
+      testingUncaughtExceptionHandler.exceptionPromise.future,
+      Duration.Inf)
+
+    caughtException should equal (error)
+  }
+
+  @Test
+  def testUncaughtExceptionHandlerFromActor(): Unit = {
+    val error = new UnknownError()
+    val actor = robustActorSystem.actorOf(Props.create(classOf[UncaughtExceptionActor], error))
+
+    actor ! Failure
+
+    val caughtException = Await.result(
+      testingUncaughtExceptionHandler.exceptionPromise.future,
+      Duration.Inf)
+
+    caughtException should equal (error)
+  }
+}
+
+class TestingUncaughtExceptionHandler extends UncaughtExceptionHandler {
+  val exceptionPromise: Promise[Throwable] = Promise()
+
+  override def uncaughtException(t: Thread, e: Throwable): Unit = {
+    exceptionPromise.complete(Success(e))
+  }
+}
+
+class UncaughtExceptionActor(failure: Throwable) extends Actor {
+  override def receive: Receive = {
+    case Failure => {
+      throw failure
+    };
+  }
+}
+
+case object Failure

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -352,7 +352,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 		final int sequenceEnd = 5000;
 		final long expectedSum = Parallelism * sequenceEnd * (sequenceEnd + 1) / 2;
 
-		final ActorSystem system = new RobustActorSystem("Test", AkkaUtils.getDefaultAkkaConfig());
+		final ActorSystem system = RobustActorSystem.create("Test", AkkaUtils.getDefaultAkkaConfig());
 		final TestingServer testingServer = new TestingServer();
 		final TemporaryFolder temporaryFolder = new TemporaryFolder();
 		temporaryFolder.create();

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -71,6 +71,7 @@ import org.apache.flink.util.TestLogger;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.PoisonPill;
+import akka.actor.RobustActorSystem;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
 import org.junit.AfterClass;
@@ -351,7 +352,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 		final int sequenceEnd = 5000;
 		final long expectedSum = Parallelism * sequenceEnd * (sequenceEnd + 1) / 2;
 
-		final ActorSystem system = ActorSystem.create("Test", AkkaUtils.getDefaultAkkaConfig());
+		final ActorSystem system = new RobustActorSystem("Test", AkkaUtils.getDefaultAkkaConfig());
 		final TestingServer testingServer = new TestingServer();
 		final TemporaryFolder temporaryFolder = new TemporaryFolder();
 		temporaryFolder.create();

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
+import akka.actor.RobustActorSystem;
 import akka.testkit.JavaTestKit;
 import org.junit.Test;
 
@@ -67,7 +68,7 @@ public class LocalFlinkMiniClusterITCase extends TestLogger {
 	@Test
 	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() throws InterruptedException, TimeoutException {
 
-		final ActorSystem system = ActorSystem.create("Testkit", AkkaUtils.getDefaultAkkaConfig());
+		final ActorSystem system = new RobustActorSystem("Testkit", AkkaUtils.getDefaultAkkaConfig());
 		LocalFlinkMiniCluster miniCluster = null;
 
 		final int numTMs = 3;

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -68,7 +68,7 @@ public class LocalFlinkMiniClusterITCase extends TestLogger {
 	@Test
 	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() throws InterruptedException, TimeoutException {
 
-		final ActorSystem system = new RobustActorSystem("Testkit", AkkaUtils.getDefaultAkkaConfig());
+		final ActorSystem system = RobustActorSystem.create("Testkit", AkkaUtils.getDefaultAkkaConfig());
 		LocalFlinkMiniCluster miniCluster = null;
 
 		final int numTMs = 3;


### PR DESCRIPTION
## What is the purpose of the change

Using the ExecutorThreadFactory hardens the system because it uses the FatalExitExceptionHandler
as UncaughtExceptionHandler which terminates the JVM in case of an exception.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
