### PR TITLE
[FLINK-10218] Allow writing DataSet without explicit path parameter

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1732,6 +1732,21 @@ public abstract class DataSet<T> {
 	 * This method adds a data sink to the program.
 	 *
 	 * @param outputFormat The FileOutputFormat to write the DataSet.
+	 * @return The DataSink that writes the DataSet.
+	 *
+	 * @see FileOutputFormat
+	 */
+	public DataSink<T> write(FileOutputFormat<T> outputFormat) {
+		Preconditions.checkNotNull(outputFormat, "Output format must not be null.");
+		Preconditions.checkNotNull(outputFormat.getOutputFilePath(), "File path must not be null.");
+		return output(outputFormat);
+	}
+
+	/**
+	 * Writes a DataSet using a {@link FileOutputFormat} to a specified location.
+	 * This method adds a data sink to the program.
+	 *
+	 * @param outputFormat The FileOutputFormat to write the DataSet.
 	 * @param filePath The path to the location where the DataSet is written.
 	 * @return The DataSink that writes the DataSet.
 	 *


### PR DESCRIPTION
## What is the purpose of the change

Add an file output helper method, which requires only FileOutputFormat parameter, to DataSet API. This can avoid setting duplicate path parameters, since the output path could be found in FileOutputFormat.

## Brief change log

  - *Add an file output helper method, which requires only FileOutputFormat parameter, to DataSet API.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
