### PR TITLE
[FLINK-10321][network] Simplify the condition of BroadcastPartitioner

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
@@ -30,22 +30,18 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class BroadcastPartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	int[] returnArray;
-	boolean set;
-	int setNumber;
+	private int[] returnArray;
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
 			int numberOfOutputChannels) {
-		if (set && setNumber == numberOfOutputChannels) {
+		if (returnArray != null && returnArray.length == numberOfOutputChannels) {
 			return returnArray;
 		} else {
 			this.returnArray = new int[numberOfOutputChannels];
 			for (int i = 0; i < numberOfOutputChannels; i++) {
 				returnArray[i] = i;
 			}
-			set = true;
-			setNumber = numberOfOutputChannels;
 			return returnArray;
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

The current  `BroadcastPartitioner` uses the vars of `set` and `setNumber` as the condition for returning channel arrays.

Instead of using `set` and `setNumber`, we can just check whether `returnArray.length == numberOfOutputChannels` as the condition to make it simple.

## Brief change log

  - *Remove the `set` and `setNumber` vars from `BroadcastPartitioner`*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
