### PR TITLE
[FLINK-8532] [Streaming] modify RebalancePartitioner to use a random partition as its first partition

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -33,14 +33,25 @@ import java.util.concurrent.ThreadLocalRandom;
 public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private final int[] returnArray = new int[] {ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE - 1)};
+	private final int[] returnArray = new int[] {Integer.MAX_VALUE - 1};
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
 			int numberOfOutputChannels) {
-
-		this.returnArray[0] = (this.returnArray[0] + 1) % numberOfOutputChannels;
+		int newChannel = ++this.returnArray[0];
+		if (newChannel >= numberOfOutputChannels) {
+			this.returnArray[0] = resetValue(record, numberOfOutputChannels, newChannel);
+		}
 		return this.returnArray;
+	}
+
+	private int resetValue(SerializationDelegate<StreamRecord<T>> record,
+			int numberOfOutputChannels, int newChannel) {
+		if (newChannel == Integer.MAX_VALUE) {
+			// Initializes the first partition, this branch is only entered when initializing.
+			return ThreadLocalRandom.current().nextInt(numberOfOutputChannels);
+		}
+		return 0;
 	}
 
 	public StreamPartitioner<T> copy() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -21,6 +21,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import java.util.Random;
+
 /**
  * Partitioner that distributes the data equally by cycling through the output
  * channels.
@@ -36,9 +38,13 @@ public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
 			int numberOfOutputChannels) {
-		int newChannel = ++this.returnArray[0];
-		if (newChannel >= numberOfOutputChannels) {
-			this.returnArray[0] = 0;
+		if (this.returnArray[0] < 0) {
+			this.returnArray[0] = new Random().nextInt(numberOfOutputChannels);
+		} else {
+			int newChannel = ++this.returnArray[0];
+			if (newChannel >= numberOfOutputChannels) {
+				this.returnArray[0] = 0;
+			}
 		}
 		return this.returnArray;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 
 /**
  * Partitioner that distributes the data equally by cycling through the output
@@ -33,19 +33,13 @@ import java.util.concurrent.ThreadLocalRandom;
 public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private final int[] returnArray = new int[] {-1};
+	private final int[] returnArray = new int[] {new Random().nextInt(Integer.MAX_VALUE - 1)};
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
 			int numberOfOutputChannels) {
-		if (this.returnArray[0] < 0) {
-			this.returnArray[0] = ThreadLocalRandom.current().nextInt(numberOfOutputChannels);
-		} else {
-			int newChannel = ++this.returnArray[0];
-			if (newChannel >= numberOfOutputChannels) {
-				this.returnArray[0] = 0;
-			}
-		}
+
+		this.returnArray[0] = (this.returnArray[0] + 1) % numberOfOutputChannels;
 		return this.returnArray;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Partitioner that distributes the data equally by cycling through the output
@@ -39,7 +39,7 @@ public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
 			int numberOfOutputChannels) {
 		if (this.returnArray[0] < 0) {
-			this.returnArray[0] = new Random().nextInt(numberOfOutputChannels);
+			this.returnArray[0] = ThreadLocalRandom.current().nextInt(numberOfOutputChannels);
 		} else {
 			int newChannel = ++this.returnArray[0];
 			if (newChannel >= numberOfOutputChannels) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Partitioner that distributes the data equally by cycling through the output
@@ -33,7 +33,7 @@ import java.util.Random;
 public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private final int[] returnArray = new int[] {new Random().nextInt(Integer.MAX_VALUE - 1)};
+	private final int[] returnArray = new int[] {ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE - 1)};
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitionerTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link RebalancePartitioner}.
@@ -52,9 +53,11 @@ public class RebalancePartitionerTest {
 	@Test
 	public void testSelectChannelsInterval() {
 		sd.setInstance(streamRecord);
-		assertEquals(0, distributePartitioner.selectChannels(sd, 3)[0]);
-		assertEquals(1, distributePartitioner.selectChannels(sd, 3)[0]);
-		assertEquals(2, distributePartitioner.selectChannels(sd, 3)[0]);
-		assertEquals(0, distributePartitioner.selectChannels(sd, 3)[0]);
+		int initialChannel = distributePartitioner.selectChannels(sd, 3)[0];
+		assertTrue(0 <= initialChannel);
+		assertTrue(3 > initialChannel);
+		assertEquals((initialChannel + 1) % 3, distributePartitioner.selectChannels(sd, 3)[0]);
+		assertEquals((initialChannel + 2) % 3, distributePartitioner.selectChannels(sd, 3)[0]);
+		assertEquals((initialChannel + 3) % 3, distributePartitioner.selectChannels(sd, 3)[0]);
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -220,38 +219,42 @@ public class PartitionerITCase extends AbstractTestBase {
 	}
 
 	private static void verifyRebalancePartitioning(List<Tuple2<Integer, String>> rebalancePartitionResult) {
-		List<Tuple2<Integer, String>> expected0 = Arrays.asList(
+		List<List<Tuple2<Integer, String>>> expected = Arrays.asList(
+			Arrays.asList(
 				new Tuple2<Integer, String>(0, "a"),
 				new Tuple2<Integer, String>(1, "b"),
 				new Tuple2<Integer, String>(2, "b"),
 				new Tuple2<Integer, String>(0, "a"),
 				new Tuple2<Integer, String>(1, "a"),
 				new Tuple2<Integer, String>(2, "c"),
-				new Tuple2<Integer, String>(0, "a"));
+				new Tuple2<Integer, String>(0, "a")),
 
-		List<Tuple2<Integer, String>> expected1 = Arrays.asList(
+			Arrays.asList(
 				new Tuple2<Integer, String>(1, "a"),
 				new Tuple2<Integer, String>(2, "b"),
 				new Tuple2<Integer, String>(0, "b"),
 				new Tuple2<Integer, String>(1, "a"),
 				new Tuple2<Integer, String>(2, "a"),
 				new Tuple2<Integer, String>(0, "c"),
-				new Tuple2<Integer, String>(1, "a"));
+				new Tuple2<Integer, String>(1, "a")),
 
-		List<Tuple2<Integer, String>> expected2 = Arrays.asList(
+			Arrays.asList(
 				new Tuple2<Integer, String>(2, "a"),
 				new Tuple2<Integer, String>(0, "b"),
 				new Tuple2<Integer, String>(1, "b"),
 				new Tuple2<Integer, String>(2, "a"),
 				new Tuple2<Integer, String>(0, "a"),
 				new Tuple2<Integer, String>(1, "c"),
-				new Tuple2<Integer, String>(2, "a"));
+				new Tuple2<Integer, String>(2, "a")));
 
-		assertTrue(
-				new HashSet<Tuple2<Integer, String>>(expected0).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult)) ||
-				new HashSet<Tuple2<Integer, String>>(expected1).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult)) ||
-				new HashSet<Tuple2<Integer, String>>(expected2).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult))
-		);
+		int matchedNum = 0;
+		for (List<Tuple2<Integer, String>> e : expected) {
+			if (new HashSet<Tuple2<Integer, String>>(e).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult))) {
+				++matchedNum;
+			}
+		}
+
+		assertEquals(1, matchedNum);
 	}
 
 	private static void verifyGlobalPartitioning(List<Tuple2<Integer, String>> globalPartitionResult) {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -162,7 +163,7 @@ public class PartitionerITCase extends AbstractTestBase {
 		verifyHashPartitioning(hashPartitionResult);
 		verifyCustomPartitioning(customPartitionResult);
 		verifyBroadcastPartitioning(broadcastPartitionResult);
-		verifyRebalancePartitioning(forwardPartitionResult);
+		verifyForwardPartitioning(forwardPartitionResult);
 		verifyRebalancePartitioning(rebalancePartitionResult);
 		verifyGlobalPartitioning(globalPartitionResult);
 	}
@@ -218,7 +219,7 @@ public class PartitionerITCase extends AbstractTestBase {
 				new HashSet<Tuple2<Integer, String>>(broadcastPartitionResult));
 	}
 
-	private static void verifyRebalancePartitioning(List<Tuple2<Integer, String>> rebalancePartitionResult) {
+	private static void verifyForwardPartitioning(List<Tuple2<Integer, String>> forwardPartitionResult) {
 		List<Tuple2<Integer, String>> expected = Arrays.asList(
 				new Tuple2<Integer, String>(0, "a"),
 				new Tuple2<Integer, String>(1, "b"),
@@ -230,7 +231,42 @@ public class PartitionerITCase extends AbstractTestBase {
 
 		assertEquals(
 				new HashSet<Tuple2<Integer, String>>(expected),
-				new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult));
+				new HashSet<Tuple2<Integer, String>>(forwardPartitionResult));
+	}
+
+	private static void verifyRebalancePartitioning(List<Tuple2<Integer, String>> rebalancePartitionResult) {
+		List<Tuple2<Integer, String>> expected0 = Arrays.asList(
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(1, "b"),
+				new Tuple2<Integer, String>(2, "b"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(2, "c"),
+				new Tuple2<Integer, String>(0, "a"));
+
+		List<Tuple2<Integer, String>> expected1 = Arrays.asList(
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(2, "b"),
+				new Tuple2<Integer, String>(0, "b"),
+				new Tuple2<Integer, String>(1, "a"),
+				new Tuple2<Integer, String>(2, "a"),
+				new Tuple2<Integer, String>(0, "c"),
+				new Tuple2<Integer, String>(1, "a"));
+
+		List<Tuple2<Integer, String>> expected2 = Arrays.asList(
+				new Tuple2<Integer, String>(2, "a"),
+				new Tuple2<Integer, String>(0, "b"),
+				new Tuple2<Integer, String>(1, "b"),
+				new Tuple2<Integer, String>(2, "a"),
+				new Tuple2<Integer, String>(0, "a"),
+				new Tuple2<Integer, String>(1, "c"),
+				new Tuple2<Integer, String>(2, "a"));
+
+		assertTrue(
+				new HashSet<Tuple2<Integer, String>>(expected0).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult)) ||
+				new HashSet<Tuple2<Integer, String>>(expected1).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult)) ||
+				new HashSet<Tuple2<Integer, String>>(expected2).equals(new HashSet<Tuple2<Integer, String>>(rebalancePartitionResult))
+		);
 	}
 
 	private static void verifyGlobalPartitioning(List<Tuple2<Integer, String>> globalPartitionResult) {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
@@ -163,7 +163,7 @@ public class PartitionerITCase extends AbstractTestBase {
 		verifyHashPartitioning(hashPartitionResult);
 		verifyCustomPartitioning(customPartitionResult);
 		verifyBroadcastPartitioning(broadcastPartitionResult);
-		verifyForwardPartitioning(forwardPartitionResult);
+		verifyRebalancePartitioning(forwardPartitionResult);
 		verifyRebalancePartitioning(rebalancePartitionResult);
 		verifyGlobalPartitioning(globalPartitionResult);
 	}
@@ -217,21 +217,6 @@ public class PartitionerITCase extends AbstractTestBase {
 		assertEquals(
 				new HashSet<Tuple2<Integer, String>>(expected),
 				new HashSet<Tuple2<Integer, String>>(broadcastPartitionResult));
-	}
-
-	private static void verifyForwardPartitioning(List<Tuple2<Integer, String>> forwardPartitionResult) {
-		List<Tuple2<Integer, String>> expected = Arrays.asList(
-				new Tuple2<Integer, String>(0, "a"),
-				new Tuple2<Integer, String>(1, "b"),
-				new Tuple2<Integer, String>(2, "b"),
-				new Tuple2<Integer, String>(0, "a"),
-				new Tuple2<Integer, String>(1, "a"),
-				new Tuple2<Integer, String>(2, "c"),
-				new Tuple2<Integer, String>(0, "a"));
-
-		assertEquals(
-				new HashSet<Tuple2<Integer, String>>(expected),
-				new HashSet<Tuple2<Integer, String>>(forwardPartitionResult));
 	}
 
 	private static void verifyRebalancePartitioning(List<Tuple2<Integer, String>> rebalancePartitionResult) {


### PR DESCRIPTION
## What is the purpose of the change
This pull request makes RebalancePartitioner to use a random partition as its first partition, rather than the same 0th. In this way we avoid message sending to the same subtask at one moment, which may cause lag of the subtask, and make some other subtask with no message arrived to be idle. This helps RebalancePartitioner balance message better, and increase throughput.


## Brief change log
  - RebalancePartitioner starts with a random partition rather than the same 0th partition
  - corresponding RebalancePartitionerTest


## Verifying this change


This change is already covered by existing tests, such as RebalancePartitionerTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( yes )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)