### PR TITLE
[FLINK-10151] [State TTL] Fix false recursion call in TransformingStateTableKeyGroupPartitioner.tryAddToSource

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -268,7 +268,7 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 		int tryAddToSource(int currentIndex, CopyOnWriteStateTable.StateTableEntry<K, N, S> entry) {
 			CopyOnWriteStateTable.StateTableEntry<K, N, S> filteredEntry = filterEntry(entry);
 			if (filteredEntry != null) {
-				return tryAddToSource(currentIndex, filteredEntry);
+				return super.tryAddToSource(currentIndex, filteredEntry);
 			}
 			return currentIndex;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/HeapAsyncSnapshotTtlStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/HeapAsyncSnapshotTtlStateTest.java
@@ -21,14 +21,14 @@ package org.apache.flink.runtime.state.ttl;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 
-/** Test suite for heap state TTL. */
-public class HeapTtlStateTest extends TtlStateTestBase {
+/** Test suite for heap state TTL with asynchronous snapshotting. */
+public class HeapAsyncSnapshotTtlStateTest extends TtlStateTestBase {
 	@Override
 	protected StateBackendTestContext createStateBackendTestContext(TtlTimeProvider timeProvider) {
 		return new StateBackendTestContext(timeProvider) {
 			@Override
 			protected StateBackend createStateBackend() {
-				return new MemoryStateBackend(false);
+				return new MemoryStateBackend(true);
 			}
 		};
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/HeapSyncSnapshotTtlStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/HeapSyncSnapshotTtlStateTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl;
+
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+/** Test suite for heap state TTL with synchronous snapshotting. */
+public class HeapSyncSnapshotTtlStateTest extends TtlStateTestBase {
+	@Override
+	protected StateBackendTestContext createStateBackendTestContext(TtlTimeProvider timeProvider) {
+		return new StateBackendTestContext(timeProvider) {
+			@Override
+			protected StateBackend createStateBackend() {
+				return new MemoryStateBackend(false);
+			}
+		};
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes bug in `TransformingStateTableKeyGroupPartitioner.tryAddToSource` which calls itself instead of its super method.

## Brief change log

  - call `super.tryAddToSource` in `TransformingStateTableKeyGroupPartitioner.tryAddToSource`
  - extend TTL test suite with asynchronous snapshot mode for heap backend

## Verifying this change

State TTL unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
