### PR TITLE
[FLINK-10235][kafka] Explicitly cast custom partitioner classes

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -335,7 +335,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 					case CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM:
 						final Class<? extends FlinkKafkaPartitioner> partitionerClass =
 							descriptorProperties.getClass(CONNECTOR_SINK_PARTITIONER_CLASS, FlinkKafkaPartitioner.class);
-						return Optional.of(InstantiationUtil.instantiate(partitionerClass));
+						return Optional.of((FlinkKafkaPartitioner<Row>) InstantiationUtil.instantiate(partitionerClass));
 					default:
 						throw new TableException("Unsupported sink partitioner. Validator should have checked that.");
 				}


### PR DESCRIPTION
This PR fixes a jdk9 incompatibility regarding generics. The method compilation fails on java 9 since the CONNECTOR_SINK_PARTITIONER_VALUE_CUSTOM branch returns an Optional<? extends FlinkKafkaPartitioner>, but the method requires a Optional<FlinkKafkaPartitioner<Row>>.

The compiler obviously cannot infer that the instantiated partitioner is always a `FlinkKafkaPartitioner<Row>` (since it technically could work on any type), so we have to help a bit.