### PR TITLE
[FLINK-10283][runtime] Remove misleading logging in FileCache

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -226,7 +226,6 @@ public class FileCache {
 			Set<ExecutionAttemptID> jobRefCounter = jobRefHolders.get(jobId);
 
 			if (jobRefCounter == null || jobRefCounter.isEmpty()) {
-				LOG.warn("improper use of releaseJob() without a matching number of createTmpFiles() calls for jobId " + jobId);
 				return;
 			}
 


### PR DESCRIPTION
## What is the purpose of the change

Removes a misleading WARN message  as createTmpFiles is only called when the DistributedCache was used, but releaseJob is always called as part of the task cleanup routine.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
