### PR TITLE
[hotfix][flink-connector-filesystem] modify typo in BucketingSink

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -1049,7 +1049,7 @@ public class BucketingSink<T>
 	}
 
 	/**
-	 * Sets the prefix of part files.  The default is no suffix.
+	 * Sets the suffix of part files.  The default is no suffix.
 	 */
 	public BucketingSink<T> setPartSuffix(String partSuffix) {
 		this.partSuffix = partSuffix;


### PR DESCRIPTION
## What is the purpose of the change

Modify the annotation in the BucketingSink.java of setPartSuffix()