### PR TITLE
[FLINK-10207][build] Bump checkstyle to 8.9

### DIFF
--- a/docs/flinkDev/ide_setup.md
+++ b/docs/flinkDev/ide_setup.md
@@ -87,7 +87,7 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 1. Install the "Checkstyle-IDEA" plugin from the IntelliJ plugin repository.
 2. Configure the plugin by going to Settings -> Other Settings -> Checkstyle.
 3. Set the "Scan Scope" to "Only Java sources (including tests)".
-4. Select _8.4_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
+4. Select _8.9_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
 5. In the "Configuration File" pane, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -60,15 +60,15 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.UUID;
 
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import scala.concurrent.Await;
-import scala.concurrent.duration.Duration;
 
 /**
  * Simple and maybe stupid test to check the {@link ClusterClient} class.

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/src/main/java/org/apache/flink/streaming/tests/StatefulStreamJobUpgradeTestProgram.java
@@ -29,14 +29,14 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
 import org.apache.flink.streaming.tests.artificialstate.ComplexPayload;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createArtificialKeyedStateMapper;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createEventSource;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createSemanticsCheckMapper;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createTimestampExtractor;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.setupEnvironment;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Test upgrade of generic stateful job for Flink's DataStream API operators and primitives.

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
@@ -26,11 +26,11 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.fail;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
+
+import static org.junit.Assert.fail;
 
 /**
  * Base class for tests for {@link ParameterTool}.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaJobManagerRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaJobManagerRetrieverTest.java
@@ -39,10 +39,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import scala.concurrent.Await;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-
-import scala.concurrent.Await;
 
 /**
  * Test for the {@link AkkaJobManagerRetriever}.

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskManagerRunnerFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskManagerRunnerFactoryTest.java
@@ -27,15 +27,15 @@ import org.apache.flink.runtime.security.modules.SecurityModule;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link YarnTaskManagerRunnerFactory}.

--- a/pom.xml
+++ b/pom.xml
@@ -1387,7 +1387,7 @@ under the License.
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
 							<!-- Note: match version with docs/internals/ide_setup.md -->
-							<version>8.4</version>
+							<version>8.9</version>
 						</dependency>
 					</dependencies>
 					<executions>


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps the checkstyle version to 8.9, which is a prerequisite for compiling with java 9.

## Brief change log

* bump version to 8.9
* updated IDE setup docs
* fixed a number of checkstyle violations that weren't detected previously

## Verifying this change

I had to setup a local VM with jdk 9 to encounter the issue and verify the fix. Travis is unfortunately unreliable for this, as some jdk 9 incompatibilities that I encountered locally didn't occur on travis (which is actually **very** problematic).
