### PR TITLE
[FLINK-10201] [table] [test] The batchTestUtil was mistakenly used in some stream sql tests

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/CorrelateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/CorrelateTest.scala
@@ -106,7 +106,7 @@ class CorrelateTest extends TableTestBase {
 
   @Test
   def testLeftOuterJoinAsSubQuery(): Unit = {
-    val util = batchTestUtil()
+    val util = streamTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     util.addTable[(Int, Long, String)]("MyTable2", 'a2, 'b2, 'c2)
@@ -121,13 +121,13 @@ class CorrelateTest extends TableTestBase {
         | ON c2 = s """.stripMargin
 
     val expected = binaryNode(
-      "DataSetJoin",
-      batchTableNode(1),
+      "DataStreamJoin",
+      streamTableNode(1),
       unaryNode(
-        "DataSetCalc",
+        "DataStreamCalc",
         unaryNode(
-          "DataSetCorrelate",
-          batchTableNode(0),
+          "DataStreamCorrelate",
+          streamTableNode(0),
           term("invocation", "func1($cor0.c)"),
           term("correlate", "table(func1($cor0.c))"),
           term("select", "a", "b", "c", "f0"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
@@ -173,29 +173,26 @@ class SetOperatorsTest extends TableTestBase {
 
   @Test
   def testValuesWithCast(): Unit = {
-    val util = batchTestUtil()
+    val util = streamTestUtil()
 
     val expected = naryNode(
-      "DataSetUnion",
+      "DataStreamUnion",
       List(
-        unaryNode("DataSetCalc",
-          values("DataSetValues",
-            tuples(List("0")),
-            "values=[ZERO]"),
+        unaryNode("DataStreamCalc",
+          values("DataStreamValues",
+            tuples(List("0"))),
           term("select", "1 AS EXPR$0, 1 AS EXPR$1")),
-        unaryNode("DataSetCalc",
-          values("DataSetValues",
-            tuples(List("0")),
-            "values=[ZERO]"),
+        unaryNode("DataStreamCalc",
+          values("DataStreamValues",
+            tuples(List("0"))),
           term("select", "2 AS EXPR$0, 2 AS EXPR$1")),
-        unaryNode("DataSetCalc",
-          values("DataSetValues",
-            tuples(List("0")),
-            "values=[ZERO]"),
+        unaryNode("DataStreamCalc",
+          values("DataStreamValues",
+            tuples(List("0"))),
           term("select", "3 AS EXPR$0, 3 AS EXPR$1"))
       ),
       term("all", "true"),
-      term("union", "EXPR$0, EXPR$1")
+      term("union all", "EXPR$0, EXPR$1")
     )
 
     util.verifySql(


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes two improper test cases that mistakenly use batchTestUtil for stream sql.

## Brief change log

Replaces the `batchTestUtil` with `streamTestUtil` in `SetOperatorsTest.testValuesWithCast()` and `CorrelateTest.testLeftOuterJoinAsSubQuery()`.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
