### PR TITLE
[FLINK-10304] [client] Remove deprecated AbstractYarnClusterDescriptor field

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -36,7 +36,6 @@ import static org.apache.flink.client.cli.CliFrontend.setJobManagerAddressInConf
 /**
  * Base class for {@link CustomCommandLine} implementations which specify a JobManager address and
  * a ZooKeeper namespace.
- *
  */
 public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<T> {
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -106,7 +106,8 @@ import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.getDynamicProperties;
 
 /**
- * The descriptor with deployment information for spawning or resuming a {@link YarnClusterClient}.
+ * The descriptor with deployment information for spawning or resuming
+ * a {@link org.apache.flink.yarn.cli.FlinkYarnSessionCli}.
  */
 public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractYarnClusterDescriptor.class);
@@ -136,8 +137,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	protected List<File> shipFiles = new LinkedList<>();
 
 	private final Configuration flinkConfiguration;
-
-	private boolean detached;
 
 	private String customName;
 
@@ -313,22 +312,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			}
 		}
 		return false;
-	}
-
-	/**
-	 * @deprecated The cluster descriptor should not know about this option.
-	 */
-	@Deprecated
-	public void setDetachedMode(boolean detachedMode) {
-		this.detached = detachedMode;
-	}
-
-	/**
-	 * @deprecated The cluster descriptor should not know about this option.
-	 */
-	@Deprecated
-	public boolean isDetachedMode() {
-		return detached;
 	}
 
 	public String getZookeeperNamespace() {
@@ -997,7 +980,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_HOME_DIR, homeDir.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_SHIP_FILES, envShipFileList.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_SLOTS, String.valueOf(clusterSpecification.getSlotsPerTaskManager()));
-		appMasterEnv.put(YarnConfigKeys.ENV_DETACHED, String.valueOf(detached));
 		appMasterEnv.put(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE, getZookeeperNamespace());
 		appMasterEnv.put(YarnConfigKeys.FLINK_YARN_FILES, yarnFilesDir.toUri().toString());
 
@@ -1088,13 +1070,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			lastAppState = appState;
 			Thread.sleep(250);
 		}
-		// print the application id for user to cancel themselves.
-		if (isDetachedMode()) {
-			LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
-					"Flink on YARN, use the following command or a YARN web interface to stop " +
-					"it:\nyarn application -kill " + appId + "\nPlease also note that the " +
-					"temporary files of the YARN session in the home directory will not be removed.");
-		}
+
 		// since deployment was successful, remove the hook
 		ShutdownHookUtil.removeShutdownHook(deploymentFailureHook, getClass().getSimpleName(), LOG);
 		return report;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -58,7 +58,11 @@ import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Java representation of a running Flink cluster within YARN.
+ *
+ * @deprecated This class is for legacy(non FLIP-6) codebase. Its replacement is
+ * {@link org.apache.flink.yarn.cli.FlinkYarnSessionCli}.
  */
+@Deprecated
 public class YarnClusterClient extends ClusterClient<ApplicationId> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(YarnClusterClient.class);
@@ -234,7 +238,7 @@ public class YarnClusterClient extends ClusterClient<ApplicationId> {
 
 	@Override
 	public boolean isDetached() {
-		return super.isDetached() || clusterDescriptor.isDetachedMode();
+		return super.isDetached();
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -33,7 +33,6 @@ public class YarnConfigKeys {
 	public static final String ENV_CLIENT_HOME_DIR = "_CLIENT_HOME_DIR";
 	public static final String ENV_CLIENT_SHIP_FILES = "_CLIENT_SHIP_FILES";
 	public static final String ENV_SLOTS = "_SLOTS";
-	public static final String ENV_DETACHED = "_DETACHED";
 	public static final String ENV_DYNAMIC_PROPERTIES = "_DYNAMIC_PROPERTIES";
 
 	public static final String ENV_FLINK_CLASSPATH = "_FLINK_CLASSPATH";

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -349,10 +349,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 		yarnClusterDescriptor.setDynamicPropertiesEncoded(dynamicPropertiesEncoded);
 
-		if (cmd.hasOption(YARN_DETACHED_OPTION.getOpt()) || cmd.hasOption(DETACHED_OPTION.getOpt())) {
-			yarnClusterDescriptor.setDetachedMode(true);
-		}
-
 		if (cmd.hasOption(name.getOpt())) {
 			yarnClusterDescriptor.setName(cmd.getOptionValue(name.getOpt()));
 		}
@@ -638,7 +634,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 					}
 				}
 
-				if (yarnClusterDescriptor.isDetachedMode()) {
+				if (cmd.hasOption(YARN_DETACHED_OPTION.getOpt()) || cmd.hasOption(DETACHED_OPTION.getOpt())) {
 					LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
 						"Flink on YARN, use the following command or a YARN web interface to stop it:\n" +
 						"yarn application -kill " + yarnApplicationId);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -44,6 +44,8 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
+import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.YARN_DETACHED_OPTION;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -120,21 +122,17 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 	@Test
 	public void testCorrectSettingOfDetachedMode() throws Exception {
-		String[] params =
-			new String[] {"-yd"};
-
-		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
+		final FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
 			new Configuration(),
 			tmp.getRoot().getAbsolutePath(),
 			"y",
 			"yarn");
 
-		final CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+		CommandLine commandLine = yarnCLI.parseCommandLineOptions(new String[] {"-yd"}, true);
+		assertTrue(commandLine.hasOption(YARN_DETACHED_OPTION.getOpt()));
 
-		AbstractYarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
-
-		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
-		assertTrue(descriptor.isDetachedMode());
+		commandLine = yarnCLI.parseCommandLineOptions(new String[] {"-d"}, true);
+		assertTrue(commandLine.hasOption(DETACHED_OPTION.getOpt()));
 	}
 
 	@Test


### PR DESCRIPTION
## Brief change log

Remove deprecated AbstractYarnClusterDescriptor field

## Verifying this change

This change is already covered by existing tests, such as `FlinkYarnSessionCliTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers:(no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
