### PR TITLE
[FLINK-10050] Support allowedLateness in CoGroupedStreams

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -40,6 +40,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.Trigger;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Collector;
@@ -183,7 +184,7 @@ public class CoGroupedStreams<T1, T2> {
 			 */
 			@PublicEvolving
 			public <W extends Window> WithWindow<T1, T2, KEY, W> window(WindowAssigner<? super TaggedUnion<T1, T2>, W> assigner) {
-				return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType, assigner, null, null);
+				return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType, assigner, null, null, null);
 			}
 		}
 	}
@@ -215,6 +216,8 @@ public class CoGroupedStreams<T1, T2> {
 
 		private final Evictor<? super TaggedUnion<T1, T2>, ? super W> evictor;
 
+		private final Time allowedLateness;
+
 		protected WithWindow(DataStream<T1> input1,
 				DataStream<T2> input2,
 				KeySelector<T1, KEY> keySelector1,
@@ -222,7 +225,8 @@ public class CoGroupedStreams<T1, T2> {
 				TypeInformation<KEY> keyType,
 				WindowAssigner<? super TaggedUnion<T1, T2>, W> windowAssigner,
 				Trigger<? super TaggedUnion<T1, T2>, ? super W> trigger,
-				Evictor<? super TaggedUnion<T1, T2>, ? super W> evictor) {
+				Evictor<? super TaggedUnion<T1, T2>, ? super W> evictor,
+				Time allowedLateness) {
 			this.input1 = input1;
 			this.input2 = input2;
 
@@ -233,6 +237,8 @@ public class CoGroupedStreams<T1, T2> {
 			this.windowAssigner = windowAssigner;
 			this.trigger = trigger;
 			this.evictor = evictor;
+
+			this.allowedLateness = allowedLateness;
 		}
 
 		/**
@@ -241,7 +247,7 @@ public class CoGroupedStreams<T1, T2> {
 		@PublicEvolving
 		public WithWindow<T1, T2, KEY, W> trigger(Trigger<? super TaggedUnion<T1, T2>, ? super W> newTrigger) {
 			return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType,
-					windowAssigner, newTrigger, evictor);
+					windowAssigner, newTrigger, evictor, allowedLateness);
 		}
 
 		/**
@@ -254,7 +260,17 @@ public class CoGroupedStreams<T1, T2> {
 		@PublicEvolving
 		public WithWindow<T1, T2, KEY, W> evictor(Evictor<? super TaggedUnion<T1, T2>, ? super W> newEvictor) {
 			return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType,
-					windowAssigner, trigger, newEvictor);
+					windowAssigner, trigger, newEvictor, allowedLateness);
+		}
+
+		/**
+		 * Sets the time by which elements are allowed to be late.
+		 * @see WindowedStream#allowedLateness(Time)
+		 */
+		@PublicEvolving
+		public WithWindow<T1, T2, KEY, W> allowedLateness(Time newLateness) {
+			return new WithWindow<>(input1, input2, keySelector1, keySelector2, keyType,
+					windowAssigner, trigger, evictor, newLateness);
 		}
 
 		/**
@@ -330,6 +346,9 @@ public class CoGroupedStreams<T1, T2> {
 			}
 			if (evictor != null) {
 				windowOp.evictor(evictor);
+			}
+			if (allowedLateness != null) {
+				windowOp.allowedLateness(allowedLateness);
 			}
 
 			return windowOp.apply(new CoGroupWindowFunction<T1, T2, T, KEY, W>(function), resultType);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.Function;
@@ -113,7 +114,8 @@ public class WindowedStream<T, K, W extends Window> {
 	private Evictor<? super T, ? super W> evictor;
 
 	/** The user-specified allowed lateness. */
-	private long allowedLateness = 0L;
+	@VisibleForTesting
+	long allowedLateness = 0L;
 
 	/**
 	 * Side output {@code OutputTag} for late data. If no tag is set late data will simply be

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/CoGroupedStreamsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/CoGroupedStreamsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.api.common.functions.CoGroupFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit test for {@link CoGroupedStreams}.
+ */
+public class CoGroupedStreamsTest {
+	private DataStream<String> dataStream1;
+	private DataStream<String> dataStream2;
+	private KeySelector<String, String> keySelector;
+	private TumblingEventTimeWindows tsAssigner;
+	private CoGroupFunction<String, String, String> coGroupFunction;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void setUp() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		dataStream1 = env.fromElements("a1", "a2", "a3");
+		dataStream2 = env.fromElements("a1", "a2");
+		keySelector = element -> element;
+		tsAssigner = TumblingEventTimeWindows.of(Time.milliseconds(1));
+		coGroupFunction = (CoGroupFunction<String, String, String>) (first, second, out) -> out.collect("");
+	}
+
+	@Test
+	public void testNullAllowedLatenessThrows() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("The allowed lateness must not be null");
+
+		dataStream1
+			.coGroup(dataStream2)
+			.where(keySelector)
+			.equalTo(keySelector)
+			.window(tsAssigner)
+			.allowedLateness(null);
+	}
+
+	@Test
+	public void testDelegateToCoGrouped() {
+		Time lateness = Time.milliseconds(42);
+
+		CoGroupedStreams.WithWindow<String, String, String, TimeWindow> withLateness = dataStream1
+			.coGroup(dataStream2)
+			.where(keySelector)
+			.equalTo(keySelector)
+			.window(tsAssigner)
+			.allowedLateness(lateness);
+
+		withLateness.apply(coGroupFunction, BasicTypeInfo.STRING_TYPE_INFO);
+
+		Assert.assertEquals(lateness.toMilliseconds(), withLateness.windowOp.allowedLateness);
+	}
+
+	@Test
+	public void testSetAllowedLateness() {
+		Time lateness = Time.milliseconds(42);
+
+		CoGroupedStreams.WithWindow<String, String, String, TimeWindow> withLateness = dataStream1
+			.coGroup(dataStream2)
+			.where(keySelector)
+			.equalTo(keySelector)
+			.window(tsAssigner)
+			.allowedLateness(lateness);
+
+		Assert.assertEquals(lateness, withLateness.allowedLateness);
+	}
+
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/JoinedStreamsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/JoinedStreamsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit test for {@link JoinedStreams}.
+ */
+public class JoinedStreamsTest {
+	private DataStream<String> dataStream1;
+	private DataStream<String> dataStream2;
+	private KeySelector<String, String> keySelector;
+	private TumblingEventTimeWindows tsAssigner;
+	private JoinFunction<String, String, String> joinFunction;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void setUp() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		dataStream1 = env.fromElements("a1", "a2", "a3");
+		dataStream2 = env.fromElements("a1", "a2");
+		keySelector = element -> element;
+		tsAssigner = TumblingEventTimeWindows.of(Time.milliseconds(1));
+		joinFunction = (first, second) -> first + second;
+	}
+
+	@Test
+	public void testNullAllowedLatenessThrows() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("The allowed lateness must not be null");
+
+		dataStream1
+			.join(dataStream2)
+			.where(keySelector)
+			.equalTo(keySelector)
+			.window(tsAssigner)
+			.allowedLateness(null);
+	}
+
+	@Test
+	public void testDelegateToCoGrouped() {
+		Time lateness = Time.milliseconds(42);
+
+		JoinedStreams.WithWindow<String, String, String, TimeWindow> withLateness = dataStream1
+			.join(dataStream2)
+			.where(keySelector)
+			.equalTo(keySelector)
+			.window(tsAssigner)
+			.allowedLateness(lateness);
+
+		withLateness.apply(joinFunction, BasicTypeInfo.STRING_TYPE_INFO);
+
+		Assert.assertEquals(lateness, withLateness.coGroupedWindow.allowedLateness);
+	}
+
+	@Test
+	public void testSetAllowedLateness() {
+		Time lateness = Time.milliseconds(42);
+
+		JoinedStreams.WithWindow<String, String, String, TimeWindow> withLateness = dataStream1
+			.join(dataStream2)
+			.where(keySelector)
+			.equalTo(keySelector)
+			.window(tsAssigner)
+			.allowedLateness(lateness);
+
+		Assert.assertEquals(lateness, withLateness.allowedLateness);
+	}
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.streaming.api.datastream.{CoGroupedStreams => JavaCoGroupedStreams}
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner
 import org.apache.flink.streaming.api.windowing.evictors.Evictor
+import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.Window
 import org.apache.flink.util.Collector
@@ -112,7 +113,7 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
           throw new UnsupportedOperationException(
             "You first need to specify KeySelectors for both inputs using where() and equalTo().")
         }
-        new WithWindow[W](clean(assigner), null, null)
+        new WithWindow[W](clean(assigner), null, null, null)
       }
 
       /**
@@ -125,7 +126,8 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
       class WithWindow[W <: Window](
           windowAssigner: WindowAssigner[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], W],
           trigger: Trigger[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W],
-          evictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W]) {
+          evictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W],
+          allowedLateness: Time) {
 
         /**
          * Sets the [[Trigger]] that should be used to trigger window emission.
@@ -133,7 +135,7 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
         @PublicEvolving
         def trigger(newTrigger: Trigger[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W])
             : WithWindow[W] = {
-          new WithWindow[W](windowAssigner, newTrigger, evictor)
+          new WithWindow[W](windowAssigner, newTrigger, evictor, allowedLateness)
         }
 
         /**
@@ -147,7 +149,16 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
         def evictor(
             newEvictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W])
             : WithWindow[W] = {
-          new WithWindow[W](windowAssigner, trigger, newEvictor)
+          new WithWindow[W](windowAssigner, trigger, newEvictor, allowedLateness)
+        }
+
+        /**
+          * Sets the time by which elements are allowed to be late.
+          * Delegates to [[WindowedStream#allowedLateness(Time)]]
+          */
+        @PublicEvolving
+        def allowedLateness(newLateness: Time): WithWindow[W] = {
+          new WithWindow[W](windowAssigner, trigger, evictor, newLateness)
         }
 
         /**
@@ -202,6 +213,7 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
             .window(windowAssigner)
             .trigger(trigger)
             .evictor(evictor)
+            .allowedLateness(allowedLateness)
             .apply(clean(function), implicitly[TypeInformation[T]]))
         }
       }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.streaming.api.datastream.{JoinedStreams => JavaJoinedStreams, CoGroupedStreams => JavaCoGroupedStreams}
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner
 import org.apache.flink.streaming.api.windowing.evictors.Evictor
+import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.Window
 import org.apache.flink.util.Collector
@@ -110,7 +111,7 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
             "You first need to specify KeySelectors for both inputs using where() and equalTo().")
         }
 
-        new WithWindow[W](clean(assigner), null, null)
+        new WithWindow[W](clean(assigner), null, null, null)
       }
 
       /**
@@ -122,7 +123,8 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
       class WithWindow[W <: Window](
           windowAssigner: WindowAssigner[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], W],
           trigger: Trigger[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W],
-          evictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W]) {
+          evictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W],
+          allowedLateness: Time) {
 
         /**
          * Sets the [[Trigger]] that should be used to trigger window emission.
@@ -130,7 +132,7 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
         @PublicEvolving
         def trigger(newTrigger: Trigger[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W])
         : WithWindow[W] = {
-          new WithWindow[W](windowAssigner, newTrigger, evictor)
+          new WithWindow[W](windowAssigner, newTrigger, evictor, allowedLateness)
         }
 
         /**
@@ -142,7 +144,16 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
         @PublicEvolving
         def evictor(newEvictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W])
         : WithWindow[W] = {
-          new WithWindow[W](windowAssigner, trigger, newEvictor)
+          new WithWindow[W](windowAssigner, trigger, newEvictor, allowedLateness)
+        }
+
+        /**
+          * Sets the time by which elements are allowed to be late.
+          * Delegates to [[WindowedStream#allowedLateness(Time)]]
+          */
+        @PublicEvolving
+        def allowedLateness(newLateness: Time): WithWindow[W] = {
+          new WithWindow[W](windowAssigner, trigger, evictor, newLateness)
         }
 
         /**
@@ -191,6 +202,7 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
             .window(windowAssigner)
             .trigger(trigger)
             .evictor(evictor)
+            .allowedLateness(allowedLateness)
             .apply(clean(function), implicitly[TypeInformation[T]]))
         }
 
@@ -208,6 +220,7 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
             .window(windowAssigner)
             .trigger(trigger)
             .evictor(evictor)
+            .allowedLateness(allowedLateness)
             .apply(clean(function), implicitly[TypeInformation[T]]))
         }
       }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
@@ -124,7 +124,7 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
           windowAssigner: WindowAssigner[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], W],
           trigger: Trigger[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W],
           evictor: Evictor[_ >: JavaCoGroupedStreams.TaggedUnion[T1, T2], _ >: W],
-          allowedLateness: Time) {
+          val allowedLateness: Time) {
 
         /**
          * Sets the [[Trigger]] that should be used to trigger window emission.
@@ -153,6 +153,7 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
           */
         @PublicEvolving
         def allowedLateness(newLateness: Time): WithWindow[W] = {
+          require(newLateness != null, "The allowed lateness must not be null")
           new WithWindow[W](windowAssigner, trigger, evictor, newLateness)
         }
 
@@ -196,14 +197,19 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
 
           val join = new JavaJoinedStreams[T1, T2](input1.javaStream, input2.javaStream)
 
-          asScalaStream(join
+          val withWindow = join
             .where(keySelector1)
             .equalTo(keySelector2)
             .window(windowAssigner)
             .trigger(trigger)
             .evictor(evictor)
-            .allowedLateness(allowedLateness)
-            .apply(clean(function), implicitly[TypeInformation[T]]))
+          val withLateness = if (allowedLateness != null) {
+            withWindow.allowedLateness(allowedLateness)
+          } else {
+            withWindow
+          }
+
+          asScalaStream(withLateness.apply(clean(function), implicitly[TypeInformation[T]]))
         }
 
         /**
@@ -214,13 +220,19 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
 
           val join = new JavaJoinedStreams[T1, T2](input1.javaStream, input2.javaStream)
 
-          asScalaStream(join
+          val withWindow = join
             .where(keySelector1)
             .equalTo(keySelector2)
             .window(windowAssigner)
             .trigger(trigger)
             .evictor(evictor)
-            .allowedLateness(allowedLateness)
+          val withLateness = if (allowedLateness != null) {
+            withWindow.allowedLateness(allowedLateness)
+          } else {
+            withWindow
+          }
+
+          asScalaStream(withLateness
             .apply(clean(function), implicitly[TypeInformation[T]]))
         }
       }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CoGroupedStreamsTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CoGroupedStreamsTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.junit.{Assert, Test}
+
+/**
+  * Unit test for [[org.apache.flink.streaming.api.scala.CoGroupedStreams]]
+  */
+class CoGroupedStreamsTest {
+  private val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+  private val dataStream1 = env.fromElements("a1", "a2", "a3")
+  private val dataStream2 = env.fromElements("a1", "a2")
+  private val keySelector = (s: String) => s
+  private val tsAssigner = TumblingEventTimeWindows.of(Time.milliseconds(1))
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testNullAllowedLatenessThrows(): Unit = {
+    dataStream1.coGroup(dataStream2)
+      .where(keySelector)
+      .equalTo(keySelector)
+      .window(tsAssigner)
+      .allowedLateness(null)
+  }
+
+  @Test
+  def testSetAllowedLateness(): Unit = {
+    val lateness = Time.milliseconds(42)
+    val withLateness = dataStream1.coGroup(dataStream2)
+      .where(keySelector)
+      .equalTo(keySelector)
+      .window(tsAssigner)
+      .allowedLateness(lateness)
+    Assert.assertEquals(lateness, withLateness.allowedLateness)
+  }
+
+}

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/JoinedStreamsTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/JoinedStreamsTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.junit.{Assert, Test}
+
+/**
+  * Unit test for [[org.apache.flink.streaming.api.scala.JoinedStreams]]
+  */
+class JoinedStreamsTest {
+  private val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+  private val dataStream1 = env.fromElements("a1", "a2", "a3")
+  private val dataStream2 = env.fromElements("a1", "a2")
+  private val keySelector = (s: String) => s
+  private val tsAssigner = TumblingEventTimeWindows.of(Time.milliseconds(1))
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testNullAllowedLatenessThrows(): Unit = {
+    dataStream1.join(dataStream2)
+      .where(keySelector)
+      .equalTo(keySelector)
+      .window(tsAssigner)
+      .allowedLateness(null)
+  }
+
+  @Test
+  def testSetAllowedLateness(): Unit = {
+    val lateness = Time.milliseconds(42)
+    val withLateness = dataStream1.join(dataStream2)
+      .where(keySelector)
+      .equalTo(keySelector)
+      .window(tsAssigner)
+      .allowedLateness(lateness)
+    Assert.assertEquals(lateness, withLateness.allowedLateness)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change
[https://issues.apache.org/jira/browse/FLINK-10050](https://issues.apache.org/jira/browse/FLINK-10050)
Add 'allowedLateness' method to coGroup and join streams API.


## Brief change log

- add 'allowedLateness' for CoGroupedStreams/JoinedStreams java and scala API
- delegate calls to underlying WindowedStream (as for Trigger/Evictor scenario)


## Verifying this change

This change is a trivial rework.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
