### PR TITLE
[FLINK-10223][LOG]Logging with resourceId during taskmanager startup

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -710,6 +710,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			WorkerRegistration<WorkerType> registration =
 				new WorkerRegistration<>(taskExecutorGateway, newWorker, dataPort, hardwareDescription);
 
+			log.info("Registering TaskManager {} ({}) at ResourceManager", taskExecutorResourceId, taskExecutorAddress);
 			taskExecutors.put(taskExecutorResourceId, registration);
 
 			taskManagerHeartbeatManager.monitorTarget(taskExecutorResourceId, new HeartbeatTarget<Void>() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -349,6 +349,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		checkNotNull(rpcService);
 		checkNotNull(highAvailabilityServices);
 
+		LOG.info("Starting taskManager {}", resourceID);
+
 		InetAddress remoteAddress = InetAddress.getByName(rpcService.getAddress());
 
 		TaskManagerServicesConfiguration taskManagerServicesConfiguration =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -349,7 +349,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		checkNotNull(rpcService);
 		checkNotNull(highAvailabilityServices);
 
-		LOG.info("Starting taskManager {}", resourceID);
+		LOG.info("Starting TaskManager with ResourceID: {}", resourceID);
 
 		InetAddress remoteAddress = InetAddress.getByName(rpcService.getAddress());
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -350,7 +350,7 @@ class JobManager(
           hardwareInformation,
           numberOfSlots) =>
       // we are being informed by the ResourceManager that a new task manager is available
-      log.debug(s"RegisterTaskManager: $msg")
+      log.info(s"RegisterTaskManager: $msg")
 
       val taskManager = sender()
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1831,7 +1831,7 @@ object TaskManager {
       taskManagerClass: Class[_ <: TaskManager])
     : Unit = {
 
-    LOG.info("Starting TaskManager")
+    LOG.info(s"Starting TaskManager $resourceID")
 
     // Bring up the TaskManager actor system first, bind it to the given address.
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1831,7 +1831,7 @@ object TaskManager {
       taskManagerClass: Class[_ <: TaskManager])
     : Unit = {
 
-    LOG.info(s"Starting TaskManager $resourceID")
+    LOG.info(s"Starting TaskManager with ResourceID: $resourceID")
 
     // Bring up the TaskManager actor system first, bind it to the given address.
 


### PR DESCRIPTION
## What is the purpose of the change

Log the resourceId during taskmanager startup to help with find the specific taskmanager when encountering an exception happened in a certain tm 


## Brief change log

  - add two minor log

## Verifying this change

verify by running a local cluster

```
Jying@Jying:flink-1.7-SNAPSHOT$ cat log/flink-Jying-taskexecutor-0-Jying-Pro-MacBook.local.log | grep "Starting taskManager"
2018-09-11 07:55:29,457 INFO  org.apache.flink.runtime.taskexecutor.TaskManagerRunner       - Starting taskManager 13d3e0bab7dcae1d979665acb5afaa31
```
and the centralized info (location & resourceId)on the master node

```
**on yarn**
2018-09-11 08:19:50,219 INFO org.apache.flink.yarn.YarnJobManager                          - RegisterTaskManager: RegisterTaskManager(container_e1043_1536578936033_0002_01_000002,container_e1043_1536578936033_0002_01_000002 @ xxxxx.com (dataPort=41617),cores=24, physMem=67303518208, heap=711589888, managed=711589888,1,60000)

**standalone**
2018-09-11 11:19:30,520 INFO  org.apache.flink.runtime.resourcemanager.StandaloneResourceManager  - Registering TaskManager 53239e45c0ea47df730c273fdcee1f76 (akka.tcp://flink@localhost:56448/user/taskmanager_0) at ResourceManager
```