### PR TITLE
[FLINK-8247] [Mesos] Support case where hadoop is not on classpath

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/HadoopUserOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/HadoopUserOverlay.java
@@ -57,15 +57,15 @@ public class HadoopUserOverlay implements ContainerOverlay {
 	}
 
 	public static Builder newBuilder() {
-		// First check if we have Hadoop in the ClassPath. If not, we simply don't do anything.
+		// First check if we have Hadoop specific dependencies in the ClassPath. If not, we simply don't do anything.
 		try {
 			Class.forName(
 				"org.apache.hadoop.security.UserGroupInformation",
 				false,
 				HadoopUserOverlay.class.getClassLoader());
 		} catch (ClassNotFoundException e) {
-			LOG.info("Cannot create Hadoop User Overlay because Hadoop cannot be found in the Classpath.");
-			return new NoOpHadoopUserOverlayBuilder();
+			LOG.info("Cannot create Hadoop User Overlay because Hadoop specific dependencies cannot be found in the Classpath.");
+			return new EmptyHadoopUserOverlayBuilder();
 		}
 
 		return new HadoopUserOverlayBuilder();
@@ -84,9 +84,9 @@ public class HadoopUserOverlay implements ContainerOverlay {
 	}
 
 	/**
-	 * A builder for {@link HadoopUserOverlay} for when hadoop doesn't exist on the classpath
+	 * A builder for {@link HadoopUserOverlay} when hadoop doesn't exist on the classpath
 	 */
-	public static class NoOpHadoopUserOverlayBuilder implements Builder {
+	public static class EmptyHadoopUserOverlayBuilder implements Builder {
 		@Override
 		public Builder fromEnvironment(Configuration globalConfiguration) throws IOException {
 			return this;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/HadoopUserOverlayTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/overlays/HadoopUserOverlayTest.java
@@ -60,7 +60,8 @@ public class HadoopUserOverlayTest extends ContainerOverlayTestBase {
 			@Override
 			public Object run() {
 				try {
-					HadoopUserOverlay.Builder builder = HadoopUserOverlay.newBuilder().fromEnvironment(conf);
+					HadoopUserOverlay.HadoopUserOverlayBuilder builder =
+						(HadoopUserOverlay.HadoopUserOverlayBuilder) HadoopUserOverlay.newBuilder().fromEnvironment(conf);
 					assertEquals(ugi, builder.ugi);
 					return null;
 				}


### PR DESCRIPTION
## What is the purpose of the change

The hadoop-free distribution of Flink currently does not work on mesos, as the call to ```HadoopUserOverlay.newBuilder().fromEnvironment(configuration).build()``` fails with a class not found exception. This change guards against that error by checking for Hadoop on the classpath when loading UserGroupInformation; modeled after HadoopModuleFactory.

## Brief change log

- *Updated HadoopUserOverlay to handle case where Hadoop is not on CP, without breaking API*

## Verifying this change

This change can be verified as follows:

  - *Manually verified the change by starting a Flink Appmaster instance in mesos, without the hadoop uber jar in the lib dir*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
