### PR TITLE
[hotfix][benchmarks] Add network broadcast benchmark

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -87,6 +87,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 	protected IOManager ioManager;
 
 	protected int channels;
+	protected boolean broadcastMode = false;
 	protected boolean localMode = false;
 
 	protected ResultPartitionID[] partitionIds;
@@ -100,6 +101,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 		setUp(
 			writers,
 			channels,
+			false,
 			localMode,
 			senderBufferPoolSize,
 			receiverBufferPoolSize,
@@ -123,10 +125,12 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 	public void setUp(
 			int writers,
 			int channels,
+			boolean broadcastMode,
 			boolean localMode,
 			int senderBufferPoolSize,
 			int receiverBufferPoolSize,
 			Configuration config) throws Exception {
+		this.broadcastMode = broadcastMode;
 		this.localMode = localMode;
 		this.channels = channels;
 		this.partitionIds = new ResultPartitionID[writers];

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBroadcastThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBroadcastThroughputBenchmark.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Network throughput benchmarks executed by the external
+ * <a href="https://github.com/dataArtisans/flink-benchmarks">flink-benchmarks</a> project.
+ */
+public class StreamNetworkBroadcastThroughputBenchmark extends StreamNetworkThroughputBenchmark {
+
+	/**
+	 * Same as {@link StreamNetworkThroughputBenchmark#setUp(int, int, int, boolean, int, int)}
+	 * but also setups broadcast mode.
+	 */
+	@Override
+	public void setUp(
+			int recordWriters,
+			int channels,
+			int flushTimeout,
+			boolean localMode,
+			int senderBufferPoolSize,
+			int receiverBufferPoolSize) throws Exception {
+		setUp(
+			recordWriters,
+			channels,
+			flushTimeout,
+			true,
+			localMode,
+			senderBufferPoolSize,
+			receiverBufferPoolSize,
+			new Configuration()
+		);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBroadcastThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBroadcastThroughputBenchmarkTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+/**
+ * Tests for various network benchmarks based on {@link StreamNetworkBroadcastThroughputBenchmark}.
+ */
+public class StreamNetworkBroadcastThroughputBenchmarkTest extends StreamNetworkThroughputBenchmarkTest {
+	@Override
+	protected StreamNetworkThroughputBenchmark createBenchmark() {
+		return new StreamNetworkBroadcastThroughputBenchmark();
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
@@ -75,7 +75,7 @@ public class StreamNetworkPointToPointBenchmark {
 	 */
 	public void setUp(long flushTimeout, Configuration config) throws Exception {
 		environment = new StreamNetworkBenchmarkEnvironment<>();
-		environment.setUp(1, 1, false, -1, -1, config);
+		environment.setUp(1, 1, false, false, -1, -1, config);
 
 		receiver = environment.createReceiver();
 		recordWriter = environment.createRecordWriter(0, flushTimeout);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -29,9 +29,9 @@ import java.util.concurrent.TimeUnit;
  * <a href="https://github.com/dataArtisans/flink-benchmarks">flink-benchmarks</a> project.
  */
 public class StreamNetworkThroughputBenchmark {
-	private StreamNetworkBenchmarkEnvironment<LongValue> environment;
-	private ReceiverThread receiver;
-	private LongRecordWriterThread[] writerThreads;
+	protected StreamNetworkBenchmarkEnvironment<LongValue> environment;
+	protected ReceiverThread receiver;
+	protected LongRecordWriterThread[] writerThreads;
 
 	public void executeBenchmark(long records) throws Exception {
 		executeBenchmark(records, Long.MAX_VALUE);
@@ -75,6 +75,7 @@ public class StreamNetworkThroughputBenchmark {
 			recordWriters,
 			channels,
 			flushTimeout,
+			false,
 			localMode,
 			senderBufferPoolSize,
 			receiverBufferPoolSize,
@@ -95,16 +96,26 @@ public class StreamNetworkThroughputBenchmark {
 			int recordWriters,
 			int channels,
 			int flushTimeout,
+			boolean broadcastMode,
 			boolean localMode,
 			int senderBufferPoolSize,
 			int receiverBufferPoolSize,
 			Configuration config) throws Exception {
 		environment = new StreamNetworkBenchmarkEnvironment<>();
-		environment.setUp(recordWriters, channels, localMode, senderBufferPoolSize, receiverBufferPoolSize, config);
+		environment.setUp(
+			recordWriters,
+			channels,
+			broadcastMode,
+			localMode,
+			senderBufferPoolSize,
+			receiverBufferPoolSize,
+			config);
 		receiver = environment.createReceiver();
 		writerThreads = new LongRecordWriterThread[recordWriters];
 		for (int writer = 0; writer < recordWriters; writer++) {
-			writerThreads[writer] = new LongRecordWriterThread(environment.createRecordWriter(writer, flushTimeout));
+			writerThreads[writer] = new LongRecordWriterThread(
+				environment.createRecordWriter(writer, flushTimeout),
+				broadcastMode);
 			writerThreads[writer].start();
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -33,9 +33,13 @@ public class StreamNetworkThroughputBenchmarkTest {
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 
+	protected StreamNetworkThroughputBenchmark createBenchmark() {
+		return new StreamNetworkThroughputBenchmark();
+	}
+
 	@Test
 	public void pointToPointBenchmark() throws Exception {
-		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();
+		StreamNetworkThroughputBenchmark benchmark = createBenchmark();
 		benchmark.setUp(1, 1, 100);
 		try {
 			benchmark.executeBenchmark(1_000);
@@ -107,7 +111,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 
 	@Test
 	public void pointToMultiPointBenchmark() throws Exception {
-		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();
+		StreamNetworkThroughputBenchmark benchmark = createBenchmark();
 		benchmark.setUp(1, 100, 100);
 		try {
 			benchmark.executeBenchmark(1_000);
@@ -119,7 +123,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 
 	@Test
 	public void multiPointToPointBenchmark() throws Exception {
-		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();
+		StreamNetworkThroughputBenchmark benchmark = createBenchmark();
 		benchmark.setUp(4, 1, 100);
 		try {
 			benchmark.executeBenchmark(1_000);
@@ -131,7 +135,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 
 	@Test
 	public void multiPointToMultiPointBenchmark() throws Exception {
-		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();
+		StreamNetworkThroughputBenchmark benchmark = createBenchmark();
 		benchmark.setUp(4, 100, 100);
 		try {
 			benchmark.executeBenchmark(1_000);


### PR DESCRIPTION
This is a simple change in benchmarks (tests). It adds a new network benchmark testing `broadcastEmit` to provide a cover for example  to this PR:

https://github.com/apache/flink/pull/6417

Please also check: https://github.com/dataArtisans/flink-benchmarks/pull/10

CC @zhijiangW could you take a look? :)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

