### PR TITLE
[FLINK-9567][runtime][yarn] Fix the yarn container over allocation in…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -290,7 +290,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		int mem = resourceProfile.getMemoryInMB() < 0 ? defaultTaskManagerMemoryMB : resourceProfile.getMemoryInMB();
 		int vcore = resourceProfile.getCpuCores() < 1 ? defaultCpus : (int) resourceProfile.getCpuCores();
 		Resource capability = Resource.newInstance(mem, vcore);
-		requestYarnContainer(capability, priority);
+		internalRequestYarnContainer(capability, priority);
 	}
 
 	@Override
@@ -375,7 +375,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 						workerNodeMap.remove(resourceId);
 						resourceManagerClient.releaseAssignedContainer(container.getId());
 						// and ask for a new one
-						requestYarnContainer(container.getResource(), container.getPriority());
+						internalRequestYarnContainer(container.getResource(), container.getPriority());
 					}
 				} else {
 					// return the excessive containers


### PR DESCRIPTION
# Second commit for Flink-9567.
The first commit ignore the region failover strategy could also cause the yarn container overallocation. This PR is a supplement for #6237 
All the changes are already covered by tests in YarnResourceManagerTest.