### PR TITLE
[FLINK-10119] [table] Add failure handlers for JsonRowDeserializationSchema

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowFormatFactory.java
@@ -50,6 +50,7 @@ public class JsonRowFormatFactory extends TableFormatFactoryBase<Row>
 		properties.add(JsonValidator.FORMAT_JSON_SCHEMA);
 		properties.add(JsonValidator.FORMAT_SCHEMA);
 		properties.add(JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD);
+		properties.add(JsonValidator.FORMAT_FAILURE_HANDLER);
 		return properties;
 	}
 
@@ -62,6 +63,8 @@ public class JsonRowFormatFactory extends TableFormatFactoryBase<Row>
 
 		descriptorProperties.getOptionalBoolean(JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD)
 				.ifPresent(schema::setFailOnMissingField);
+		descriptorProperties.getOptionalString(JsonValidator.FORMAT_FAILURE_HANDLER)
+			.ifPresent(schema::setFailureHandler);
 
 		return schema;
 	}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/Json.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/Json.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_DERIVE_SCHEMA;
+import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_FAILURE_HANDLER;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_FAIL_ON_MISSING_FIELD;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_JSON_SCHEMA;
 import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_SCHEMA;
@@ -37,6 +38,7 @@ import static org.apache.flink.table.descriptors.JsonValidator.FORMAT_TYPE_VALUE
 public class Json extends FormatDescriptor {
 
 	private Boolean failOnMissingField;
+	private String failureHandler;
 	private Boolean deriveSchema;
 	private String jsonSchema;
 	private String schema;
@@ -56,6 +58,15 @@ public class Json extends FormatDescriptor {
 	 */
 	public Json failOnMissingField(boolean failOnMissingField) {
 		this.failOnMissingField = failOnMissingField;
+		return this;
+	}
+
+	/**
+	 * Sets failure handler for deserializing json messages.
+	 * @param failureHandler see failureHandlers in {@link JsonValidator}.
+	 */
+	public Json failureHandler(String failureHandler) {
+		this.failureHandler = failureHandler;
 		return this;
 	}
 
@@ -126,6 +137,10 @@ public class Json extends FormatDescriptor {
 
 		if (failOnMissingField != null) {
 			properties.putBoolean(FORMAT_FAIL_ON_MISSING_FIELD, failOnMissingField);
+		}
+
+		if (failureHandler != null) {
+			properties.putString(FORMAT_FAILURE_HANDLER, failureHandler);
 		}
 
 		return properties.asMap();

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/JsonValidator.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/table/descriptors/JsonValidator.java
@@ -21,6 +21,9 @@ package org.apache.flink.table.descriptors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
   * Validator for {@link Json}.
   */
@@ -31,6 +34,16 @@ public class JsonValidator extends FormatDescriptorValidator {
 	public static final String FORMAT_SCHEMA = "format.schema";
 	public static final String FORMAT_JSON_SCHEMA = "format.json-schema";
 	public static final String FORMAT_FAIL_ON_MISSING_FIELD = "format.fail-on-missing-field";
+	public static final String FORMAT_FAILURE_HANDLER = "format.failure-handler";
+
+	public static final String FAILURE_HANDLER_FAIL = "fail";
+	public static final String FAILURE_HANDLER_IGNORE = "ignore";
+	public static final String FAILURE_HANDLER_ERROR_FIELD = "error-field";
+
+	private final List<String> failureHandlers = Arrays.asList(
+		FAILURE_HANDLER_FAIL,
+		FAILURE_HANDLER_IGNORE,
+		FAILURE_HANDLER_ERROR_FIELD);
 
 	@Override
 	public void validate(DescriptorProperties properties) {
@@ -52,6 +65,7 @@ public class JsonValidator extends FormatDescriptorValidator {
 			properties.validateString(FORMAT_JSON_SCHEMA, false, 1);
 		}
 
+		properties.validateEnumValues(FORMAT_FAILURE_HANDLER, true, failureHandlers);
 		properties.validateBoolean(FORMAT_FAIL_ON_MISSING_FIELD, true);
 	}
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the {@link JsonRowDeserializationSchema}.
@@ -177,6 +179,41 @@ public class JsonRowDeserializationSchemaTest {
 		} catch (IOException e) {
 			Assert.assertTrue(e.getCause() instanceof IllegalStateException);
 		}
+	}
+
+	/**
+	 * Test deserialization with failure handlers "ignore".
+	 */
+	@Test
+	public void testFailureHandlerIgnore() throws IOException {
+		final JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(
+			Types.ROW_NAMED(
+				new String[] { "name" },
+				Types.STRING)
+		);
+
+		deserializationSchema.setFailureHandler("ignore");
+		final Row row = deserializationSchema.deserialize("zxvdd".getBytes());
+		assertNull(row);
+	}
+
+	/**
+	 * Test deserialization with failure handlers "error-field".
+	 */
+	@Test
+	public void testFailureHandlerErrorField() throws IOException {
+		final JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(
+			Types.ROW_NAMED(
+				new String[] { "name", "age" },
+				Types.STRING, Types.INT)
+		);
+		deserializationSchema.setFailureHandler("error-field");
+
+		final Row row = deserializationSchema.deserialize("zxvdd".getBytes());
+		assertEquals(3, row.getArity());
+		assertNull(row.getField(0));
+		assertNull(row.getField(1));
+		assertNotNull(row.getField(2));
 	}
 
 	/**

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowFormatFactoryTest.java
@@ -84,7 +84,8 @@ public class JsonRowFormatFactoryTest extends TestLogger {
 		final Map<String, String> properties = toMap(
 			new Json()
 				.jsonSchema(JSON_SCHEMA)
-				.failOnMissingField(true));
+				.failOnMissingField(true)
+				.failureHandler("fail"));
 
 		testJsonSchemaSerializationSchema(properties);
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/table/descriptors/JsonTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/table/descriptors/JsonTest.java
@@ -70,6 +70,11 @@ public class JsonTest extends DescriptorTestBase {
 		addPropertyAndVerify(descriptors().get(0), "format.schema", "DDD");
 	}
 
+	@Test(expected = ValidationException.class)
+	public void testUnknownFailureHandler() {
+		addPropertyAndVerify(descriptors().get(0), "format.failure-handler", "ABC");
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	@Override
@@ -83,7 +88,8 @@ public class JsonTest extends DescriptorTestBase {
 				Types.ROW(
 					new String[]{"test1", "test2"},
 					new TypeInformation[]{Types.STRING(), Types.SQL_TIMESTAMP()}))
-			.failOnMissingField(true);
+			.failOnMissingField(true)
+			.failureHandler("error-field");
 
 		final Descriptor desc4 = new Json().deriveSchema();
 
@@ -108,6 +114,7 @@ public class JsonTest extends DescriptorTestBase {
 		props3.put("format.property-version", "1");
 		props3.put("format.schema", "ROW<test1 VARCHAR, test2 TIMESTAMP>");
 		props3.put("format.fail-on-missing-field", "true");
+		props3.put("format.failure-handler", "error-field");
 
 		final Map<String, String> props4 = new HashMap<>();
 		props4.put("format.type", "json");


### PR DESCRIPTION
## What is the purpose of the change
The program will throw runtime exceptions and exit if json messages cannot be parsed correctly, which doesn't make sense to developers because it's very normal for them to receive dirty data from the source.
Now we offer format.failure-handler to deal with this kind of json data.
1. "fail": the deserialization will throw an exception.
2. "ignore": the deserialization will return a null value, which will be ignored.
3. "error-field": An additional field will be added into the row to store error messages and the other fields will be null. 

## Brief change log
* Add format.failure-handler in JsonValidator and failureHandler in Json.
* Optimize JsonRowDeserializationSchema to deal with "error" data.
* Add unit tests.

## Verifying this change

Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no