### PR TITLE
[FLINK-9781][build] Fix scala-maven-plugin for Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1541,6 +1541,11 @@ under the License.
 					<groupId>net.alchim31.maven</groupId>
 					<artifactId>scala-maven-plugin</artifactId>
 					<version>3.2.2</version>
+					<configuration>
+						<args>
+							<arg>-nobootcp</arg>
+						</args>
+					</configuration>
 				</plugin>
 
 				<!-- Configuration for the binary compatibility checker -->


### PR DESCRIPTION
## What is the purpose of the change

This PR allows the `scala-maven-plugin` to be used with Java 9 by adding the `-nocpboot` option, which is the commonly accepted workaround. This shouldn't have any repercussions when using java 8.
