### PR TITLE
[FLINK-10247][Metrics] Run MetricQueryService in separate thread pool

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
@@ -71,12 +71,7 @@ public class MetricQueryService extends UntypedActor {
 	private final Map<Counter, Tuple2<QueryScopeInfo, String>> counters = new HashMap<>();
 	private final Map<Histogram, Tuple2<QueryScopeInfo, String>> histograms = new HashMap<>();
 	private final Map<Meter, Tuple2<QueryScopeInfo, String>> meters = new HashMap<>();
-	private ExecutorService threadpool;
-
-	@Override public void preStart() throws Exception {
-		super.preStart();
-		threadpool = Executors.newSingleThreadExecutor();
-	}
+	private final ExecutorService threadpool = Executors.newSingleThreadExecutor();
 
 	@Override
 	public void postStop() {
@@ -256,11 +251,11 @@ public class MetricQueryService extends UntypedActor {
 					MetricDumpSerialization.MetricSerializationResult dump = serializer.serialize(counters, gauges, histograms, meters);
 					sender.tell(dump, self);
 				} else {
-					LOG.warn("MetricQueryServiceActor received an invalid message. " + message.toString());
-					sender.tell(new Status.Failure(new IOException("MetricQueryServiceActor received an invalid message. " + message.toString())), self);
+					LOG.warn("MetricQueryServiceActor received an invalid message: {}.", message.toString());
+					sender.tell(new Status.Failure(new IOException("MetricQueryServiceActor received an invalid message: " + message.toString() + ".")), self);
 				}
 			} catch (Exception e) {
-				LOG.warn("An exception occurred while processing a message.", e);
+				LOG.warn("An exception occurred while processing a Metric related message.", e);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaExecutorMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaExecutorMode.java
@@ -1,0 +1,11 @@
+package org.apache.flink.runtime.rpc.akka;
+
+/**
+ * Created by Shimin Yang on 2018/9/21.
+ */
+public enum AkkaExecutorMode {
+	/** Used by default, use fork-join-executor dispatcher **/
+	FORK_JOIN_EXECUTOR,
+	/** Use single thread (Pinned) dispatcher **/
+	SINGLE_THREAD_EXECUTOR
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -35,6 +35,7 @@ import org.jboss.netty.channel.ChannelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -71,7 +72,17 @@ public class AkkaRpcServiceUtils {
 	 * @throws Exception      Thrown is some other error occurs while creating akka actor system
 	 */
 	public static RpcService createRpcService(String hostname, int port, Configuration configuration) throws Exception {
+		return createRpcService(hostname, port, configuration, AkkaExecutorMode.FORK_JOIN_EXECUTOR);
+	}
+
+	public static RpcService createRpcService(
+		String hostname,
+		int port,
+		Configuration configuration,
+		@Nonnull AkkaExecutorMode executorMode) throws Exception {
 		LOG.info("Starting AkkaRpcService at {}.", NetUtils.unresolvedHostAndPortToNormalizedString(hostname, port));
+
+		Preconditions.checkNotNull(executorMode);
 
 		final ActorSystem actorSystem;
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -28,6 +28,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration.{AkkaOptions, Configuration, IllegalConfigurationException, SecurityOptions}
 import org.apache.flink.runtime.net.SSLUtils
+import org.apache.flink.runtime.rpc.akka.{AkkaExecutorMode, AkkaRpcServiceUtils}
 import org.apache.flink.util.NetUtils
 import org.jboss.netty.channel.ChannelException
 import org.jboss.netty.logging.{InternalLoggerFactory, Slf4JLoggerFactory}
@@ -121,6 +122,22 @@ object AkkaUtils {
     *
     * @param configuration containing the user provided configuration values
     * @param hostname to bind against. If null, then the loopback interface is used
+    * @param port to bind against\
+    * @param executorMode containing the user specified mode of executor
+    * @return A remote Akka config
+    */
+  def getAkkaConfig(configuration: Configuration,
+                    hostname: String,
+                    port: Int,
+                    executorMode: AkkaExecutorMode): Config = {
+    getAkkaConfig(configuration, Some((hostname, port)), executorMode)
+  }
+
+  /**
+    * Return a remote Akka config for the given configuration values.
+    *
+    * @param configuration containing the user provided configuration values
+    * @param hostname to bind against. If null, then the loopback interface is used
     * @param port to bind against
     * @return A remote Akka config
     */
@@ -153,7 +170,60 @@ object AkkaUtils {
   @throws(classOf[UnknownHostException])
   def getAkkaConfig(configuration: Configuration,
                     externalAddress: Option[(String, Int)]): Config = {
-    val defaultConfig = getBasicAkkaConfig(configuration)
+    getAkkaConfig(configuration, externalAddress, AkkaExecutorMode.FORK_JOIN_EXECUTOR)
+  }
+
+  /**
+    * Creates an akka config with the provided configuration values. If the listening address is
+    * specified, then the actor system will listen on the respective address.
+    *
+    * @param configuration instance containing the user provided configuration values
+    * @param externalAddress optional tuple of bindAddress and port to be reachable at.
+    *                        If None is given, then an Akka config for local actor system
+    *                        will be returned
+    * @return Akka config
+    */
+  @throws(classOf[UnknownHostException])
+  def getAkkaConfig(configuration: Configuration,
+                    externalAddress: Option[(String, Int)],
+                    executorMode: AkkaExecutorMode): Config = {
+    val defaultConfig = executorMode match {
+      case AkkaExecutorMode.FORK_JOIN_EXECUTOR =>
+        getBasicAkkaConfig(configuration)
+      case AkkaExecutorMode.SINGLE_THREAD_EXECUTOR =>
+        getSingleThreadExecutorBasicAkkaConfig(configuration)
+    }
+
+    externalAddress match {
+
+      case Some((hostname, port)) =>
+
+        val remoteConfig = getRemoteAkkaConfig(configuration,
+          // the wildcard IP lets us bind to all network interfaces
+          NetUtils.getWildcardIPAddress, port,
+          hostname, port)
+
+        remoteConfig.withFallback(defaultConfig)
+
+      case None =>
+        defaultConfig
+    }
+  }
+
+  /**
+    * Creates an akka config with the provided configuration values which use single thread executor.
+    * If the listening address is specified, then the actor system will listen on the respective address.
+    *
+    * @param configuration instance containing the user provided configuration values
+    * @param externalAddress optional tuple of bindAddress and port to be reachable at.
+    *                        If None is given, then an Akka config for local actor system
+    *                        will be returned
+    * @return Akka config
+    */
+  @throws(classOf[UnknownHostException])
+  def getSingleThreadExecutorAkkaConfig(configuration: Configuration,
+                    externalAddress: Option[(String, Int)]): Config = {
+    val defaultConfig = getSingleThreadExecutorBasicAkkaConfig(configuration)
 
     externalAddress match {
 
@@ -182,29 +252,12 @@ object AkkaUtils {
   }
 
   /**
-   * Gets the basic Akka config which is shared by remote and local actor systems.
+   * Gets the basic Akka config with fork join executor which is shared by remote and local actor systems.
    *
    * @param configuration instance which contains the user specified values for the configuration
    * @return Flink's basic Akka config
    */
   private def getBasicAkkaConfig(configuration: Configuration): Config = {
-    val akkaThroughput = configuration.getInteger(AkkaOptions.DISPATCHER_THROUGHPUT)
-    val lifecycleEvents = configuration.getBoolean(AkkaOptions.LOG_LIFECYCLE_EVENTS)
-
-    val jvmExitOnFatalError = if (
-      configuration.getBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR)){
-      "on"
-    } else {
-      "off"
-    }
-
-    val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
-
-    val logLevel = getLogLevel
-
-    val supervisorStrategy = classOf[StoppingSupervisorWithoutLoggingActorKilledExceptionStrategy]
-      .getCanonicalName
-
     val forkJoinExecutorParallelismFactor =
       configuration.getDouble(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR)
 
@@ -223,37 +276,83 @@ object AkkaUtils {
          | }
        """.stripMargin
 
+    getBasicAkkaConfigWithParticularExecutor(configuration, forkJoinExecutorConfig)
+  }
+
+  /**
+    * Gets the basic Akka config with single thread executor which is shared by remote and local actor systems.
+    *
+    * @param configuration instance which contains the user specified values for the configuration
+    * @return Flink's basic Akka config
+    */
+  private def getSingleThreadExecutorBasicAkkaConfig(configuration: Configuration): Config = {
+    val singleThreadExecutorConfig =
+      s"""
+         | single-thread-executor {
+         |   executor = "thread-pool-executor"
+         |   type = PinnedDispatcher
+         | }
+       """.stripMargin
+
+    getBasicAkkaConfigWithParticularExecutor(configuration, singleThreadExecutorConfig)
+  }
+
+  /**
+    * Gets the basic Akka config which is shared by remote and local actor systems.
+    *
+    * @param configuration instance which contains the user specified values for the configuration
+    * @param executorConfig the akka config for particular executor
+    * @return Flink's basic Akka config
+    */
+  private def getBasicAkkaConfigWithParticularExecutor(configuration: Configuration, executorConfig: String): Config = {
+    val akkaThroughput = configuration.getInteger(AkkaOptions.DISPATCHER_THROUGHPUT)
+    val lifecycleEvents = configuration.getBoolean(AkkaOptions.LOG_LIFECYCLE_EVENTS)
+
+    val jvmExitOnFatalError = if (
+      configuration.getBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR)){
+      "on"
+    } else {
+      "off"
+    }
+
+    val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
+
+    val logLevel = getLogLevel
+
+    val supervisorStrategy = classOf[StoppingSupervisorWithoutLoggingActorKilledExceptionStrategy]
+      .getCanonicalName
+
     val config =
       s"""
-        |akka {
-        | daemonic = off
-        |
+         |akka {
+         | daemonic = off
+         |
         | loggers = ["akka.event.slf4j.Slf4jLogger"]
-        | logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
-        | log-config-on-start = off
-        |
+         | logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+         | log-config-on-start = off
+         |
         | jvm-exit-on-fatal-error = $jvmExitOnFatalError
-        |
+         |
         | serialize-messages = off
-        |
+         |
         | loglevel = $logLevel
-        | stdout-loglevel = OFF
-        |
+         | stdout-loglevel = OFF
+         |
         | log-dead-letters = $logLifecycleEvents
-        | log-dead-letters-during-shutdown = $logLifecycleEvents
-        |
+         | log-dead-letters-during-shutdown = $logLifecycleEvents
+         |
         | actor {
-        |   guardian-supervisor-strategy = $supervisorStrategy
-        |
+         |   guardian-supervisor-strategy = $supervisorStrategy
+         |
         |   warn-about-java-serializer-usage = off
-        |
+         |
         |   default-dispatcher {
-        |     throughput = $akkaThroughput
-        |
-        |   $forkJoinExecutorConfig
-        |   }
-        | }
-        |}
+         |     throughput = $akkaThroughput
+         |
+        |   $executorConfig
+         |   }
+         | }
+         |}
       """.stripMargin
 
     ConfigFactory.parseString(config)


### PR DESCRIPTION
## What is the purpose of the change

Introduce a dedicated thread pool for MetricQueryService to process messages.


## Brief change log
  - Add a single executor thread pool for MetricQueryService
  - Wrap the logic of processing message in a Runnable and submit to the thread pool once receiving any message


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - Design: Using a Single Executor thread pool to avoid racing condition, messages will still be processed one by one.
