### PR TITLE
[FLINK-10242][metrics] Disable latency metrics by default

### DIFF
--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -13,6 +13,11 @@
             <td>Defines the number of measured latencies to maintain at each operator.</td>
         </tr>
         <tr>
+            <td><h5>metrics.latency.interval</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Defines the interval at which latency tracking marks are emitted from the sources. Disables latency tracking if set to 0 or a negative value. Enabling this feature can significantly impact the performance of the cluster.</td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.&lt;name&gt;.&lt;parameter&gt;</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Configures the parameter &lt;parameter&gt; for the reporter named &lt;name&gt;.</td>

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1638,8 +1638,9 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
 
 ## Latency tracking
 
-Flink allows to track the latency of records traveling through the system. To enable the latency tracking
-a `latencyTrackingInterval` (in milliseconds) has to be set to a positive value in the `ExecutionConfig`.
+Flink allows to track the latency of records traveling through the system. This feature is disabled by default.
+To enable the latency tracking you must set the `latencyTrackingInterval` to a positive number in either the
+[Flink configuration]({{ site.baseurl }}/ops/config.html#metrics-latency-interval) or `ExecutionConfig`.
 
 At the `latencyTrackingInterval`, the sources will periodically emit a special record, called a `LatencyMarker`.
 The marker contains a timestamp from the time when the record has been emitted at the sources.
@@ -1658,6 +1659,9 @@ latency issues caused by individual machines.
 
 Currently, Flink assumes that the clocks of all machines in the cluster are in sync. We recommend setting
 up an automated clock synchronisation service (like NTP) to avoid false latency results.
+
+<span class="label label-danger">Warning</span> Enabling latency metrics can significantly impact the performance
+of the cluster. It is highly recommended to only use them for debugging purposes.
 
 ## REST API integration
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.util.Preconditions;
 
@@ -131,7 +132,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/**
 	 * Interval in milliseconds for sending latency tracking marks from the sources to the sinks.
 	 */
-	private long latencyTrackingInterval = 2000L;
+	private long latencyTrackingInterval = MetricOptions.LATENCY_INTERVAL.defaultValue();
+
+	private boolean isLatencyTrackingConfigured = false;
 
 	/**
 	 * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
@@ -234,8 +237,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * Interval for sending latency tracking marks from the sources to the sinks.
 	 * Flink will send latency tracking marks from the sources at the specified interval.
 	 *
-	 * Recommended value: 2000 (2 seconds).
-	 *
 	 * Setting a tracking interval <= 0 disables the latency tracking.
 	 *
 	 * @param interval Interval in milliseconds.
@@ -243,6 +244,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	@PublicEvolving
 	public ExecutionConfig setLatencyTrackingInterval(long interval) {
 		this.latencyTrackingInterval = interval;
+		this.isLatencyTrackingConfigured = true;
 		return this;
 	}
 
@@ -256,12 +258,17 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	/**
-	 * Returns if latency tracking is enabled
-	 * @return True, if the tracking is enabled, false otherwise.
+	 * @deprecated will be removed in a future version
 	 */
 	@PublicEvolving
+	@Deprecated
 	public boolean isLatencyTrackingEnabled() {
-		return latencyTrackingInterval > 0;
+		return isLatencyTrackingConfigured && latencyTrackingInterval > 0;
+	}
+
+	@Internal
+	public boolean isLatencyTrackingConfigured() {
+		return isLatencyTrackingConfigured;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -103,6 +104,13 @@ public class MetricOptions {
 		key("metrics.scope.operator")
 			.defaultValue("<host>.taskmanager.<tm_id>.<job_name>.<operator_name>.<subtask_index>")
 			.withDescription("Defines the scope format string that is applied to all metrics scoped to an operator.");
+
+	public static final ConfigOption<Long> LATENCY_INTERVAL =
+		key("metrics.latency.interval")
+			.defaultValue(0L)
+			.withDescription("Defines the interval at which latency tracking marks are emitted from the sources." +
+				" Disables latency tracking if set to 0 or a negative value. Enabling this feature can significantly" +
+				" impact the performance of the cluster.");
 
 	/** The number of measured latencies to maintain at each operator. */
 	public static final ConfigOption<Integer> LATENCY_HISTORY_SIZE =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -45,7 +45,6 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.Preconditions;
@@ -91,6 +90,8 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 	private final JobVertexID jobVertexID;
 
+	private final TaskManagerRuntimeInfo taskManagerRuntimeInfo;
+
 	private final BroadcastVariableManager bcVarManager = new BroadcastVariableManager();
 
 	private final AccumulatorRegistry accumulatorRegistry;
@@ -127,7 +128,8 @@ public class MockEnvironment implements Environment, AutoCloseable {
 		int parallelism,
 		int subtaskIndex,
 		ClassLoader userCodeClassLoader,
-		TaskMetricGroup taskMetricGroup) {
+		TaskMetricGroup taskMetricGroup,
+		TaskManagerRuntimeInfo taskManagerRuntimeInfo) {
 
 		this.jobID = jobID;
 		this.jobVertexID = jobVertexID;
@@ -140,6 +142,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 		this.memManager = new MemoryManager(memorySize, 1);
 		this.ioManager = new IOManagerAsync();
+		this.taskManagerRuntimeInfo = taskManagerRuntimeInfo;
 
 		this.executionConfig = executionConfig;
 		this.inputSplitProvider = inputSplitProvider;
@@ -212,7 +215,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 	@Override
 	public TaskManagerRuntimeInfo getTaskManagerInfo() {
-		return new TestingTaskManagerRuntimeInfo();
+		return this.taskManagerRuntimeInfo;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 
 public class MockEnvironmentBuilder {
 	private String taskName = "mock-task";
@@ -43,6 +45,7 @@ public class MockEnvironmentBuilder {
 	private JobID jobID = new JobID();
 	private JobVertexID jobVertexID = new JobVertexID();
 	private TaskMetricGroup taskMetricGroup = UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
+	private TaskManagerRuntimeInfo taskManagerRuntimeInfo = new TestingTaskManagerRuntimeInfo();
 
 	public MockEnvironmentBuilder setTaskName(String taskName) {
 		this.taskName = taskName;
@@ -76,6 +79,11 @@ public class MockEnvironmentBuilder {
 
 	public MockEnvironmentBuilder setExecutionConfig(ExecutionConfig executionConfig) {
 		this.executionConfig = executionConfig;
+		return this;
+	}
+
+	public MockEnvironmentBuilder setTaskManagerRuntimeInfo(TaskManagerRuntimeInfo taskManagerRuntimeInfo){
+		this.taskManagerRuntimeInfo = taskManagerRuntimeInfo;
 		return this;
 	}
 
@@ -129,6 +137,7 @@ public class MockEnvironmentBuilder {
 			parallelism,
 			subtaskIndex,
 			userCodeClassLoader,
-			taskMetricGroup);
+			taskMetricGroup,
+			taskManagerRuntimeInfo);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.api.common.functions.StoppableFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -30,10 +29,7 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.operators.StoppableStreamSource;
 import org.apache.flink.streaming.api.operators.StreamSource;
-import org.apache.flink.streaming.api.operators.StreamSourceContexts;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
@@ -54,7 +50,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -63,120 +58,7 @@ import static org.mockito.Mockito.when;
  * Tests for {@link StreamSource} operators.
  */
 @SuppressWarnings("serial")
-public class StreamSourceOperatorTest {
-
-	@Test
-	public void testEmitMaxWatermarkForFiniteSource() throws Exception {
-
-		// regular stream source operator
-		StreamSource<String, FiniteSource<String>> operator =
-				new StreamSource<>(new FiniteSource<String>());
-
-		final List<StreamElement> output = new ArrayList<>();
-
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, 0);
-		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
-
-		assertEquals(1, output.size());
-		assertEquals(Watermark.MAX_WATERMARK, output.get(0));
-	}
-
-	@Test
-	public void testNoMaxWatermarkOnImmediateCancel() throws Exception {
-
-		final List<StreamElement> output = new ArrayList<>();
-
-		// regular stream source operator
-		final StreamSource<String, InfiniteSource<String>> operator =
-				new StreamSource<>(new InfiniteSource<String>());
-
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, 0);
-		operator.cancel();
-
-		// run and exit
-		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
-
-		assertTrue(output.isEmpty());
-	}
-
-	@Test
-	public void testNoMaxWatermarkOnAsyncCancel() throws Exception {
-
-		final List<StreamElement> output = new ArrayList<>();
-		final Thread runner = Thread.currentThread();
-
-		// regular stream source operator
-		final StreamSource<String, InfiniteSource<String>> operator =
-				new StreamSource<>(new InfiniteSource<String>());
-
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, 0);
-
-		// trigger an async cancel in a bit
-		new Thread("canceler") {
-			@Override
-			public void run() {
-				try {
-					Thread.sleep(200);
-				} catch (InterruptedException ignored) {}
-				operator.cancel();
-				runner.interrupt();
-			}
-		}.start();
-
-		// run and wait to be canceled
-		try {
-			operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
-		}
-		catch (InterruptedException ignored) {}
-
-		assertTrue(output.isEmpty());
-	}
-
-	@Test
-	public void testNoMaxWatermarkOnImmediateStop() throws Exception {
-
-		final List<StreamElement> output = new ArrayList<>();
-
-		// regular stream source operator
-		final StoppableStreamSource<String, InfiniteSource<String>> operator =
-				new StoppableStreamSource<>(new InfiniteSource<String>());
-
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, 0);
-		operator.stop();
-
-		// run and stop
-		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
-
-		assertTrue(output.isEmpty());
-	}
-
-	@Test
-	public void testNoMaxWatermarkOnAsyncStop() throws Exception {
-
-		final List<StreamElement> output = new ArrayList<>();
-
-		// regular stream source operator
-		final StoppableStreamSource<String, InfiniteSource<String>> operator =
-				new StoppableStreamSource<>(new InfiniteSource<String>());
-
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, 0);
-
-		// trigger an async cancel in a bit
-		new Thread("canceler") {
-			@Override
-			public void run() {
-				try {
-					Thread.sleep(200);
-				} catch (InterruptedException ignored) {}
-				operator.stop();
-			}
-		}.start();
-
-		// run and wait to be stopped
-		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
-
-		assertTrue(output.isEmpty());
-	}
+public class StreamSourceOperatorLatencyMetricsTest {
 
 	/**
 	 * Test that latency marks are emitted.
@@ -194,10 +76,10 @@ public class StreamSourceOperatorTest {
 
 		// regular stream source operator
 		final StreamSource<Long, ProcessingTimeServiceSource> operator =
-				new StreamSource<>(new ProcessingTimeServiceSource(testProcessingTimeService, processingTimes));
+			new StreamSource<>(new ProcessingTimeServiceSource(testProcessingTimeService, processingTimes));
 
 		// emit latency marks every 10 milliseconds.
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, latencyMarkInterval, testProcessingTimeService);
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, latencyMarkInterval, testProcessingTimeService);
 
 		// run and wait to be stopped
 		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<Long>(output));
@@ -225,66 +107,15 @@ public class StreamSourceOperatorTest {
 		Assert.assertTrue(output.get(i).isWatermark());
 	}
 
-	@Test
-	public void testAutomaticWatermarkContext() throws Exception {
-
-		// regular stream source operator
-		final StoppableStreamSource<String, InfiniteSource<String>> operator =
-			new StoppableStreamSource<>(new InfiniteSource<String>());
-
-		long watermarkInterval = 10;
-		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
-		processingTimeService.setCurrentTime(0);
-
-		setupSourceOperator(operator, TimeCharacteristic.IngestionTime, watermarkInterval, 0, processingTimeService);
-
-		final List<StreamElement> output = new ArrayList<>();
-
-		StreamSourceContexts.getSourceContext(TimeCharacteristic.IngestionTime,
-			operator.getContainingTask().getProcessingTimeService(),
-			operator.getContainingTask().getCheckpointLock(),
-			operator.getContainingTask().getStreamStatusMaintainer(),
-			new CollectorOutput<String>(output),
-			operator.getExecutionConfig().getAutoWatermarkInterval(),
-			-1);
-
-		// periodically emit the watermarks
-		// even though we start from 1 the watermark are still
-		// going to be aligned with the watermark interval.
-
-		for (long i = 1; i < 100; i += watermarkInterval)  {
-			processingTimeService.setCurrentTime(i);
-		}
-
-		assertTrue(output.size() == 9);
-
-		long nextWatermark = 0;
-		for (StreamElement el : output) {
-			nextWatermark += watermarkInterval;
-			Watermark wm = (Watermark) el;
-			assertTrue(wm.getTimestamp() == nextWatermark);
-		}
-	}
-
 	// ------------------------------------------------------------------------
 
 	@SuppressWarnings("unchecked")
 	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
-			TimeCharacteristic timeChar,
-			long watermarkInterval,
-			long latencyMarkInterval) {
-		setupSourceOperator(operator, timeChar, watermarkInterval, latencyMarkInterval, new TestProcessingTimeService());
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
-												TimeCharacteristic timeChar,
-												long watermarkInterval,
-												long latencyMarkInterval,
-												final ProcessingTimeService timeProvider) {
+	                                            TimeCharacteristic timeChar,
+	                                            long latencyMarkInterval,
+	                                            final ProcessingTimeService timeProvider) {
 
 		ExecutionConfig executionConfig = new ExecutionConfig();
-		executionConfig.setAutoWatermarkInterval(watermarkInterval);
 		executionConfig.setLatencyTrackingInterval(latencyMarkInterval);
 
 		StreamConfig cfg = new StreamConfig(new Configuration());
@@ -321,40 +152,6 @@ public class StreamSourceOperatorTest {
 	}
 
 	// ------------------------------------------------------------------------
-
-	private static final class FiniteSource<T> implements SourceFunction<T>, StoppableFunction {
-
-		@Override
-		public void run(SourceContext<T> ctx) {}
-
-		@Override
-		public void cancel() {}
-
-		@Override
-		public void stop() {}
-	}
-
-	private static final class InfiniteSource<T> implements SourceFunction<T>, StoppableFunction {
-
-		private volatile boolean running = true;
-
-		@Override
-		public void run(SourceContext<T> ctx) throws Exception {
-			while (running) {
-				Thread.sleep(20);
-			}
-		}
-
-		@Override
-		public void cancel() {
-			running = false;
-		}
-
-		@Override
-		public void stop() {
-			running = false;
-		}
-	}
 
 	private static final class ProcessingTimeServiceSource implements SourceFunction<Long> {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -21,10 +21,12 @@ package org.apache.flink.streaming.runtime.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -38,6 +40,7 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.CollectorOutput;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -55,20 +58,104 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link StreamSource} operators.
+ * Tests for the emission of latency markers by {@link StreamSource} operators.
  */
-@SuppressWarnings("serial")
-public class StreamSourceOperatorLatencyMetricsTest {
+public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
+
+	private static final long maxProcessingTime = 100L;
+	private static final long latencyMarkInterval = 10L;
 
 	/**
-	 * Test that latency marks are emitted.
+	 * Verifies that by default no latency metrics are emitted.
 	 */
 	@Test
-	public void testLatencyMarkEmission() throws Exception {
-		final List<StreamElement> output = new ArrayList<>();
+	public void testLatencyMarkEmissionDisabled() throws Exception {
+		testLatencyMarkEmission(0, (operator, timeProvider) -> {
+			setupSourceOperator(operator, new ExecutionConfig(), MockEnvironment.builder().build(), timeProvider);
+		});
+	}
 
-		final long maxProcessingTime = 100L;
-		final long latencyMarkInterval = 10L;
+	/**
+	 * Verifies that latency metrics can be enabled via the {@link ExecutionConfig}.
+	 */
+	@Test
+	public void testLatencyMarkEmissionEnabledViaExecutionConfig() throws Exception {
+		testLatencyMarkEmission((int) (maxProcessingTime / latencyMarkInterval) + 1, (operator, timeProvider) -> {
+			ExecutionConfig executionConfig = new ExecutionConfig();
+			executionConfig.setLatencyTrackingInterval(latencyMarkInterval);
+
+			setupSourceOperator(operator, executionConfig, MockEnvironment.builder().build(), timeProvider);
+		});
+	}
+
+	/**
+	 * Verifies that latency metrics can be enabled via the configuration.
+	 */
+	@Test
+	public void testLatencyMarkEmissionEnabledViaFlinkConfig() throws Exception {
+		testLatencyMarkEmission((int) (maxProcessingTime / latencyMarkInterval) + 1, (operator, timeProvider) -> {
+			Configuration tmConfig = new Configuration();
+			tmConfig.setLong(MetricOptions.LATENCY_INTERVAL, latencyMarkInterval);
+
+			Environment env = MockEnvironment.builder()
+				.setTaskManagerRuntimeInfo(new TestingTaskManagerRuntimeInfo(tmConfig))
+				.build();
+
+			setupSourceOperator(operator, new ExecutionConfig(), env, timeProvider);
+		});
+	}
+
+	/**
+	 * Verifies that latency metrics can be enabled via the {@link ExecutionConfig} even if they are disabled via
+	 * the configuration.
+	 */
+	@Test
+	public void testLatencyMarkEmissionEnabledOverrideViaExecutionConfig() throws Exception {
+		testLatencyMarkEmission((int) (maxProcessingTime / latencyMarkInterval) + 1, (operator, timeProvider) -> {
+			ExecutionConfig executionConfig = new ExecutionConfig();
+			executionConfig.setLatencyTrackingInterval(latencyMarkInterval);
+
+			Configuration tmConfig = new Configuration();
+			tmConfig.setLong(MetricOptions.LATENCY_INTERVAL, 0L);
+
+			Environment env = MockEnvironment.builder()
+				.setTaskManagerRuntimeInfo(new TestingTaskManagerRuntimeInfo(tmConfig))
+				.build();
+
+			setupSourceOperator(operator, executionConfig, env, timeProvider);
+		});
+	}
+
+	/**
+	 * Verifies that latency metrics can be disabled via the {@link ExecutionConfig} even if they are enabled via
+	 * the configuration.
+	 */
+	@Test
+	public void testLatencyMarkEmissionDisabledOverrideViaExecutionConfig() throws Exception {
+		testLatencyMarkEmission(0, (operator, timeProvider) -> {
+			Configuration tmConfig = new Configuration();
+			tmConfig.setLong(MetricOptions.LATENCY_INTERVAL, latencyMarkInterval);
+
+			Environment env = MockEnvironment.builder()
+				.setTaskManagerRuntimeInfo(new TestingTaskManagerRuntimeInfo(tmConfig))
+				.build();
+
+			ExecutionConfig executionConfig = new ExecutionConfig();
+			executionConfig.setLatencyTrackingInterval(0);
+
+			setupSourceOperator(operator, executionConfig, env, timeProvider);
+		});
+	}
+
+	private interface OperatorSetupOperation {
+		void setupSourceOperator(
+			StreamSource<Long, ?> operator,
+			TestProcessingTimeService testProcessingTimeService
+		);
+	}
+
+	private void testLatencyMarkEmission(int numberLatencyMarkers, OperatorSetupOperation operatorSetup) throws Exception {
+		final List<StreamElement> output = new ArrayList<>();
 
 		final TestProcessingTimeService testProcessingTimeService = new TestProcessingTimeService();
 		testProcessingTimeService.setCurrentTime(0L);
@@ -78,13 +165,10 @@ public class StreamSourceOperatorLatencyMetricsTest {
 		final StreamSource<Long, ProcessingTimeServiceSource> operator =
 			new StreamSource<>(new ProcessingTimeServiceSource(testProcessingTimeService, processingTimes));
 
-		// emit latency marks every 10 milliseconds.
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, latencyMarkInterval, testProcessingTimeService);
+		operatorSetup.setupSourceOperator(operator, testProcessingTimeService);
 
 		// run and wait to be stopped
 		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<Long>(output));
-
-		int numberLatencyMarkers = (int) (maxProcessingTime / latencyMarkInterval) + 1;
 
 		assertEquals(
 			numberLatencyMarkers + 1, // + 1 is the final watermark element
@@ -93,8 +177,8 @@ public class StreamSourceOperatorLatencyMetricsTest {
 		long timestamp = 0L;
 
 		int i = 0;
-		// and that its only latency markers + a final watermark
-		for (; i < output.size() - 1; i++) {
+		// verify that its only latency markers + a final watermark
+		for (; i < numberLatencyMarkers; i++) {
 			StreamElement se = output.get(i);
 			Assert.assertTrue(se.isLatencyMarker());
 			Assert.assertEquals(operator.getOperatorID(), se.asLatencyMarker().getOperatorId());
@@ -109,22 +193,17 @@ public class StreamSourceOperatorLatencyMetricsTest {
 
 	// ------------------------------------------------------------------------
 
-	@SuppressWarnings("unchecked")
-	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
-	                                            TimeCharacteristic timeChar,
-	                                            long latencyMarkInterval,
-	                                            final ProcessingTimeService timeProvider) {
-
-		ExecutionConfig executionConfig = new ExecutionConfig();
-		executionConfig.setLatencyTrackingInterval(latencyMarkInterval);
+	private static <T> void setupSourceOperator(
+			StreamSource<T, ?> operator,
+			ExecutionConfig executionConfig,
+			Environment env,
+			ProcessingTimeService timeProvider) {
 
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		cfg.setStateBackend(new MemoryStateBackend());
 
-		cfg.setTimeCharacteristic(timeChar);
+		cfg.setTimeCharacteristic(TimeCharacteristic.EventTime);
 		cfg.setOperatorID(new OperatorID());
-
-		Environment env = new DummyEnvironment("MockTwoInputTask", 1, 0);
 
 		StreamStatusMaintainer streamStatusMaintainer = mock(StreamStatusMaintainer.class);
 		when(streamStatusMaintainer.getStreamStatus()).thenReturn(StreamStatus.ACTIVE);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.functions.StoppableFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StoppableStreamSource;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.operators.StreamSourceContexts;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.util.CollectorOutput;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link StreamSource} operators.
+ */
+@SuppressWarnings("serial")
+public class StreamSourceOperatorWatermarksTest {
+
+	@Test
+	public void testEmitMaxWatermarkForFiniteSource() throws Exception {
+
+		// regular stream source operator
+		StreamSource<String, FiniteSource<String>> operator =
+				new StreamSource<>(new FiniteSource<String>());
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0);
+		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
+
+		assertEquals(1, output.size());
+		assertEquals(Watermark.MAX_WATERMARK, output.get(0));
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnImmediateCancel() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		// regular stream source operator
+		final StreamSource<String, InfiniteSource<String>> operator =
+				new StreamSource<>(new InfiniteSource<String>());
+
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0);
+		operator.cancel();
+
+		// run and exit
+		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
+
+		assertTrue(output.isEmpty());
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnAsyncCancel() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+		final Thread runner = Thread.currentThread();
+
+		// regular stream source operator
+		final StreamSource<String, InfiniteSource<String>> operator =
+				new StreamSource<>(new InfiniteSource<String>());
+
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0);
+
+		// trigger an async cancel in a bit
+		new Thread("canceler") {
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(200);
+				} catch (InterruptedException ignored) {}
+				operator.cancel();
+				runner.interrupt();
+			}
+		}.start();
+
+		// run and wait to be canceled
+		try {
+			operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
+		}
+		catch (InterruptedException ignored) {}
+
+		assertTrue(output.isEmpty());
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnImmediateStop() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		// regular stream source operator
+		final StoppableStreamSource<String, InfiniteSource<String>> operator =
+				new StoppableStreamSource<>(new InfiniteSource<String>());
+
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0);
+		operator.stop();
+
+		// run and stop
+		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
+
+		assertTrue(output.isEmpty());
+	}
+
+	@Test
+	public void testNoMaxWatermarkOnAsyncStop() throws Exception {
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		// regular stream source operator
+		final StoppableStreamSource<String, InfiniteSource<String>> operator =
+				new StoppableStreamSource<>(new InfiniteSource<String>());
+
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0);
+
+		// trigger an async cancel in a bit
+		new Thread("canceler") {
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(200);
+				} catch (InterruptedException ignored) {}
+				operator.stop();
+			}
+		}.start();
+
+		// run and wait to be stopped
+		operator.run(new Object(), mock(StreamStatusMaintainer.class), new CollectorOutput<String>(output));
+
+		assertTrue(output.isEmpty());
+	}
+
+	@Test
+	public void testAutomaticWatermarkContext() throws Exception {
+
+		// regular stream source operator
+		final StoppableStreamSource<String, InfiniteSource<String>> operator =
+			new StoppableStreamSource<>(new InfiniteSource<String>());
+
+		long watermarkInterval = 10;
+		TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+		processingTimeService.setCurrentTime(0);
+
+		setupSourceOperator(operator, TimeCharacteristic.IngestionTime, watermarkInterval, processingTimeService);
+
+		final List<StreamElement> output = new ArrayList<>();
+
+		StreamSourceContexts.getSourceContext(TimeCharacteristic.IngestionTime,
+			operator.getContainingTask().getProcessingTimeService(),
+			operator.getContainingTask().getCheckpointLock(),
+			operator.getContainingTask().getStreamStatusMaintainer(),
+			new CollectorOutput<String>(output),
+			operator.getExecutionConfig().getAutoWatermarkInterval(),
+			-1);
+
+		// periodically emit the watermarks
+		// even though we start from 1 the watermark are still
+		// going to be aligned with the watermark interval.
+
+		for (long i = 1; i < 100; i += watermarkInterval)  {
+			processingTimeService.setCurrentTime(i);
+		}
+
+		assertTrue(output.size() == 9);
+
+		long nextWatermark = 0;
+		for (StreamElement el : output) {
+			nextWatermark += watermarkInterval;
+			Watermark wm = (Watermark) el;
+			assertTrue(wm.getTimestamp() == nextWatermark);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	@SuppressWarnings("unchecked")
+	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
+			TimeCharacteristic timeChar,
+			long watermarkInterval) {
+		setupSourceOperator(operator, timeChar, watermarkInterval, new TestProcessingTimeService());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> void setupSourceOperator(StreamSource<T, ?> operator,
+												TimeCharacteristic timeChar,
+												long watermarkInterval,
+												final ProcessingTimeService timeProvider) {
+
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.setAutoWatermarkInterval(watermarkInterval);
+
+		StreamConfig cfg = new StreamConfig(new Configuration());
+		cfg.setStateBackend(new MemoryStateBackend());
+
+		cfg.setTimeCharacteristic(timeChar);
+		cfg.setOperatorID(new OperatorID());
+
+		Environment env = new DummyEnvironment("MockTwoInputTask", 1, 0);
+
+		StreamStatusMaintainer streamStatusMaintainer = mock(StreamStatusMaintainer.class);
+		when(streamStatusMaintainer.getStreamStatus()).thenReturn(StreamStatus.ACTIVE);
+
+		StreamTask<?, ?> mockTask = mock(StreamTask.class);
+		when(mockTask.getName()).thenReturn("Mock Task");
+		when(mockTask.getCheckpointLock()).thenReturn(new Object());
+		when(mockTask.getConfiguration()).thenReturn(cfg);
+		when(mockTask.getEnvironment()).thenReturn(env);
+		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
+		when(mockTask.getAccumulatorMap()).thenReturn(Collections.<String, Accumulator<?, ?>>emptyMap());
+		when(mockTask.getStreamStatusMaintainer()).thenReturn(streamStatusMaintainer);
+
+		doAnswer(new Answer<ProcessingTimeService>() {
+			@Override
+			public ProcessingTimeService answer(InvocationOnMock invocation) throws Throwable {
+				if (timeProvider == null) {
+					throw new RuntimeException("The time provider is null.");
+				}
+				return timeProvider;
+			}
+		}).when(mockTask).getProcessingTimeService();
+
+		operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static final class FiniteSource<T> implements SourceFunction<T>, StoppableFunction {
+
+		@Override
+		public void run(SourceContext<T> ctx) {}
+
+		@Override
+		public void cancel() {}
+
+		@Override
+		public void stop() {}
+	}
+
+	private static final class InfiniteSource<T> implements SourceFunction<T>, StoppableFunction {
+
+		private volatile boolean running = true;
+
+		@Override
+		public void run(SourceContext<T> ctx) throws Exception {
+			while (running) {
+				Thread.sleep(20);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		@Override
+		public void stop() {
+			running = false;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR disables latency tracking by default, and adds a config option for configuring the default latency tracking interval.

The added config option allows users to restore the previous behavior without recompiling all jobs. Job-specific configuration via the `ExecutionConfig` take precedence over the configured value, to ensure that existing jobs that disabled latency tracking continue to do so.

## Brief change log

* extend `MockEnvironment` to support setting the `TaskManagerRuntimeInfo`
* split `StreamSourceOperatorTest` into watermark/split parts

* add `MetricOptions#LATENCY_INTERVAL` for configuring the default latency tracking interval
* set `ExecutionConfig#latencyTrackingInterval` to `MetricOptions.LATENCY_INTERVAL.defaultValue()`
* add `ExecutionConfig#isLatencyTrackingConfigured` to track whether job-specific settings were applied
* modify `StreamSource#run` to take configured value into account

* deprecate `ExecutionConfig#isLatencyTrackingEnabled` since it is no longer used, misleading as it doesn't take the configuration into account and requires us to duplicate the interpretation of the interval (i.e. that latency tracking is disabled if it is <= 0)


## Verifying this change

See `StreamSourceOperatorLatencyMetricsTest`. This class is a large extension of the existing `StreamSourceOperatorTest#testLatencyMarkEmission` test (which passed before the refactoring).