### PR TITLE
[FLINK-10290] [table] Fix conversion error in StreamScan and BatchScan

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchScan.scala
@@ -22,6 +22,7 @@ import org.apache.calcite.rex.RexNode
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.plan.nodes.CommonScan
@@ -47,7 +48,7 @@ trait BatchScan extends CommonScan[Row] with DataSetRel {
       f == TimeIndicatorTypeInfo.PROCTIME_BATCH_MARKER)
 
     // conversion
-    if (inputType != internalType || hasTimeIndicator) {
+    if (!internalType.asInstanceOf[RowTypeInfo].schemaEquals(inputType) || hasTimeIndicator) {
 
       val function = generateConversionMapper(
         config,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.plan.nodes.datastream
 import org.apache.calcite.rex.RexNode
 import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.functions.ProcessFunction
@@ -50,11 +51,12 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
       f == TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER ||
       f == TimeIndicatorTypeInfo.PROCTIME_STREAM_MARKER)
 
-    if (input.getType == cRowType && !hasTimeIndicator) {
+    if (inputType == cRowType && !hasTimeIndicator) {
       // input is already a CRow with correct type
       input.asInstanceOf[DataStream[CRow]]
 
-    } else if (input.getType == internalType && !hasTimeIndicator) {
+    } else if (internalType.asInstanceOf[RowTypeInfo].schemaEquals(inputType) &&
+      !hasTimeIndicator) {
       // input is already of correct type. Only need to wrap it as CRow
       input.asInstanceOf[DataStream[Row]].map(new RichMapFunction[Row, CRow] {
         @transient private var outCRow: CRow = null

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
@@ -743,7 +743,7 @@ class TableSourceITCase(
   }
 
   @Test
-  def testTableSourceScanWithConversion(): Unit = {
+  def testTableSourceScanWithPermutedFields(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -778,4 +778,42 @@ class TableSourceITCase extends AbstractTestBase {
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
+  @Test
+  def testTableSourceScanWithConversion(): Unit = {
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = Seq(
+      Row.of(new JLong(11L), new JLong(21L), new JLong(31L)),
+      Row.of(new JLong(12L), new JLong(22L), new JLong(32L)),
+      Row.of(new JLong(13L), new JLong(23L), new JLong(33L)),
+      Row.of(new JLong(14L), new JLong(24L), new JLong(34L))
+    )
+
+    val fieldNames = Array("a", "b", "c")
+    val schema = new TableSchema(
+      fieldNames,
+      Array(Types.LONG, Types.LONG, Types.LONG))
+    val rowType = new RowTypeInfo(
+      Array(Types.LONG, Types.LONG, Types.LONG).asInstanceOf[Array[TypeInformation[_]]],
+      fieldNames)
+
+    val tableSource = new TestSimpleTableSource[Row](schema, rowType, data)
+    tEnv.registerTableSource(tableName, tableSource)
+
+    tEnv.scan(tableName)
+      .select('c, 'a, 'b)
+      .addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = Seq(
+      "31,11,21",
+      "32,12,22",
+      "33,13,23",
+      "34,14,24")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -779,7 +779,7 @@ class TableSourceITCase extends AbstractTestBase {
   }
 
   @Test
-  def testTableSourceScanWithConversion(): Unit = {
+  def testTableSourceScanPermutedFields(): Unit = {
     StreamITCase.testResults = mutable.MutableList()
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/testTableSources.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/testTableSources.scala
@@ -223,5 +223,25 @@ class TestPreserveWMTableSource[T](
   override def getReturnType: TypeInformation[T] = returnType
 
   override def getTableSchema: TableSchema = tableSchema
+}
 
+
+class TestSimpleTableSource[T](
+    tableSchema: TableSchema,
+    returnType: TypeInformation[T],
+    values: Seq[T])
+  extends StreamTableSource[T]
+    with BatchTableSource[T] {
+
+  override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[T] = {
+    execEnv.fromCollection(values.asJava, returnType)
+  }
+
+  override def getDataSet(execEnv: ExecutionEnvironment): DataSet[T] = {
+    execEnv.fromCollection(values.asJava, returnType)
+  }
+
+  override def getReturnType: TypeInformation[T] = returnType
+
+  override def getTableSchema: TableSchema = tableSchema
 }


### PR DESCRIPTION
This PR fix a bug in StreamScan and BatchScan, when converting the DataStream or DataSet.

When checking the equality of `inputType` and `internalType`, we should compare both filed types and field names.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
