### PR TITLE
[FLINK-10170] [table] Support string representation for map and array types in descriptor-based Table API

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -417,13 +417,19 @@ DECIMAL
 DATE
 TIME
 TIMESTAMP
-ROW(fieldtype, ...)              # unnamed row; e.g. ROW(VARCHAR, INT) that is mapped to Flink's RowTypeInfo
+MAP<fieldtype, fieldtype>        # generic map; e.g. MAP<VARCHAR, INT> that is mapped to Flink's MapTypeInfo
+MULTISET<fieldtype>              # multiset; e.g. MULTISET<VARCHAR> that is mapped to Flink's MultisetTypeInfo
+PRIMITIVE_ARRAY<fieldtype>       # primitive array; e.g. PRIMITIVE_ARRAY<INT> that is mapped to Flink's PrimitiveArrayTypeInfo
+BASIC_ARRAY<fieldtype>           # basic array; e.g. BASIC_ARRAY<INT> that is mapped to Flink's BasicArrayTypeInfo
+OBJECT_ARRAY<fieldtype>          # object array; e.g. OBJECT_ARRAY<POJO(org.mycompany.MyPojoClass)> that is mapped to
+                                 # Flink's ObjectArrayTypeInfo
+ROW<fieldtype, ...>              # unnamed row; e.g. ROW<VARCHAR, INT> that is mapped to Flink's RowTypeInfo
                                  # with indexed fields names f0, f1, ...
-ROW(fieldname fieldtype, ...)    # named row; e.g., ROW(myField VARCHAR, myOtherField INT) that
+ROW<fieldname fieldtype, ...>    # named row; e.g., ROW<myField VARCHAR, myOtherField INT> that
                                  # is mapped to Flink's RowTypeInfo
-POJO(class)                      # e.g., POJO(org.mycompany.MyPojoClass) that is mapped to Flink's PojoTypeInfo
-ANY(class)                       # e.g., ANY(org.mycompany.MyClass) that is mapped to Flink's GenericTypeInfo
-ANY(class, serialized)           # used for type information that is not supported by Flink's Table & SQL API
+POJO<class>                      # e.g., POJO<org.mycompany.MyPojoClass> that is mapped to Flink's PojoTypeInfo
+ANY<class>                       # e.g., ANY<org.mycompany.MyClass> that is mapped to Flink's GenericTypeInfo
+ANY<class, serialized>           # used for type information that is not supported by Flink's Table & SQL API
 {% endhighlight %}
 
 {% top %}

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/table/descriptors/JsonTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/table/descriptors/JsonTest.java
@@ -106,7 +106,7 @@ public class JsonTest extends DescriptorTestBase {
 		final Map<String, String> props3 = new HashMap<>();
 		props3.put("format.type", "json");
 		props3.put("format.property-version", "1");
-		props3.put("format.schema", "ROW(test1 VARCHAR, test2 TIMESTAMP)");
+		props3.put("format.schema", "ROW<test1 VARCHAR, test2 TIMESTAMP>");
 		props3.put("format.fail-on-missing-field", "true");
 
 		final Map<String, String> props4 = new HashMap<>();

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/CsvTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/CsvTest.scala
@@ -78,9 +78,9 @@ class CsvTest extends DescriptorTestBase {
       "format.fields.1.name" -> "field2",
       "format.fields.1.type" -> "TIMESTAMP",
       "format.fields.2.name" -> "field3",
-      "format.fields.2.type" -> "ANY(java.lang.Class)",
+      "format.fields.2.type" -> "ANY<java.lang.Class>",
       "format.fields.3.name" -> "field4",
-      "format.fields.3.type" -> "ROW(test INT, row VARCHAR)",
+      "format.fields.3.type" -> "ROW<test INT, row VARCHAR>",
       "format.line-delimiter" -> "^")
 
     val props2 = Map(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.descriptors
 
+import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.table.api.Types
+import org.apache.flink.table.runtime.utils.CommonTestData.Person
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -47,6 +49,8 @@ class TableDescriptorTest extends TableTestBase {
       .field("myfield2", Types.INT)
       .field("myfield3", Types.MAP(Types.STRING, Types.INT))
       .field("myfield4", Types.MULTISET(Types.LONG))
+      .field("myfield5", Types.PRIMITIVE_ARRAY(Types.SHORT))
+      .field("myfield6", Types.OBJECT_ARRAY(TypeExtractor.createTypeInfo(classOf[Person])))
     // CSV table source and sink do not support proctime yet
     //if (isStreaming) {
     //  schema.field("proctime", Types.SQL_TIMESTAMP).proctime()
@@ -60,6 +64,8 @@ class TableDescriptorTest extends TableTestBase {
       .field("myfield2", Types.INT)
       .field("myfield3", Types.MAP(Types.STRING, Types.INT))
       .field("myfield4", Types.MULTISET(Types.LONG))
+      .field("myfield5", Types.PRIMITIVE_ARRAY(Types.SHORT))
+      .field("myfield6", Types.OBJECT_ARRAY(TypeExtractor.createTypeInfo(classOf[Person])))
       .fieldDelimiter("#")
 
     val descriptor: RegistrableDescriptor = if (isStreaming) {
@@ -89,18 +95,28 @@ class TableDescriptorTest extends TableTestBase {
       "format.fields.1.name" -> "myfield2",
       "format.fields.1.type" -> "INT",
       "format.fields.2.name" -> "myfield3",
-      "format.fields.2.type" -> "MAP<VARCHAR,INT>",
+      "format.fields.2.type" -> "MAP<VARCHAR, INT>",
       "format.fields.3.name" -> "myfield4",
       "format.fields.3.type" -> "MULTISET<BIGINT>",
+      "format.fields.4.name" -> "myfield5",
+      "format.fields.4.type" -> "PRIMITIVE_ARRAY<SMALLINT>",
+      "format.fields.5.name" -> "myfield6",
+      "format.fields.5.type" ->
+        "OBJECT_ARRAY<POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>>",
       "format.field-delimiter" -> "#",
       "schema.0.name" -> "myfield",
       "schema.0.type" -> "VARCHAR",
       "schema.1.name" -> "myfield2",
       "schema.1.type" -> "INT",
       "schema.2.name" -> "myfield3",
-      "schema.2.type" -> "MAP<VARCHAR,INT>",
+      "schema.2.type" -> "MAP<VARCHAR, INT>",
       "schema.3.name" -> "myfield4",
-      "schema.3.type" -> "MULTISET<BIGINT>"
+      "schema.3.type" -> "MULTISET<BIGINT>",
+      "schema.4.name" -> "myfield5",
+      "schema.4.type" -> "PRIMITIVE_ARRAY<SMALLINT>",
+      "schema.5.name" -> "myfield6",
+      "schema.5.type" ->
+        "OBJECT_ARRAY<POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>>"
     )
 
     val expectedProperties = if (isStreaming) {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
@@ -45,6 +45,8 @@ class TableDescriptorTest extends TableTestBase {
     val schema = Schema()
       .field("myfield", Types.STRING)
       .field("myfield2", Types.INT)
+      .field("myfield3", Types.MAP(Types.STRING, Types.INT))
+      .field("myfield4", Types.MULTISET(Types.LONG))
     // CSV table source and sink do not support proctime yet
     //if (isStreaming) {
     //  schema.field("proctime", Types.SQL_TIMESTAMP).proctime()
@@ -56,6 +58,8 @@ class TableDescriptorTest extends TableTestBase {
     val format = Csv()
       .field("myfield", Types.STRING)
       .field("myfield2", Types.INT)
+      .field("myfield3", Types.MAP(Types.STRING, Types.INT))
+      .field("myfield4", Types.MULTISET(Types.LONG))
       .fieldDelimiter("#")
 
     val descriptor: RegistrableDescriptor = if (isStreaming) {
@@ -84,11 +88,19 @@ class TableDescriptorTest extends TableTestBase {
       "format.fields.0.type" -> "VARCHAR",
       "format.fields.1.name" -> "myfield2",
       "format.fields.1.type" -> "INT",
+      "format.fields.2.name" -> "myfield3",
+      "format.fields.2.type" -> "MAP<VARCHAR,INT>",
+      "format.fields.3.name" -> "myfield4",
+      "format.fields.3.type" -> "MULTISET<BIGINT>",
       "format.field-delimiter" -> "#",
       "schema.0.name" -> "myfield",
       "schema.0.type" -> "VARCHAR",
       "schema.1.name" -> "myfield2",
-      "schema.1.type" -> "INT"
+      "schema.1.type" -> "INT",
+      "schema.2.name" -> "myfield3",
+      "schema.2.type" -> "MAP<VARCHAR,INT>",
+      "schema.3.name" -> "myfield4",
+      "schema.3.type" -> "MULTISET<BIGINT>"
     )
 
     val expectedProperties = if (isStreaming) {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/typeutils/TypeStringUtilsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/typeutils/TypeStringUtilsTest.scala
@@ -18,14 +18,12 @@
 
 package org.apache.flink.table.typeutils
 
-import java.util
-
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.{RowTypeInfo, TypeExtractor}
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.runtime.utils.CommonTestData.{NonPojo, Person}
 import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.{Assert, Test}
+import org.junit.{Test}
 
 /**
   * Tests for string-based representation of [[TypeInformation]].
@@ -82,6 +80,16 @@ class TypeStringUtilsTest {
     testReadAndWrite(
       "ANY(org.apache.flink.table.runtime.utils.CommonTestData$NonPojo)",
       TypeExtractor.createTypeInfo(classOf[NonPojo]))
+
+    testReadAndWrite(
+      "MAP<VARCHAR,ROW(f0 DECIMAL, f1 TINYINT)>",
+      Types.MAP(Types.STRING, Types.ROW(Types.DECIMAL, Types.BYTE))
+    )
+
+    testReadAndWrite(
+      "MULTISET<ROW(f0 DECIMAL, f1 TINYINT)>",
+      Types.MULTISET(Types.ROW(Types.DECIMAL, Types.BYTE))
+    )
 
     // test escaping
     assertTrue(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/typeutils/TypeStringUtilsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/typeutils/TypeStringUtilsTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.typeutils
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{PrimitiveArrayTypeInfo, BasicArrayTypeInfo, BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.{RowTypeInfo, TypeExtractor}
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.runtime.utils.CommonTestData.{NonPojo, Person}
@@ -47,7 +47,7 @@ class TypeStringUtilsTest {
 
     // unsupported type information
     testReadAndWrite(
-      "ANY(java.lang.Void, " +
+      "ANY<java.lang.Void, " +
         "rO0ABXNyADJvcmcuYXBhY2hlLmZsaW5rLmFwaS5jb21tb24udHlwZWluZm8uQmFzaWNUeXBlSW5mb_oE8IKl" +
         "ad0GAgAETAAFY2xhenp0ABFMamF2YS9sYW5nL0NsYXNzO0wAD2NvbXBhcmF0b3JDbGFzc3EAfgABWwAXcG9z" +
         "c2libGVDYXN0VGFyZ2V0VHlwZXN0ABJbTGphdmEvbGFuZy9DbGFzcztMAApzZXJpYWxpemVydAA2TG9yZy9h" +
@@ -57,41 +57,62 @@ class TypeStringUtilsTest {
         "cgA5b3JnLmFwYWNoZS5mbGluay5hcGkuY29tbW9uLnR5cGV1dGlscy5iYXNlLlZvaWRTZXJpYWxpemVyAAAA" +
         "AAAAAAECAAB4cgBCb3JnLmFwYWNoZS5mbGluay5hcGkuY29tbW9uLnR5cGV1dGlscy5iYXNlLlR5cGVTZXJp" +
         "YWxpemVyU2luZ2xldG9ueamHqscud0UCAAB4cgA0b3JnLmFwYWNoZS5mbGluay5hcGkuY29tbW9uLnR5cGV1" +
-        "dGlscy5UeXBlU2VyaWFsaXplcgAAAAAAAAABAgAAeHA)",
+        "dGlscy5UeXBlU2VyaWFsaXplcgAAAAAAAAABAgAAeHA>",
       BasicTypeInfo.VOID_TYPE_INFO)
   }
 
   @Test
   def testWriteComplexTypes(): Unit = {
     testReadAndWrite(
-      "ROW(f0 DECIMAL, f1 TINYINT)",
+      "ROW<f0 DECIMAL, f1 TINYINT>",
       Types.ROW(Types.DECIMAL, Types.BYTE))
 
     testReadAndWrite(
-      "ROW(hello DECIMAL, world TINYINT)",
+      "ROW<hello DECIMAL, world TINYINT>",
       Types.ROW(
         Array[String]("hello", "world"),
         Array[TypeInformation[_]](Types.DECIMAL, Types.BYTE)))
 
     testReadAndWrite(
-      "POJO(org.apache.flink.table.runtime.utils.CommonTestData$Person)",
+      "POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>",
       TypeExtractor.createTypeInfo(classOf[Person]))
 
     testReadAndWrite(
-      "ANY(org.apache.flink.table.runtime.utils.CommonTestData$NonPojo)",
+      "ANY<org.apache.flink.table.runtime.utils.CommonTestData$NonPojo>",
       TypeExtractor.createTypeInfo(classOf[NonPojo]))
 
     testReadAndWrite(
-      "MAP<VARCHAR,ROW(f0 DECIMAL, f1 TINYINT)>",
+      "MAP<VARCHAR, ROW<f0 DECIMAL, f1 TINYINT>>",
       Types.MAP(Types.STRING, Types.ROW(Types.DECIMAL, Types.BYTE))
     )
 
     testReadAndWrite(
-      "MULTISET<ROW(f0 DECIMAL, f1 TINYINT)>",
+      "MULTISET<ROW<f0 DECIMAL, f1 TINYINT>>",
       Types.MULTISET(Types.ROW(Types.DECIMAL, Types.BYTE))
     )
 
+    testReadAndWrite(
+      "PRIMITIVE_ARRAY<TINYINT>",
+      PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
+    )
+
+    testReadAndWrite(
+      "BASIC_ARRAY<INT>",
+      BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO
+    )
+
+    testReadAndWrite(
+      "OBJECT_ARRAY<POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>>",
+      Types.OBJECT_ARRAY(TypeExtractor.createTypeInfo(classOf[Person]))
+    )
+
     // test escaping
+    assertTrue(
+      TypeStringUtils.readTypeInfo("ROW<\"he         \\nllo\" DECIMAL, world TINYINT>")
+        .asInstanceOf[RowTypeInfo].getFieldNames
+        .sameElements(Array[String]("he         \nllo", "world")))
+
+    // test backward compatibility with brackets ()
     assertTrue(
       TypeStringUtils.readTypeInfo("ROW(\"he         \\nllo\" DECIMAL, world TINYINT)")
         .asInstanceOf[RowTypeInfo].getFieldNames


### PR DESCRIPTION
## What is the purpose of the change

Since 1.6 the recommended way of creating source/sink table is using connector/format/schema/ descriptors. However, when declaring map types in the schema descriptor, the following exception would be thrown:

> org.apache.flink.table.api.TableException: A string representation for map types is not supported yet.

This pull request is to add string representation support for map types.

## Brief change log

- Add new `Keyword` and `PackratParser` for map types in TypeStringUtils
- Add normalization logic for map types in `TypeStringUtils.writeTypeInfo()`
- Update relevant unit tests in `TypeStringUtilsTest` and `TableDescriptorTest`

## Verifying this change

This change can be verified  covered by updated unit tests, such as *TypeStringUtilsTest* and *TableDescriptorTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)