### PR TITLE
[FLINK-8868] [table] Support Table Function as Table Source for Stream Sql

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/SourceFunctionCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/SourceFunctionCodeGenerator.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codegen
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.table.codegen.CodeGenUtils.newName
+import org.apache.flink.util.Collector
+
+/**
+  * A code generator for generating Flink [[RichSourceFunction]].
+  *
+  * @param config configuration that determines runtime behavior
+  */
+class SourceFunctionCodeGenerator[T](
+  config: TableConfig,
+  outputType: TypeInformation[T])
+  extends CodeGenerator(config, false, new RowTypeInfo(), None, None) {
+
+  def generateSourceFunction(
+    name: String,
+    generatedFunc: GeneratedExpression)
+  : GeneratedFunction[RichSourceFunction[T], T] = {
+
+    val funcName = newName(name)
+    val collectorName = newName("TableFunctionSourceCollector")
+    val configName = classOf[Configuration].getCanonicalName
+
+    val functionCode =
+      s"""
+         |public class $funcName extends ${classOf[RichSourceFunction[_]].getCanonicalName} {
+         |
+         |  ${reuseMemberCode()}
+         |
+         |  private ${collectorName} collectorProxy;
+         |
+         |  @Override
+         |  public void open(${configName} parameters) throws Exception {
+         |    ${reuseInitCode()}
+         |    ${reuseOpenCode()}
+         |    collectorProxy = new ${collectorName}();
+         |  }
+         |
+         |  @Override
+         |  public void close() throws Exception {
+         |    ${reuseCloseCode()}
+         |  }
+         |
+         |  void run(${classOf[SourceContext[_]].getCanonicalName} ctx) throws Exception {
+         |    collectorProxy.setContext(ctx);
+         |    ${generatedFunc.resultTerm}.setCollector(collectorProxy);
+         |    ${generatedFunc.code}
+         |  }
+         |
+         |  void cancel() {
+         |
+         |  }
+         |
+         |  class ${collectorName} implements ${classOf[Collector[_]].getCanonicalName} {
+         |
+         |    private ${classOf[SourceContext[_]].getCanonicalName} ctx;
+         |
+         |    public void setContext(${classOf[SourceContext[_]].getCanonicalName} ctx) {
+         |      this.ctx = ctx;
+         |    }
+         |
+         |    public void collect(Object record) {
+         |      ctx.collect(record);
+         |    }
+         |
+         |    public void close() {
+         |
+         |    }
+         |  }
+         |}
+       """.stripMargin
+
+    GeneratedFunction(funcName, outputType, functionCode)
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamTableFunctionScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamTableFunctionScan.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import java.lang.reflect.Type
+import java.util.{List => JList, Set => JSet}
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.TableFunctionScan
+import org.apache.calcite.rel.metadata.RelColumnMapping
+import org.apache.calcite.rex.{RexCall, RexNode}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
+import org.apache.flink.table.codegen.SourceFunctionCodeGenerator
+import org.apache.flink.table.functions.utils.TableSqlFunction
+import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.runtime.io.TableFunctionSource
+import org.apache.flink.table.runtime.types.CRow
+
+import scala.collection.JavaConverters._
+
+
+/**
+  * DataStream RelNode for LogicalTableFunctionScanc.
+  */
+class DataStreamTableFunctionScan(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputs: JList[RelNode],
+    rexCall: RexNode,
+    elementType: Type,
+    rowType: RelDataType,
+    columnMappings: JSet[RelColumnMapping],
+    ruleDescription: String)
+  extends TableFunctionScan(
+    cluster,
+    traitSet,
+    inputs,
+    rexCall,
+    elementType,
+    rowType,
+    columnMappings)
+  with DataStreamRel
+  with StreamScan {
+
+  override def deriveRowType(): RelDataType = rowType
+
+  override def toString: String = {
+    val call = rexCall.asInstanceOf[RexCall]
+    val sqlFunction = call.getOperator.asInstanceOf[TableSqlFunction]
+    val udtfName = sqlFunction.toString
+    val operands = call.getOperands.asScala
+      .map(getExpressionString(_, List(), None)).mkString(", ")
+    s"table($udtfName($operands))"
+  }
+
+  override def copy(
+    traitSet: RelTraitSet,
+    inputs: JList[RelNode],
+    rexCall: RexNode,
+    elementType: Type,
+    rowType: RelDataType,
+    columnMappings: JSet[RelColumnMapping]): TableFunctionScan = {
+      new DataStreamTableFunctionScan(
+        cluster,
+        traitSet,
+        inputs,
+        rexCall,
+        elementType,
+        rowType,
+        columnMappings,
+        ruleDescription
+      )
+  }
+
+  override def translateToPlan(tableEnv: StreamTableEnvironment,
+                               queryConfig: StreamQueryConfig): DataStream[CRow] = {
+
+    val sqlFunction = rexCall.asInstanceOf[RexCall].getOperator.asInstanceOf[TableSqlFunction]
+
+    val udtfTypeInfo = sqlFunction.getRowTypeInfo.asInstanceOf[TypeInformation[Any]]
+
+    val generator = new SourceFunctionCodeGenerator(tableEnv.getConfig, udtfTypeInfo)
+
+    val result = generator.generateExpression(rexCall)
+
+    val generatedSource = generator.generateSourceFunction(ruleDescription, result)
+
+    val tableFunctionSource: SourceFunction[Any] =
+      new TableFunctionSource(generatedSource.name, generatedSource.code, udtfTypeInfo)
+
+    val dataStreamSource: DataStream[Any] =
+      tableEnv
+        .execEnv
+        .addSource(tableFunctionSource)
+        .setMaxParallelism(1)
+        .setParallelism(1)
+        .returns(udtfTypeInfo)
+
+    val outputSchema = new RowSchema(rowType)
+
+    convertToInternalRow(
+      outputSchema,
+      dataStreamSource,
+      outputSchema.fieldNames.indices.toArray,
+      tableEnv.getConfig,
+      None)
+
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -200,6 +200,7 @@ object FlinkRuleSets {
     */
   val DATASTREAM_OPT_RULES: RuleSet = RuleSets.ofList(
     // translate to DataStream nodes
+    DataStreamTableFunctionScanRule.INSTANCE,
     DataStreamSortRule.INSTANCE,
     DataStreamGroupAggregateRule.INSTANCE,
     DataStreamOverAggregateRule.INSTANCE,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamTableFunctionScanRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamTableFunctionScanRule.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.calcite.plan.RelOptRule
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.datastream.DataStreamTableFunctionScan
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableFunctionScan
+
+class DataStreamTableFunctionScanRule
+  extends ConverterRule(
+    classOf[FlinkLogicalTableFunctionScan],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.DATASTREAM,
+    "DataStreamTableFunctionScanRule"
+  ) {
+
+  override def convert(rel: RelNode): RelNode = {
+    val scan: FlinkLogicalTableFunctionScan = rel.asInstanceOf[FlinkLogicalTableFunctionScan]
+    val traitSet = rel.getTraitSet.replace(FlinkConventions.DATASTREAM)
+
+    new DataStreamTableFunctionScan(
+      scan.getCluster,
+      traitSet,
+      scan.getInputs,
+      scan.getCall,
+      scan.getElementType,
+      scan.getRowType,
+      scan.getColumnMappings,
+      "DataStreamTableFunctionScanRule"
+    )
+  }
+}
+
+object DataStreamTableFunctionScanRule {
+  val INSTANCE: RelOptRule = new DataStreamTableFunctionScanRule
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/io/TableFunctionSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/io/TableFunctionSource.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.io
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.source.{RichSourceFunction, SourceFunction}
+import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.table.util.Logging
+
+class TableFunctionSource(
+  name: String,
+  code: String,
+  resultType: TypeInformation[Any])
+  extends RichSourceFunction[Any]
+  with Compiler[RichSourceFunction[Any]]
+  with Logging {
+
+  private var sourceFunction: RichSourceFunction[Any] = _
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+    LOG.debug(s"Compiling TableFunctionSource: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    LOG.debug("Instantiating TableFunctionSource.")
+    sourceFunction = clazz.newInstance()
+    sourceFunction.setRuntimeContext(getRuntimeContext)
+    sourceFunction.open(parameters)
+  }
+
+  override def close(): Unit = {
+    sourceFunction.close()
+    super.close()
+  }
+
+  override def run(ctx: SourceFunction.SourceContext[Any]): Unit = {
+    sourceFunction.run(ctx)
+  }
+
+  override def cancel(): Unit = {
+    sourceFunction.cancel()
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -257,6 +257,15 @@ class CorrelateITCase extends AbstractTestBase {
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
+
+  @Test(expected = classOf[ValidationException])
+  def testTableFunctionScanAsSource(): Unit = {
+    val tf = new VarArgsFunc0()
+    val result = tf("hello").as('a).select('a)
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+  }
+
   private def testData(
       env: StreamExecutionEnvironment)
     : DataStream[(Int, Long, String)] = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
@@ -57,12 +57,15 @@ class TableFunc1 extends TableFunction[String] {
 }
 
 class TableFunc2 extends TableFunction[Row] {
+
+  protected var base: Int = 0
+
   def eval(str: String): Unit = {
     if (str.contains("#")) {
       str.split("#").foreach({ s =>
         val row = new Row(2)
         row.setField(0, s)
-        row.setField(1, s.length)
+        row.setField(1, s.length + base)
         collect(row)
       })
     }
@@ -71,6 +74,12 @@ class TableFunc2 extends TableFunction[Row] {
   override def getResultType: TypeInformation[Row] = {
     new RowTypeInfo(BasicTypeInfo.STRING_TYPE_INFO,
                     BasicTypeInfo.INT_TYPE_INFO)
+  }
+}
+
+class TableFunc2WithBase extends TableFunc2 {
+  override def open(context: FunctionContext): Unit = {
+    base = 1
   }
 }
 


### PR DESCRIPTION
## What is the purpose of the change
Support Table Function as Table source for Stream Sql

TableFunction might produce infinite records, hence the support for batch sql should be discussed.

## Brief change log
  - Add new `DataStreamTableFunctionScan`


## Verifying this change


This change added tests and can be verified as follows:
new test cases in:
org.apache.flink.table.runtime.stream.sql.SqlITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  no
