### PR TITLE
[FLINK-10258] [sql-client] Allow streaming sources to be present for batch executions

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -236,6 +236,7 @@ public class ExecutionContext<T> {
 				TableFactoryService.find(StreamTableSourceFactory.class, sourceProperties, classLoader);
 			return factory.createStreamTableSource(sourceProperties);
 		} else if (execution.isBatchExecution()) {
+			sourceProperties = ignoreProperties(sourceProperties, new String[] {"update-mode"});
 			final BatchTableSourceFactory<?> factory = (BatchTableSourceFactory<?>)
 				TableFactoryService.find(BatchTableSourceFactory.class, sourceProperties, classLoader);
 			return factory.createBatchTableSource(sourceProperties);
@@ -249,11 +250,24 @@ public class ExecutionContext<T> {
 				TableFactoryService.find(StreamTableSinkFactory.class, sinkProperties, classLoader);
 			return factory.createStreamTableSink(sinkProperties);
 		} else if (execution.isBatchExecution()) {
+			sinkProperties = ignoreProperties(sinkProperties, new String[] {"update-mode"});
 			final BatchTableSinkFactory<?> factory = (BatchTableSinkFactory<?>)
 				TableFactoryService.find(BatchTableSinkFactory.class, sinkProperties, classLoader);
 			return factory.createBatchTableSink(sinkProperties);
 		}
 		throw new SqlExecutionException("Unsupported execution type for sinks.");
+	}
+
+	private static Map<String, String> ignoreProperties(Map<String, String> properties, String[] ignoreKeys) {
+		//the Map's original type comes from scala's type information,
+		//which did not support remove operation
+		Map<String, String> copiedProperties = new HashMap<>(properties);
+
+		for (String ignoreKey : ignoreKeys) {
+			copiedProperties.remove(ignoreKey);
+		}
+
+		return copiedProperties;
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*This pull request allow streaming sources to be present for batch executions*

## Brief change log

  - *Filtered `update-mode` while creating csv batch table source and sink*
  - *Added a test to verify it*

## Verifying this change


This change is already covered by existing tests, such as *testReuseStreamingCsvSourceIBatchExecution*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
