### PR TITLE
 [FLINK-8686] [sql-client] Limit result size for prototyping modes

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -208,7 +208,7 @@ execution:
   type: streaming                   # required: execution mode either 'batch' or 'streaming'
   result-mode: table                # required: either 'table' or 'changelog'
   max-table-result-rows: 1000000    # optional: maximum number of maintained rows in
-                                    #   'table' mode (1000000 by default, negative means unlimited)
+                                    #   'table' mode (1000000 by default, smaller 1 means unlimited)
   time-characteristic: event-time   # optional: 'processing-time' or 'event-time' (default)
   parallelism: 1                    # optional: Flink's parallelism (1 by default)
   periodic-watermarks-interval: 200 # optional: interval for periodic watermarks (200 ms by default)

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -208,7 +208,7 @@ execution:
   type: streaming                   # required: execution mode either 'batch' or 'streaming'
   result-mode: table                # required: either 'table' or 'changelog'
   max-table-result-rows: 1000000    # optional: maximum number of maintained rows in
-                                    #   'table' mode (1000000 by default)
+                                    #   'table' mode (1000000 by default, negative means unlimited)
   time-characteristic: event-time   # optional: 'processing-time' or 'event-time' (default)
   parallelism: 1                    # optional: Flink's parallelism (1 by default)
   periodic-watermarks-interval: 200 # optional: interval for periodic watermarks (200 ms by default)

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -106,7 +106,7 @@ Alice, 1
 Greg, 1
 {% endhighlight %}
 
-Both result modes can be useful during the prototyping of SQL queries.
+Both result modes can be useful during the prototyping of SQL queries. In both modes, results are stored in the Java heap memory of the SQL Client. In order to keep the CLI interface responsive, the changelog mode only shows the latest 1000 changes. The table mode allows for navigating through bigger results that are only limited by the available main memory and the configured [maximum number of rows](sqlClient.html#configuration) (`max-table-result-rows`).
 
 <span class="label label-danger">Attention</span> Queries that are executed in a batch environment, can only be retrieved using the `table` result mode.
 
@@ -167,6 +167,7 @@ Every environment file is a regular [YAML file](http://yaml.org/). An example of
 tables:
   - name: MyTableSource
     type: source
+    update-mode: append
     connector:
       type: filesystem
       path: "/path/to/something.csv"
@@ -206,6 +207,8 @@ functions:
 execution:
   type: streaming                   # required: execution mode either 'batch' or 'streaming'
   result-mode: table                # required: either 'table' or 'changelog'
+  max-table-result-rows: 1000000    # optional: maximum number of maintained rows in
+                                    #   'table' mode (1000000 by default)
   time-characteristic: event-time   # optional: 'processing-time' or 'event-time' (default)
   parallelism: 1                    # optional: Flink's parallelism (1 by default)
   periodic-watermarks-interval: 200 # optional: interval for periodic watermarks (200 ms by default)
@@ -213,7 +216,7 @@ execution:
   min-idle-state-retention: 0       # optional: table program's minimum idle state time
   max-idle-state-retention: 0       # optional: table program's maximum idle state time
   restart-strategy:                 # optional: restart strategy
-    type: fallback                  #           "fallback" to global restart strategy by default
+    type: fallback                  #   "fallback" to global restart strategy by default
 
 # Deployment properties allow for describing the cluster to which table programs are submitted to.
 

--- a/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
@@ -76,7 +76,9 @@ execution:
   # interval in ms for emitting periodic watermarks
   periodic-watermarks-interval: 200
   # 'changelog' or 'table' presentation of results
-  result-mode: changelog
+  result-mode: table
+  # maximum number of maintained rows in 'table' presentation of results
+  max-table-result-rows: 1000000
   # parallelism of the program
   parallelism: 1
   # maximum parallelism

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
@@ -50,6 +50,7 @@ import static org.jline.keymap.KeyMap.key;
  */
 public class CliChangelogResultView extends CliResultView<CliChangelogResultView.ResultChangelogOperation> {
 
+	private static final int DEFAULT_MAX_ROW_COUNT = 1000;
 	private static final int DEFAULT_REFRESH_INTERVAL = 0; // as fast as possible
 	private static final int DEFAULT_REFRESH_INTERVAL_PLAIN = 3; // every 1s
 	private static final int MIN_REFRESH_INTERVAL = 0; // every 100ms
@@ -133,6 +134,13 @@ public class CliChangelogResultView extends CliResultView<CliChangelogResultView
 					}
 
 					// update results
+
+					// formatting and printing of rows is expensive in the current implementation,
+					// therefore we limit the maximum number of lines shown in changelog mode to
+					// keep the CLI responsive
+					if (results.size() >= DEFAULT_MAX_ROW_COUNT) {
+						results.remove(0);
+					}
 					results.add(changeRow);
 
 					scrolling++;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
@@ -68,7 +68,7 @@ public class CliChangelogResultView extends CliResultView<CliChangelogResultView
 			refreshInterval = DEFAULT_REFRESH_INTERVAL;
 		}
 		previousResults = null;
-		// rows are mostly appended or deleted at index 0
+		// rows are always appended at the tail and deleted from the head of the list
 		results = new LinkedList<>();
 	}
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
@@ -34,6 +34,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import static org.apache.flink.table.client.cli.CliUtils.TIME_FORMATTER;
@@ -67,7 +68,8 @@ public class CliChangelogResultView extends CliResultView<CliChangelogResultView
 			refreshInterval = DEFAULT_REFRESH_INTERVAL;
 		}
 		previousResults = null;
-		results = new ArrayList<>();
+		// rows are mostly appended or deleted at index 0
+		results = new LinkedList<>();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
@@ -28,7 +28,6 @@ import org.jline.utils.AttributedStyle;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.table.client.cli.CliUtils.normalizeColumn;
 
@@ -182,9 +181,8 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
 	protected List<AttributedString> computeMainLines() {
 		final List<AttributedString> lines = new ArrayList<>();
 
-		IntStream.range(0, results.size()).forEach(lineIdx -> {
-			final String[] line = results.get(lineIdx);
-
+		int lineIdx = 0;
+		for (String[] line : results) {
 			final AttributedStringBuilder row = new AttributedStringBuilder();
 
 			// highlight selected row
@@ -192,7 +190,7 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
 				row.style(AttributedStyle.DEFAULT.inverse());
 			}
 
-			IntStream.range(0, line.length).forEach(colIdx -> {
+			for (int colIdx = 0; colIdx < line.length; colIdx++) {
 				final String col = line[colIdx];
 				final int columnWidth = computeColumnWidth(colIdx);
 
@@ -208,9 +206,11 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
 				} else {
 					normalizeColumn(row, col, columnWidth);
 				}
-			});
+			}
 			lines.add(row.toAttributedString());
-		});
+
+			lineIdx++;
+		}
 
 		return lines;
 	}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -92,8 +92,8 @@ public class Execution {
 		return Integer.parseInt(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_PARALLELISM, Integer.toString(128)));
 	}
 
-	public long getMaxTableResultRows() {
-		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_TABLE_RESULT_ROWS, Long.toString(1_000_000)));
+	public int getMaxTableResultRows() {
+		return Integer.parseInt(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_TABLE_RESULT_ROWS, Integer.toString(1_000_000)));
 	}
 
 	public RestartStrategies.RestartStrategyConfiguration getRestartStrategy() {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -92,6 +92,10 @@ public class Execution {
 		return Integer.parseInt(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_PARALLELISM, Integer.toString(128)));
 	}
 
+	public long getMaxTableResultRows() {
+		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_MAX_TABLE_RESULT_ROWS, Long.toString(1_000_000)));
+	}
+
 	public RestartStrategies.RestartStrategyConfiguration getRestartStrategy() {
 		final String restartStrategy = properties.getOrDefault(
 			PropertyStrings.EXECUTION_RESTART_STRATEGY_TYPE,

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/PropertyStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/PropertyStrings.java
@@ -57,6 +57,8 @@ public final class PropertyStrings {
 
 	public static final String EXECUTION_RESULT_MODE_VALUE_TABLE = "table";
 
+	public static final String EXECUTION_MAX_TABLE_RESULT_ROWS = "max-table-result-rows";
+
 	public static final String EXECUTION_RESTART_STRATEGY_TYPE = "restart-strategy.type";
 
 	public static final String EXECUTION_RESTART_STRATEGY_TYPE_VALUE_FALLBACK = "fallback";

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -76,8 +76,7 @@ public class ResultStore {
 					config,
 					gatewayAddress,
 					gatewayPort,
-					env.getExecution().getMaxTableResultRows(),
-					MaterializedCollectStreamResult.DEFAULT_OVERCOMMIT_THRESHOLD);
+					env.getExecution().getMaxTableResultRows());
 			}
 
 		} else {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -71,7 +71,12 @@ public class ResultStore {
 			if (env.getExecution().isChangelogMode()) {
 				return new ChangelogCollectStreamResult<>(outputType, config, gatewayAddress, gatewayPort);
 			} else {
-				return new MaterializedCollectStreamResult<>(outputType, config, gatewayAddress, gatewayPort);
+				return new MaterializedCollectStreamResult<>(
+					outputType,
+					config,
+					gatewayAddress,
+					gatewayPort,
+					env.getExecution().getMaxTableResultRows());
 			}
 
 		} else {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -76,7 +76,8 @@ public class ResultStore {
 					config,
 					gatewayAddress,
 					gatewayPort,
-					env.getExecution().getMaxTableResultRows());
+					env.getExecution().getMaxTableResultRows(),
+					MaterializedCollectStreamResult.DEFAULT_OVERCOMMIT_THRESHOLD);
 			}
 
 		} else {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -88,7 +88,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			int overcommitThreshold) {
 		super(outputType, config, gatewayAddress, gatewayPort);
 
-		if (maxRowCount < 0) {
+		if (maxRowCount <= 0) {
 			this.maxRowCount = Integer.MAX_VALUE;
 		} else {
 			this.maxRowCount = maxRowCount;
@@ -96,7 +96,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 		this.overcommitThreshold = overcommitThreshold;
 
 		// prepare for materialization
-		materializedTable = new ArrayList<>();
+		materializedTable = new ArrayList<>(Math.max(1, (int) (maxRowCount * 0.01))); // avoid frequent resizing
 		rowPositionCache = new HashMap<>();
 		snapshot = new ArrayList<>();
 		validRowPosition = 0;
@@ -203,9 +203,9 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 
 	private void cleanUp() {
 		// invalidate row
-		final Row deleteRow = materializedTable.get(0);
+		final Row deleteRow = materializedTable.get(validRowPosition);
 		rowPositionCache.remove(deleteRow);
-		materializedTable.set(0, null);
+		materializedTable.set(validRowPosition, null);
 
 		validRowPosition++;
 

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -198,6 +198,7 @@ public class LocalExecutorITCase extends TestLogger {
 		expectedProperties.put("execution.max-idle-state-retention", "0");
 		expectedProperties.put("execution.min-idle-state-retention", "0");
 		expectedProperties.put("execution.result-mode", "table");
+		expectedProperties.put("execution.max-table-result-rows", "100");
 		expectedProperties.put("execution.restart-strategy.type", "failure-rate");
 		expectedProperties.put("execution.restart-strategy.max-failures-per-interval", "10");
 		expectedProperties.put("execution.restart-strategy.failure-rate-interval", "99000");
@@ -264,38 +265,47 @@ public class LocalExecutorITCase extends TestLogger {
 	public void testStreamQueryExecutionTable() throws Exception {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
+
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_0", url.getPath());
 		replaceVars.put("$VAR_1", "/");
 		replaceVars.put("$VAR_2", "streaming");
 		replaceVars.put("$VAR_3", "table");
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
 
-		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
-		final SessionContext session = new SessionContext("test-session", new Environment());
+		final String query = "SELECT scalarUDF(IntegerField1), StringField1 FROM TableNumber1";
 
-		try {
-			// start job and retrieval
-			final ResultDescriptor desc = executor.executeQuery(
-				session,
-				"SELECT scalarUDF(IntegerField1), StringField1 FROM TableNumber1");
+		final List<String> expectedResults = new ArrayList<>();
+		expectedResults.add("47,Hello World");
+		expectedResults.add("27,Hello World");
+		expectedResults.add("37,Hello World");
+		expectedResults.add("37,Hello World");
+		expectedResults.add("47,Hello World");
+		expectedResults.add("57,Hello World!!!!");
 
-			assertTrue(desc.isMaterialized());
+		executeStreamQueryTable(replaceVars, query, expectedResults);
+	}
 
-			final List<String> actualResults = retrieveTableResult(executor, session, desc.getResultId());
+	@Test(timeout = 30_000L)
+	public void testStreamQueryExecutionLimitedTable() throws Exception {
+		final URL url = getClass().getClassLoader().getResource("test-data.csv");
+		Objects.requireNonNull(url);
 
-			final List<String> expectedResults = new ArrayList<>();
-			expectedResults.add("47,Hello World");
-			expectedResults.add("27,Hello World");
-			expectedResults.add("37,Hello World");
-			expectedResults.add("37,Hello World");
-			expectedResults.add("47,Hello World");
-			expectedResults.add("57,Hello World!!!!");
+		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_0", url.getPath());
+		replaceVars.put("$VAR_1", "/");
+		replaceVars.put("$VAR_2", "streaming");
+		replaceVars.put("$VAR_3", "table");
+		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+		replaceVars.put("$VAR_MAX_ROWS", "1");
 
-			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
-		} finally {
-			executor.stop(session);
-		}
+		final String query = "SELECT COUNT(*), StringField1 FROM TableNumber1 GROUP BY StringField1";
+
+		final List<String> expectedResults = new ArrayList<>();
+		expectedResults.add("1,Hello World!!!!");
+
+		executeStreamQueryTable(replaceVars, query, expectedResults);
 	}
 
 	@Test(timeout = 30_000L)
@@ -375,6 +385,28 @@ public class LocalExecutorITCase extends TestLogger {
 		}
 	}
 
+	private void executeStreamQueryTable(
+			Map<String, String> replaceVars,
+			String query,
+			List<String> expectedResults) throws Exception {
+
+		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+
+		try {
+			// start job and retrieval
+			final ResultDescriptor desc = executor.executeQuery(session, query);
+
+			assertTrue(desc.isMaterialized());
+
+			final List<String> actualResults = retrieveTableResult(executor, session, desc.getResultId());
+
+			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
+		} finally {
+			executor.stop(session);
+		}
+	}
+
 	private void verifySinkResult(String path) throws IOException {
 		final List<String> actualResults = new ArrayList<>();
 		TestBaseUtils.readAllResultLines(actualResults, path);
@@ -392,6 +424,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_2", "batch");
 		replaceVars.put("$VAR_UPDATE_MODE", "");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
 		return new LocalExecutor(
 			EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars),
 			Collections.emptyList(),

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -101,16 +101,17 @@ public class MaterializedCollectStreamResultTest {
 				InetAddress.getLocalHost(),
 				0,
 				2,  // limit the materialized table to 2 rows
-				2); // with 2 rows overcommitment
+				3); // with 3 rows overcommitment
 
 			result.isRetrieving = true;
 
+			result.processRecord(Tuple2.of(true, Row.of("D", 1)));
 			result.processRecord(Tuple2.of(true, Row.of("A", 1)));
 			result.processRecord(Tuple2.of(true, Row.of("B", 1)));
 			result.processRecord(Tuple2.of(true, Row.of("A", 1)));
 
 			assertEquals(
-				Arrays.asList(null, Row.of("B", 1), Row.of("A", 1)), // one over-committed row
+				Arrays.asList(null, null, Row.of("B", 1), Row.of("A", 1)), // one over-committed row
 				result.getMaterializedTable());
 
 			assertEquals(TypedResult.payload(2), result.snapshot(1));

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -51,8 +51,7 @@ public class MaterializedCollectStreamResultTest {
 				new ExecutionConfig(),
 				InetAddress.getLocalHost(),
 				0,
-				Integer.MAX_VALUE,
-				MaterializedCollectStreamResult.DEFAULT_OVERCOMMIT_THRESHOLD);
+				Integer.MAX_VALUE);
 
 			result.isRetrieving = true;
 
@@ -111,7 +110,7 @@ public class MaterializedCollectStreamResultTest {
 			result.processRecord(Tuple2.of(true, Row.of("A", 1)));
 
 			assertEquals(
-				Arrays.asList(null, null, Row.of("B", 1), Row.of("A", 1)), // one over-committed row
+				Arrays.asList(null, null, Row.of("B", 1), Row.of("A", 1)), // two over-committed rows
 				result.getMaterializedTable());
 
 			assertEquals(TypedResult.payload(2), result.snapshot(1));
@@ -160,6 +159,21 @@ public class MaterializedCollectStreamResultTest {
 				gatewayPort,
 				maxRowCount,
 				overcommitThreshold);
+		}
+
+		public TestMaterializedCollectStreamResult(
+				TypeInformation<Row> outputType,
+				ExecutionConfig config,
+				InetAddress gatewayAddress,
+				int gatewayPort,
+				int maxRowCount) {
+
+			super(
+				outputType,
+				config,
+				gatewayAddress,
+				gatewayPort,
+				maxRowCount);
 		}
 
 		@Override

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -123,6 +123,7 @@ execution:
   min-idle-state-retention: 0
   max-idle-state-retention: 0
   result-mode: "$VAR_3"
+  max-table-result-rows: "$VAR_MAX_ROWS"
   restart-strategy:
     type: failure-rate
     max-failures-per-interval: 10


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to make the SQL Client more robust by limiting the result size for both changelog and table result modes. In changelog mode the responsiveness of the CLI is the limiting factor. In table mode only the main memory is the limiting factor and the configurable maximum row count.

This PR is built on top of FLINK-10192.

## Brief change log

- Add a hard limit for changelog mode (1000 rows)
- Add a configurable limit for table mode

## Verifying this change

- Added test `LocalExecutorITCase#testStreamQueryExecutionLimitedTable`
- Added test `MaterializedCollectStreamResultTest#testLimitedSnapshot`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
