### PR TITLE
[FLINK-10198][state] Set Env object in DBOptions for RocksDB

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -43,6 +43,7 @@ import org.apache.flink.util.TernaryBoolean;
 
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Env;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
@@ -647,6 +648,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 		// add necessary default options
 		opt = opt.setCreateIfMissing(true);
+		opt.setEnv(Env.getDefault());
 
 		return opt;
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -48,6 +48,7 @@ import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Env;
 
 import java.io.File;
 import java.util.Collections;
@@ -380,6 +381,28 @@ public class RocksDBStateBackendConfigTest {
 	// ------------------------------------------------------------------------
 	//  RocksDB Options
 	// ------------------------------------------------------------------------
+
+	@Test
+	public void testSetDefaultEnvInOptions() throws Exception {
+		String checkpointPath = tempFolder.newFolder().toURI().toString();
+		RocksDBStateBackend rocksDbBackend = new RocksDBStateBackend(checkpointPath);
+
+		rocksDbBackend.setOptions(new OptionsFactory() {
+			@Override
+			public DBOptions createDBOptions(DBOptions currentOptions) {
+				return new DBOptions();
+			}
+
+			@Override
+			public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+				throw new UnsupportedOperationException();
+			}
+		});
+
+		try (DBOptions options = rocksDbBackend.getDbOptions()) {
+			assertEquals(Env.getDefault(), options.getEnv());
+		}
+	}
 
 	@Test
 	public void testPredefinedOptions() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

This PR always sets a default environment when creating the `DBOptions`. This could simplify resource management for multiple RocksDB instances on one machine.

See https://github.com/facebook/rocksdb/wiki/rocksdb-basics:
Support for Multiple Embedded Databases in the same process
A common use-case for RocksDB is that applications inherently partition their data set into logical partitions or shards. This technique benefits application load balancing and fast recovery from faults. This means that a single server process should be able to operate multiple RocksDB databases simultaneously. This is done via an environment object named Env. Among other things, a thread pool is associated with an Env. If applications want to share a common thread pool (for background compactions) among multiple database instances, then it should use the same Env object for opening those databases.

Similarly, multiple database instances may share the same block cache.

## Verifying this change

This change added tests and can be verified as follows:
`RocksDBStateBackendConfigTest#testSetDefaultEnvInOptions`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
