### PR TITLE
[FLINK-10281] [table] Table function parse regular expression contains backslash failed

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -186,7 +186,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
       }
 
   lazy val singleQuoteStringLiteral: Parser[Expression] =
-    ("'" + """([^'\p{Cntrl}\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*""" + "'").r ^^ {
+    ("'" + """([^'\p{Cntrl}]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*""" + "'").r ^^ {
       str => Literal(str.substring(1, str.length - 1))
     }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/LiteralTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/LiteralTest.scala
@@ -25,6 +25,8 @@ import org.apache.flink.table.api.Types
 import org.apache.flink.table.expressions.utils.{ExpressionTestBase, Func3}
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.types.Row
+
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class LiteralTest extends ExpressionTestBase {
@@ -86,6 +88,19 @@ class LiteralTest extends ExpressionTestBase {
       s"Func3(42, '$hello')",
       s"Func3(42, '$hello')",
       s"42 and $hello")
+  }
+
+  @Test
+  def testParseRegularExpression(): Unit = {
+    assertEquals(
+      "foo([\\w]+)",
+      (ExpressionParser.parseExpression("'foothebar'.regexExtract('foo([\\w]+)', 1)"))
+        .asInstanceOf[Call].args(1).asInstanceOf[Literal].value)
+
+    assertEquals(
+      "\\d{3}",
+      (ExpressionParser.parseExpression("'123'.similar('\\d{3}')"))
+        .asInstanceOf[Call].args(1).asInstanceOf[Literal].value)
   }
 
   def testData: Any = {


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes Table function parse regular expression contains backslash failed*


## Brief change log

  - *Changed `singleQuoteStringLiteral` in `ExpressionParser`*

## Verifying this change


This change is already covered by existing tests, such as *LiteralTest#testParseRegularExpression*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
