### PR TITLE
[FLINK-10234][runtime] Fix ambiguous lambda usage

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -200,7 +200,7 @@ public class FutureUtils {
 						} else {
 							if (retries > 0 && retryPredicate.test(throwable)) {
 								final ScheduledFuture<?> scheduledFuture = scheduledExecutor.schedule(
-									() -> retryOperationWithDelay(resultFuture, operation, retries - 1, retryDelay, retryPredicate, scheduledExecutor),
+									(Runnable) () -> retryOperationWithDelay(resultFuture, operation, retries - 1, retryDelay, retryPredicate, scheduledExecutor),
 									retryDelay.toMilliseconds(),
 									TimeUnit.MILLISECONDS);
 
@@ -282,7 +282,7 @@ public class FutureUtils {
 							resultFuture.complete(t);
 						} else if (deadline.hasTimeLeft()) {
 							final ScheduledFuture<?> scheduledFuture = scheduledExecutor.schedule(
-								() -> retrySuccessfulOperationWithDelay(resultFuture, operation, retryDelay, deadline, acceptancePredicate, scheduledExecutor),
+								(Runnable) () -> retrySuccessfulOperationWithDelay(resultFuture, operation, retryDelay, deadline, acceptancePredicate, scheduledExecutor),
 								retryDelay.toMilliseconds(),
 								TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a jdk9 incompatibility caused by lambdas. The problem is that the compiler cannot determine whether the lambda should be a Runnable or a Callable<V>, resulting in incompatible bounds for the return type.