### PR TITLE
[FLINK-10327][streaming] Expose processWatermarks notifications to (Co)ProcessFunction

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/ProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/ProcessFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
@@ -83,6 +84,15 @@ public abstract class ProcessFunction<I, O> extends AbstractRichFunction {
 	 *                   to fail and may trigger recovery.
 	 */
 	public void onTimer(long timestamp, OnTimerContext ctx, Collector<O> out) throws Exception {}
+
+	/**
+	 * Called when watermark has advanced.
+	 *
+	 * @param mark The {@link Watermark} that triggered this call
+	 * @param out The collector to emit resulting elements to
+	 */
+	public void processWatermark(Watermark mark, Collector<O> out) throws Exception {
+	}
 
 	/**
 	 * Information available in an invocation of {@link #processElement(Object, Context, Collector)}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/CoProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/CoProcessFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
@@ -97,6 +98,39 @@ public abstract class CoProcessFunction<IN1, IN2, OUT> extends AbstractRichFunct
 	 *                   to fail and may trigger recovery.
 	 */
 	public void onTimer(long timestamp, OnTimerContext ctx, Collector<OUT> out) throws Exception {}
+
+	/**
+	 * Called when combined watermark of both inputs has advanced.
+	 *
+	 * @param mark The {@link Watermark} that triggered this call
+	 * @param out The collector to emit resulting elements to
+	 */
+	public void processWatermark(Watermark mark, Collector<OUT> out) throws Exception {
+	}
+
+	/**
+	 * Called when watermark of the first input has advanced. If this update will trigger an update
+	 * of the combined watermark, this call will be followed by {@link #processWatermark(Watermark, Collector)}
+	 * call.
+	 *
+	 * @param mark The {@link Watermark} that triggered this call
+	 * @param out The collector to emit resulting elements to. Results emitted will have a timestamp
+	 *            set to the value before advancing combined watermark.
+	 */
+	public void processWatermark1(Watermark mark, Collector<OUT> out) throws Exception {
+	}
+
+	/**
+	 * Called when watermark of the second input has advanced. If this update will trigger an update
+	 * of the combined watermark, this call will be followed by {@link #processWatermark(Watermark, Collector)}
+	 * call.
+	 *
+	 * @param mark The {@link Watermark} that triggered this call
+	 * @param out The collector to emit resulting elements to. Results emitted will have a timestamp
+	 *            set to the value before advancing combined watermark.
+	 */
+	public void processWatermark2(Watermark mark, Collector<OUT> out) throws Exception {
+	}
 
 	/**
 	 * Information available in an invocation of {@link #processElement1(Object, Context, Collector)}/

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
@@ -69,6 +69,8 @@ public class ProcessOperator<IN, OUT>
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
+		collector.setAbsoluteTimestamp(mark.getTimestamp());
+		userFunction.processWatermark(mark, collector);
 		super.processWatermark(mark);
 		this.currentWatermark = mark.getTimestamp();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoProcessOperator.java
@@ -79,7 +79,24 @@ public class CoProcessOperator<IN1, IN2, OUT>
 	}
 
 	@Override
+	public void processWatermark1(Watermark mark) throws Exception {
+		collector.setAbsoluteTimestamp(currentWatermark);
+		userFunction.processWatermark1(mark, collector);
+		super.processWatermark1(mark);
+	}
+
+	@Override
+	public void processWatermark2(Watermark mark) throws Exception {
+		collector.setAbsoluteTimestamp(currentWatermark);
+		userFunction.processWatermark2(mark, collector);
+		super.processWatermark2(mark);
+	}
+
+	@Override
 	public void processWatermark(Watermark mark) throws Exception {
+		collector.setAbsoluteTimestamp(mark.getTimestamp());
+		userFunction.processWatermark(mark, collector);
+
 		super.processWatermark(mark);
 		currentWatermark = mark.getTimestamp();
 	}


### PR DESCRIPTION
This PR exposes hooks for `processWatermark`, `processWatermark1` and `processWatermark2` to `ProcessFunction` and `CoProcessFunction`.

## Verifying this change

Added new tests to `ProcessOperatorTest` and `CoProcessOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
