### PR TITLE
[FLINK-10162][flink-runtime][flink-runtime-web] add host in checkpoint detail

### DIFF
--- a/flink-runtime-web/web-dashboard/app/partials/jobs/job.plan.node.checkpoints.details.jade
+++ b/flink-runtime-web/web-dashboard/app/partials/jobs/job.plan.node.checkpoints.details.jade
@@ -128,6 +128,7 @@ div(ng-if="checkpoint")
             thead
               tr
                 td #[strong Subtask #]
+                td #[strong Host]
                 td #[strong Acknowledgement Time]
                 td #[strong End to End Duration]
                 td #[strong State Size]
@@ -138,6 +139,7 @@ div(ng-if="checkpoint")
             tbody
               tr(ng-repeat="subtask in subtaskDetails[v.id]['subtasks']")
                 td {{ subtask['index'] + 1 }}
+                td {{ subtask['hostId'] }}
                 td(ng-if-start="subtask['status'] == 'completed'") {{ subtask['ack_timestamp'] | amDateFormat:'H:mm:ss' }}
                 td {{ subtask['end_to_end_duration'] | humanizeDuration }}
                 td {{ subtask['state_size'] | humanizeBytes }}

--- a/flink-runtime-web/web-dashboard/web/partials/jobs/job.plan.node.checkpoints.details.html
+++ b/flink-runtime-web/web-dashboard/web/partials/jobs/job.plan.node.checkpoints.details.html
@@ -135,6 +135,7 @@ limitations under the License.
             <thead>
               <tr>
                 <td><strong>Subtask #</strong></td>
+                <td><strong>Host</strong></td>
                 <td><strong>Acknowledgement Time</strong></td>
                 <td><strong>End to End Duration</strong></td>
                 <td><strong>State Size</strong></td>
@@ -147,6 +148,7 @@ limitations under the License.
             <tbody>
               <tr ng-repeat="subtask in subtaskDetails[v.id]['subtasks']">
                 <td>{{ subtask['index'] + 1 }}</td>
+                <td>{{ subtask['hostId'] }}</td>
                 <td ng-if-start="subtask['status'] == 'completed'">{{ subtask['ack_timestamp'] | amDateFormat:'H:mm:ss' }}</td>
                 <td>{{ subtask['end_to_end_duration'] | humanizeDuration }}</td>
                 <td>{{ subtask['state_size'] | humanizeBytes }}</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -327,6 +328,8 @@ public class PendingCheckpoint {
 
 			List<OperatorID> operatorIDs = vertex.getJobVertex().getOperatorIDs();
 			int subtaskIndex = vertex.getParallelSubtaskIndex();
+			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
+			String locationString = location == null ? "(unassigned)" : location.getHostname() + ":" + location.dataPort();
 			long ackTimestamp = System.currentTimeMillis();
 
 			long stateSize = 0L;
@@ -368,6 +371,7 @@ public class PendingCheckpoint {
 
 				SubtaskStateStats subtaskStateStats = new SubtaskStateStats(
 					subtaskIndex,
+					locationString,
 					ackTimestamp,
 					stateSize,
 					metrics.getSyncDurationMillis(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
@@ -39,6 +39,9 @@ public class SubtaskStateStats implements Serializable {
 	/** Index of this sub task. */
 	private final int subtaskIndex;
 
+	/** Location of this sub task. */
+	private final String subtaskLocation;
+
 	/**
 	 * Timestamp when the ack from this sub task was received at the
 	 * coordinator.
@@ -64,6 +67,7 @@ public class SubtaskStateStats implements Serializable {
 	 * Creates the stats for a single subtask.
 	 *
 	 * @param subtaskIndex Index of the subtask.
+	 * @param subtaskLocation Location of the subtask.
 	 * @param ackTimestamp Timestamp when the acknowledgement of this subtask was received at the coordinator.
 	 * @param stateSize Size of the checkpointed state at this subtask.
 	 * @param syncCheckpointDuration Checkpoint duration at the task (synchronous part)
@@ -73,6 +77,7 @@ public class SubtaskStateStats implements Serializable {
 	 */
 	SubtaskStateStats(
 			int subtaskIndex,
+			String subtaskLocation,
 			long ackTimestamp,
 			long stateSize,
 			long syncCheckpointDuration,
@@ -82,6 +87,7 @@ public class SubtaskStateStats implements Serializable {
 
 		checkArgument(subtaskIndex >= 0, "Negative subtask index");
 		this.subtaskIndex = subtaskIndex;
+		this.subtaskLocation = subtaskLocation;
 		checkArgument(stateSize >= 0, "Negative state size");
 		this.stateSize = stateSize;
 		this.ackTimestamp = ackTimestamp;
@@ -98,6 +104,15 @@ public class SubtaskStateStats implements Serializable {
 	 */
 	public int getSubtaskIndex() {
 		return subtaskIndex;
+	}
+
+	/**
+	 * Returns the subtask location.
+	 *
+	 * @return Subtask Location.
+	 */
+	public String getSubtaskLocation() {
+		return subtaskLocation;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -178,6 +178,7 @@ public class TaskCheckpointStatisticDetailsHandler
 			} else {
 				result.add(new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics(
 					i,
+					subtask.getSubtaskLocation(),
 					subtask.getAckTimestamp(),
 					subtask.getEndToEndDuration(triggerTimestamp),
 					subtask.getStateSize(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
@@ -204,6 +204,7 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 			gen.writeNumberField("index", i);
 
 			if (subtask != null) {
+				gen.writeStringField("hostId", subtask.getSubtaskLocation());
 				gen.writeStringField("status", "completed");
 				gen.writeNumberField("ack_timestamp", subtask.getAckTimestamp());
 				gen.writeNumberField("end_to_end_duration", subtask.getEndToEndDuration(checkpoint.getTriggerTimestamp()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
@@ -87,6 +87,8 @@ public class SubtaskCheckpointStatistics {
 	 */
 	public static final class CompletedSubtaskCheckpointStatistics extends SubtaskCheckpointStatistics {
 
+		public static final String FIELD_NAME_LOCATION = "location";
+
 		public static final String FIELD_NAME_ACK_TIMESTAMP = "ack_timestamp";
 
 		public static final String FIELD_NAME_DURATION = "end_to_end_duration";
@@ -96,6 +98,9 @@ public class SubtaskCheckpointStatistics {
 		public static final String FIELD_NAME_CHECKPOINT_DURATION = "checkpoint";
 
 		public static final String FIELD_NAME_ALIGNMENT = "alignment";
+
+		@JsonProperty(FIELD_NAME_LOCATION)
+		private final String location;
 
 		@JsonProperty(FIELD_NAME_ACK_TIMESTAMP)
 		private final long ackTimestamp;
@@ -115,17 +120,23 @@ public class SubtaskCheckpointStatistics {
 		@JsonCreator
 		public CompletedSubtaskCheckpointStatistics(
 				@JsonProperty(FIELD_NAME_INDEX) int index,
+				@JsonProperty(FIELD_NAME_LOCATION) String location,
 				@JsonProperty(FIELD_NAME_ACK_TIMESTAMP) long ackTimestamp,
 				@JsonProperty(FIELD_NAME_DURATION) long duration,
 				@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 				@JsonProperty(FIELD_NAME_CHECKPOINT_DURATION) CheckpointDuration checkpointDuration,
 				@JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment alignment) {
 			super(index, "completed");
+			this.location = location;
 			this.ackTimestamp = ackTimestamp;
 			this.duration = duration;
 			this.stateSize = stateSize;
 			this.checkpointDuration = checkpointDuration;
 			this.alignment = alignment;
+		}
+
+		public String getLocation() {
+			return location;
 		}
 
 		public long getAckTimestamp() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -389,6 +389,7 @@ public class CheckpointStatsTrackerTest {
 
 		SubtaskStateStats subtaskStats = new SubtaskStateStats(
 			0,
+			"0.0.0.0:0",
 			ackTimestamp,
 			stateSize,
 			ignored,
@@ -473,6 +474,6 @@ public class CheckpointStatsTrackerTest {
 	}
 
 	private SubtaskStateStats createSubtaskStats(int index) {
-		return new SubtaskStateStats(index, 0, 0, 0, 0, 0, 0);
+		return new SubtaskStateStats(index,"0.0.0.0:0", 0, 0, 0, 0, 0, 0);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -322,7 +322,7 @@ public class CompletedCheckpointTest {
 			1337,
 			123129837912L,
 			123819239812L,
-			new SubtaskStateStats(123, 213123, 123123, 0, 0, 0, 0),
+			new SubtaskStateStats(123, "0.0.0.0:0",213123, 123123, 0, 0, 0, 0),
 			null);
 
 		CompletedCheckpointStats copy = CommonTestUtils.createCopySerializable(completed);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
@@ -274,6 +274,7 @@ public class PendingCheckpointStatsTest {
 	private SubtaskStateStats createSubtaskStats(int index) {
 		return new SubtaskStateStats(
 			index,
+			"0.0.0.0:0",
 			Integer.MAX_VALUE + (long) index,
 			Integer.MAX_VALUE + (long) index,
 			Integer.MAX_VALUE + (long) index,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateStatsTest.java
@@ -32,6 +32,7 @@ public class SubtaskStateStatsTest {
 	public void testSimpleAccess() throws Exception {
 		SubtaskStateStats stats = new SubtaskStateStats(
 			0,
+			"0.0.0.0:0",
 			Integer.MAX_VALUE + 1L,
 			Integer.MAX_VALUE + 2L,
 			Integer.MAX_VALUE + 3L,
@@ -63,6 +64,7 @@ public class SubtaskStateStatsTest {
 	public void testIsJavaSerializable() throws Exception {
 		SubtaskStateStats stats = new SubtaskStateStats(
 			0,
+			"0.0.0.0:0",
 			Integer.MAX_VALUE + 1L,
 			Integer.MAX_VALUE + 2L,
 			Integer.MAX_VALUE + 3L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateStatsTest.java
@@ -58,6 +58,7 @@ public class TaskStateStatsTest {
 		for (int i = 0; i < subtasks.length; i++) {
 			subtasks[i] = new SubtaskStateStats(
 				i,
+				"0.0.0.0:0",
 				rand.nextInt(128),
 				rand.nextInt(128),
 				rand.nextInt(128),
@@ -78,7 +79,7 @@ public class TaskStateStatsTest {
 			assertEquals(alignmentBuffered, taskStats.getAlignmentBuffered());
 		}
 
-		assertFalse(taskStats.reportSubtaskStats(new SubtaskStateStats(0, 0, 0, 0, 0, 0, 0)));
+		assertFalse(taskStats.reportSubtaskStats(new SubtaskStateStats(0, "0.0.0.0:0",0, 0, 0, 0, 0, 0)));
 
 		// Test that all subtasks are taken into the account for the summary.
 		// The correctness of the actual results is checked in the test of the
@@ -105,6 +106,7 @@ public class TaskStateStatsTest {
 		for (int i = 0; i < subtasks.length; i++) {
 			subtasks[i] = new SubtaskStateStats(
 				i,
+				"0.0.0.0:0",
 				rand.nextInt(128),
 				rand.nextInt(128),
 				rand.nextInt(128),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
@@ -51,6 +51,7 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest extends RestResponse
 		subtaskCheckpointStatistics.add(new SubtaskCheckpointStatistics.PendingSubtaskCheckpointStatistics(0));
 		subtaskCheckpointStatistics.add(new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics(
 			1,
+			"0.0.0.0:0",
 			4L,
 			13L,
 			1337L,


### PR DESCRIPTION
Add the host information to the checkpoint so that if the checkpoint fails, you can specifically login to the appropriate machine to see the cause of the failure.