### PR TITLE
    [FLINK-10205] Batch Job: InputSplit Fault tolerant for DataSource…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
@@ -72,4 +72,11 @@ public class DefaultInputSplitAssigner implements InputSplitAssigner {
 		}
 		return next;
 	}
+
+	@Override
+	public void returnInputSplit(InputSplit split, int taskId) {
+		synchronized (this.splits){
+			this.splits.add(split);
+		}
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
@@ -74,9 +74,11 @@ public class DefaultInputSplitAssigner implements InputSplitAssigner {
 	}
 
 	@Override
-	public void returnInputSplit(InputSplit split, int taskId) {
-		synchronized (this.splits){
-			this.splits.add(split);
+	public void returnInputSplit(List<InputSplit> splits, int taskId) {
+		synchronized (this.splits) {
+			for (InputSplit split : splits) {
+				this.splits.add(split);
+			}
 		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.core.io.InputSplit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.core.io.InputSplitAssigner;
@@ -199,6 +200,15 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 					return null;
 				}
 			}
+		}
+	}
+
+	@Override
+	public void returnInputSplit(InputSplit split, int taskId) {
+		synchronized (this.unassigned){
+			LocatableInputSplitWithCount lisw = new LocatableInputSplitWithCount((LocatableInputSplit)split);
+			this.remoteSplitChooser.addInputSplit(lisw);
+			this.unassigned.add(lisw);
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/LocatableInputSplitAssigner.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -204,11 +205,13 @@ public final class LocatableInputSplitAssigner implements InputSplitAssigner {
 	}
 
 	@Override
-	public void returnInputSplit(InputSplit split, int taskId) {
-		synchronized (this.unassigned){
-			LocatableInputSplitWithCount lisw = new LocatableInputSplitWithCount((LocatableInputSplit)split);
-			this.remoteSplitChooser.addInputSplit(lisw);
-			this.unassigned.add(lisw);
+	public void returnInputSplit(List<InputSplit> splits, int taskId) {
+		synchronized (this.unassigned) {
+			for (InputSplit split : splits) {
+				LocatableInputSplitWithCount lisw = new LocatableInputSplitWithCount((LocatableInputSplit) split);
+				this.remoteSplitChooser.addInputSplit(lisw);
+				this.unassigned.add(lisw);
+			}
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/ReplicatingInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/ReplicatingInputSplitAssigner.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.util.Preconditions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,5 +78,11 @@ public class ReplicatingInputSplitAssigner implements InputSplitAssigner {
 			return is;
 		}
 
+	}
+
+	@Override
+	public void returnInputSplit(InputSplit split, int taskId) {
+		Preconditions.checkArgument(taskId >=0 && taskId < assignCounts.length);
+		assignCounts[taskId] = 0;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/ReplicatingInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/ReplicatingInputSplitAssigner.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Assigns each InputSplit to each requesting parallel instance.
@@ -81,7 +82,7 @@ public class ReplicatingInputSplitAssigner implements InputSplitAssigner {
 	}
 
 	@Override
-	public void returnInputSplit(InputSplit split, int taskId) {
+	public void returnInputSplit(List<InputSplit> splits, int taskId) {
 		Preconditions.checkArgument(taskId >=0 && taskId < assignCounts.length);
 		assignCounts[taskId] = 0;
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/io/InputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/InputSplitAssigner.java
@@ -38,4 +38,8 @@ public interface InputSplitAssigner {
 	 */
 	InputSplit getNextInputSplit(String host, int taskId);
 
+	/**
+	 * return the split to assigner if the task fail to process it.
+	 * */
+	void returnInputSplit(InputSplit split, int taskId);
 }

--- a/flink-core/src/main/java/org/apache/flink/core/io/InputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/InputSplitAssigner.java
@@ -21,6 +21,8 @@ package org.apache.flink.core.io;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import java.util.List;
+
 /**
  * An input split assigner distributes the {@link InputSplit}s among the instances on which a
  * data source exists.
@@ -39,7 +41,10 @@ public interface InputSplitAssigner {
 	InputSplit getNextInputSplit(String host, int taskId);
 
 	/**
-	 * return the split to assigner if the task fail to process it.
+	 * Return the split to assigner if the task fail to process it.
+	 *
+	 * @param splits The list of input split to be returned.
+	 * @param taskId The id of task that fail to process the input split.
 	 * */
-	void returnInputSplit(InputSplit split, int taskId);
+	void returnInputSplit(List<InputSplit> splits, int taskId);
 }

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/distcp/FileCopyTaskInputFormat.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/distcp/FileCopyTaskInputFormat.java
@@ -62,6 +62,13 @@ public class FileCopyTaskInputFormat implements InputFormat<FileCopyTask, FileCo
 			LOGGER.info("Getting copy task for task: " + taskId);
 			return splits.poll();
 		}
+
+		@Override
+		public void returnInputSplit(InputSplit split, int taskId) {
+			synchronized (this.splits) {
+				splits.offer((FileCopyTaskInputSplit) split);
+			}
+		}
 	}
 
 	@Override

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/distcp/FileCopyTaskInputFormat.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/distcp/FileCopyTaskInputFormat.java
@@ -64,9 +64,11 @@ public class FileCopyTaskInputFormat implements InputFormat<FileCopyTask, FileCo
 		}
 
 		@Override
-		public void returnInputSplit(InputSplit split, int taskId) {
+		public void returnInputSplit(List<InputSplit> splits, int taskId) {
 			synchronized (this.splits) {
-				splits.offer((FileCopyTaskInputSplit) split);
+				for (InputSplit split : splits) {
+					this.splits.offer((FileCopyTaskInputSplit) split);
+				}
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -180,8 +180,6 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private volatile IOMetrics ioMetrics;
 
-	private int currentSplitIndex = 0;
-
 	// --------------------------------------------------------------------------------------------
 
 	/**
@@ -316,7 +314,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	public InputSplit getNextInputSplit() {
 		final LogicalSlot slot = this.getAssignedResource();
 		final String host = slot != null ? slot.getTaskManagerLocation().getHostname() : null;
-		return this.vertex.getNextInputSplit(this.currentSplitIndex++, host);
+		return this.vertex.getNextInputSplit(host);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -179,6 +180,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private volatile IOMetrics ioMetrics;
 
+	private int currentSplitIndex = 0;
+
 	// --------------------------------------------------------------------------------------------
 
 	/**
@@ -308,6 +311,12 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			// do not allow resource assignment if we are not in state SCHEDULED
 			return false;
 		}
+	}
+
+	public InputSplit getNextInputSplit() {
+		final LogicalSlot slot = this.getAssignedResource();
+		final String host = slot != null ? slot.getTaskManagerLocation().getHostname() : null;
+		return this.vertex.getNextInputSplit(this.currentSplitIndex++, host);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
@@ -105,6 +106,9 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	/** The current or latest execution attempt of this vertex's task. */
 	private volatile Execution currentExecution;	// this field must never be null
 
+	/** input split*/
+	private ArrayList<InputSplit> inputSplits;
+
 	// --------------------------------------------------------------------------------------------
 
 	/**
@@ -186,6 +190,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		getExecutionGraph().registerExecution(currentExecution);
 
 		this.timeout = timeout;
+		this.inputSplits = new ArrayList<>();
 	}
 
 
@@ -248,6 +253,19 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 	public CoLocationConstraint getLocationConstraint() {
 		return locationConstraint;
+	}
+
+	public InputSplit getNextInputSplit(int index, String host) {
+		final int taskId = this.getParallelSubtaskIndex();
+		synchronized (this.inputSplits) {
+			if (index < this.inputSplits.size()) {
+				return this.inputSplits.get(index);
+			} else {
+				final InputSplit nextInputSplit = this.jobVertex.getSplitAssigner().getNextInputSplit(host, taskId);
+				this.inputSplits.add(nextInputSplit);
+				return nextInputSplit;
+			}
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -608,6 +608,13 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 				this.currentExecution = newExecution;
 
+				synchronized (this.inputSplits){
+					for (InputSplit split: this.inputSplits){
+						this.jobVertex.getSplitAssigner().returnInputSplit(split, this.getParallelSubtaskIndex());
+					}
+					this.inputSplits.clear();
+				}
+
 				CoLocationGroup grp = jobVertex.getCoLocationGroup();
 				if (grp != null) {
 					this.locationConstraint = grp.getLocationConstraint(subTaskIndex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -255,16 +255,12 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		return locationConstraint;
 	}
 
-	public InputSplit getNextInputSplit(int index, String host) {
+	public InputSplit getNextInputSplit(String host) {
 		final int taskId = this.getParallelSubtaskIndex();
 		synchronized (this.inputSplits) {
-			if (index < this.inputSplits.size()) {
-				return this.inputSplits.get(index);
-			} else {
-				final InputSplit nextInputSplit = this.jobVertex.getSplitAssigner().getNextInputSplit(host, taskId);
-				this.inputSplits.add(nextInputSplit);
-				return nextInputSplit;
-			}
+			final InputSplit nextInputSplit = this.jobVertex.getSplitAssigner().getNextInputSplit(host, taskId);
+			this.inputSplits.add(nextInputSplit);
+			return nextInputSplit;
 		}
 	}
 
@@ -610,7 +606,9 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 
 				synchronized (this.inputSplits){
 					for (InputSplit split: this.inputSplits){
-						this.jobVertex.getSplitAssigner().returnInputSplit(split, this.getParallelSubtaskIndex());
+						if (split != null) {
+							this.jobVertex.getSplitAssigner().returnInputSplit(split, this.getParallelSubtaskIndex());
+						}
 					}
 					this.inputSplits.clear();
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.core.io.InputSplit;
-import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.StoppingException;
@@ -570,16 +569,12 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			return FutureUtils.completedExceptionally(new Exception("Cannot find execution vertex for vertex ID " + vertexID));
 		}
 
-		final InputSplitAssigner splitAssigner = vertex.getSplitAssigner();
-		if (splitAssigner == null) {
+		if (vertex.getSplitAssigner() == null) {
 			log.error("No InputSplitAssigner for vertex ID {}.", vertexID);
 			return FutureUtils.completedExceptionally(new Exception("No InputSplitAssigner for vertex ID " + vertexID));
 		}
 
-		final LogicalSlot slot = execution.getAssignedResource();
-		final int taskId = execution.getVertex().getParallelSubtaskIndex();
-		final String host = slot != null ? slot.getTaskManagerLocation().getHostname() : null;
-		final InputSplit nextInputSplit = splitAssigner.getNextInputSplit(host, taskId);
+		final InputSplit nextInputSplit = execution.getNextInputSplit();
 
 		if (log.isDebugEnabled()) {
 			log.debug("Send next input split {}.", nextInputSplit);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -961,6 +961,7 @@ public class JobMasterTest extends TestLogger {
 			InputSplit nullSplit1 = InstantiationUtil.deserializeObject(
 				gateway.requestNextInputSplit(vertexID, newExecution.getAttemptId()).get().getInputSplitData(), ClassLoader.getSystemClassLoader());
 			Assert.assertNull(nullSplit1);
+
 		} finally {
 			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomInputSplitProgram.java
@@ -151,5 +151,12 @@ public class CustomInputSplitProgram {
 				}
 			}
 		}
+
+		@Override
+		public void returnInputSplit(InputSplit split, int taskId) {
+			synchronized (this) {
+				remainingSplits.add((CustomInputSplit) split);
+			}
+		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomInputSplitProgram.java
@@ -153,9 +153,11 @@ public class CustomInputSplitProgram {
 		}
 
 		@Override
-		public void returnInputSplit(InputSplit split, int taskId) {
+		public void returnInputSplit(List<InputSplit> splits, int taskId) {
 			synchronized (this) {
-				remainingSplits.add((CustomInputSplit) split);
+				for (InputSplit split : splits) {
+					remainingSplits.add((CustomInputSplit) split);
+				}
 			}
 		}
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
@@ -157,6 +157,13 @@ public class StreamingCustomInputSplitProgram {
 				}
 			}
 		}
+
+		@Override
+		public void returnInputSplit(InputSplit split, int taskId) {
+			synchronized (this) {
+				remainingSplits.add((CustomInputSplit) split);
+			}
+		}
 	}
 
 	private static class NoOpSink implements SinkFunction<Tuple2<Integer, Double>> {

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingCustomInputSplitProgram.java
@@ -159,9 +159,11 @@ public class StreamingCustomInputSplitProgram {
 		}
 
 		@Override
-		public void returnInputSplit(InputSplit split, int taskId) {
+		public void returnInputSplit(List<InputSplit> splits, int taskId) {
 			synchronized (this) {
-				remainingSplits.add((CustomInputSplit) split);
+				for (InputSplit split : splits) {
+					remainingSplits.add((CustomInputSplit) split);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

    Today DataSource Task pull InputSplits from JobManager to achieve better
    performance, however, when a DataSourceTask failed and rerun, it will
    not get the same splits as its previous version. this will introduce
    inconsistent result or even data corruption.

    Furthermore,  if there are two executions run at the same time (in batch
    scenario), this two executions should process same splits.

    we need to fix the issue to make the inputs of a DataSourceTask
    deterministic. The propose is save all splits into ExecutionVertex and
    DataSourceTask will pull split from there.


## Brief change log

  - *JobMaster getNextInputSplit from Execution*
  - *Execution forward getNextInputSplit and the sequence number of the request to ExecutionVertex*
  - *If the sequence number exist in the ExecutionVertex return, else calculate and cache*

## Verifying this change

This change added tests and can be verified as follows:
  - *covered by existing test*
  - *Added a new test that validates the scenario that getNextInputSplit multiple times with different Execution attempts per ExecutionVertex*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
