### PR TITLE
[FLINK-10254][backend]Fix inappropriate checkNotNull in stateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -100,9 +100,11 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider) {
 
+		Preconditions.checkArgument(numberOfKeyGroups >= 1, "NumberOfKeyGroups must be a positive number");
+
 		this.kvStateRegistry = kvStateRegistry;
 		this.keySerializer = Preconditions.checkNotNull(keySerializer);
-		this.numberOfKeyGroups = Preconditions.checkNotNull(numberOfKeyGroups);
+		this.numberOfKeyGroups = numberOfKeyGroups;
 		this.userCodeClassLoader = Preconditions.checkNotNull(userCodeClassLoader);
 		this.keyGroupRange = Preconditions.checkNotNull(keyGroupRange);
 		this.cancelStreamRegistry = new CloseableRegistry();


### PR DESCRIPTION
## What is the purpose of the change

The argument checked in `AbstractKeyedStateBackend` of numOfKeyGroups is inappropriate, and it should be checked with the value bigger than 1. 