### PR TITLE
[FLINK-10192] [sql-client] Fix SQL Client table visualization mode

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/TypedResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/TypedResult.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.client.gateway;
 
+import java.util.Objects;
+
 /**
  * Result with an attached type (actual payload, EOS, etc.).
  *
@@ -53,6 +55,23 @@ public class TypedResult<P> {
 	@Override
 	public String toString() {
 		return "TypedResult<" + type + ">";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TypedResult<?> that = (TypedResult<?>) o;
+		return type == that.type && Objects.equals(payload, that.payload);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, payload);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local.result;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link MaterializedCollectStreamResult}.
+ */
+public class MaterializedCollectStreamResultTest {
+
+	@Test
+	public void testSnapshot() throws UnknownHostException {
+		final TypeInformation<Row> type = Types.ROW(Types.STRING, Types.LONG);
+
+		TestMaterializedCollectStreamResult result = null;
+		try {
+			result = new TestMaterializedCollectStreamResult(
+				type,
+				new ExecutionConfig(),
+				InetAddress.getLocalHost(),
+				0);
+
+			result.isRetrieving = true;
+
+			result.processRecord(Tuple2.of(true, Row.of("A", 1)));
+			result.processRecord(Tuple2.of(true, Row.of("B", 1)));
+			result.processRecord(Tuple2.of(true, Row.of("A", 1)));
+			result.processRecord(Tuple2.of(true, Row.of("C", 2)));
+
+			assertEquals(TypedResult.payload(4), result.snapshot(1));
+
+			assertEquals(Collections.singletonList(Row.of("A", 1)), result.retrievePage(1));
+			assertEquals(Collections.singletonList(Row.of("B", 1)), result.retrievePage(2));
+			assertEquals(Collections.singletonList(Row.of("A", 1)), result.retrievePage(3));
+			assertEquals(Collections.singletonList(Row.of("C", 2)), result.retrievePage(4));
+
+			result.processRecord(Tuple2.of(false, Row.of("A", 1)));
+
+			assertEquals(TypedResult.payload(3), result.snapshot(1));
+
+			assertEquals(Collections.singletonList(Row.of("A", 1)), result.retrievePage(1));
+			assertEquals(Collections.singletonList(Row.of("B", 1)), result.retrievePage(2));
+			assertEquals(Collections.singletonList(Row.of("C", 2)), result.retrievePage(3));
+
+			result.processRecord(Tuple2.of(false, Row.of("C", 2)));
+			result.processRecord(Tuple2.of(false, Row.of("A", 1)));
+
+			assertEquals(TypedResult.payload(1), result.snapshot(1));
+
+			assertEquals(Collections.singletonList(Row.of("B", 1)), result.retrievePage(1));
+		} finally {
+			if (result != null) {
+				result.close();
+			}
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Helper classes
+	// --------------------------------------------------------------------------------------------
+
+	private static class TestMaterializedCollectStreamResult extends MaterializedCollectStreamResult {
+
+		public boolean isRetrieving;
+
+		public TestMaterializedCollectStreamResult(
+				TypeInformation<Row> outputType,
+				ExecutionConfig config,
+				InetAddress gatewayAddress,
+				int gatewayPort) {
+
+			super(
+				outputType,
+				config,
+				gatewayAddress,
+				gatewayPort);
+		}
+
+		@Override
+		protected boolean isRetrieving() {
+			return isRetrieving;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the wrong materialization for the debugging visualization in table mode.


## Brief change log

- Rework the caching mechanism in `MaterializedCollectStreamResult`.

## Verifying this change

- Unit test added in `MaterializedCollectStreamResultTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
