### PR TITLE
[FLINK-9891] Added hook to shutdown cluster if a session was created in per-job mode.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -58,10 +58,10 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.ShutdownHookUtil;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.apache.flink.util.ShutdownHookUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
## What is the purpose of the change

Change minimizes probability of a per-job yarn session cluster surviving after client exited. It restores the Flink 1.4 and below cli behaviour.


## Brief change log

  - when per-job yarn cluster is deployed, a shutdown hook installed
  - when shutdown hook is called, it terminates the deployed cluster
  - when cli terminates normally, shutdown hook is called by cli and deinstalled
  - otherwise, java runtime will call shutdown hook


## Verifying this change

We verified the change manually by submitting a DataSet API application to Yarn and killing client before job terminated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
