### PR TITLE
[FLINK-10144]delete unused import akka.actor.ActorRef in TaskManagerMessages.scala

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.messages
 
 import java.util.UUID
-
-import akka.actor.ActorRef
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
 import org.apache.flink.runtime.instance.InstanceID
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request aim to delete an useless import `import akka.actor.ActorRef` in org.apache.flink.runtime.messages.TaskManagerMessages.scala*


## Brief change log

*delete unused `import akka.actor.ActorRef` in `org.apache.flink.runtime.messages.TaskManagerMessages.scala`*


## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.test.recovery.TaskManagerFailureRecoveryITCase.testRestartWithFailingTaskManager()*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)