### PR TITLE
[FLINK-10082][metrics][slf4j] Provide initial size to StringBuilder

### DIFF
--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporter.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporter.java
@@ -76,7 +76,8 @@ public class Slf4jReporter extends AbstractReporter implements Scheduled {
 	@Override
 	public void report() {
 		// initialize with previous size to avoid repeated resizing of backing array
-		StringBuilder builder = new StringBuilder(previousSize);
+		// pad the size to allow deviations in the final string, for example due to different double value representations
+		StringBuilder builder = new StringBuilder((int) (previousSize * 1.1));
 
 		builder
 			.append(lineSeparator)

--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporter.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/metrics/slf4j/Slf4jReporter.java
@@ -42,6 +42,9 @@ public class Slf4jReporter extends AbstractReporter implements Scheduled {
 	private static final Logger LOG = LoggerFactory.getLogger(Slf4jReporter.class);
 	private static final String lineSeparator = System.lineSeparator();
 
+	// the initial size roughly fits ~150 metrics with default scope settings
+	private int previousSize = 16384;
+
 	@VisibleForTesting
 	Map<Gauge<?>, String> getGauges() {
 		return gauges;
@@ -72,7 +75,9 @@ public class Slf4jReporter extends AbstractReporter implements Scheduled {
 
 	@Override
 	public void report() {
-		StringBuilder builder = new StringBuilder();
+		// initialize with previous size to avoid repeated resizing of backing array
+		StringBuilder builder = new StringBuilder(previousSize);
+
 		builder
 			.append(lineSeparator)
 			.append("=========================== Starting metrics report ===========================")
@@ -134,6 +139,8 @@ public class Slf4jReporter extends AbstractReporter implements Scheduled {
 			.append("=========================== Finished metrics report ===========================")
 			.append(lineSeparator);
 		LOG.info(builder.toString());
+
+		previousSize = builder.length();
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Small modification to the `Slf4jReporter` to initialize the used `StringBuilder` with the size of the previous report, to prevent frequent resizing of the backing array.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.