### PR TITLE
[FLINK-10141][network] optimisations reducing lock contention

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -306,8 +306,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		int numAddedBuffers;
 
 		synchronized (bufferQueue) {
-			// Important: check the isReleased state inside synchronized block, so there is no
-			// race condition when recycle and releaseAllResources running in parallel.
+			// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+			// after releaseAllResources() released all buffers (see below for details).
 			if (isReleased.get()) {
 				try {
 					inputGate.returnExclusiveSegments(Collections.singletonList(segment));
@@ -368,8 +368,13 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 				checkState(isWaitingForFloatingBuffers,
 					"This channel should be waiting for floating buffers.");
 
-				// Important: double check the isReleased state inside synchronized block, so there is no
-				// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
+				// Important: make sure that we never add a buffer after releaseAllResources()
+				// released all buffers. Following scenarios exist:
+				// 1) releaseAllResources() already released buffers inside bufferQueue
+				// -> then isReleased is set correctly
+				// 2) releaseAllResources() did not yet release buffers from bufferQueue
+				// -> we may or may not have set isReleased yet but will always wait for the
+				//    lock on bufferQueue to release buffers
 				if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
 					isWaitingForFloatingBuffers = false;
 					recycleBuffer = false; // just in case
@@ -385,10 +390,10 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 				} else {
 					needMoreBuffers = true;
 				}
+			}
 
-				if (unannouncedCredit.getAndAdd(1) == 0) {
-					notifyCreditAvailable();
-				}
+			if (unannouncedCredit.getAndAdd(1) == 0) {
+				notifyCreditAvailable();
 			}
 
 			return needMoreBuffers;
@@ -484,8 +489,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		int numRequestedBuffers = 0;
 
 		synchronized (bufferQueue) {
-			// Important: check the isReleased state inside synchronized block, so there is no
-			// race condition when onSenderBacklog and releaseAllResources running in parallel.
+			// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+			// after releaseAllResources() released all buffers (see above for details).
 			if (isReleased.get()) {
 				return;
 			}
@@ -510,33 +515,40 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	}
 
 	public void onBuffer(Buffer buffer, int sequenceNumber, int backlog) throws IOException {
-		boolean success = false;
+		boolean recycleBuffer = true;
 
 		try {
+
+			final boolean wasEmpty;
 			synchronized (receivedBuffers) {
-				if (!isReleased.get()) {
-					if (expectedSequenceNumber == sequenceNumber) {
-						final boolean wasEmpty = receivedBuffers.isEmpty();
-
-						receivedBuffers.add(buffer);
-						expectedSequenceNumber++;
-
-						if (wasEmpty) {
-							notifyChannelNonEmpty();
-						}
-
-						success = true;
-					} else {
-						onError(new BufferReorderingException(expectedSequenceNumber, sequenceNumber));
-					}
+				// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+				// after releaseAllResources() released all buffers from receivedBuffers
+				// (see above for details).
+				if (isReleased.get()) {
+					return;
 				}
+
+				if (expectedSequenceNumber != sequenceNumber) {
+					onError(new BufferReorderingException(expectedSequenceNumber, sequenceNumber));
+					return;
+				}
+
+				wasEmpty = receivedBuffers.isEmpty();
+				receivedBuffers.add(buffer);
+				recycleBuffer = false;
 			}
 
-			if (success && backlog >= 0) {
+			++expectedSequenceNumber;
+
+			if (wasEmpty) {
+				notifyChannelNonEmpty();
+			}
+
+			if (backlog >= 0) {
 				onSenderBacklog(backlog);
 			}
 		} finally {
-			if (!success) {
+			if (recycleBuffer) {
 				buffer.recycleBuffer();
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -545,7 +545,7 @@ public class SingleInputGate implements InputGate {
 
 				currentChannel = inputChannelsWithData.remove();
 				enqueuedInputChannelsWithData.clear(currentChannel.getChannelIndex());
-				moreAvailable = inputChannelsWithData.size() > 0;
+				moreAvailable = !inputChannelsWithData.isEmpty();
 			}
 
 			result = currentChannel.getNextBuffer();


### PR DESCRIPTION
## What is the purpose of the change

With the changes around introducing credit-based flow control as well as the low latency changes, unfortunately, we also introduced some lock contention on `RemoteInputChannel#bufferQueue` and `RemoteInputChannel#receivedBuffers`. Additionally, we were asking for queue sizes when the only thing we need is whether it is empty or not.

As a result, we saw high CPU load during "idle" stream processing jobs with no events in the stream but only watermarks (every 500ms) and many slots on a single machine.

## Brief change log

- move `notifyCreditAvailable()` out of the lock around `RemoteInputChannel#bufferQueue`
- move `notifyChannelNonEmpty()` out of the lock around `RemoteInputChannel#receivedBuffers`
- replace `RemoteInputChannel#receivedBuffers.size()` with `receivedBuffers.isEmpty()` when this is the only thing needed
- replace `SingleInputGate#inputChannelsWithData.size()` with `inputChannelsWithData.isEmpty()` when this is the only thing needed
- minor code style improvement in `CreditBasedPartitionRequestClientHandler` to improve readability

## Verifying this change

- This change is already covered by existing tests, such as `RemoteInputChannelTest`, `SingleInputGateTest`,..., and everything using the network stack.
- Manually verified that less CPU is used with a `SocketWindowWordCount` with some added shuffles, no input elements, only watermarks every 500ms with 4 TMs, 10 slots each on a single (laptop) machine (together with #6555).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** (per buffer)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
