### PR TITLE
[FLINK-10189] Fix FindBugs warnings: Inefficient use of keySet iterat…

### DIFF
--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/HBaseTableSource.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/HBaseTableSource.java
@@ -144,9 +144,10 @@ public class HBaseTableSource implements BatchTableSource<Row>, ProjectableTable
 		for (int field : fields) {
 			String family = famNames[field];
 			Map<String, TypeInformation<?>> familyInfo = hBaseSchema.getFamilyInfo(family);
-			for (String qualifier : familyInfo.keySet()) {
+			for (Map.Entry<String, TypeInformation<?>> entry : familyInfo.entrySet()) {
 				// create the newSchema
-				newTableSource.addColumn(family, qualifier, familyInfo.get(qualifier).getTypeClass());
+				String qualifier = entry.getKey();
+				newTableSource.addColumn(family, qualifier, entry.getValue().getTypeClass());
 			}
 		}
 		return newTableSource;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -68,8 +68,9 @@ class TtlMapState<K, N, UK, UV>
 			return;
 		}
 		Map<UK, TtlValue<UV>> ttlMap = new HashMap<>(map.size());
-		for (UK key : map.keySet()) {
-			ttlMap.put(key, wrapWithTs(map.get(key)));
+		for (Map.Entry<UK, UV> entry : map.entrySet()) {
+			UK key = entry.getKey();
+			ttlMap.put(key, wrapWithTs(entry.getValue()));
 		}
 		original.putAll(ttlMap);
 	}


### PR DESCRIPTION
This PR fixes two WMI_WRONG_MAP_ITERATOR warnings reported by FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)):
```
M P WMI: org.apache.flink.runtime.state.ttl.TtlMapState.putAll(Map) makes inefficient use of keySet iterator instead of entrySet iterator  At TtlMapState.java:[line 72]
M P WMI: org.apache.flink.addons.hbase.HBaseTableSource.projectFields(int[]) makes inefficient use of keySet iterator instead of entrySet iterator  At HBaseTableSource.java:[line 19]
```
The description of the bug is as follows:
> **WMI: Inefficient use of keySet iterator instead of entrySet iterator (WMI_WRONG_MAP_ITERATOR)**
> This method accesses the value of a Map entry, using a key that was retrieved from keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.
> [http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR](http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR)