### PR TITLE
[FLINK-10341][shell script] Add option to print flink command when running bin/flink

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink
+++ b/flink-dist/src/main/flink-bin/bin/flink
@@ -52,4 +52,10 @@ export FLINK_ROOT_DIR
 export FLINK_CONF_DIR
 
 # Add HADOOP_CLASSPATH to allow the usage of Hadoop file systems
-exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.client.cli.CliFrontend "$@"
+FLINK_COMMAND="$JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.client.cli.CliFrontend "$@""
+
+if [[ -n "${PRINT_FLINK_COMMAND}" ]]; then
+  echo "FLINK_COMMAND:${FLINK_COMMAND}"
+fi
+
+exec ${FLINK_COMMAND}


### PR DESCRIPTION
## What is the purpose of the change

The purpose is to print the final java command when running `bin/flink`, this would be useful for developer to debug the flink program especially when hitting weird launch issue such as classpath issue.  

## Brief change log

Just introduce env variable `PRINT_FLINK_COMMAND`, when it is set, user can see the final java command.

## Verifying this change

User can print flink command via setting env PRINT_FLINK_COMMAND.

e.g. 
```
export PRINT_FLINK_COMMAND=1 
bin/flink run -h
```

Here's the output
```
FLINK_COMMAND:/Library/Java/JavaVirtualMachines/jdk1.8.0_172.jdk/Contents/Home/bin/java  -Dlog.file=/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/log/flink-jzhang-client-HW12527.log -Dlog4j.configuration=file:/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/conf/log4j-cli.properties -Dlogback.configurationFile=file:/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/conf/logback.xml -classpath :/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/lib/flink-dist_2.11-1.7-SNAPSHOT.jar:/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/lib/flink-python_2.11-1.7-SNAPSHOT.jar:/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/lib/flink-shaded-hadoop2-uber-1.7-SNAPSHOT.jar:/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/lib/log4j-1.2.17.jar:/Users/jzhang/github/flink/flink-dist/target/flink-1.7-SNAPSHOT-bin/flink-1.7-SNAPSHOT/lib/slf4j-log4j12-1.7.7.jar::: org.apache.flink.client.cli.CliFrontend run -h

Action "run" compiles and runs a program.

  Syntax: run [OPTIONS] <jar-file> <arguments>
  "run" action options:
     -c,--class <classname>               Class with the program entry point
                                          ("main" method or "getPlan()" method.
                                          Only needed if the JAR file does not
                                          specify the class in its manifest.
...
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
