### PR TITLE
[FLINK-10230] [sql-client] Support printing the query of a view

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -497,6 +497,12 @@ Views can also be created within a CLI session using the `CREATE VIEW` statement
 CREATE VIEW MyNewView AS SELECT MyField2 FROM MyTableSource;
 {% endhighlight %}
 
+Views created within a CLI session can also be shown it's `CREATE VIEW` statement using the `SHOW CREATE VIEW` statement:
+
+{% highlight text %}
+SHOW CREATE VIEW MyNewView
+{% endhighlight %}
+
 Views created within a CLI session can also be removed again using the `DROP VIEW` statement:
 
 {% highlight text %}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -257,6 +257,9 @@ public class CliClient {
 			case INSERT_INTO:
 				callInsertInto(cmdCall);
 				break;
+			case SHOW_CREATE_VIEW:
+				callShowCreateView(cmdCall);
+				break;
 			case CREATE_VIEW:
 				callCreateView(cmdCall);
 				break;
@@ -414,6 +417,18 @@ public class CliClient {
 			return false;
 		}
 		return true;
+	}
+
+	private void callShowCreateView(SqlCommandCall cmdCall) {
+		final String name = cmdCall.operands[0];
+		final String query = executor.getCreateView(context, name);
+
+		if (query == null) {
+			printExecutionError(CliStrings.MESSAGE_VIEW_NOT_FOUND);
+			return;
+		}
+
+		printInfo(query);
 	}
 
 	private void callCreateView(SqlCommandCall cmdCall) {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -52,6 +52,7 @@ public final class CliStrings {
 		.append(formatCommand(SqlCommand.INSERT_INTO, "Inserts the results of a SQL SELECT query into a declared table sink."))
 		.append(formatCommand(SqlCommand.CREATE_VIEW, "Creates a virtual table from a SQL query. Syntax: 'CREATE VIEW <name> AS <query>;'"))
 		.append(formatCommand(SqlCommand.DROP_VIEW, "Deletes a previously created virtual table. Syntax: 'DROP VIEW <name>;'"))
+		.append(formatCommand(SqlCommand.SHOW_CREATE_VIEW, "Shows the CREATE VIEW statement with the given view name."))
 		.append(formatCommand(SqlCommand.SOURCE, "Reads a SQL SELECT query from a file and executes it on the Flink cluster."))
 		.append(formatCommand(SqlCommand.SET, "Sets a session configuration property. Syntax: 'SET <key>=<value>;'. Use 'SET;' for listing all properties."))
 		.append(formatCommand(SqlCommand.RESET, "Resets all session configuration properties."))

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -107,6 +107,11 @@ public final class SqlCommandParser {
 			"(INSERT\\s+INTO.*)",
 			SINGLE_OPERAND),
 
+		SHOW_CREATE_VIEW(
+			"SHOW\\s+CREATE\\s+VIEW\\s+(.*)",
+			SINGLE_OPERAND
+		),
+
 		CREATE_VIEW(
 			"CREATE\\s+VIEW\\s+(\\S+)\\s+AS\\s+(.*)",
 			(operands) -> {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -51,6 +51,11 @@ public interface Executor {
 	List<String> listUserDefinedFunctions(SessionContext session) throws SqlExecutionException;
 
 	/**
+	 * Returns the statement of creating view with a given view name.
+	 */
+	String getCreateView(SessionContext session, String name) throws SqlExecutionException;
+
+	/**
 	 * Returns the schema of a table. Throws an exception if the table could not be found. The
 	 * schema might contain time attribute types for helping the user during debugging a query.
 	 */

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -205,6 +205,14 @@ public class LocalExecutor implements Executor {
 	}
 
 	@Override
+	public String getCreateView(SessionContext session, String name) throws SqlExecutionException {
+		return getOrCreateExecutionContext(session)
+			.getMergedEnvironment()
+			.getViews()
+			.get(name);
+	}
+
+	@Override
 	public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
 			.createEnvironmentInstance()

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -109,6 +109,11 @@ public class CliClientTest extends TestLogger {
 		}
 
 		@Override
+		public String getCreateView(SessionContext session, String name) throws SqlExecutionException {
+			return null;
+		}
+
+		@Override
 		public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
 			return null;
 		}

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -64,6 +64,12 @@ public class SqlCommandParserTest {
 		testValidSqlCommand(
 			"CREATE   VIEW    MyTable   AS     SELECT 1+1 FROM y",
 			new SqlCommandCall(SqlCommand.CREATE_VIEW, new String[]{"MyTable", "SELECT 1+1 FROM y"}));
+		testValidSqlCommand(
+			"SHOW CREATE VIEW MyTable",
+			new SqlCommandCall(SqlCommand.SHOW_CREATE_VIEW, new String[]{"MyTable"}));
+		testValidSqlCommand(
+			"	SHOW CREATE VIEW 	MyTable",
+			new SqlCommandCall(SqlCommand.SHOW_CREATE_VIEW, new String[]{"MyTable"}));
 		testInvalidSqlCommand("CREATE VIEW x SELECT 1+1"); // missing AS
 		testValidSqlCommand("DROP VIEW MyTable", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"MyTable"}));
 		testValidSqlCommand("DROP VIEW  MyTable", new SqlCommandCall(SqlCommand.DROP_VIEW, new String[]{"MyTable"}));

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -176,6 +176,25 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test
+	public void testGetCreateView() throws Exception {
+		final Executor executor = createDefaultExecutor(clusterClient);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		executor.validateSession(session);
+
+		//check exists view
+		assertEquals("SELECT scalarUDF(IntegerField1) FROM TableNumber1", executor.getCreateView(session, "TestView1"));
+
+		session.addView("AdditionalView1", "SELECT 1");
+		session.addView("AdditionalView2", "SELECT * FROM AdditionalView1");
+
+		assertEquals(session.getViews().get("AdditionalView1"), "SELECT 1");
+		assertEquals(session.getViews().get("AdditionalView2"), "SELECT * FROM AdditionalView1");
+
+		session.removeView("AdditionalView1");
+		assertEquals(null, session.getViews().get("AdditionalView1"));
+	}
+
+	@Test
 	public void testGetSessionProperties() throws Exception {
 		final Executor executor = createDefaultExecutor(clusterClient);
 		final SessionContext session = new SessionContext("test-session", new Environment());


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support printing the query of a view*

## Brief change log

  - *Support printing the query of a view with statement `SHOW CREATE VIEW`*


## Verifying this change

This change is already covered by existing tests, such as *SqlCommandParserTest#testCommands and LocalExecutorITCase#testShowCreateView*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
