### PR TITLE
[FLINK-9432] Support extract timeunit: DECADE, EPOCH, ISODOW, ISOYEAR…

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -3102,6 +3102,9 @@ EXTRACT(timeintervalunit FROM temporal)
       <td>
         <p>Returns a long value extracted from the <i>timeintervalunit</i> part of <i>temporal</i>.</p>
         <p>E.g., <code>EXTRACT(DAY FROM DATE '2006-06-05')</code> returns 5.</p>
+        <p>Where <i>timeintervalunit<i> is <code>
+           MILLENNIUM | CENTURY | DECADE | YEAR | QUARTER | MONTH | WEEK | DOY | ISOYEAR | 
+           DOW | ISODOW | DAY | HOUR | MINUTE | SECOND | EPOCH | MILLISECOND | MICROSECOND</code></p>
       </td>
     </tr>
 

--- a/flink-libraries/flink-table/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
@@ -91,6 +91,11 @@ public class DateTimeUtils {
 	public static final long MILLIS_PER_DAY = 86400000; // = 24 * 60 * 60 * 1000
 
 	/**
+	 * The number of seconds in a day.
+	 */
+	public static final long SECONDS_PER_DAY = 86_400; // = 24 * 60 * 60
+
+	/**
 	 * Calendar set to the epoch (1970-01-01 00:00:00 UTC). Useful for
 	 * initializing other values. Calendars are not immutable, so be careful not
 	 * to screw up this object for everyone else.
@@ -719,7 +724,13 @@ public class DateTimeUtils {
 	}
 
 	public static long unixDateExtract(TimeUnitRange range, long date) {
-		return julianExtract(range, (int) date + EPOCH_JULIAN);
+		switch (range) {
+			case EPOCH:
+				// no need to extract year/month/day, just multiply
+				return date * SECONDS_PER_DAY;
+			default:
+				return julianExtract(range, (int) date + EPOCH_JULIAN);
+		}
 	}
 
 	private static int julianExtract(TimeUnitRange range, int julian) {
@@ -743,6 +754,14 @@ public class DateTimeUtils {
 		switch (range) {
 			case YEAR:
 				return year;
+			case ISOYEAR:
+				int weekNumber = getIso8601WeekNumber(julian, year, month, day);
+				if (weekNumber == 1 && month == 12) {
+					return year + 1;
+				} else if (month == 1 && weekNumber > 50) {
+					return year - 1;
+				}
+				return year;
 			case QUARTER:
 				return (month + 2) / 3;
 			case MONTH:
@@ -751,15 +770,15 @@ public class DateTimeUtils {
 				return day;
 			case DOW:
 				return (int) floorMod(julian + 1, 7) + 1; // sun=1, sat=7
+			case ISODOW:
+				return (int) floorMod(julian, 7) + 1; // mon=1, sun=7
 			case WEEK:
-				long fmofw = firstMondayOfFirstWeek(year);
-				if (julian < fmofw) {
-					fmofw = firstMondayOfFirstWeek(year - 1);
-				}
-				return (int) (julian - fmofw) / 7 + 1;
+				return getIso8601WeekNumber(julian, year, month, day);
 			case DOY:
 				final long janFirst = ymdToJulian(year, 1, 1);
 				return (int) (julian - janFirst) + 1;
+			case DECADE:
+				return year / 10;
 			case CENTURY:
 				return year > 0
 					? (year + 99) / 100
@@ -781,6 +800,30 @@ public class DateTimeUtils {
 		final long janFirst = ymdToJulian(year, 1, 1);
 		final long janFirstDow = floorMod(janFirst + 1, 7); // sun=0, sat=6
 		return janFirst + (11 - janFirstDow) % 7 - 3;
+	}
+
+	/** Returns the ISO-8601 week number based on year, month, day.
+	 * Per ISO-8601 it is the Monday of the week that contains Jan 4,
+	 * or equivalently, it is a Monday between Dec 29 and Jan 4.
+	 * Sometimes it is in the year before the given year, sometimes after. */
+	private static int getIso8601WeekNumber(int julian, int year, int month, int day) {
+		long fmofw = firstMondayOfFirstWeek(year);
+		if (month == 12 && day > 28) {
+			if (31 - day + 4 > 7 - ((int) floorMod(julian, 7) + 1)
+				&& 31 - day + (int) (floorMod(julian, 7) + 1) >= 4) {
+				return (int) (julian - fmofw) / 7 + 1;
+			} else {
+				return 1;
+			}
+		} else if (month == 1 && day < 5) {
+			if (4 - day <= 7 - ((int) floorMod(julian, 7) + 1)
+				&& day - ((int) (floorMod(julian, 7) + 1)) >= -3) {
+				return 1;
+			} else {
+				return (int) (julian - firstMondayOfFirstWeek(year - 1)) / 7 + 1;
+			}
+		}
+		return (int) (julian - fmofw) / 7 + 1;
 	}
 
 	/** Extracts a time unit from a UNIX date (milliseconds since epoch). */

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1853,12 +1853,56 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "315")
 
     testSqlApi(
+      "EXTRACT(EPOCH FROM f18)",
+      "847608883")
+
+    testSqlApi(
+      "EXTRACT(EPOCH FROM TIMESTAMP '2018-10-11 12:23:12.345')",
+      "1539260582")
+
+    // TODO looks like a Calcite issue for cases like extract(millisecond from date)
+    //  should be 0 but not
+    //testSqlApi(
+    //  "EXTRACT(MILLISECOND FROM f16)",
+    //  "0")
+
+    testSqlApi(
+      "EXTRACT(MILLISECOND FROM TIMESTAMP '2018-10-11 12:23:12.345')",
+      "345")
+
+    testSqlApi(
+      "EXTRACT(MILLISECOND FROM TIME '10:54:41.096')",
+      "96")
+
+    // TODO looks like a Calcite issue for cases like extract(microsecond from date)
+    //  should be 0 but not
+    //testSqlApi(
+    //  "EXTRACT(MICROSECOND FROM f16)",
+    //  "0")
+
+    testSqlApi(
+      "EXTRACT(MICROSECOND FROM TIMESTAMP '2018-10-11 12:23:12.345')",
+      "345000")
+
+    testSqlApi(
+      "EXTRACT(MICROSECOND FROM TIME '10:54:41.096')",
+      "96000")
+
+    testSqlApi(
       "EXTRACT(DOW FROM f18)",
       "1")
 
     testSqlApi(
       "EXTRACT(DOW FROM f16)",
       "1")
+
+    testSqlApi(
+      "EXTRACT(ISODOW FROM f16)",
+      "7")
+
+    testSqlApi(
+      "EXTRACT(ISODOW FROM f18)",
+      "7")
 
     testSqlApi(
       "EXTRACT(WEEK FROM f18)",
@@ -1875,6 +1919,22 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(
       "YEAR(f16)",
       "1996")
+
+    testSqlApi(
+      "EXTRACT(ISOYEAR FROM f16)",
+      "1996")
+
+    testSqlApi(
+      "EXTRACT(ISOYEAR FROM f18)",
+      "1996")
+
+    testSqlApi(
+      "EXTRACT(DECADE FROM f16)",
+      "199")
+
+    testSqlApi(
+      "EXTRACT(DECADE FROM f18)",
+      "199")
 
     testSqlApi(
       "QUARTER(f18)",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -108,6 +108,26 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
     testSqlApi("EXTRACT(DOY FROM TIME '12:42:25')", "0")
   }
 
+  @Test(expected = classOf[ValidationException])
+  def testISODOWWithTimeWhichIsUnsupported(): Unit = {
+    testSqlApi("EXTRACT(ISODOW FROM TIME '12:42:25')", "0")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testISOYearWithTimeWhichIsUnsupported(): Unit = {
+    testSqlApi("EXTRACT(ISOYEAR FROM TIME '12:42:25')", "0")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testDecadeWithTimeWhichIsUnsupported(): Unit = {
+    testSqlApi("EXTRACT(DECADE FROM TIME '12:42:25')", "0")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testEpochWithTimeWhichIsUnsupported(): Unit = {
+    testSqlApi("EXTRACT(EPOCH FROM TIME '12:42:25')", "0")
+  }
+
   private def testExtractFromTimeZeroResult(unit: TimeUnit): Unit = {
     testSqlApi("EXTRACT(" + unit + " FROM TIME '00:00:00')", "0")
   }


### PR DESCRIPTION
## What is the purpose of the change
The PR provides implementation of `extract` function for timeunits: `decade`, `epoch`, `isodow`, `isoyear`, 'millisecond`,`microsecond`

## Brief change log

- support timeunits `extract`
- documentation updates (mention all possible timeunits for `extract`)
- tests

## Verifying this change
  - *Added tests validates the result of `extract` call*
  - *Added tests validates that `extract` of `isodow`, `isodoy`, `epoch`, `decade` for time is incorrect*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
    functions.md updated
