### PR TITLE
[FLINK-10267][State] Fix arbitrary iterator access on RocksDBMapIterator

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -595,6 +595,8 @@ class RocksDBMapState<K, N, UK, UV>
 				 */
 				if (lastEntry != null && !lastEntry.deleted) {
 					iterator.next();
+					cacheEntries.add(lastEntry);
+					cacheIndex = 1;
 				}
 
 				while (true) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix the arbitrary iterator access on RocksDBMapIterator to avoid unexpected exception.

## Brief change log

Fix the `RocksDBMapIterator#loadCache()` logical to add not-removed `lastEntry` as the first entry in `cacheEntries`. 

## Verifying this change

This change added tests and can be verified as follows:
  - Added unit test for `StateBackendTestBase#testMapState()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
