### PR TITLE
[FLINK-10233][core] Reverse deprecation of ConfigOption#withDescription(String)

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -125,11 +125,9 @@ public class ConfigOption<T> {
 	 *
 	 * @param description The description for this option.
 	 * @return A new config option, with given description.
-	 * @deprecated use version with {@link Description}
 	 */
-	@Deprecated
 	public ConfigOption<T> withDescription(final String description) {
-		return new ConfigOption<>(key, description, defaultValue, deprecatedKeys);
+		return withDescription(Description.builder().text(description).build());
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR reverses the deprecation of `ConfigOption#withDescription(String)` to retain it for convenience.
