### PR TITLE
[FLINK-10163] [sql-client] Support views in SQL Client

### DIFF
--- a/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
@@ -25,7 +25,7 @@
 
 
 #==============================================================================
-# Table Sources
+# Table Sources & Sinks
 #==============================================================================
 
 # Define table sources and sinks here.
@@ -37,6 +37,17 @@ tables: [] # empty list
 #   connector: ...
 #   format: ...
 #   schema: ...
+
+#==============================================================================
+# Table Views
+#==============================================================================
+
+# Define frequently used SQL queries here that define a virtual table.
+
+views: [] # empty list
+# A typical view definition looks like:
+# - name: ...
+#   query: "SELECT ..."
 
 #==============================================================================
 # User-defined functions

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.client.cli.CliOptionsParser;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.local.LocalExecutor;
 
 import org.slf4j.Logger;
@@ -46,7 +47,7 @@ import java.util.List;
  * and allows for managing queries via console.
  *
  * <p>For debugging in an IDE you can execute the main method of this class using:
- * "embedded --defaults /path/to/-sql-client-defaults.yaml --jar /path/to/target/flink-sql-client-*.jar"
+ * "embedded --defaults /path/to/sql-client-defaults.yaml --jar /path/to/target/flink-sql-client-*.jar"
  *
  * <p>Make sure that the FLINK_CONF_DIR environment variable is set.
  */
@@ -94,6 +95,9 @@ public class SqlClient {
 				context = new SessionContext(options.getSessionId(), sessionEnv);
 			}
 
+			// validate the environment (defaults and session)
+			validateEnvironment(context, executor);
+
 			// add shutdown hook
 			Runtime.getRuntime().addShutdownHook(new EmbeddedShutdownThread(context, executor));
 
@@ -126,6 +130,17 @@ public class SqlClient {
 	}
 
 	// --------------------------------------------------------------------------------------------
+
+	private static void validateEnvironment(SessionContext context, Executor executor) {
+		System.out.print("Validating current environment...");
+		try {
+			executor.validateSession(context);
+			System.out.println("done.");
+		} catch (SqlExecutionException e) {
+			throw new SqlClientException(
+				"Current environment is invalid. Please check your configuration files again.", e);
+		}
+	}
 
 	private static void shutdown(SessionContext context, Executor executor) {
 		System.out.println();

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -50,6 +50,8 @@ public final class CliStrings {
 		.append(formatCommand(SqlCommand.EXPLAIN, "Describes the execution plan of a query or table with the given name."))
 		.append(formatCommand(SqlCommand.SELECT, "Executes a SQL SELECT query on the Flink cluster."))
 		.append(formatCommand(SqlCommand.INSERT_INTO, "Inserts the results of a SQL SELECT query into a declared table sink."))
+		.append(formatCommand(SqlCommand.CREATE_VIEW, "Creates a virtual table from a SQL query. Syntax: 'CREATE VIEW <name> AS <query>'"))
+		.append(formatCommand(SqlCommand.DROP_VIEW, "Deletes a previously created virtual table. Syntax: 'DROP VIEW <name>'"))
 		.append(formatCommand(SqlCommand.SOURCE, "Reads a SQL SELECT query from a file and executes it on the Flink cluster."))
 		.append(formatCommand(SqlCommand.SET, "Sets a session configuration property. Syntax: 'SET <key>=<value>'. Use 'SET' for listing all properties."))
 		.append(formatCommand(SqlCommand.RESET, "Resets all session configuration properties."))
@@ -115,7 +117,7 @@ public final class CliStrings {
 
 	public static final String MESSAGE_EMPTY = "Result was empty.";
 
-	public static final String MESSAGE_UNKNOWN_SQL = "Unknown SQL statement.";
+	public static final String MESSAGE_UNKNOWN_SQL = "Unknown or invalid SQL statement.";
 
 	public static final String MESSAGE_UNKNOWN_TABLE = "Unknown table.";
 
@@ -127,13 +129,24 @@ public final class CliStrings {
 
 	public static final String MESSAGE_STATEMENT_SUBMITTED = "Table update statement has been successfully submitted to the cluster:";
 
-	public static final String MESSAGE_INVALID_PATH = "Path is invalid.";
-
 	public static final String MESSAGE_MAX_SIZE_EXCEEDED = "The given file exceeds the maximum number of characters.";
 
 	public static final String MESSAGE_WILL_EXECUTE = "Executing the following statement:";
 
 	public static final String MESSAGE_UNSUPPORTED_SQL = "Unsupported SQL statement.";
+
+	public static final String MESSAGE_VIEW_CREATED = "View has been created.";
+
+	public static final String MESSAGE_VIEW_REMOVED = "View has been removed.";
+
+	public static final String MESSAGE_VIEW_ALREADY_EXISTS = "A view with this name has already been defined in the current CLI session.";
+
+	public static final String MESSAGE_VIEW_NOT_FOUND = "The given view does not exist in the current CLI session. " +
+		"Only views created with a CREATE VIEW statement can be accessed.";
+
+	public static final String MESSAGE_VIEW_NOT_REMOVED = "The given view cannot be removed without affecting other views.";
+
+	public static final String MESSAGE_ENVIRONMENT_INVALID = "The configured environment is invalid. Please check your environment files again.";
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.table.client.cli;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Simple parser for determining the type of command and its parameters.
@@ -30,86 +35,121 @@ public final class SqlCommandParser {
 	}
 
 	public static Optional<SqlCommandCall> parse(String stmt) {
-		String trimmed = stmt.trim();
+		// normalize
+		stmt = stmt.trim();
 		// remove ';' at the end because many people type it intuitively
-		if (trimmed.endsWith(";")) {
-			trimmed = trimmed.substring(0, trimmed.length() - 1);
+		if (stmt.endsWith(";")) {
+			stmt = stmt.substring(0, stmt.length() - 1).trim();
 		}
+
+		// parse
 		for (SqlCommand cmd : SqlCommand.values()) {
-			int pos = 0;
-			int tokenCount = 0;
-			for (String token : trimmed.split("\\s")) {
-				pos += token.length() + 1; // include space character
-				// check for content
-				if (token.length() > 0) {
-					// match
-					if (tokenCount < cmd.tokens.length && token.equalsIgnoreCase(cmd.tokens[tokenCount])) {
-						if (tokenCount == cmd.tokens.length - 1) {
-							final SqlCommandCall call = new SqlCommandCall(
-								cmd,
-								splitOperands(cmd, trimmed, trimmed.substring(Math.min(pos, trimmed.length())))
-							);
-							return Optional.of(call);
-						}
-					} else {
-						// next sql command
-						break;
-					}
-					tokenCount++; // check next token
+			final Matcher matcher = cmd.pattern.matcher(stmt);
+			if (matcher.matches()) {
+				final String[] groups = new String[matcher.groupCount()];
+				for (int i = 0; i < groups.length; i++) {
+					groups[i] = matcher.group(i + 1);
 				}
+				return cmd.operandConverter.apply(groups)
+					.map((operands) -> new SqlCommandCall(cmd, operands));
 			}
 		}
 		return Optional.empty();
 	}
 
-	private static String[] splitOperands(SqlCommand cmd, String originalCall, String operands) {
-		switch (cmd) {
-			case SET:
-				final int delimiter = operands.indexOf('=');
-				if (delimiter < 0) {
-					return new String[] {};
-				} else {
-					return new String[] {operands.substring(0, delimiter), operands.substring(delimiter + 1)};
-				}
-			case SELECT:
-			case INSERT_INTO:
-				return new String[] {originalCall};
-			default:
-				return new String[] {operands};
-		}
-	}
-
 	// --------------------------------------------------------------------------------------------
+
+	private static final Function<String[], Optional<String[]>> NO_OPERANDS =
+		(operands) -> Optional.of(new String[0]);
+
+	private static final Function<String[], Optional<String[]>> SINGLE_OPERAND =
+		(operands) -> Optional.of(new String[]{operands[0]});
+
+	private static final int DEFAULT_PATTERN_FLAGS = Pattern.CASE_INSENSITIVE | Pattern.DOTALL;
 
 	/**
 	 * Supported SQL commands.
 	 */
 	enum SqlCommand {
-		QUIT("quit"),
-		EXIT("exit"),
-		CLEAR("clear"),
-		HELP("help"),
-		SHOW_TABLES("show tables"),
-		SHOW_FUNCTIONS("show functions"),
-		DESCRIBE("describe"),
-		EXPLAIN("explain"),
-		SELECT("select"),
-		INSERT_INTO("insert into"),
-		SET("set"),
-		RESET("reset"),
-		SOURCE("source");
+		QUIT(
+			"(QUIT|EXIT)",
+			NO_OPERANDS),
 
-		public final String command;
-		public final String[] tokens;
+		CLEAR(
+			"CLEAR",
+			NO_OPERANDS),
 
-		SqlCommand(String command) {
-			this.command = command;
-			this.tokens = command.split(" ");
+		HELP(
+			"HELP",
+			NO_OPERANDS),
+
+		SHOW_TABLES(
+			"SHOW\\s+TABLES",
+			NO_OPERANDS),
+
+		SHOW_FUNCTIONS(
+			"SHOW\\s+FUNCTIONS",
+			NO_OPERANDS),
+
+		DESCRIBE(
+			"DESCRIBE\\s+(.*)",
+			SINGLE_OPERAND),
+
+		EXPLAIN(
+			"EXPLAIN\\s+(.*)",
+			SINGLE_OPERAND),
+
+		SELECT(
+			"(SELECT.*)",
+			SINGLE_OPERAND),
+
+		INSERT_INTO(
+			"(INSERT\\s+INTO.*)",
+			SINGLE_OPERAND),
+
+		CREATE_VIEW(
+			"CREATE\\s+VIEW\\s+(\\S+)\\s+AS\\s+(.*)",
+			(operands) -> {
+				if (operands.length < 2) {
+					return Optional.empty();
+				}
+				return Optional.of(new String[]{operands[0], operands[1]});
+			}),
+
+		DROP_VIEW(
+			"DROP\\s+VIEW\\s+(.*)",
+			SINGLE_OPERAND),
+
+		SET(
+			"SET(\\s+(\\S+)\\s*=(.*))?", // whitespace is only ignored on the left side of '='
+			(operands) -> {
+				if (operands.length < 3) {
+					return Optional.empty();
+				} else if (operands[0] == null) {
+					return Optional.of(new String[0]);
+				}
+				return Optional.of(new String[]{operands[1], operands[2]});
+			}),
+
+		RESET(
+			"RESET",
+			NO_OPERANDS),
+
+		SOURCE(
+			"SOURCE\\s+(.*)",
+			SINGLE_OPERAND);
+
+		public final Pattern pattern;
+		public final Function<String[], Optional<String[]>> operandConverter;
+
+		SqlCommand(String matchingRegex, Function<String[], Optional<String[]>> operandConverter) {
+			this.pattern = Pattern.compile(matchingRegex, DEFAULT_PATTERN_FLAGS);
+			this.operandConverter = operandConverter;
 		}
 
 		@Override
 		public String toString() {
-			return command.toUpperCase();
+			return super.toString().replace('_', ' ');
 		}
 	}
 
@@ -123,6 +163,34 @@ public final class SqlCommandParser {
 		public SqlCommandCall(SqlCommand command, String[] operands) {
 			this.command = command;
 			this.operands = operands;
+		}
+
+		public SqlCommandCall(SqlCommand command) {
+			this(command, new String[0]);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			SqlCommandCall that = (SqlCommandCall) o;
+			return command == that.command && Arrays.equals(operands, that.operands);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = Objects.hash(command);
+			result = 31 * result + Arrays.hashCode(operands);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return command + "(" + Arrays.toString(operands) + ")";
 		}
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/ConfigUtil.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/ConfigUtil.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.client.config;
 
+import org.apache.flink.table.client.SqlClientException;
+
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.io.IOContext;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +40,20 @@ public class ConfigUtil {
 
 	private ConfigUtil() {
 		// private
+	}
+
+	/**
+	 * Extracts an early string property from YAML (before normalization).
+	 */
+	public static String extractEarlyStringProperty(Map<String, Object> map, String key, String parent) {
+		if (!map.containsKey(key)) {
+			throw new SqlClientException("The '" + key + "' attribute of " + parent + " is missing.");
+		}
+		final Object object = map.get(key);
+		if (object == null || !(object instanceof String) || ((String) object).trim().length() <= 0) {
+			throw new SqlClientException("Invalid " + parent + " " + key + " '" + object + "'.");
+		}
+		return (String) object;
 	}
 
 	/**

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/UserDefinedFunction.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/UserDefinedFunction.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.table.client.config;
 
-import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.FunctionDescriptor;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.flink.table.client.config.ConfigUtil.extractEarlyStringProperty;
 
 /**
  * Descriptor for user-defined functions.
@@ -33,7 +34,7 @@ public class UserDefinedFunction extends FunctionDescriptor {
 	private String name;
 	private Map<String, String> properties;
 
-	private static final String NAME = "name";
+	private static final String FUNCTION_NAME = "name";
 
 	private UserDefinedFunction(String name, Map<String, String> properties) {
 		this.name = name;
@@ -52,16 +53,10 @@ public class UserDefinedFunction extends FunctionDescriptor {
 	 * Creates a user-defined function descriptor with the given config.
 	 */
 	public static UserDefinedFunction create(Map<String, Object> config) {
-		if (!config.containsKey(NAME)) {
-			throw new SqlClientException("The 'name' attribute of a function is missing.");
-		}
-		final Object name = config.get(NAME);
-		if (name == null || !(name instanceof String) || ((String) name).trim().length() <= 0) {
-			throw new SqlClientException("Invalid function name '" + name + "'.");
-		}
+		final String name = extractEarlyStringProperty(config, FUNCTION_NAME, "function");
 		final Map<String, Object> properties = new HashMap<>(config);
-		properties.remove(NAME);
-		return new UserDefinedFunction((String) name, ConfigUtil.normalizeYaml(properties));
+		properties.remove(FUNCTION_NAME);
+		return new UserDefinedFunction(name, ConfigUtil.normalizeYaml(properties));
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -98,6 +98,11 @@ public interface Executor {
 	ProgramTargetDescriptor executeUpdate(SessionContext session, String statement) throws SqlExecutionException;
 
 	/**
+	 * Validates the current session. For example, it checks whether all views are still valid.
+	 */
+	void validateSession(SessionContext session) throws SqlExecutionException;
+
+	/**
 	 * Stops the executor.
 	 */
 	void stop(SessionContext session);

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.table.client.config.Environment;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,13 +32,20 @@ import java.util.Objects;
 public class SessionContext {
 
 	private final String name;
+
 	private final Environment defaultEnvironment;
+
 	private final Map<String, String> sessionProperties;
+
+	private final Map<String, String> views;
 
 	public SessionContext(String name, Environment defaultEnvironment) {
 		this.name = name;
 		this.defaultEnvironment = defaultEnvironment;
 		this.sessionProperties = new HashMap<>();
+		// the order of how views are registered matters because
+		// they might reference each other
+		this.views = new LinkedHashMap<>();
 	}
 
 	public void setSessionProperty(String key, String value) {
@@ -47,18 +56,33 @@ public class SessionContext {
 		sessionProperties.clear();
 	}
 
+	public void addView(String name, String query) {
+		views.put(name, query);
+	}
+
+	public void removeView(String name) {
+		views.remove(name);
+	}
+
+	public Map<String, String> getViews() {
+		return Collections.unmodifiableMap(views);
+	}
+
 	public String getName() {
 		return name;
 	}
 
 	public Environment getEnvironment() {
-		// enrich with session properties
-		return Environment.enrich(defaultEnvironment, sessionProperties);
+		return Environment.enrich(
+			defaultEnvironment,
+			sessionProperties,
+			views);
 	}
 
 	public SessionContext copy() {
 		final SessionContext session = new SessionContext(name, defaultEnvironment);
 		session.sessionProperties.putAll(sessionProperties);
+		session.views.putAll(views);
 		return session;
 	}
 
@@ -73,11 +97,16 @@ public class SessionContext {
 		SessionContext context = (SessionContext) o;
 		return Objects.equals(name, context.name) &&
 			Objects.equals(defaultEnvironment, context.defaultEnvironment) &&
-			Objects.equals(sessionProperties, context.sessionProperties);
+			Objects.equals(sessionProperties, context.sessionProperties) &&
+			Objects.equals(views, context.views);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name, defaultEnvironment, sessionProperties);
+		return Objects.hash(
+			name,
+			defaultEnvironment,
+			sessionProperties,
+			views);
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -289,6 +289,12 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public void validateSession(SessionContext session) throws SqlExecutionException {
+		// throws exceptions if an environment cannot be created with the given session context
+		getOrCreateExecutionContext(session).createEnvironmentInstance();
+	}
+
+	@Override
 	public void stop(SessionContext session) {
 		resultStore.getResults().forEach((resultId) -> {
 			try {

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -154,6 +154,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public void validateSession(SessionContext session) throws SqlExecutionException {
+			// nothing to do
+		}
+
+		@Override
 		public void stop(SessionContext session) {
 			// nothing to do
 		}

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommand;
+import org.apache.flink.table.client.cli.SqlCommandParser.SqlCommandCall;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link SqlCommandParser}.
+ */
+public class SqlCommandParserTest {
+
+	@Test
+	public void testCommands() {
+		testValidSqlCommand("QUIT;", new SqlCommandCall(SqlCommand.QUIT));
+		testValidSqlCommand("eXiT", new SqlCommandCall(SqlCommand.QUIT));
+		testValidSqlCommand("CLEAR", new SqlCommandCall(SqlCommand.CLEAR));
+		testValidSqlCommand("SHOW TABLES", new SqlCommandCall(SqlCommand.SHOW_TABLES));
+		testValidSqlCommand("  SHOW   TABLES   ", new SqlCommandCall(SqlCommand.SHOW_TABLES));
+		testValidSqlCommand("SHOW FUNCTIONS", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
+		testValidSqlCommand("  SHOW    FUNCTIONS   ", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
+		testValidSqlCommand("DESCRIBE MyTable", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"MyTable"}));
+		testValidSqlCommand("DESCRIBE         MyTable     ", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"MyTable"}));
+		testInvalidSqlCommand("DESCRIBE  "); // no table name
+		testValidSqlCommand(
+			"EXPLAIN SELECT complicated FROM table",
+			new SqlCommandCall(SqlCommand.EXPLAIN, new String[]{"SELECT complicated FROM table"}));
+		testInvalidSqlCommand("EXPLAIN  "); // no query
+		testValidSqlCommand(
+			"SELECT complicated FROM table",
+			new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT complicated FROM table"}));
+		testValidSqlCommand(
+			"   SELECT  complicated FROM table    ",
+			new SqlCommandCall(SqlCommand.SELECT, new String[]{"SELECT  complicated FROM table"}));
+		testValidSqlCommand(
+			"INSERT INTO other SELECT 1+1",
+			new SqlCommandCall(SqlCommand.INSERT_INTO, new String[]{"INSERT INTO other SELECT 1+1"}));
+		testValidSqlCommand(
+			"CREATE VIEW x AS SELECT 1+1",
+			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"x", "SELECT 1+1"}));
+		testValidSqlCommand(
+			"CREATE   VIEW    MyTable   AS     SELECT 1+1 FROM y",
+			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"MyTable", "SELECT 1+1 FROM y"}));
+		testInvalidSqlCommand("CREATE VIEW x SELECT 1+1"); // missing AS
+		testValidSqlCommand("DROP VIEW MyTable", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"MyTable"}));
+		testValidSqlCommand("DROP VIEW  MyTable", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"MyTable"}));
+		testInvalidSqlCommand("DROP VIEW");
+		testValidSqlCommand("SET", new SqlCommandCall(SqlCommand.SET));
+		testValidSqlCommand("SET x=y", new SqlCommandCall(SqlCommand.SET, new String[] {"x", "y"}));
+		testValidSqlCommand("SET    x  = y", new SqlCommandCall(SqlCommand.SET, new String[] {"x", " y"}));
+		testValidSqlCommand("reset;", new SqlCommandCall(SqlCommand.RESET));
+		testValidSqlCommand("source /my/file", new SqlCommandCall(SqlCommand.SOURCE, new String[] {"/my/file"}));
+		testInvalidSqlCommand("source"); // missing path
+	}
+
+	private void testInvalidSqlCommand(String stmt) {
+		final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(stmt);
+		if (actualCall.isPresent()) {
+			fail();
+		}
+	}
+
+	private void testValidSqlCommand(String stmt, SqlCommandCall expectedCall) {
+		final Optional<SqlCommandCall> actualCall = SqlCommandParser.parse(stmt);
+		if (!actualCall.isPresent()) {
+			fail();
+		}
+		assertEquals(expectedCall, actualCall.get());
+	}
+}

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -79,10 +79,11 @@ public class ExecutionContextTest {
 	}
 
 	@Test
-	public void testSourceSinks() throws Exception {
+	public void testTables() throws Exception {
 		final ExecutionContext<?> context = createExecutionContext();
 		final Map<String, TableSource<?>> sources = context.getTableSources();
 		final Map<String, TableSink<?>> sinks = context.getTableSinks();
+		final Map<String, String> views = context.getMergedEnvironment().getViews();
 
 		assertEquals(
 			new HashSet<>(Arrays.asList("TableSourceSink", "TableNumber1", "TableNumber2")),
@@ -91,6 +92,10 @@ public class ExecutionContextTest {
 		assertEquals(
 			new HashSet<>(Collections.singletonList("TableSourceSink")),
 			sinks.keySet());
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("TestView1", "TestView2")),
+			views.keySet());
 
 		assertArrayEquals(
 			new String[]{"IntegerField1", "StringField1"},
@@ -119,7 +124,7 @@ public class ExecutionContextTest {
 		final TableEnvironment tableEnv = context.createEnvironmentInstance().getTableEnvironment();
 
 		assertArrayEquals(
-			new String[]{"TableNumber1", "TableNumber2", "TableSourceSink"},
+			new String[]{"TableNumber1", "TableNumber2", "TableSourceSink", "TestView1", "TestView2"},
 			tableEnv.listTables());
 	}
 

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -83,6 +83,12 @@ tables:
         - name: StringField
           type: VARCHAR
 
+views:
+  - name: TestView1
+    query: SELECT scalarUDF(IntegerField1) FROM TableNumber1
+  - name: TestView2
+    query: SELECT * FROM TestView1
+
 functions:
   - name: scalarUDF
     from: class


### PR DESCRIPTION
## What is the purpose of the change

Adds initial support for views in SQL Client. It adds the following statements:
- `CREATE VIEW`: Creates a virtual table from a SQL query. Syntax: 'CREATE VIEW <name> AS <query>'
- `SHOW VIEW`: Describes a previously created virtual table. Syntax: 'SHOW VIEW <name>'
- `DROP VIEW`: Deletes a previously created virtual table. Syntax: 'DROP VIEW <name>'

It also adds the section `views` to environment files.


## Brief change log

- Rewritten statement parser for statements with more than 1 operand
- View support added throughout the SQL Client
- Initial validation of environment files during startup
- Code clean up


## Verifying this change

- `SqlCommandParserTest`
- `ExecutionContextTest`
- `LocalExecutorITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
