### PR TITLE
[FLINK-6670][tests] Remove CommonTestUtils#createTempDirectory 

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -35,7 +35,6 @@ import org.apache.flink.batch.connectors.cassandra.CassandraRowOutputFormat;
 import org.apache.flink.batch.connectors.cassandra.CassandraTupleOutputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplit;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -54,7 +53,9 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,6 @@ import static org.junit.Assert.assertTrue;
 public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<String, Integer, Integer>, CassandraTupleWriteAheadSink<Tuple3<String, Integer, Integer>>> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(CassandraConnectorITCase.class);
-	private static File tmpDir;
 
 	private static final boolean EMBEDDED = true;
 
@@ -144,16 +144,15 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 		}
 	}
 
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startCassandra() throws IOException {
 
-		// generate temporary files
-		tmpDir = CommonTestUtils.createTempDirectory();
 		ClassLoader classLoader = CassandraConnectorITCase.class.getClassLoader();
 		File file = new File(classLoader.getResource("cassandra.yaml").getFile());
-		File tmp = new File(tmpDir.getAbsolutePath() + File.separator + "cassandra.yaml");
-
-		assertTrue(tmp.createNewFile());
+		File tmp = TEMPORARY_FOLDER.newFile("cassandra.yaml");
 
 		try (
 			BufferedWriter b = new BufferedWriter(new FileWriter(tmp));
@@ -220,11 +219,6 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 
 		if (cassandra != null) {
 			cassandra.stop();
-		}
-
-		if (tmpDir != null) {
-			//noinspection ResultOfMethodCallIgnored
-			tmpDir.delete();
 		}
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -119,7 +119,6 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 	private static final ArrayList<Tuple3<String, Integer, Integer>> collection = new ArrayList<>(20);
 	private static final ArrayList<Row> rowCollection = new ArrayList<>(20);
 
-	private static final String[] FIELD_NAMES = {"id", "counter", "batch_id"};
 	private static final TypeInformation[] FIELD_TYPES = {
 		BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO};
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -29,7 +29,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.util.UUID;
 
 /**
  * This class contains auxiliary methods for unit tests.
@@ -148,19 +147,6 @@ public class CommonTestUtils {
 			writer.println("log4j.logger.org.apache.zookeeper=OFF");
 			writer.flush();
 		}
-	}
-
-	public static File createTempDirectory() throws IOException {
-		File tempDir = new File(System.getProperty("java.io.tmpdir"));
-
-		for (int i = 0; i < 10; i++) {
-			File dir = new File(tempDir, UUID.randomUUID().toString());
-			if (!dir.exists() && dir.mkdirs()) {
-				return dir;
-			}
-		}
-
-		throw new IOException("Could not create temporary file directory");
 	}
 
 	/**

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -41,8 +41,9 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.pattern.Patterns;
 import akka.util.Timeout;
-import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +88,9 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
 	protected static final int PARALLELISM = 4;
 
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	@Test
 	public void testTaskManagerProcessFailure() throws Exception {
 
@@ -117,7 +121,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 			CommonTestUtils.printLog4jDebugConfig(tempLogFile);
 
 			// coordination between the processes goes through a directory
-			coordinateTempDir = CommonTestUtils.createTempDirectory();
+			coordinateTempDir = temporaryFolder.newFolder();
 
 			// find a free port to start the JobManager
 			final int jobManagerPort = NetUtils.getAvailablePort();
@@ -267,14 +271,6 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 			}
 			if (jmActorSystem != null) {
 				jmActorSystem.shutdown();
-			}
-			if (coordinateTempDir != null) {
-				try {
-					FileUtils.deleteDirectory(coordinateTempDir);
-				}
-				catch (Throwable t) {
-					// we can ignore this
-				}
 			}
 
 			if (highAvailabilityServices != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -52,7 +52,6 @@ import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.JobManagerActorTestUtils;
 import org.apache.flink.runtime.testutils.JobManagerProcess;
 import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
@@ -82,7 +81,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -113,42 +111,23 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 	@Rule
 	public RetryRule retryRule = new RetryRule();
 
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	private static final ZooKeeperTestEnvironment ZooKeeper = new ZooKeeperTestEnvironment(1);
 
 	private static final FiniteDuration TestTimeOut = new FiniteDuration(5, TimeUnit.MINUTES);
 
-	private static final File FileStateBackendBasePath;
-
-	static {
-		try {
-			FileStateBackendBasePath = CommonTestUtils.createTempDirectory();
-		}
-		catch (IOException e) {
-			throw new RuntimeException("Error in test setup. Could not create directory.", e);
-		}
-	}
-
 	@AfterClass
-	public static void tearDown() throws Exception {
+	public static void tearDown() {
 		try {
 			ZooKeeper.shutdown();
 		} catch (Exception ignored) {
-		}
-
-		try {
-			if (FileStateBackendBasePath != null) {
-				FileUtils.deleteDirectory(FileStateBackendBasePath);
-			}
-		} catch (IOException ignored) {
 		}
 	}
 
 	@Before
 	public void cleanUp() throws Exception {
-		if (FileStateBackendBasePath != null && FileStateBackendBasePath.exists()) {
-			FileUtils.cleanDirectory(FileStateBackendBasePath);
-		}
-
 		ZooKeeper.deleteAll();
 	}
 
@@ -179,7 +158,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 	public void testCheckpointRecoveryFailure() throws Exception {
 		final Deadline testDeadline = TestTimeOut.fromNow();
 		final String zooKeeperQuorum = ZooKeeper.getConnectString();
-		final String fileStateBackendPath = FileStateBackendBasePath.getAbsoluteFile().toString();
+		final String fileStateBackendPath = temporaryFolder.newFolder().toString();
 
 		Configuration config = ZooKeeperTestUtils.createZooKeeperHAConfig(
 			zooKeeperQuorum,
@@ -266,7 +245,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 				testDeadline.timeLeft());
 
 			// Remove all files
-			FileUtils.deleteDirectory(FileStateBackendBasePath);
+			FileUtils.deleteDirectory(new File(fileStateBackendPath));
 
 			// Kill the leader
 			leadingJobManagerProcess.destroy();
@@ -340,7 +319,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 	public void testCheckpointedStreamingProgramIncrementalRocksDB() throws Exception {
 		testCheckpointedStreamingProgram(
 			new RocksDBStateBackend(
-				new FsStateBackend(FileStateBackendBasePath.getAbsoluteFile().toURI(), 16),
+				new FsStateBackend(temporaryFolder.newFolder().getAbsoluteFile().toURI(), 16),
 				true));
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureBatchRecoveryITCase.java
@@ -96,8 +96,6 @@ public class JobManagerHAProcessFailureBatchRecoveryITCase extends TestLogger {
 
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-	
-	private File zookeeperStoragePath;
 
 	@AfterClass
 	public static void tearDown() throws Exception {
@@ -141,7 +139,7 @@ public class JobManagerHAProcessFailureBatchRecoveryITCase extends TestLogger {
 	 * @param coordinateDir Coordination directory
 	 * @throws Exception
 	 */
-	public void testJobManagerFailure(String zkQuorum, final File coordinateDir) throws Exception {
+	public void testJobManagerFailure(String zkQuorum, final File coordinateDir, final File zookeeperStoragePath) throws Exception {
 		Configuration config = new Configuration();
 		config.setString(CoreOptions.MODE, CoreOptions.LEGACY_MODE);
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
@@ -215,7 +213,7 @@ public class JobManagerHAProcessFailureBatchRecoveryITCase extends TestLogger {
 
 	@Test
 	public void testJobManagerProcessFailure() throws Exception {
-		zookeeperStoragePath = temporaryFolder.newFolder();
+		final File zookeeperStoragePath = temporaryFolder.newFolder();
 
 		// Config
 		final int numberOfJobManagers = 2;
@@ -311,7 +309,7 @@ public class JobManagerHAProcessFailureBatchRecoveryITCase extends TestLogger {
 				@Override
 				public void run() {
 					try {
-						testJobManagerFailure(ZooKeeper.getConnectString(), coordinateDirClosure);
+						testJobManagerFailure(ZooKeeper.getConnectString(), coordinateDirClosure, zookeeperStoragePath);
 					}
 					catch (Throwable t) {
 						t.printStackTrace();

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureBatchRecoveryITCase.java
@@ -139,7 +139,7 @@ public class JobManagerHAProcessFailureBatchRecoveryITCase extends TestLogger {
 	 * @param coordinateDir Coordination directory
 	 * @throws Exception
 	 */
-	public void testJobManagerFailure(String zkQuorum, final File coordinateDir, final File zookeeperStoragePath) throws Exception {
+	private void testJobManagerFailure(String zkQuorum, final File coordinateDir, final File zookeeperStoragePath) throws Exception {
 		Configuration config = new Configuration();
 		config.setString(CoreOptions.MODE, CoreOptions.LEGACY_MODE);
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");


### PR DESCRIPTION
## What is the purpose of the change

This PR removes `CommonTestUtils#createTempDirectory`, as `TemporaryFolders` should be used for creating temporary folders during tests.

As such all usages were replaced with `TemporaryFolders`.

## Verifying this change

This change is already covered by existing tests.
