### PR TITLE
 [FLINK-10209][build] Exclude jdk.tools dependency from hadoop 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,13 @@ under the License.
 	<profiles>
 
 		<profile>
+			<id>java9</id>
+			<activation>
+				<jdk>9</jdk>
+			</activation>
+		</profile>
+
+		<profile>
 			<id>fast</id>
 			<activation>
 				<property>

--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,35 @@ under the License.
 			<activation>
 				<jdk>9</jdk>
 			</activation>
+
+			<dependencyManagement>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.hadoop</groupId>
+						<artifactId>hadoop-common</artifactId>
+						<exclusions>
+							<exclusion>
+								<!-- This dependency is not available with java 9.-->
+								<groupId>jdk.tools</groupId>
+								<artifactId>jdk.tools</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+
+					<dependency>
+						<groupId>org.apache.hadoop</groupId>
+						<artifactId>hadoop-common</artifactId>
+						<type>test-jar</type>
+						<exclusions>
+							<exclusion>
+								<!-- This dependency is not available with java 9.-->
+								<groupId>jdk.tools</groupId>
+								<artifactId>jdk.tools</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
 		</profile>
 
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1603,6 +1603,9 @@ under the License.
 							<skipPomModules>true</skipPomModules>
 							<!-- Don't break build on newly added maven modules -->
 							<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
+							<includeModules>
+								<includeModule>.*flink.*</includeModule>
+							</includeModules>
 						</parameter>
 						<dependencies>
 							<dependency>


### PR DESCRIPTION
## What is the purpose of the change

This PR excludes the `jdk.tools` dependency from hadoop when building with java 9. This dependency is for the `tools.jar` that was distributed in jdk8 and below, but no longer present in jdk9+.

## Brief change log

* add `java9` profile that is automatically activated when using java 9
* add `dependencyManagement` entry for `hadoop-common` that excludes the `jdk.tools` dependency
* restrict `japicmp` plugin to flink artifacts
  * This change was necessary since the plugin apparently looks at all artifacts defined in the pom. The added `hadoop-common` entry in the `dependencyManagement` has no version attached and thus can't be resolved on it's own in non-hadoop modules, which always caused the build to fail. Explicitly filtering for flink modules appears to fix this.

## Verifying this change

Use `mvn help:active-profiles` to verify that the profile is not activated on java 8 but on java 9.

I ran this commit (along with other prerequisites for java 9) here: https://travis-ci.org/zentol/flink/builds/423911810
	