### PR TITLE
[FLINK-10142][network] reduce locking around credit notification

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
@@ -171,10 +171,7 @@ public class PartitionRequestClient {
 	}
 
 	public void notifyCreditAvailable(RemoteInputChannel inputChannel) {
-		// We should skip the notification if the client is already closed.
-		if (!closeReferenceCounter.isDisposed()) {
-			clientHandler.notifyCreditAvailable(inputChannel);
-		}
+		clientHandler.notifyCreditAvailable(inputChannel);
 	}
 
 	public void close(RemoteInputChannel inputChannel) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -289,10 +289,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	private void notifyCreditAvailable() {
 		checkState(partitionRequestClient != null, "Tried to send task event to producer before requesting a queue.");
 
-		// We should skip the notification if this channel is already released.
-		if (!isReleased.get()) {
-			partitionRequestClient.notifyCreditAvailable(this);
-		}
+		partitionRequestClient.notifyCreditAvailable(this);
 	}
 
 	/**
@@ -354,13 +351,6 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	 */
 	@Override
 	public boolean notifyBufferAvailable(Buffer buffer) {
-		// Check the isReleased state outside synchronized block first to avoid
-		// deadlock with releaseAllResources running in parallel.
-		if (isReleased.get()) {
-			buffer.recycleBuffer();
-			return false;
-		}
-
 		boolean recycleBuffer = true;
 		try {
 			boolean needMoreBuffers = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -306,8 +306,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		int numAddedBuffers;
 
 		synchronized (bufferQueue) {
-			// Important: check the isReleased state inside synchronized block, so there is no
-			// race condition when recycle and releaseAllResources running in parallel.
+			// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+			// after releaseAllResources() released all buffers (see below for details).
 			if (isReleased.get()) {
 				try {
 					inputGate.returnExclusiveSegments(Collections.singletonList(segment));
@@ -368,8 +368,13 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 				checkState(isWaitingForFloatingBuffers,
 					"This channel should be waiting for floating buffers.");
 
-				// Important: double check the isReleased state inside synchronized block, so there is no
-				// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
+				// Important: make sure that we never add a buffer after releaseAllResources()
+				// released all buffers. Following scenarios exist:
+				// 1) releaseAllResources() already released buffers inside bufferQueue
+				// -> then isReleased is set correctly
+				// 2) releaseAllResources() did not yet release buffers from bufferQueue
+				// -> we may or may not have set isReleased yet but will always wait for the
+				//    lock on bufferQueue to release buffers
 				if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
 					isWaitingForFloatingBuffers = false;
 					recycleBuffer = false; // just in case
@@ -385,10 +390,10 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 				} else {
 					needMoreBuffers = true;
 				}
+			}
 
-				if (unannouncedCredit.getAndAdd(1) == 0) {
-					notifyCreditAvailable();
-				}
+			if (unannouncedCredit.getAndAdd(1) == 0) {
+				notifyCreditAvailable();
 			}
 
 			return needMoreBuffers;
@@ -484,8 +489,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		int numRequestedBuffers = 0;
 
 		synchronized (bufferQueue) {
-			// Important: check the isReleased state inside synchronized block, so there is no
-			// race condition when onSenderBacklog and releaseAllResources running in parallel.
+			// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+			// after releaseAllResources() released all buffers (see above for details).
 			if (isReleased.get()) {
 				return;
 			}
@@ -510,33 +515,40 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	}
 
 	public void onBuffer(Buffer buffer, int sequenceNumber, int backlog) throws IOException {
-		boolean success = false;
+		boolean recycleBuffer = true;
 
 		try {
+
+			final boolean wasEmpty;
 			synchronized (receivedBuffers) {
-				if (!isReleased.get()) {
-					if (expectedSequenceNumber == sequenceNumber) {
-						final boolean wasEmpty = receivedBuffers.isEmpty();
-
-						receivedBuffers.add(buffer);
-						expectedSequenceNumber++;
-
-						if (wasEmpty) {
-							notifyChannelNonEmpty();
-						}
-
-						success = true;
-					} else {
-						onError(new BufferReorderingException(expectedSequenceNumber, sequenceNumber));
-					}
+				// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+				// after releaseAllResources() released all buffers from receivedBuffers
+				// (see above for details).
+				if (isReleased.get()) {
+					return;
 				}
+
+				if (expectedSequenceNumber != sequenceNumber) {
+					onError(new BufferReorderingException(expectedSequenceNumber, sequenceNumber));
+					return;
+				}
+
+				wasEmpty = receivedBuffers.isEmpty();
+				receivedBuffers.add(buffer);
+				recycleBuffer = false;
 			}
 
-			if (success && backlog >= 0) {
+			++expectedSequenceNumber;
+
+			if (wasEmpty) {
+				notifyChannelNonEmpty();
+			}
+
+			if (backlog >= 0) {
 				onSenderBacklog(backlog);
 			}
 		} finally {
-			if (!success) {
+			if (recycleBuffer) {
 				buffer.recycleBuffer();
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -545,7 +545,7 @@ public class SingleInputGate implements InputGate {
 
 				currentChannel = inputChannelsWithData.remove();
 				enqueuedInputChannelsWithData.clear(currentChannel.getChannelIndex());
-				moreAvailable = inputChannelsWithData.size() > 0;
+				moreAvailable = !inputChannelsWithData.isEmpty();
 			}
 
 			result = currentChannel.getNextBuffer();


### PR DESCRIPTION
## What is the purpose of the change

When credit-based flow control was introduced, we also added some checks and optimisations for uncommon code paths that make common code paths unnecessarily more expensive, e.g. checking whether a channel was released before forwarding a credit notification to Netty. Such checks would have to be confirmed by the Netty thread anyway and thus only add additional load for something that happens only once (per channel). This PR removes these additional checks.

Please note that this PR builds upon #6553.

## Brief change log

- from `PartitionRequestClient`: remove checking whether we have already been disposed
- from `RemoteInputChannel#notifyCreditAvailable()`: remove check for `isReleased` (checked when the notification arrives at Netty's thread)
- from `RemoteInputChannel#notifyBufferAvailable()`: we must check inside `synchronized (bufferQueue)` anyway and there is no race condition with `releaseAllResources()` as previously mentioned there (the previous check also did not really prevent any race if it existed!)

## Verifying this change

- covered by existing tests, such as `RemoteInputChannelTest` and in general everything using the network stack
- added `RemoteInputChannelTest#testConcurrentNotifyBufferAvailableAndRelease`
- check for reduced CPU load (together with #6553)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** (per buffer)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
