### PR TITLE
[FLINK-9735] Potential resource leak in RocksDBStateBackend#getDbOptions

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -30,6 +30,8 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -42,6 +44,8 @@ import java.util.List;
  * External resource for tests that require an instance of RocksDB.
  */
 public class RocksDBResource extends ExternalResource {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RocksDBResource.class);
 
 	/** Factory for {@link DBOptions} and {@link ColumnFamilyOptions}. */
 	private final OptionsFactory optionsFactory;
@@ -74,11 +78,25 @@ public class RocksDBResource extends ExternalResource {
 		this(new OptionsFactory() {
 			@Override
 			public DBOptions createDBOptions(DBOptions currentOptions) {
+				//close it before reuse the reference.
+				try {
+					currentOptions.close();
+				} catch (Exception e) {
+					LOG.error("Close previous DBOptions's instance failed.", e);
+				}
+
 				return PredefinedOptions.FLASH_SSD_OPTIMIZED.createDBOptions();
 			}
 
 			@Override
 			public ColumnFamilyOptions createColumnOptions(ColumnFamilyOptions currentOptions) {
+				//close it before reuse the reference.
+				try {
+					currentOptions.close();
+				} catch (Exception e) {
+					LOG.error("Close previous DBOptions's instance failed.", e);
+				}
+
 				return PredefinedOptions.FLASH_SSD_OPTIMIZED.createColumnOptions();
 			}
 		});


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix Potential resource leak in RocksDBStateBackend#getDbOptions*


## Brief change log

  - *Close DBOption object before rewriting it*

## Verifying this change

This change is already covered by existing tests*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
