### PR TITLE
[FLINK-10229] [sql-client] Support listing of views

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -504,6 +504,12 @@ Views created within a CLI session can also be removed again using the `DROP VIE
 DROP VIEW MyNewView;
 {% endhighlight %}
 
+Displays all of the views in the current session using the `SHOW VIEWS` statement:
+
+{% highlight text %}
+SHOW VIEWS
+{% endhighlight %}
+
 <span class="label label-danger">Attention</span> The definition of views in the CLI is limited to the mentioned syntax above. Defining a schema for views or escaping whitespaces in table names will be supported in future versions.
 
 {% top %}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -266,6 +266,9 @@ public class CliClient {
 			case SHOW_TABLES:
 				callShowTables();
 				break;
+			case SHOW_VIEWS:
+				callShowViews();
+				break;
 			case SHOW_FUNCTIONS:
 				callShowFunctions();
 				break;
@@ -355,6 +358,23 @@ public class CliClient {
 			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
 		} else {
 			tables.forEach((v) -> terminal.writer().println(v));
+		}
+		terminal.flush();
+	}
+
+	private void callShowViews() {
+		final List<String> views;
+		try {
+			views = executor.listViews(context);
+		} catch (SqlExecutionException e) {
+			printExecutionException(e);
+			return;
+		}
+
+		if (views.isEmpty()) {
+			terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
+		} else {
+			views.forEach((v) -> terminal.writer().println(v));
 		}
 		terminal.flush();
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -45,6 +45,7 @@ public final class CliStrings {
 		.append(formatCommand(SqlCommand.CLEAR, "Clears the current terminal."))
 		.append(formatCommand(SqlCommand.HELP, "Prints the available commands."))
 		.append(formatCommand(SqlCommand.SHOW_TABLES, "Shows all registered tables."))
+		.append(formatCommand(SqlCommand.SHOW_VIEWS, "Shows all registered views."))
 		.append(formatCommand(SqlCommand.SHOW_FUNCTIONS, "Shows all registered user-defined functions."))
 		.append(formatCommand(SqlCommand.DESCRIBE, "Describes the schema of a table with the given name."))
 		.append(formatCommand(SqlCommand.EXPLAIN, "Describes the execution plan of a query or table with the given name."))

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -87,6 +87,10 @@ public final class SqlCommandParser {
 			"SHOW\\s+TABLES",
 			NO_OPERANDS),
 
+		SHOW_VIEWS(
+			"SHOW\\s+VIEWS",
+			NO_OPERANDS),
+
 		SHOW_FUNCTIONS(
 			"SHOW\\s+FUNCTIONS",
 			NO_OPERANDS),

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -46,6 +46,11 @@ public interface Executor {
 	List<String> listTables(SessionContext session) throws SqlExecutionException;
 
 	/**
+	 * Lists all views known to the executor.
+	 */
+	List<String> listViews(SessionContext session) throws SqlExecutionException;
+
+	/**
 	 * Lists all user-defined functions known to the executor.
 	 */
 	List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -200,6 +200,17 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public List<String> listViews(SessionContext session) throws SqlExecutionException {
+		List<String> viewList = new ArrayList<>();
+		session.getViews().keySet().forEach((viewName) -> viewList.add(viewName));
+
+		//sort
+		Collections.sort(viewList);
+
+		return viewList;
+	}
+
+	@Override
 	public List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException {
 		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
 			.createEnvironmentInstance()

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -164,6 +164,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public List<String> listViews(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -131,6 +131,11 @@ public class CliResultViewTest {
 		}
 
 		@Override
+		public List<String> listViews(SessionContext session) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -40,6 +40,8 @@ public class SqlCommandParserTest {
 		testValidSqlCommand("CLEAR", new SqlCommandCall(SqlCommand.CLEAR));
 		testValidSqlCommand("SHOW TABLES", new SqlCommandCall(SqlCommand.SHOW_TABLES));
 		testValidSqlCommand("  SHOW   TABLES   ", new SqlCommandCall(SqlCommand.SHOW_TABLES));
+		testValidSqlCommand("SHOW VIEWS", new SqlCommandCall(SqlCommand.SHOW_VIEWS));
+		testValidSqlCommand("	SHOW   VIEWS", new SqlCommandCall(SqlCommand.SHOW_VIEWS));
 		testValidSqlCommand("SHOW FUNCTIONS", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
 		testValidSqlCommand("  SHOW    FUNCTIONS   ", new SqlCommandCall(SqlCommand.SHOW_FUNCTIONS));
 		testValidSqlCommand("DESCRIBE MyTable", new SqlCommandCall(SqlCommand.DESCRIBE, new String[]{"MyTable"}));

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -150,6 +150,24 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test
+	public void testListViews() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+
+		session.addView(ViewEntry.create("TestView3", "SELECT 1"));
+		session.addView(ViewEntry.create("MyView1", "SELECT 1"));
+		session.addView(ViewEntry.create("aView1", "SELECT 1"));
+
+		final List<String> actualViews = executor.listViews(session);
+		final List<String> expectedViews = Arrays.asList(
+			"MyView1",
+			"TestView3",
+			"aView1");
+
+		assertEquals(expectedViews, actualViews);
+	}
+
+	@Test
 	public void testListTables() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support listing of views*


## Brief change log

  - *Support sql `SHOW VIEWS`*

## Verifying this change

This change added tests and can be verified as follows:

  - *SqlCommandParserTest#testCommands to test command parsing*
  - *LocalExecutorITCase#testListViews*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
