### PR TITLE
[hotfix][docs] missing </td> breaking metrics page

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1486,6 +1486,7 @@ Thus, in order to infer the metric identifier:
       <td>bytesRequestedPerFetch</td>
       <td>stream, shardId</td>
       <td>The bytes requested (2 Mbps / loopFrequencyHz) in a single call to getRecords.
+      </td>
       <td>Gauge</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Adding a missing `</td>` to metrics.md. 

In both [master](https://ci.apache.org/projects/flink/flink-docs-master/monitoring/metrics.html#kinesis-connectors) and [release-1.6](https://ci.apache.org/projects/flink/flink-docs-release-1.6/monitoring/metrics.html#kinesis-connectors) the Kinesis Connectors section of the metrics doc page is broken, and appears like this:

    Kinesis Connectors
    </tr> </tbody> </table> ## Latency tracking Flink allows to track the latency of rec...