### PR TITLE
[FLINK-10119][Kafka Connector] - JsonRowDeserializeSchema deserialize message with error

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowFormatFactory.java
@@ -60,6 +60,8 @@ public class JsonRowFormatFactory implements SerializationSchemaFactory<Row>, De
 		properties.add(JsonValidator.FORMAT_JSON_SCHEMA);
 		properties.add(JsonValidator.FORMAT_SCHEMA);
 		properties.add(JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD);
+		properties.add(JsonValidator.FORMAT_NULL_ERROR_LINE);
+		properties.add(JsonValidator.FORMAT_ADDITIONAL_ERROR_FIELD);
 		properties.add(FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA());
 		properties.addAll(SchemaValidator.getSchemaDerivationKeys());
 		return properties;
@@ -74,6 +76,10 @@ public class JsonRowFormatFactory implements SerializationSchemaFactory<Row>, De
 
 		descriptorProperties.getOptionalBoolean(JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD)
 				.ifPresent(schema::setFailOnMissingField);
+		descriptorProperties.getOptionalBoolean(JsonValidator.FORMAT_NULL_ERROR_LINE)
+			.ifPresent(schema::setNullErrorLine);
+		descriptorProperties.getOptionalBoolean(JsonValidator.FORMAT_ADDITIONAL_ERROR_FIELD)
+			.ifPresent(schema::setAdditionalErrorField);
 
 		return schema;
 	}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/Json.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/Json.java
@@ -24,8 +24,10 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA;
+import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_ADDITIONAL_ERROR_FIELD;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_JSON_SCHEMA;
+import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_NULL_ERROR_LINE;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_SCHEMA;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_TYPE_VALUE;
 
@@ -35,6 +37,8 @@ import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_TYPE_VALUE
 public class Json extends FormatDescriptor {
 
 	private Boolean failOnMissingField;
+	private Boolean nullErrorLine;
+	private Boolean additionalErrorField;
 	private Boolean deriveSchema;
 	private String jsonSchema;
 	private String schema;
@@ -54,6 +58,27 @@ public class Json extends FormatDescriptor {
 	 */
 	public Json failOnMissingField(boolean failOnMissingField) {
 		this.failOnMissingField = failOnMissingField;
+		return this;
+	}
+
+	/**
+	 * Sets flag whether to ignore the line if exception is thrown.
+	 *
+	 * @param nullErrorLine If set to true, the line will be ignored if exception is thrown.
+	 */
+	public Json nullErrorLine(boolean nullErrorLine) {
+		this.nullErrorLine = nullErrorLine;
+		return this;
+	}
+
+	/**
+	 * Sets flag whether to add an additional field to store error messages if exception is thrown.
+	 *
+	 * @param additionalErrorField If set to true, there will be an additional field to store
+	 *                             if exception is thrown.
+	 */
+	public Json additionalErrorField(boolean additionalErrorField) {
+		this.additionalErrorField = additionalErrorField;
 		return this;
 	}
 
@@ -125,6 +150,14 @@ public class Json extends FormatDescriptor {
 
 		if (failOnMissingField != null) {
 			properties.putBoolean(FORMAT_FAIL_ON_MISSING_FIELD, failOnMissingField);
+		}
+
+		if (nullErrorLine != null) {
+			properties.putBoolean(FORMAT_NULL_ERROR_LINE, nullErrorLine);
+		}
+
+		if (additionalErrorField != null) {
+			properties.putBoolean(FORMAT_ADDITIONAL_ERROR_FIELD, additionalErrorField);
 		}
 	}
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/JsonValidator.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/JsonValidator.java
@@ -29,6 +29,8 @@ public class JsonValidator extends FormatDescriptorValidator {
 	public static final String FORMAT_SCHEMA = "format.schema";
 	public static final String FORMAT_JSON_SCHEMA = "format.json-schema";
 	public static final String FORMAT_FAIL_ON_MISSING_FIELD = "format.fail-on-missing-field";
+	public static final String FORMAT_NULL_ERROR_LINE = "format.null-error-line";
+	public static final String FORMAT_ADDITIONAL_ERROR_FIELD = "format.additional-error-field";
 
 	@Override
 	public void validate(DescriptorProperties properties) {
@@ -51,5 +53,7 @@ public class JsonValidator extends FormatDescriptorValidator {
 		}
 
 		properties.validateBoolean(FORMAT_FAIL_ON_MISSING_FIELD, true);
+		properties.validateBoolean(FORMAT_NULL_ERROR_LINE, true);
+		properties.validateBoolean(FORMAT_ADDITIONAL_ERROR_FIELD, true);
 	}
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the {@link JsonRowDeserializationSchema}.
@@ -177,6 +179,41 @@ public class JsonRowDeserializationSchemaTest {
 		} catch (IOException e) {
 			Assert.assertTrue(e.getCause() instanceof IllegalStateException);
 		}
+	}
+
+	/**
+	 * Test deserialization with setting nullErrorLine true.
+	 */
+	@Test
+	public void testNullErrorLine() throws IOException {
+		final JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(
+			Types.ROW_NAMED(
+				new String[] { "name" },
+				Types.STRING)
+		);
+		deserializationSchema.setNullErrorLine(true);
+
+		final Row row = deserializationSchema.deserialize("zxvdd".getBytes());
+		assertNull(row.getField(0));
+	}
+
+	/**
+	 * Test deserialization with setting additionalErrorField true.
+	 */
+	@Test
+	public void testAdditionalErrorField() throws IOException {
+		final JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(
+			Types.ROW_NAMED(
+				new String[] { "name", "age" },
+				Types.STRING, Types.INT)
+		);
+		deserializationSchema.setAdditionalErrorField(true);
+
+		final Row row = deserializationSchema.deserialize("zxvdd".getBytes());
+		assertEquals(3, row.getArity());
+		assertNull(row.getField(0));
+		assertNull(row.getField(1));
+		assertNotNull(row.getField(2));
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change
The program will throw runtime exceptions and exit if json messages cannot be parsed correctly, which doesn't make sense to developers because it's very normal for them to receive dirty data from the source.
Now we offer two properties to deal with this kind of json data.
1. format.null-error-line: set all fields in the row null.
2. format.additional-error-field: set all fields in the row null and add an additional field to store the error messages which can be read by developers.

## Brief change log
* Add two format properties.
* Optimize JsonRowDeserializationSchema to deal with "error" data.
* Add unit tests.

## Verifying this change

Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no