### PR TITLE
[FLINK-6437][History Server] Move history server configuration to a separate file

### DIFF
--- a/docs/monitoring/historyserver.md
+++ b/docs/monitoring/historyserver.md
@@ -50,7 +50,7 @@ The configuration keys `jobmanager.archive.fs.dir` and `historyserver.archive.fs
 
 **JobManager**
 
-The archiving of completed jobs happens on the JobManager, which uploads the archived job information to a file system directory. You can configure the directory to archive completed jobs in `flink-conf.yaml` by setting a directory via `jobmanager.archive.fs.dir`.
+The archiving of completed jobs happens on the JobManager, which uploads the archived job information to a file system directory. You can configure the directory to archive completed jobs in `flink-historyserver-conf.yaml` by setting a directory via `jobmanager.archive.fs.dir`.
 
 {% highlight yaml %}
 # Directory to upload completed job information

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -164,6 +164,8 @@ The configuration keys in this section are independent of the used resource mana
 
 ### History Server
 
+**Note:** History Server related configuration items have been moved to the `flink-historyserver-conf.yaml` file. Flink will read the configuration in the `flink-historyserver-conf.yaml` file first, and Flink will attempt to read the relevant configuration items from `flink-conf.yaml` only if it does not exist. Keeping these configuration items in `flink-conf.yaml` is for backward compatibility purposes only.
+
 You have to configure `jobmanager.archive.fs.dir` in order to archive terminated jobs and add it to the list of monitored directories via `historyserver.archive.fs.dir` if you want to display them via the HistoryServer's web frontend.
 
 - `jobmanager.archive.fs.dir`: Directory to upload information about terminated jobs to. You have to add this directory to the list of monitored directories of the history server via `historyserver.archive.fs.dir`.

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -58,6 +58,13 @@ under the License.
 			<outputDirectory>conf</outputDirectory>
 			<fileMode>0644</fileMode>
 		</file>
+
+		<!-- copy the history server config file -->
+		<file>
+			<source>src/main/resources/flink-historyserver-conf.yaml</source>
+			<outputDirectory>conf</outputDirectory>
+			<fileMode>0644</fileMode>
+		</file>
 	</files>
 
 	<fileSets>

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -225,6 +225,11 @@ rest.port: 8081
 # HistoryServer
 #==============================================================================
 
+# History Server related configuration items have been moved to the `flink-historyserver-conf.yaml` file.
+# Flink will read the configuration in the `flink-historyserver-conf.yaml` file first,
+# and Flink will attempt to read the relevant configuration items from `flink-conf.yaml` only if it does not exist.
+# Keeping these configuration items in `flink-conf.yaml` is for backward compatibility purposes only.
+
 # The HistoryServer is started and stopped via bin/historyserver.sh (start|stop)
 
 # Directory to upload completed jobs to. Add this directory to the list of

--- a/flink-dist/src/main/resources/flink-historyserver-conf.yaml
+++ b/flink-dist/src/main/resources/flink-historyserver-conf.yaml
@@ -1,0 +1,40 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+#==============================================================================
+# HistoryServer
+#==============================================================================
+
+# The HistoryServer is started and stopped via bin/historyserver.sh (start|stop)
+
+# Directory to upload completed jobs to. Add this directory to the list of
+# monitored directories of the HistoryServer as well (see below).
+#jobmanager.archive.fs.dir: hdfs:///completed-jobs/
+
+# The address under which the web-based HistoryServer listens.
+#historyserver.web.address: 0.0.0.0
+
+# The port under which the web-based HistoryServer listens.
+#historyserver.web.port: 8082
+
+# Comma separated list of directories to monitor for completed jobs.
+#historyserver.archive.fs.dir: hdfs:///completed-jobs/
+
+# Interval in milliseconds for refreshing the monitored directories.
+#historyserver.archive.fs.refresh-interval: 10000

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -100,7 +100,7 @@ public class HistoryServer {
 		String configDir = pt.getRequired("configDir");
 
 		LOG.info("Loading configuration from {}", configDir);
-		final Configuration flinkConfig = GlobalConfiguration.loadConfiguration(configDir);
+		final Configuration flinkConfig = GlobalConfiguration.loadHistoryServerConfiguration(configDir);
 
 		try {
 			FileSystem.initialize(flinkConfig);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request move history server configuration to a separate file*

## Brief change log

  - *Move history server configuration to a separate file*


## Verifying this change

*This change has been manually tested (locally compiled and packaged, started with the History Server server)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
