### PR TITLE
[FLINK-10132] Incremental cleanup of local expired state with TTL dis…

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
@@ -323,6 +323,11 @@ public class KvStateServerHandlerTest extends TestLogger {
 					}
 
 					@Override
+					public final VoidNamespace getCurrentNamespace() {
+						return null;
+					}
+
+					@Override
 					public byte[] getSerializedValue(
 							final byte[] serializedKeyAndNamespace,
 							final TypeSerializer<Integer> safeKeySerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
  * @param <K> The key by which state is keyed.
  */
 public interface KeyedStateBackend<K>
-	extends InternalKeyContext<K>, KeyedStateFactory, PriorityQueueSetFactory, Disposable {
+	extends InternalKeyContext<K>, KeyedStateFactory<K>, PriorityQueueSetFactory, Disposable {
 
 	/**
 	 * Sets the current key that is used for partitioned state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -106,4 +106,25 @@ public interface KeyedStateBackend<K>
 
 	@Override
 	void dispose();
+
+	/** State backend will call {@link KeyChangeListener#keyChanged} when key context changes if supported. */
+	default void registerKeyChangeListener(KeyChangeListener<K> listener) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Stop calling listener registered in {@link #registerKeyChangeListener}.
+	 *
+	 * @return returns true iff listener was registered before.
+	 */
+	default boolean deregisterKeyChangeListener(KeyChangeListener<K> listener) {
+		throw new UnsupportedOperationException();
+	}
+
+	/** Listener is given a callback when {@link #setCurrentKey} is called (key context changes). */
+	@FunctionalInterface
+	interface KeyChangeListener<K> {
+		/** Callback when key context changes. */
+		void keyChanged(K newKey);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFactory.java
@@ -26,8 +26,12 @@ import org.apache.flink.runtime.state.internal.InternalKvState;
 
 import javax.annotation.Nonnull;
 
-/** This factory produces concrete internal state objects. */
-public interface KeyedStateFactory {
+/**
+ * This factory produces concrete internal state objects.
+ *
+ * @param <K> type of state key
+ */
+public interface KeyedStateFactory<K> {
 
 	/**
 	 * Creates and returns a new {@link InternalKvState}.
@@ -64,5 +68,5 @@ public interface KeyedStateFactory {
 	<N, SV, SEV, S extends State, IS extends S> IS createInternalState(
 		@Nonnull TypeSerializer<N> namespaceSerializer,
 		@Nonnull StateDescriptor<S, SV> stateDesc,
-		@Nonnull StateSnapshotTransformFactory<SEV> snapshotTransformFactory) throws Exception;
+		@Nonnull StateSnapshotTransformFactory<K, N, SEV> snapshotTransformFactory) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -40,10 +40,11 @@ import java.util.Objects;
  * Compound meta information for a registered state in a keyed state backend. This combines all serializers and the
  * state name.
  *
+ * @param <K> Type of key
  * @param <N> Type of namespace
  * @param <S> Type of state value
  */
-public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStateMetaInfoBase {
+public class RegisteredKeyValueStateBackendMetaInfo<K, N, S> extends RegisteredStateMetaInfoBase {
 
 	@Nonnull
 	private final StateDescriptor.Type stateType;
@@ -52,7 +53,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	@Nonnull
 	private final TypeSerializer<S> stateSerializer;
 	@Nullable
-	private final StateSnapshotTransformer<S> snapshotTransformer;
+	private final StateSnapshotTransformer<K, N, S> snapshotTransformer;
 
 	public RegisteredKeyValueStateBackendMetaInfo(
 		@Nonnull StateDescriptor.Type stateType,
@@ -67,7 +68,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		@Nonnull String name,
 		@Nonnull TypeSerializer<N> namespaceSerializer,
 		@Nonnull TypeSerializer<S> stateSerializer,
-		@Nullable StateSnapshotTransformer<S> snapshotTransformer) {
+		@Nullable StateSnapshotTransformer<K, N, S> snapshotTransformer) {
 
 		super(name);
 		this.stateType = stateType;
@@ -104,7 +105,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	}
 
 	@Nullable
-	public StateSnapshotTransformer<S> getSnapshotTransformer() {
+	public StateSnapshotTransformer<K, N, S> getSnapshotTransformer() {
 		return snapshotTransformer;
 	}
 
@@ -118,7 +119,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 			return false;
 		}
 
-		RegisteredKeyValueStateBackendMetaInfo<?, ?> that = (RegisteredKeyValueStateBackendMetaInfo<?, ?>) o;
+		RegisteredKeyValueStateBackendMetaInfo<?, ?, ?> that = (RegisteredKeyValueStateBackendMetaInfo<?, ?, ?>) o;
 
 		if (!stateType.equals(that.stateType)) {
 			return false;
@@ -157,11 +158,11 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	 * serializers that are compatible for the restored k/v state bytes.
 	 */
 	@Nonnull
-	public static <N, S> RegisteredKeyValueStateBackendMetaInfo<N, S> resolveKvStateCompatibility(
+	public static <K, N, S> RegisteredKeyValueStateBackendMetaInfo<K, N, S> resolveKvStateCompatibility(
 		StateMetaInfoSnapshot restoredStateMetaInfoSnapshot,
 		TypeSerializer<N> newNamespaceSerializer,
 		StateDescriptor<?, S> newStateDescriptor,
-		@Nullable StateSnapshotTransformer<S> snapshotTransformer) throws StateMigrationException {
+		@Nullable StateSnapshotTransformer<K, N, S> snapshotTransformer) throws StateMigrationException {
 
 		Preconditions.checkState(restoredStateMetaInfoSnapshot.getBackendStateType()
 				== StateMetaInfoSnapshot.BackendStateType.KEY_VALUE,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -87,6 +87,11 @@ public abstract class AbstractHeapState<K, N, SV> implements InternalKvState<K, 
 	}
 
 	@Override
+	public final N getCurrentNamespace() {
+		return currentNamespace;
+	}
+
+	@Override
 	public byte[] getSerializedValue(
 			final byte[] serializedKeyAndNamespace,
 			final TypeSerializer<K> safeKeySerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
@@ -204,7 +204,7 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	 * @param keyContext the key context.
 	 * @param metaInfo   the meta information, including the type serializer for state copy-on-write.
 	 */
-	CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
+	CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo) {
 		this(keyContext, metaInfo, 1024);
 	}
 
@@ -217,7 +217,7 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	 * @throws IllegalArgumentException when the capacity is less than zero.
 	 */
 	@SuppressWarnings("unchecked")
-	private CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo, int capacity) {
+	private CopyOnWriteStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo, int capacity) {
 		super(keyContext, metaInfo);
 
 		// initialized tables to EMPTY_TABLE.
@@ -547,12 +547,12 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> implemen
 	}
 
 	@Override
-	public RegisteredKeyValueStateBackendMetaInfo<N, S> getMetaInfo() {
+	public RegisteredKeyValueStateBackendMetaInfo<K, N, S> getMetaInfo() {
 		return metaInfo;
 	}
 
 	@Override
-	public void setMetaInfo(RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
+	public void setMetaInfo(RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo) {
 		this.metaInfo = metaInfo;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -147,7 +147,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 					localKeySerializer.serialize(element.key, dov);
 					localStateSerializer.serialize(element.state, dov);
 				};
-			StateSnapshotTransformer<S> stateSnapshotTransformer = owningStateTable.metaInfo.getSnapshotTransformer();
+			StateSnapshotTransformer<K, N, S> stateSnapshotTransformer = owningStateTable.metaInfo.getSnapshotTransformer();
 			StateTableKeyGroupPartitioner<K, N, S> stateTableKeyGroupPartitioner = stateSnapshotTransformer != null ?
 				new TransformingStateTableKeyGroupPartitioner<>(
 					snapshotData,
@@ -246,7 +246,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 	 */
 	protected static final class TransformingStateTableKeyGroupPartitioner<K, N, S>
 		extends StateTableKeyGroupPartitioner<K, N, S> {
-		private final StateSnapshotTransformer<S> stateSnapshotTransformer;
+		private final StateSnapshotTransformer<K, N, S> stateSnapshotTransformer;
 
 		TransformingStateTableKeyGroupPartitioner(
 			@Nonnull CopyOnWriteStateTable.StateTableEntry<K, N, S>[] snapshotData,
@@ -254,7 +254,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 			@Nonnull KeyGroupRange keyGroupRange,
 			int totalKeyGroups,
 			@Nonnull ElementWriterFunction<CopyOnWriteStateTable.StateTableEntry<K, N, S>> elementWriterFunction,
-			@Nonnull StateSnapshotTransformer<S> stateSnapshotTransformer) {
+			@Nonnull StateSnapshotTransformer<K, N, S> stateSnapshotTransformer) {
 			super(
 				snapshotData,
 				stateTableSize,
@@ -275,7 +275,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 
 		private CopyOnWriteStateTable.StateTableEntry<K, N, S> filterEntry(
 			CopyOnWriteStateTable.StateTableEntry<K, N, S> entry) {
-			S transformedValue = stateSnapshotTransformer.filterOrTransform(entry.state);
+			S transformedValue = stateSnapshotTransformer.filterOrTransform(entry.key, entry.namespace, entry.state);
 			if (transformedValue != null) {
 				CopyOnWriteStateTable.StateTableEntry<K, N, S> filteredEntry = entry;
 				if (transformedValue != entry.state) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
@@ -73,7 +73,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 	 * @param keyContext the key context.
 	 * @param metaInfo the meta information for this state table.
 	 */
-	public NestedMapsStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
+	public NestedMapsStateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo) {
 		super(keyContext, metaInfo);
 		this.keyGroupOffset = keyContext.getKeyGroupRange().getStartKeyGroup();
 
@@ -335,9 +335,11 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 		private final TypeSerializer<K> keySerializer;
 		private final TypeSerializer<N> namespaceSerializer;
 		private final TypeSerializer<S> stateSerializer;
-		private final StateSnapshotTransformer<S> snapshotFilter;
+		private final StateSnapshotTransformer<K, N, S> snapshotFilter;
 
-		NestedMapsStateTableSnapshot(NestedMapsStateTable<K, N, S> owningTable, StateSnapshotTransformer<S> snapshotFilter) {
+		NestedMapsStateTableSnapshot(
+			NestedMapsStateTable<K, N, S> owningTable,
+			StateSnapshotTransformer<K, N, S> snapshotFilter) {
 			super(owningTable);
 			this.snapshotFilter = snapshotFilter;
 			this.keySerializer = owningStateTable.keyContext.getKeySerializer();
@@ -402,7 +404,7 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 				Map<K, S> filteredNamespaceMap = filtered.computeIfAbsent(namespace, n -> new HashMap<>());
 				for (Map.Entry<K, S> keyEntry : namespaceEntry.getValue().entrySet()) {
 					K key = keyEntry.getKey();
-					S transformedvalue = snapshotFilter.filterOrTransform(keyEntry.getValue());
+					S transformedvalue = snapshotFilter.filterOrTransform(keyEntry.getKey(), namespace, keyEntry.getValue());
 					if (transformedvalue != null) {
 						filteredNamespaceMap.put(key, transformedvalue);
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
@@ -48,14 +48,14 @@ public abstract class StateTable<K, N, S> implements StateSnapshotRestore {
 	/**
 	 * Combined meta information such as name and serializers for this state.
 	 */
-	protected RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo;
+	protected RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo;
 
 	/**
 	 *
 	 * @param keyContext the key context provides the key scope for all put/get/delete operations.
 	 * @param metaInfo the meta information, including the type serializer for state copy-on-write.
 	 */
-	public StateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
+	public StateTable(InternalKeyContext<K> keyContext, RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo) {
 		this.keyContext = Preconditions.checkNotNull(keyContext);
 		this.metaInfo = Preconditions.checkNotNull(metaInfo);
 	}
@@ -176,11 +176,11 @@ public abstract class StateTable<K, N, S> implements StateSnapshotRestore {
 		return metaInfo.getNamespaceSerializer();
 	}
 
-	public RegisteredKeyValueStateBackendMetaInfo<N, S> getMetaInfo() {
+	public RegisteredKeyValueStateBackendMetaInfo<K, N, S> getMetaInfo() {
 		return metaInfo;
 	}
 
-	public void setMetaInfo(RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo) {
+	public void setMetaInfo(RegisteredKeyValueStateBackendMetaInfo<K, N, S> metaInfo) {
 		this.metaInfo = metaInfo;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalKvState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalKvState.java
@@ -83,6 +83,13 @@ public interface InternalKvState<K, N, V> extends State {
 	void setCurrentNamespace(N namespace);
 
 	/**
+	 * Gets the current namespace, which will be used when using the state access methods.
+	 *
+	 * @return the current namespace.
+	 */
+	N getCurrentNamespace();
+
+	/**
 	 * Returns the serialized value for the given key and namespace.
 	 *
 	 * <p>If no value is associated with key and namespace, <code>null</code>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/AbstractTtlState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/AbstractTtlState.java
@@ -33,7 +33,7 @@ import org.apache.flink.util.function.ThrowingConsumer;
  * @param <TTLSV> The type of values kept internally in state with TTL
  * @param <S> Type of originally wrapped state object
  */
-abstract class AbstractTtlState<K, N, SV, TTLSV, S extends InternalKvState<K, N, TTLSV>>
+public abstract class AbstractTtlState<K, N, SV, TTLSV, S extends InternalKvState<K, N, TTLSV>>
 	extends AbstractTtlDecorator<S>
 	implements InternalKvState<K, N, SV> {
 	private final TypeSerializer<SV> valueSerializer;
@@ -91,7 +91,7 @@ abstract class AbstractTtlState<K, N, SV, TTLSV, S extends InternalKvState<K, N,
 		accessCallback.run();
 	}
 
-	abstract void cleanupIfExpired() throws Exception;
+	public abstract void cleanupIfExpired() throws Exception;
 
 	<V> void cleanupIfExpired(TtlValue<V> ttlValue) {
 		if (expired(ttlValue)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAggregatingState.java
@@ -57,7 +57,7 @@ class TtlAggregatingState<K, N, IN, ACC, OUT>
 	}
 
 	@Override
-	void cleanupIfExpired() throws Exception {
+	public void cleanupIfExpired() throws Exception {
 		cleanupIfExpired(original.getInternal());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldingState.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.state.ttl;
 
 import org.apache.flink.api.common.state.AggregatingState;
-import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
 
 /**
@@ -35,27 +33,25 @@ import org.apache.flink.runtime.state.internal.InternalFoldingState;
 class TtlFoldingState<K, N, T, ACC>
 	extends AbstractTtlState<K, N, ACC, TtlValue<ACC>, InternalFoldingState<K, N, T, TtlValue<ACC>>>
 	implements InternalFoldingState<K, N, T, ACC> {
-	TtlFoldingState(
-		InternalFoldingState<K, N, T, TtlValue<ACC>> originalState,
-		StateTtlConfig config,
-		TtlTimeProvider timeProvider,
-		TypeSerializer<ACC> valueSerializer) {
-		super(originalState, config, timeProvider, valueSerializer);
+	TtlFoldingState(TtlStateContext<InternalFoldingState<K, N, T, TtlValue<ACC>>, ACC> ttlStateContext) {
+		super(ttlStateContext);
 	}
 
 	@Override
 	public ACC get() throws Exception {
+		accessCallback.run();
 		return getInternal();
 	}
 
 	@Override
 	public void add(T value) throws Exception {
+		accessCallback.run();
 		original.add(value);
 	}
 
 	@Override
-	public void clear() {
-		original.clear();
+	void cleanupIfExpired() throws Exception {
+		cleanupIfExpired(original.getInternal());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlFoldingState.java
@@ -50,7 +50,7 @@ class TtlFoldingState<K, N, T, ACC>
 	}
 
 	@Override
-	void cleanupIfExpired() throws Exception {
+	public void cleanupIfExpired() throws Exception {
 		cleanupIfExpired(original.getInternal());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlIncrementalCleanup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlIncrementalCleanup.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * Internal service for queueing detected expired state keys between full snapshot thread and state processing thread.
+ *
+ * <p>If configured in {@link org.apache.flink.api.common.state.StateTtlConfig.FullSnapshotCleanupStrategy},
+ * {@link TtlStateSnapshotTransformer} uses this service class to queue detected expired state keys if queue is not full.
+ * {@link AbstractTtlState} wrappers give this service {@code stateAccessed()} callback
+ * whenever this state is accessed for any key. This service then pulls up to certain number of potentially expired keys,
+ * checks their state and clears it if it is still expired since having been queued:
+ *
+ * Snapshot thread:
+ * snapshotting -> |state key/value| -> TtlStateSnapshotTransformer -> |expired state keys| -> TtlIncrementalCleanup -> queue
+ *
+ * Main record processing thread of operator:
+ * touch state -> AbstractTtlState -> TtlIncrementalCleanup.stateAccessed() -> pull queue -> AbstractTtlState.cleanupIfExpired()
+ *
+ * @param <K> type of state key
+ * @param <N> type of state namespace
+ */
+class TtlIncrementalCleanup<K, N> {
+	private final BlockingDeque<Tuple2<K, N>> cleanupQueue;
+	private final int cleanupSize;
+	private final KeyedStateBackend<K> keyContext;
+	private AbstractTtlState<K, N, ?, ?, ?> ttlState;
+
+	/**
+	 * TtlIncrementalCleanup constructor
+	 *
+	 * @param queueSize max cleanup queue size
+	 * @param cleanupSize max number of queued keys to incrementally cleanup upon state access
+	 * @param keyContext state backend to switch keys for cleanup
+	 */
+	TtlIncrementalCleanup(
+		int queueSize,
+		int cleanupSize,
+		KeyedStateBackend<K> keyContext) {
+		Preconditions.checkArgument(cleanupSize > 0);
+		this.cleanupQueue = queueSize > 0 ? new LinkedBlockingDeque<>(queueSize) : new LinkedBlockingDeque<>();
+		this.cleanupSize = cleanupSize;
+		this.keyContext = keyContext;
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	<V> void addIfExpired(K key, N namespace, V value, V filteredValue) {
+		if (filteredValue == null || value != filteredValue) {
+			addExpiredIfCapacityAvailable(key, namespace);
+		}
+	}
+
+	private void addExpiredIfCapacityAvailable(K key, N namespace) {
+		Tuple2<K, N> expired = Tuple2.of(key, namespace);
+		if (!Objects.equals(cleanupQueue.peekLast(), expired)) {
+			cleanupQueue.offerLast(expired);
+		}
+	}
+
+	void stateAccessed() {
+		K currentKey = keyContext.getCurrentKey();
+		N currentNamespace = ttlState.getCurrentNamespace();
+		try {
+			int polled = 0;
+			Tuple2<K, N> state;
+			while (polled < cleanupSize && (state = cleanupQueue.pollFirst()) != null) {
+				runCleanup(state.f0, state.f1);
+				polled++;
+			}
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Failed to lazily clean up state with TTL", e);
+		} finally {
+			keyContext.setCurrentKey(currentKey);
+			ttlState.setCurrentNamespace(currentNamespace);
+		}
+	}
+
+	private void runCleanup(K key, N namespace) throws Exception {
+		keyContext.setCurrentKey(key);
+		ttlState.setCurrentNamespace(namespace);
+		ttlState.cleanupIfExpired();
+	}
+
+	/**
+	 * As TTL state wrapper depends on this class through {@link TtlStateSnapshotTransformer.Factory},
+	 * it has to be set here after its construction is done.
+	 */
+	void setTtlState(AbstractTtlState<K, N, ?, ?, ?> ttlState) {
+		this.ttlState = ttlState;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlListState.java
@@ -88,7 +88,7 @@ class TtlListState<K, N, T> extends
 	}
 
 	@Override
-	void cleanupIfExpired() throws Exception {
+	public void cleanupIfExpired() throws Exception {
 		Iterable<TtlValue<T>> ttlValue = original.get();
 		if (ttlValue != null) {
 			List<TtlValue<T>> unexpired = collect(ttlValue).stream()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -110,7 +110,7 @@ class TtlMapState<K, N, UK, UV>
 	}
 
 	@Override
-	void cleanupIfExpired() throws Exception {
+	public void cleanupIfExpired() throws Exception {
 		Iterable<Map.Entry<UK, TtlValue<UV>>> ttlValue = original.entries();
 		if (ttlValue != null) {
 			for (Iterator<Map.Entry<UK, TtlValue<UV>>> iterator = ttlValue.iterator(); iterator.hasNext(); ) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -44,26 +42,25 @@ import java.util.function.Function;
 class TtlMapState<K, N, UK, UV>
 	extends AbstractTtlState<K, N, Map<UK, UV>, Map<UK, TtlValue<UV>>, InternalMapState<K, N, UK, TtlValue<UV>>>
 	implements InternalMapState<K, N, UK, UV> {
-	TtlMapState(
-		InternalMapState<K, N, UK, TtlValue<UV>> original,
-		StateTtlConfig config,
-		TtlTimeProvider timeProvider,
-		TypeSerializer<Map<UK, UV>> valueSerializer) {
-		super(original, config, timeProvider, valueSerializer);
+	TtlMapState(TtlStateContext<InternalMapState<K, N, UK, TtlValue<UV>>, Map<UK, UV>> ttlStateContext) {
+		super(ttlStateContext);
 	}
 
 	@Override
 	public UV get(UK key) throws Exception {
+		accessCallback.run();
 		return getWithTtlCheckAndUpdate(() -> original.get(key), v -> original.put(key, v), () -> original.remove(key));
 	}
 
 	@Override
 	public void put(UK key, UV value) throws Exception {
+		accessCallback.run();
 		original.put(key, wrapWithTs(value));
 	}
 
 	@Override
 	public void putAll(Map<UK, UV> map) throws Exception {
+		accessCallback.run();
 		if (map == null) {
 			return;
 		}
@@ -76,6 +73,7 @@ class TtlMapState<K, N, UK, UV>
 
 	@Override
 	public void remove(UK key) throws Exception {
+		accessCallback.run();
 		original.remove(key);
 	}
 
@@ -91,6 +89,7 @@ class TtlMapState<K, N, UK, UV>
 
 	private <R> Iterable<R> entries(
 		Function<Map.Entry<UK, UV>, R> resultMapper) throws Exception {
+		accessCallback.run();
 		Iterable<Map.Entry<UK, TtlValue<UV>>> withTs = original.entries();
 		return () -> new EntriesIterator<>(withTs == null ? Collections.emptyList() : withTs, resultMapper);
 	}
@@ -111,8 +110,16 @@ class TtlMapState<K, N, UK, UV>
 	}
 
 	@Override
-	public void clear() {
-		original.clear();
+	void cleanupIfExpired() throws Exception {
+		Iterable<Map.Entry<UK, TtlValue<UV>>> ttlValue = original.entries();
+		if (ttlValue != null) {
+			for (Iterator<Map.Entry<UK, TtlValue<UV>>> iterator = ttlValue.iterator(); iterator.hasNext(); ) {
+				Map.Entry<UK, TtlValue<UV>> e = iterator.next();
+				if (expired(e.getValue())) {
+					iterator.remove();
+				}
+			}
+		}
 	}
 
 	private class EntriesIterator<R> implements Iterator<R> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlReducingState.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 
 import java.util.Collection;
@@ -35,26 +33,25 @@ class TtlReducingState<K, N, T>
 	extends AbstractTtlState<K, N, T, TtlValue<T>, InternalReducingState<K, N, TtlValue<T>>>
 	implements InternalReducingState<K, N, T> {
 	TtlReducingState(
-		InternalReducingState<K, N, TtlValue<T>> originalState,
-		StateTtlConfig config,
-		TtlTimeProvider timeProvider,
-		TypeSerializer<T> valueSerializer) {
-		super(originalState, config, timeProvider, valueSerializer);
+		TtlStateContext<InternalReducingState<K, N, TtlValue<T>>, T> tTtlStateContext) {
+		super(tTtlStateContext);
 	}
 
 	@Override
 	public T get() throws Exception {
+		accessCallback.run();
 		return getInternal();
 	}
 
 	@Override
 	public void add(T value) throws Exception {
+		accessCallback.run();
 		original.add(wrapWithTs(value));
 	}
 
 	@Override
-	public void clear() {
-		original.clear();
+	void cleanupIfExpired() throws Exception {
+		cleanupIfExpired(original.getInternal());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlReducingState.java
@@ -50,7 +50,7 @@ class TtlReducingState<K, N, T>
 	}
 
 	@Override
-	void cleanupIfExpired() throws Exception {
+	public void cleanupIfExpired() throws Exception {
 		cleanupIfExpired(original.getInternal());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+class TtlStateContext<T, SV> {
+	/** Wrapped original state handler. */
+	final T original;
+	final StateTtlConfig config;
+	final TtlTimeProvider timeProvider;
+	final TypeSerializer<SV> valueSerializer;
+	final Runnable accessCallback;
+
+	TtlStateContext(
+		T original,
+		StateTtlConfig config,
+		TtlTimeProvider timeProvider,
+		TypeSerializer<SV> valueSerializer,
+		Runnable accessCallback) {
+		this.original = original;
+		this.config = config;
+		this.timeProvider = timeProvider;
+		this.valueSerializer = valueSerializer;
+		this.accessCallback = accessCallback;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -202,6 +202,10 @@ public class TtlStateFactory<K, N, SV, S extends State, IS extends S> {
 		TtlIncrementalCleanup<K, N> incrementalCleanup = null;
 		if (config != null && config.isIncrementalCleanupActive()) {
 			incrementalCleanup = new TtlIncrementalCleanup<>(config.getQueueSizePerState(), config.getCleanupSize(), stateBackend);
+			if (config.runCleanupForEveryRecord()) {
+				TtlIncrementalCleanup<K, N> finalIncrementalCleanup = incrementalCleanup;
+				stateBackend.registerKeyChangeListener(stub -> finalIncrementalCleanup.stateAccessed());
+			}
 		}
 		return incrementalCleanup;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -33,6 +33,9 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+import org.apache.flink.runtime.state.ttl.cleanup.StateTransformerWithIncCleanup;
+import org.apache.flink.runtime.state.ttl.cleanup.TtlIncrementalCleanup;
+import org.apache.flink.runtime.state.ttl.cleanup.TtlStateSnapshotTransformer;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.SupplierWithException;
@@ -186,7 +189,10 @@ public class TtlStateFactory<K, N, SV, S extends State, IS extends S> {
 		if (!ttlConfig.getCleanupStrategies().inFullSnapshot()) {
 			return StateSnapshotTransformFactory.noTransform();
 		} else {
-			return new TtlStateSnapshotTransformer.Factory<>(timeProvider, ttl, incrementalCleanup);
+			StateSnapshotTransformFactory<K, N, TtlValue<SV>> transformFactory =
+				new TtlStateSnapshotTransformer.Factory<>(timeProvider, ttl, incrementalCleanup);
+			return StateTransformerWithIncCleanup.Factory
+				.wrapWithIncCleanupIfEnabled(transformFactory, incrementalCleanup);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -31,7 +31,7 @@ import org.apache.flink.api.common.typeutils.CompositeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.state.KeyedStateFactory;
+import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
@@ -46,44 +46,46 @@ import java.util.stream.Stream;
 /**
  * This state factory wraps state objects, produced by backends, with TTL logic.
  */
-public class TtlStateFactory<N, SV, S extends State, IS extends S> {
-	public static <N, SV, S extends State, IS extends S> IS createStateAndWrapWithTtlIfEnabled(
+public class TtlStateFactory<K, N, SV, S extends State, IS extends S> {
+	public static <K, N, SV, S extends State, IS extends S> IS createStateAndWrapWithTtlIfEnabled(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc,
-		KeyedStateFactory originalStateFactory,
+		KeyedStateBackend<K> stateBackend,
 		TtlTimeProvider timeProvider) throws Exception {
 		Preconditions.checkNotNull(namespaceSerializer);
 		Preconditions.checkNotNull(stateDesc);
-		Preconditions.checkNotNull(originalStateFactory);
+		Preconditions.checkNotNull(stateBackend);
 		Preconditions.checkNotNull(timeProvider);
 		return  stateDesc.getTtlConfig().isEnabled() ?
-			new TtlStateFactory<N, SV, S, IS>(
-				namespaceSerializer, stateDesc, originalStateFactory, timeProvider)
+			new TtlStateFactory<K, N, SV, S, IS>(
+				namespaceSerializer, stateDesc, stateBackend, timeProvider)
 				.createState() :
-			originalStateFactory.createInternalState(namespaceSerializer, stateDesc);
+			stateBackend.createInternalState(namespaceSerializer, stateDesc);
 	}
 
 	private final Map<Class<? extends StateDescriptor>, SupplierWithException<IS, Exception>> stateFactories;
 
 	private final TypeSerializer<N> namespaceSerializer;
 	private final StateDescriptor<S, SV> stateDesc;
-	private final KeyedStateFactory originalStateFactory;
+	private final KeyedStateBackend<K> stateBackend;
 	private final StateTtlConfig ttlConfig;
 	private final TtlTimeProvider timeProvider;
 	private final long ttl;
+	private final TtlIncrementalCleanup<K, N> incrementalCleanup;
 
 	private TtlStateFactory(
 		TypeSerializer<N> namespaceSerializer,
 		StateDescriptor<S, SV> stateDesc,
-		KeyedStateFactory originalStateFactory,
+		KeyedStateBackend<K> stateBackend,
 		TtlTimeProvider timeProvider) {
 		this.namespaceSerializer = namespaceSerializer;
 		this.stateDesc = stateDesc;
-		this.originalStateFactory = originalStateFactory;
+		this.stateBackend = stateBackend;
 		this.ttlConfig = stateDesc.getTtlConfig();
 		this.timeProvider = timeProvider;
 		this.ttl = ttlConfig.getTtl().toMilliseconds();
 		this.stateFactories = createStateFactories();
+		this.incrementalCleanup = getTtlIncrementalCleanup();
 	}
 
 	@SuppressWarnings("deprecation")
@@ -98,6 +100,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
 	}
 
+	@SuppressWarnings("unchecked")
 	private IS createState() throws Exception {
 		SupplierWithException<IS, Exception> stateFactory = stateFactories.get(stateDesc.getClass());
 		if (stateFactory == null) {
@@ -105,16 +108,18 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 				stateDesc.getClass(), TtlStateFactory.class);
 			throw new FlinkRuntimeException(message);
 		}
-		return stateFactory.get();
+		IS state = stateFactory.get();
+		if (incrementalCleanup != null) {
+			incrementalCleanup.setTtlState((AbstractTtlState<K, N, ?, ?, ?>) state);
+		}
+		return state;
 	}
 
 	@SuppressWarnings("unchecked")
 	private IS createValueState() throws Exception {
 		ValueStateDescriptor<TtlValue<SV>> ttlDescriptor = new ValueStateDescriptor<>(
 			stateDesc.getName(), new TtlSerializer<>(stateDesc.getSerializer()));
-		return (IS) new TtlValueState<>(
-			originalStateFactory.createInternalState(namespaceSerializer, ttlDescriptor, getSnapshotTransformFactory()),
-			ttlConfig, timeProvider, stateDesc.getSerializer());
+		return (IS) new TtlValueState<>(createTtlStateContext(ttlDescriptor));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -122,10 +127,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 		ListStateDescriptor<T> listStateDesc = (ListStateDescriptor<T>) stateDesc;
 		ListStateDescriptor<TtlValue<T>> ttlDescriptor = new ListStateDescriptor<>(
 			stateDesc.getName(), new TtlSerializer<>(listStateDesc.getElementSerializer()));
-		return (IS) new TtlListState<>(
-			originalStateFactory.createInternalState(
-				namespaceSerializer, ttlDescriptor, getSnapshotTransformFactory()),
-			ttlConfig, timeProvider, listStateDesc.getSerializer());
+		return (IS) new TtlListState<>(createTtlStateContext(ttlDescriptor));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -135,9 +137,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 			stateDesc.getName(),
 			mapStateDesc.getKeySerializer(),
 			new TtlSerializer<>(mapStateDesc.getValueSerializer()));
-		return (IS) new TtlMapState<>(
-			originalStateFactory.createInternalState(namespaceSerializer, ttlDescriptor, getSnapshotTransformFactory()),
-			ttlConfig, timeProvider, mapStateDesc.getSerializer());
+		return (IS) new TtlMapState<>(createTtlStateContext(ttlDescriptor));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -147,9 +147,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 			stateDesc.getName(),
 			new TtlReduceFunction<>(reducingStateDesc.getReduceFunction(), ttlConfig, timeProvider),
 			new TtlSerializer<>(stateDesc.getSerializer()));
-		return (IS) new TtlReducingState<>(
-			originalStateFactory.createInternalState(namespaceSerializer, ttlDescriptor, getSnapshotTransformFactory()),
-			ttlConfig, timeProvider, stateDesc.getSerializer());
+		return (IS) new TtlReducingState<>(createTtlStateContext(ttlDescriptor));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -160,9 +158,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 			aggregatingStateDescriptor.getAggregateFunction(), ttlConfig, timeProvider);
 		AggregatingStateDescriptor<IN, TtlValue<SV>, OUT> ttlDescriptor = new AggregatingStateDescriptor<>(
 			stateDesc.getName(), ttlAggregateFunction, new TtlSerializer<>(stateDesc.getSerializer()));
-		return (IS) new TtlAggregatingState<>(
-			originalStateFactory.createInternalState(namespaceSerializer, ttlDescriptor, getSnapshotTransformFactory()),
-			ttlConfig, timeProvider, stateDesc.getSerializer(), ttlAggregateFunction);
+		return (IS) new TtlAggregatingState<>(createTtlStateContext(ttlDescriptor), ttlAggregateFunction);
 	}
 
 	@SuppressWarnings({"deprecation", "unchecked"})
@@ -175,17 +171,37 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 			ttlInitAcc,
 			new TtlFoldFunction<>(foldingStateDescriptor.getFoldFunction(), ttlConfig, timeProvider, initAcc),
 			new TtlSerializer<>(stateDesc.getSerializer()));
-		return (IS) new TtlFoldingState<>(
-			originalStateFactory.createInternalState(namespaceSerializer, ttlDescriptor, getSnapshotTransformFactory()),
-			ttlConfig, timeProvider, stateDesc.getSerializer());
+		return (IS) new TtlFoldingState<>(createTtlStateContext(ttlDescriptor));
 	}
 
-	private StateSnapshotTransformFactory<?> getSnapshotTransformFactory() {
+	@SuppressWarnings("unchecked")
+	private <OIS, TTLCON, TTLDES> TTLCON createTtlStateContext(TTLDES ttlDescriptor) throws Exception {
+		OIS origianlState = (OIS) stateBackend.createInternalState(
+			namespaceSerializer, (StateDescriptor<S, TtlValue<SV>>) ttlDescriptor, getSnapshotTransformFactory());
+		return (TTLCON) new TtlStateContext<>(
+			origianlState, ttlConfig, timeProvider, stateDesc.getSerializer(), getTtlIncrementalCleanupCallback());
+	}
+
+	private StateSnapshotTransformFactory<K, N, TtlValue<SV>> getSnapshotTransformFactory() {
 		if (!ttlConfig.getCleanupStrategies().inFullSnapshot()) {
 			return StateSnapshotTransformFactory.noTransform();
 		} else {
-			return new TtlStateSnapshotTransformer.Factory<>(timeProvider, ttl);
+			return new TtlStateSnapshotTransformer.Factory<>(timeProvider, ttl, incrementalCleanup);
 		}
+	}
+
+	private TtlIncrementalCleanup<K, N> getTtlIncrementalCleanup() {
+		StateTtlConfig.FullSnapshotCleanupStrategy config =
+			ttlConfig.getCleanupStrategies().getFullSnapshotCleanupStrategy();
+		TtlIncrementalCleanup<K, N> incrementalCleanup = null;
+		if (config != null && config.isIncrementalCleanupActive()) {
+			incrementalCleanup = new TtlIncrementalCleanup<>(config.getQueueSizePerState(), config.getCleanupSize(), stateBackend);
+		}
+		return incrementalCleanup;
+	}
+
+	private Runnable getTtlIncrementalCleanupCallback() {
+		return incrementalCleanup == null ? () -> { } : incrementalCleanup::stateAccessed;
 	}
 
 	/** Serializer for user state value with TTL. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlUtils.java
@@ -19,12 +19,12 @@
 package org.apache.flink.runtime.state.ttl;
 
 /** Common functions related to State TTL. */
-class TtlUtils {
+public class TtlUtils {
 	static <V> boolean expired(TtlValue<V> ttlValue, long ttl, TtlTimeProvider timeProvider) {
 		return ttlValue != null && expired(ttlValue.getLastAccessTimestamp(), ttl, timeProvider);
 	}
 
-	static boolean expired(long ts, long ttl, TtlTimeProvider timeProvider) {
+	public static boolean expired(long ts, long ttl, TtlTimeProvider timeProvider) {
 		return getExpirationTimestamp(ts, ttl) <= timeProvider.currentTimestamp();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValue.java
@@ -27,7 +27,9 @@ import java.io.Serializable;
  *
  * @param <T> Type of the user value of state with TTL
  */
-class TtlValue<T> implements Serializable {
+public class TtlValue<T> implements Serializable {
+	private static final long serialVersionUID = -847779322371798744L;
+
 	private final T userValue;
 	private final long lastAccessTimestamp;
 
@@ -41,7 +43,7 @@ class TtlValue<T> implements Serializable {
 		return userValue;
 	}
 
-	long getLastAccessTimestamp() {
+	public long getLastAccessTimestamp() {
 		return lastAccessTimestamp;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValueState.java
@@ -49,7 +49,7 @@ class TtlValueState<K, N, T>
 	}
 
 	@Override
-	void cleanupIfExpired() throws Exception {
+	public void cleanupIfExpired() throws Exception {
 		cleanupIfExpired(original.value());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/cleanup/StateTransformerWithIncCleanup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/cleanup/StateTransformerWithIncCleanup.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.cleanup;
+
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.ttl.TtlValue;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+/**
+ * State snapshot transformer with incremental cleanup of local state with TTL.
+ *
+ * <p>This class wraps the original transformer with logic which passes the detected expired state
+ * to incremental cleanup service.
+ *
+ * @param <K> type of state key
+ * @param <N> type of state namespace
+ * @param <T> type of state
+ */
+public class StateTransformerWithIncCleanup<K, N, T> implements StateSnapshotTransformer<K, N, T> {
+	private final StateSnapshotTransformer<K, N, T> originalTransformer;
+	private final TtlIncrementalCleanup<K, N> ttlIncrementalCleanup;
+
+	private StateTransformerWithIncCleanup(
+		@Nonnull StateSnapshotTransformer<K, N, T> originalTransformer,
+		@Nonnull TtlIncrementalCleanup<K, N> ttlIncrementalCleanup) {
+		this.originalTransformer = originalTransformer;
+		this.ttlIncrementalCleanup = ttlIncrementalCleanup;
+	}
+
+	@Override
+	@Nullable
+	public T filterOrTransform(@Nonnull K key, @Nonnull N namespace, @Nullable T value) {
+		if (value == null) {
+			return null;
+		}
+		T filteredValue = originalTransformer.filterOrTransform(key, namespace, value);
+		ttlIncrementalCleanup.addIfExpired(key, namespace, value, filteredValue);
+		return filteredValue;
+	}
+
+	/** Wraps factory of snapshot transformer with incremental cleanup of local state with TTL. */
+	public static class Factory<K, N, T> implements StateSnapshotTransformFactory<K, N, TtlValue<T>> {
+		private final StateSnapshotTransformFactory<K, N, TtlValue<T>> originalFactory;
+		private final TtlIncrementalCleanup<K, N> ttlIncrementalCleanup;
+
+		private Factory(
+			@Nonnull StateSnapshotTransformFactory<K, N, TtlValue<T>> originalFactory,
+			@Nonnull TtlIncrementalCleanup<K, N> ttlIncrementalCleanup) {
+			this.originalFactory = originalFactory;
+			this.ttlIncrementalCleanup = ttlIncrementalCleanup;
+		}
+
+		public static <K, N, T> StateSnapshotTransformFactory<K, N, TtlValue<T>> wrapWithIncCleanupIfEnabled(
+			@Nonnull StateSnapshotTransformFactory<K, N, TtlValue<T>> originalFactory,
+			@Nullable TtlIncrementalCleanup<K, N> ttlIncrementalCleanup) {
+			return ttlIncrementalCleanup != null ?
+				new Factory<>(originalFactory, ttlIncrementalCleanup) : originalFactory;
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<K, N, TtlValue<T>>> createForDeserializedState() {
+			return originalFactory.createForDeserializedState()
+				.map(t -> new StateTransformerWithIncCleanup<>(t, ttlIncrementalCleanup));
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<K, N, byte[]>> createForSerializedState() {
+			return originalFactory.createForSerializedState()
+				.map(t -> new StateTransformerWithIncCleanup<>(t, ttlIncrementalCleanup));
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/cleanup/TtlIncrementalCleanup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/cleanup/TtlIncrementalCleanup.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.runtime.state.ttl.cleanup;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.ttl.AbstractTtlState;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
@@ -36,29 +37,29 @@ import java.util.concurrent.LinkedBlockingDeque;
  * whenever this state is accessed for any key. This service then pulls up to certain number of potentially expired keys,
  * checks their state and clears it if it is still expired since having been queued:
  *
- * Snapshot thread:
+ * <p>Snapshot thread:
  * snapshotting -> |state key/value| -> TtlStateSnapshotTransformer -> |expired state keys| -> TtlIncrementalCleanup -> queue
  *
- * Main record processing thread of operator:
+ * <p>Main record processing thread of operator:
  * touch state -> AbstractTtlState -> TtlIncrementalCleanup.stateAccessed() -> pull queue -> AbstractTtlState.cleanupIfExpired()
  *
  * @param <K> type of state key
  * @param <N> type of state namespace
  */
-class TtlIncrementalCleanup<K, N> {
+public class TtlIncrementalCleanup<K, N> {
 	private final BlockingDeque<Tuple2<K, N>> cleanupQueue;
 	private final int cleanupSize;
 	private final KeyedStateBackend<K> keyContext;
 	private AbstractTtlState<K, N, ?, ?, ?> ttlState;
 
 	/**
-	 * TtlIncrementalCleanup constructor
+	 * TtlIncrementalCleanup constructor.
 	 *
 	 * @param queueSize max cleanup queue size
 	 * @param cleanupSize max number of queued keys to incrementally cleanup upon state access
 	 * @param keyContext state backend to switch keys for cleanup
 	 */
-	TtlIncrementalCleanup(
+	public TtlIncrementalCleanup(
 		int queueSize,
 		int cleanupSize,
 		KeyedStateBackend<K> keyContext) {
@@ -82,7 +83,7 @@ class TtlIncrementalCleanup<K, N> {
 		}
 	}
 
-	void stateAccessed() {
+	public void stateAccessed() {
 		K currentKey = keyContext.getCurrentKey();
 		N currentNamespace = ttlState.getCurrentNamespace();
 		try {
@@ -110,7 +111,7 @@ class TtlIncrementalCleanup<K, N> {
 	 * As TTL state wrapper depends on this class through {@link TtlStateSnapshotTransformer.Factory},
 	 * it has to be set here after its construction is done.
 	 */
-	void setTtlState(AbstractTtlState<K, N, ?, ?, ?> ttlState) {
+	public void setTtlState(AbstractTtlState<K, N, ?, ?, ?> ttlState) {
 		this.ttlState = ttlState;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateRegistryTest.java
@@ -314,6 +314,11 @@ public class KvStateRegistryTest extends TestLogger {
 		}
 
 		@Override
+		public final VoidNamespace getCurrentNamespace() {
+			return null;
+		}
+
+		@Override
 		public byte[] getSerializedValue(
 				final byte[] serializedKeyAndNamespace,
 				final TypeSerializer<Integer> safeKeySerializer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -132,7 +132,7 @@ public class SerializationProxiesTest {
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 
 		for (StateMetaInfoSnapshot snapshot : serializationProxy.getStateMetaInfoSnapshots()) {
-			final RegisteredKeyValueStateBackendMetaInfo<?, ?> restoredMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
+			final RegisteredKeyValueStateBackendMetaInfo<?, ?, ?> restoredMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
 			Assert.assertTrue(restoredMetaInfo.getNamespaceSerializer() instanceof UnloadableDummyTypeSerializer);
 			Assert.assertTrue(restoredMetaInfo.getStateSerializer() instanceof UnloadableDummyTypeSerializer);
 			Assert.assertEquals(namespaceSerializer.snapshotConfiguration(), snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER));
@@ -198,7 +198,7 @@ public class SerializationProxiesTest {
 				new DataInputViewStreamWrapper(in), classLoader);
 		}
 
-		RegisteredKeyValueStateBackendMetaInfo<?, ?> restoredMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
+		RegisteredKeyValueStateBackendMetaInfo<?, ?, ?> restoredMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
 
 		Assert.assertEquals(name, restoredMetaInfo.getName());
 		Assert.assertTrue(restoredMetaInfo.getNamespaceSerializer() instanceof UnloadableDummyTypeSerializer);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -53,7 +53,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 */
 	@Test
 	public void testPutGetRemoveContainsTransform() throws Exception {
-		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer, ArrayList<Integer>> metaInfo =
 			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
@@ -125,7 +125,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 */
 	@Test
 	public void testIncrementalRehash() {
-		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer, ArrayList<Integer>> metaInfo =
 			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
@@ -170,7 +170,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	@Test
 	public void testRandomModificationsAndCopyOnWriteIsolation() throws Exception {
 
-		final RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+		final RegisteredKeyValueStateBackendMetaInfo<Integer, Integer, ArrayList<Integer>> metaInfo =
 			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
@@ -325,7 +325,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 */
 	@Test
 	public void testCopyOnWriteContracts() {
-		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer, ArrayList<Integer>> metaInfo =
 			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",
@@ -400,7 +400,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 		final TestDuplicateSerializer stateSerializer = new TestDuplicateSerializer();
 		final TestDuplicateSerializer keySerializer = new TestDuplicateSerializer();
 
-		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer> metaInfo =
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer, Integer> metaInfo =
 			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.VALUE,
 				"test",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/StateTableSnapshotCompatibilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/StateTableSnapshotCompatibilityTest.java
@@ -47,7 +47,7 @@ public class StateTableSnapshotCompatibilityTest {
 	@Test
 	public void checkCompatibleSerializationFormats() throws IOException {
 		final Random r = new Random(42);
-		RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
+		RegisteredKeyValueStateBackendMetaInfo<Integer, Integer, ArrayList<Integer>> metaInfo =
 			new RegisteredKeyValueStateBackendMetaInfo<>(
 				StateDescriptor.Type.UNKNOWN,
 				"test",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -44,7 +44,7 @@ import static org.junit.Assume.assumeThat;
 
 /** State TTL base test suite. */
 @RunWith(Parameterized.class)
-public abstract class TtlStateTestBase {
+public abstract class  TtlStateTestBase {
 	private static final long TTL = 100;
 
 	private MockTtlTimeProvider timeProvider;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -401,7 +401,7 @@ public abstract class  TtlStateTestBase {
 
 	@Test
 	public void testFullSnapshotCleanupQueue() throws Exception {
-		initTest(getConfBuilder(TTL).cleanupFullSnapshotAndLocalState(10, 5).build());
+		initTest(getConfBuilder(TTL).cleanupFullSnapshotAndLocalState(10, 5, false).build());
 
 		timeProvider.time = 0;
 		sbetc.setCurrentKey("k1");
@@ -424,6 +424,26 @@ public abstract class  TtlStateTestBase {
 		assertEquals("Expired state should be unavailable", ctx().emptyValue, ctx().get());
 		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
 		// after k1 access k2 should be also cleared from cleanup queue
+		sbetc.setCurrentKey("k2");
+		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
+	}
+
+	@Test
+	public void testFullSnapshotCleanupQueueWithKeyChangedCallback() throws Exception {
+		initTest(getConfBuilder(TTL).cleanupFullSnapshotAndLocalState(10, 5, true).build());
+
+		timeProvider.time = 0;
+		sbetc.setCurrentKey("k1");
+		ctx().update(ctx().updateEmpty);
+		sbetc.setCurrentKey("k2");
+		ctx().update(ctx().updateEmpty);
+
+		timeProvider.time = 120;
+		sbetc.takeSnapshot();
+
+		// all state expired, check that storage is cleaned up
+		sbetc.setCurrentKey("k1");
+		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
 		sbetc.setCurrentKey("k2");
 		assertEquals("Original state should be cleared on access", ctx().emptyValue, ctx().getOriginal());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalKvState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalKvState.java
@@ -59,6 +59,11 @@ abstract class MockInternalKvState<K, N, T> implements InternalKvState<K, N, T> 
 	}
 
 	@Override
+	public final N getCurrentNamespace() {
+		return currentNamespace;
+	}
+
+	@Override
 	public byte[] getSerializedValue(
 		byte[] serializedKeyAndNamespace,
 		TypeSerializer safeKeySerializer,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -122,6 +122,11 @@ public abstract class AbstractRocksDBState<K, N, V, S extends State> implements 
 	}
 
 	@Override
+	public final N getCurrentNamespace() {
+		return currentNamespace;
+	}
+
+	@Override
 	public byte[] getSerializedValue(
 			final byte[] serializedKeyAndNamespace,
 			final TypeSerializer<K> safeKeySerializer,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -171,7 +171,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<K, N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBAggregatingState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -103,7 +103,7 @@ class RocksDBFoldingState<K, N, T, ACC>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<K, N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBFoldingState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -165,7 +165,7 @@ class RocksDBReducingState<K, N, V>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<K, N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBReducingState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -114,7 +114,7 @@ class RocksDBValueState<K, N, V>
 	@SuppressWarnings("unchecked")
 	static <K, N, SV, S extends State, IS extends S> IS create(
 		StateDescriptor<S, SV> stateDesc,
-		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<K, N, SV>> registerResult,
 		RocksDBKeyedStateBackend<K> backend) {
 		return (IS) new RocksDBValueState<>(
 			registerResult.f0,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
@@ -18,28 +18,39 @@
 
 package org.apache.flink.contrib.streaming.state.iterator;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.RocksDBKeySerializationUtils;
 import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.core.memory.ByteArrayDataInputView;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.RocksIterator;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
+
 /**
  * Wrapper around {@link RocksIterator} that applies a given {@link StateSnapshotTransformer} to the elements
  * during the iteration.
+ *
+ * @param <K> type of key
+ * @param <N> type of namespace
  */
-public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {
-
+public class RocksTransformingIteratorWrapper<K, N> extends RocksIteratorWrapper {
 	@Nonnull
-	private final StateSnapshotTransformer<byte[]> stateSnapshotTransformer;
+	private final RocksDBSnapshotTransformContext<K, N, byte[]> transformContext;
 	private byte[] current;
+	private final ByteArrayDataInputView div;
 
 	public RocksTransformingIteratorWrapper(
 		@Nonnull RocksIterator iterator,
-		@Nonnull StateSnapshotTransformer<byte[]> stateSnapshotTransformer) {
+		@Nonnull RocksDBSnapshotTransformContext<K, N, byte[]> transformContext) {
 		super(iterator);
-		this.stateSnapshotTransformer = stateSnapshotTransformer;
+		this.transformContext = transformContext;
+		this.div = new ByteArrayDataInputView();
 	}
 
 	@Override
@@ -66,9 +77,43 @@ public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {
 		filterOrTransform(super::prev);
 	}
 
-	private void filterOrTransform(@Nonnull Runnable advance) {
-		while (isValid() && (current = stateSnapshotTransformer.filterOrTransform(super.value())) == null) {
+	private void filterOrTransform(Runnable advance) {
+		while (isValid() && (current = filterNextValue()) == null) {
 			advance.run();
+		}
+	}
+
+	private byte[] filterNextValue() {
+		Tuple2<K, N> keyAndNs = deserializeKeyAndNamespaces();
+		return transformContext.getTransformer().filterOrTransform(keyAndNs.f0, keyAndNs.f1, super.value());
+	}
+
+	private Tuple2<K, N> deserializeKeyAndNamespaces() {
+		byte[] rocksdbKey = key();
+		int keyGroupPrefixBytes = transformContext.getKeyGroupPrefixBytes();
+		div.setData(rocksdbKey, keyGroupPrefixBytes, rocksdbKey.length - keyGroupPrefixBytes);
+		return Tuple2.of(readKey(div), readNamespace(div));
+	}
+
+	private K readKey(ByteArrayDataInputView dataInput) {
+		try {
+			return RocksDBKeySerializationUtils.readKey(
+				transformContext.getKeySerializer(),
+				dataInput,
+				transformContext.isAmbiguousKeyPossible());
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Unexpected key deserialization failure whiling filtering state", e);
+		}
+	}
+
+	private N readNamespace(ByteArrayDataInputView dataInput) {
+		try {
+			return RocksDBKeySerializationUtils.readNamespace(
+				transformContext.getNamespaceSerializer(),
+				dataInput,
+				transformContext.isAmbiguousKeyPossible());
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Unexpected namespace deserialization failure whiling filtering state", e);
 		}
 	}
 
@@ -78,5 +123,47 @@ public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {
 			throw new IllegalStateException("value() method cannot be called if isValid() is false");
 		}
 		return current;
+	}
+
+	/** State context needed by {@link RocksTransformingIteratorWrapper}. */
+	public static class RocksDBSnapshotTransformContext<K, N, T> {
+		private final int keyGroupPrefixBytes;
+		private final TypeSerializer<K> keySerializer;
+		private final TypeSerializer<N> namespaceSerializer;
+		private final StateSnapshotTransformer<K, N, T> transformer;
+		private final boolean ambiguousKeyPossible;
+
+		public RocksDBSnapshotTransformContext(
+			int keyGroupPrefixBytes,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer,
+			StateSnapshotTransformer<K, N, T> transformer) {
+			this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+			this.keySerializer = keySerializer;
+			this.namespaceSerializer = namespaceSerializer;
+			this.transformer = transformer;
+			this.ambiguousKeyPossible =
+				RocksDBKeySerializationUtils.isAmbiguousKeyPossible(keySerializer, namespaceSerializer);
+		}
+
+		public int getKeyGroupPrefixBytes() {
+			return keyGroupPrefixBytes;
+		}
+
+		public TypeSerializer<K> getKeySerializer() {
+			return keySerializer;
+		}
+
+		public TypeSerializer<N> getNamespaceSerializer() {
+			return namespaceSerializer;
+		}
+
+		StateSnapshotTransformer<K, N, T> getTransformer() {
+			return transformer;
+		}
+
+		boolean isAmbiguousKeyPossible() {
+			return ambiguousKeyPossible;
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR extends the cleanup of full snapshot from the expired state. A queue is added between a snapshotting thread which discovers expired state during its full scan and main thread which accesses state. The main thread incrementally pulls the queue and cleans up local state if still applicable.

## Brief change log

  - add FullSnapshotCleanupStrategy config for this feature, users can activate it in state config builder StateTtlConfig.Builder.cleanupFullSnapshotAndLocalState
  - Add key and namespace parameters to StateSnapshotTransformer interface to save expired keys in queue and address state later for cleanup
  - Parse key/namespace bytes in RocksDb and pass them in both backends to StateSnapshotTransformer
  - add TtlIncrementalCleanup service which wraps queue with expiration specific add/pull logic
  - add call from TtlStateSnapshotTransformer to TtlIncrementalCleanup.addIfExpired to enqueue expired keys
  - add callback from states to TtlIncrementalCleanup.stateAccessed when state is touched
  - add check/cleanup in TTL state wrappers when pulled from queue AbstractTtlState.cleanupIfExpired
  - add test for the feature TtlStateTestBase.testFullSnapshotCleanupQueue

## Verifying this change

unit tests of TTL logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
