### PR TITLE
[FLINK-10222] [table] Table scalar function expression parses error when function name equals the exists keyword suffix

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -42,7 +42,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
   // Convert the keyword into an case insensitive Parser
   implicit def keyword2Parser(kw: Keyword): Parser[String] = {
-    ("""(?i)\Q""" + kw.key + """\E""").r
+    ("""(?i)\Q""" + kw.key +
+      """\E(?![_$a-zA-Z0-9\u005f\u0024\u0061-\u007a\u0041-\u005a\u0030-\u0039])""").r
   }
 
   // Keyword

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/KeywordParseTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/KeywordParseTest.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.expressions.utils.ExpressionTestBase
+import org.apache.flink.types.Row
+import org.junit.{Assert, Test}
+
+/**
+  * Tests keyword as suffix.
+  */
+class KeywordParseTest extends ExpressionTestBase {
+
+  @Test
+  def testFunctionNameContainsSuffixKeyword(): Unit = {
+    // ASC / DESC (no parameter)
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.ascii()")).asInstanceOf[Call]).functionName,
+      "ASCII")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.iiascii()")).asInstanceOf[Call]).functionName,
+      "IIASCII")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.iiasc()")).asInstanceOf[Call]).functionName,
+      "IIASC")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.descabc()")).asInstanceOf[Call]).functionName,
+      "DESCABC")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.abcdescabc()")).asInstanceOf[Call]).functionName,
+      "ABCDESCABC")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.abcdesc()")).asInstanceOf[Call]).functionName,
+      "ABCDESC")
+    // LOG has parameter
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.logabc()")).asInstanceOf[Call]).functionName,
+      "LOGABC")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.abclogabc()")).asInstanceOf[Call]).functionName,
+      "ABCLOGABC")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.abclog()")).asInstanceOf[Call]).functionName,
+      "ABCLOG")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.log2()")).asInstanceOf[Call]).functionName,
+      "LOG2")
+    Assert.assertEquals(
+      ((ExpressionParser.parseExpression("f0.log10()")).asInstanceOf[Call]).functionName,
+      "LOG10")
+  }
+
+  override def testData: Any = new Row(0)
+
+  override def typeInfo: TypeInformation[Any] =
+    new RowTypeInfo().asInstanceOf[TypeInformation[Any]]
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix Table scalar function expression parses error when function name equals the exists keyword suffix*


## Brief change log

  - *uses an exact matching mode for some suffix keyword*

## Verifying this change

This change added tests and can be verified as follows:

  - *KeywordAsSuffixTest#testFunctionNameContainsSuffixKeyword*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
