### PR TITLE
[FLINK-10116] [types] Fix getTotalFields() implementation of multiple TypeInformation.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NothingTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NothingTypeInfo.java
@@ -53,7 +53,7 @@ public class NothingTypeInfo extends TypeInformation<Nothing> {
 	@Override
 	@PublicEvolving
 	public int getTotalFields() {
-		return 0;
+		return 1;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -111,6 +111,7 @@ public abstract class TypeInformation<T> implements Serializable {
 	 * fields, in the case of composite types. In the example below, the OuterType type has three
 	 * fields in total.
 	 *
+	 * <p>The total number of fields must be at least 1.
 	 *
 	 * @return The number of fields in this type, including its sub-fields (for composite types)
 	 */

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
@@ -95,6 +95,16 @@ public abstract class TypeInformationTestBase<T extends TypeInformation<?>> exte
 		}
 	}
 
+	@Test
+	public void testGetTotalFields() {
+		final T[] testData = getTestData();
+		for (T typeInfo : testData) {
+			assertTrue(
+				"Number of total fields must be at least 1",
+				typeInfo.getTotalFields() > 0);
+		}
+	}
+
 	private static class UnrelatedTypeInfo extends TypeInformation<Object> {
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MissingTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/MissingTypeInfoTest.java
@@ -41,4 +41,9 @@ public class MissingTypeInfoTest extends TypeInformationTestBase<MissingTypeInfo
 	public void testSerialization() {
 		// this class is not intended to be serialized
 	}
+
+	@Override
+	public void testGetTotalFields() {
+		// getTotalFields is not meant to be called
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoFactoryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoFactoryTest.java
@@ -387,7 +387,7 @@ public class TypeInfoFactoryTest {
 
 		@Override
 		public int getTotalFields() {
-			return 0;
+			return 1;
 		}
 
 		@Override

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/VoidNamespaceTypeInfo.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/VoidNamespaceTypeInfo.java
@@ -52,7 +52,7 @@ public class VoidNamespaceTypeInfo extends TypeInformation<VoidNamespace> {
 
 	@Override
 	public int getTotalFields() {
-		return 0;
+		return 1;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceTypeInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceTypeInfo.java
@@ -55,7 +55,7 @@ public class VoidNamespaceTypeInfo extends TypeInformation<VoidNamespace> {
 	@Override
 	@PublicEvolving
 	public int getTotalFields() {
-		return 0;
+		return 1;
 	}
 
 	@Override

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
@@ -32,7 +32,7 @@ class ScalaNothingTypeInfo extends TypeInformation[Nothing] {
   @PublicEvolving
   override def getArity: Int = 0
   @PublicEvolving
-  override def getTotalFields: Int = 0
+  override def getTotalFields: Int = 1
   @PublicEvolving
   override def getTypeClass: Class[Nothing] = classOf[Nothing]
   @PublicEvolving

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
@@ -31,7 +31,7 @@ class UnitTypeInfo extends TypeInformation[Unit] {
   @PublicEvolving
   override def getArity(): Int = 0
   @PublicEvolving
-  override def getTotalFields(): Int = 0
+  override def getTotalFields(): Int = 1
   @PublicEvolving
   override def getTypeClass(): Class[Unit] = classOf[Unit]
   @PublicEvolving


### PR DESCRIPTION
## What is the purpose of the change

Fixes the implementation of `TypeInformation.getTotalFields()` of several type informations. The method is used to determine the number of flattened fields to skip when determining key positions. Since a type info needs to be skipped even if it does not have nested fields, the method must return at least `1`.

## Brief change log

* fixed all incorrect `TypeInformation` implementations
* extended the JavaDoc of `TypeInformation.getTotalFields()`

## Verifying this change

* added a new method to `TypeInformationTestBase` validating that the number of fields is at least 1.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
