### PR TITLE
[FLINK-9043] restore from the latest job's completed checkpoint with …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1138,7 +1138,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			if (!checkpointCoordinator.restoreLatestCheckpointedState(
 				newExecutionGraph.getAllVertices(),
 				false,
-				false)) {
+				false,
+				userCodeLoader)) {
 
 				// check whether we can restore from a savepoint
 				tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, jobGraph.getSavepointRestoreSettings());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/HDFSUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/HDFSUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage.CHECKPOINT_DIR_PREFIX;
+import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage.METADATA_FILE_NAME;
+
+public class HDFSUtils {
+	private static final Logger log = LoggerFactory.getLogger(HDFSUtils.class);
+
+	public static String HDFS_PREFIX = "hdfs";
+
+	public static String VIEWFS_PREFIX = "viewfs";
+
+	public static String getFullPathForLatestJobCompletedCheckpointMeta(String path) throws Exception {
+		// get job directory list
+		FileStatus[] jobList = getFileListByHDFSPath(path);
+
+		if(jobList != null && jobList.length >= 2) {
+			// get the latest job by modified time
+			String latestJobDir = getLatestJobDirectory(jobList);
+			log.info("Latest job directory: {}", latestJobDir);
+
+			if(latestJobDir != null && !latestJobDir.isEmpty()) {
+				FileStatus[] jobSubList = getFileListByHDFSPath(path + "/" + latestJobDir);
+				if(jobSubList != null && jobSubList.length > 1) {
+					for(FileStatus fileStatus2: jobSubList) {
+						log.info("Sub directory {} for latest job {}", fileStatus2.getPath().getName(), latestJobDir);
+						if(fileStatus2.getPath().getName().contains(CHECKPOINT_DIR_PREFIX)) {
+							return path + "/" + latestJobDir + "/" + fileStatus2.getPath().getName() + "/" + METADATA_FILE_NAME;
+						}
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static String getLatestJobDirectory(FileStatus[] jobList) {
+		String result = null;
+		// the max modify time directory is for the current job
+		long maxModifyTime = 0L;
+		// the latest job directory
+		long secondModifyTime = 0L;
+		for (FileStatus fileStatus: jobList) {
+			if(fileStatus.getModificationTime() > maxModifyTime) {
+				maxModifyTime = fileStatus.getModificationTime();
+			}
+		}
+
+		log.info("Max modify time: {}", maxModifyTime);
+
+		for (FileStatus fileStatus: jobList) {
+			if(fileStatus.getModificationTime() != maxModifyTime && fileStatus.getModificationTime() > secondModifyTime) {
+				secondModifyTime = fileStatus.getModificationTime();
+				result = fileStatus.getPath().getName();
+				log.info("Set second directory to {} with time {}", result, secondModifyTime);
+			}
+		}
+		return result;
+	}
+
+	public static FileStatus[] getFileListByHDFSPath(String path) throws Exception {
+		if (path == null || path.isEmpty()) {
+			throw new Exception("HDFS path is null");
+		}
+
+		FileStatus[] status = null;
+		log.info("Get file list by hdfs path: {}", path);
+
+		try {
+			FileSystem fs = FileSystem.get(new Configuration());
+			status = fs.listStatus(new Path(path));
+			log.info("File List for path {}", path);
+			for (FileStatus fileStatus: status) {
+				log.info("name: {}, modify time: {}", fileStatus.getPath().getName(), fileStatus.getModificationTime());
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return status;
+	}
+}


### PR DESCRIPTION
  - For [FLINK-9043](https://issues.apache.org/jira/browse/FLINK-9043?filter=-6&jql=project%20%3D%20FLINK%20AND%20created%20%3E%3D%20-1w%20order%20by%20created%20DESC)

  ## What is the purpose of the change

  What we aim to do is to recover from the hdfs path automatically with the latest job's completed checkpoint. Currently, we can use 'run -s' with the metadata path manully, which is easy for single flink job to recover. But we have managed a lot of flink jobs, we want each flink job recovered just like spark streaming with getorcreate method from the latest completed jobs, without records lost. 

  - Each flink job has it own hdfs checkpoint path
  - Only support for HDFS(hdfs:// or viewfs://)
  - Support for RocksDBStateBackend and FsStateBackend
  - Support for legacy mode and new mode(dynamic scaling)

  ## Brief change log

  - add hdfs utils to get the latest job completed checkpoint metadata path
  - recover from the metadata path for legacy mode and new mode

  ## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

  ## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)