### PR TITLE
[hotfix][doc][sql-client] Fix the example configuration yaml file by …

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -279,7 +279,7 @@ tables:
     connector:
       property-version: 1
       type: kafka
-      version: 0.11
+      version: "0.11"
       topic: TaxiRides
       startup-mode: earliest-offset
       properties:
@@ -422,7 +422,7 @@ tables:
     connector:
       property-version: 1
       type: kafka
-      version: 0.11
+      version: "0.11"
       topic: OutputTopic
       properties:
         - key: zookeeper.connect


### PR DESCRIPTION
## What is the purpose of the change

Fix a problem in sql client doc.


## Brief change log
- Add a double quote to the kafka version in the yaml configuration, otherwise will lead to a org.apache.flink.table.api.NoMatchingTableFactoryException if using the yaml example.
