### PR TITLE
[FLINK-10349] Unify stopActor utils

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClientActorTest;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -29,7 +30,6 @@ import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -148,7 +148,7 @@ public class ClientConnectionTest extends TestLogger {
 			assertEquals(leaderId, gateway.leaderSessionID());
 		} finally {
 			if (actorRef != null) {
-				TestingUtils.stopActorGracefully(actorRef);
+				ActorUtils.stopActorGracefully(actorRef);
 			}
 
 			actorSystem.shutdown();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/ActorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/ActorUtils.java
@@ -27,6 +27,8 @@ import akka.pattern.Patterns;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,8 +39,6 @@ import java.util.concurrent.TimeoutException;
 
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
-
-import javax.annotation.Nonnull;
 
 /**
  * Utility functions for the interaction with Akka {@link akka.actor.Actor}.
@@ -136,8 +136,6 @@ public class ActorUtils {
 
 		stopActorsGracefully(actorRefs.toArray(new ActorRef[0]));
 	}
-
-
 
 	private ActorUtils() {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/FlinkUntypedActorTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.actor.Kill;
 import akka.actor.Props;
 import akka.actor.RobustActorSystem;
 import akka.testkit.JavaTestKit;
@@ -81,7 +80,7 @@ public class FlinkUntypedActorTest extends TestLogger {
 			assertEquals(3, underlyingActor.getMessageCounter());
 
 		} finally {
-			stopActor(actor);
+			ActorUtils.stopActor(actor);
 		}
 	}
 
@@ -114,13 +113,7 @@ public class FlinkUntypedActorTest extends TestLogger {
 			}
 
 		} finally {
-			stopActor(actor);
-		}
-	}
-
-	private static void stopActor(ActorRef actor) {
-		if (actor != null) {
-			actor.tell(Kill.getInstance(), ActorRef.noSender());
+			ActorUtils.stopActor(actor);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/QuarantineMonitorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/QuarantineMonitorTest.java
@@ -130,9 +130,9 @@ public class QuarantineMonitorTest extends TestLogger {
 
 			Assert.assertEquals(actorSystem1Address.toString(), quarantineFuture.get());
 		} finally {
-			TestingUtils.stopActor(watchee);
-			TestingUtils.stopActor(watcher);
-			TestingUtils.stopActor(monitor);
+			ActorUtils.stopActor(watchee);
+			ActorUtils.stopActor(watcher);
+			ActorUtils.stopActor(monitor);
 		}
 	}
 
@@ -171,9 +171,9 @@ public class QuarantineMonitorTest extends TestLogger {
 
 			Assert.assertEquals(actorSystem1Address.toString(), quarantineFuture.get());
 		} finally {
-			TestingUtils.stopActor(watchee);
-			TestingUtils.stopActor(watcher);
-			TestingUtils.stopActor(monitor);
+			ActorUtils.stopActor(watchee);
+			ActorUtils.stopActor(watcher);
+			ActorUtils.stopActor(monitor);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/akka/QuarantineMonitorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/akka/QuarantineMonitorTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.akka;
 
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ClusterShutdownITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ClusterShutdownITCase.java
@@ -22,6 +22,7 @@ import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
 import org.apache.flink.runtime.clusterframework.messages.StopClusterSuccessful;
@@ -41,8 +42,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import scala.Option;
-
-import java.util.Arrays;
 
 /**
  * Runs tests to ensure that a cluster is shutdown properly.
@@ -129,8 +128,7 @@ public class ClusterShutdownITCase extends TestLogger {
 					StopClusterSuccessful.getInstance()
 				);
 			} finally {
-				TestingUtils.stopActorGatewaysGracefully(Arrays.asList(
-					jobManager, taskManager, forwardingActor));
+				ActorUtils.stopActorsGracefully(jobManager, taskManager, forwardingActor);
 			}
 
 		}};
@@ -207,8 +205,7 @@ public class ClusterShutdownITCase extends TestLogger {
 					StopClusterSuccessful.getInstance()
 				);
 			} finally {
-				TestingUtils.stopActorGatewaysGracefully(Arrays.asList(
-					jobManager, taskManager, resourceManager, forwardingActor));
+				ActorUtils.stopActorsGracefully(jobManager, taskManager, resourceManager, forwardingActor);
 			}
 
 		}};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.clusterframework;
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -41,9 +42,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import scala.Option;
-
-
-import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -152,8 +150,7 @@ public class ResourceManagerITCase extends TestLogger {
 				assertEquals(1, reply.resources.size());
 				assertTrue(reply.resources.contains(resourceID));
 			} finally {
-				TestingUtils.stopActorGatewaysGracefully(Arrays.asList(
-					jobManager, resourceManager, forwardingActor));
+				ActorUtils.stopActorsGracefully(jobManager, resourceManager, forwardingActor);
 			}
 
 		}};
@@ -215,8 +212,7 @@ public class ResourceManagerITCase extends TestLogger {
 
 				assertEquals(1, reply.resources.size());
 			} finally {
-				TestingUtils.stopActorGatewaysGracefully(Arrays.asList(
-					jobManager, resourceManager, taskManager, forwardingActor));
+				ActorUtils.stopActorsGracefully(jobManager, resourceManager, taskManager, forwardingActor);
 			}
 
 		}};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -415,7 +416,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 			// verify that the JobManager terminated
 			testProbe.expectTerminated(jobManager, timeout);
 		} finally {
-			TestingUtils.stopActor(jobManager);
+			ActorUtils.stopActor(jobManager);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
@@ -116,7 +117,7 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 
 			Await.ready(leaderFuture, duration);
 		} finally {
-			TestingUtils.stopActor(jm);
+			ActorUtils.stopActor(jm);
 		}
 
 	}
@@ -162,7 +163,7 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 
 			Await.ready(leader2Future, duration);
 		} finally {
-			TestingUtils.stopActor(jm2);
+			ActorUtils.stopActor(jm2);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest.handler.legacy.backpressure;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaJobManagerGateway;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
@@ -277,8 +278,8 @@ public class BackPressureStatsTrackerImplITCase extends TestLogger {
 					}
 				};
 			} finally {
-				TestingUtils.stopActor(jobManger);
-				TestingUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManger);
+				ActorUtils.stopActor(taskManager);
 
 				highAvailabilityServices.closeAndCleanupAllData();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/StackTraceSampleCoordinatorITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest.handler.legacy.backpressure;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaJobManagerGateway;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
@@ -193,8 +194,8 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 					}
 				};
 			} finally {
-				TestingUtils.stopActor(jobManger);
-				TestingUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManger);
+				ActorUtils.stopActor(taskManager);
 
 				highAvailabilityServices.closeAndCleanupAllData();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -26,6 +26,7 @@ import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
@@ -60,15 +61,13 @@ import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.flink.runtime.testingUtils.TestingUtils.stopActor;
 import static org.apache.flink.runtime.testingUtils.TestingUtils.createTaskManager;
-import static org.apache.flink.runtime.testingUtils.TestingUtils.stopActorGatewaysGracefully;
-import static org.apache.flink.runtime.testingUtils.TestingUtils.stopActorGracefully;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -189,7 +188,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 				e.printStackTrace();
 				fail(e.getMessage());
 			} finally {
-				stopActorGatewaysGracefully(Arrays.asList(taskManager1, taskManager2, jobManager, resourceManager));
+				ActorUtils.stopActorsGracefully(taskManager1, taskManager2, jobManager, resourceManager);
 
 				embeddedHaServices.closeAndCleanupAllData();
 			}
@@ -240,7 +239,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 
 				assertTrue(response instanceof TaskManagerMessages.RegisteredAtJobManager);
 			} finally {
-				stopActorGatewaysGracefully(Arrays.asList(taskManager, jobManager));
+				ActorUtils.stopActorsGracefully(taskManager, jobManager);
 
 				embeddedHaServices.closeAndCleanupAllData();
 			}
@@ -301,7 +300,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 				e.printStackTrace();
 				fail(e.getMessage());
 			} finally {
-				stopActorGracefully(taskManager);
+				ActorUtils.stopActorsGracefully(taskManager);
 			}
 		}};
 	}
@@ -371,7 +370,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 					}
 				};
 			} finally {
-				stopActorGatewaysGracefully(Arrays.asList(taskManager, jm));
+				ActorUtils.stopActorsGracefully(taskManager, jm);
 			}
 		}};
 	}
@@ -469,7 +468,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 					+ maxExpectedNumberOfRegisterTaskManagerMessages,
 					registerTaskManagerMessages.length <= maxExpectedNumberOfRegisterTaskManagerMessages);
 			} finally {
-				stopActorGatewaysGracefully(Arrays.asList(taskManager, jm));
+				ActorUtils.stopActorsGracefully(taskManager, jm);
 			}
 		}};
 	}
@@ -533,7 +532,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 
 				// kill the first forwarding JobManager
 				watch(fakeJobManager1Gateway.actor());
-				stopActor(fakeJobManager1Gateway.actor());
+				ActorUtils.stopActorsGracefully(fakeJobManager1Gateway.actor());
 
 				final ActorGateway gateway = fakeJobManager1Gateway;
 
@@ -598,7 +597,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 				e.printStackTrace();
 				fail(e.getMessage());
 			} finally {
-				stopActorGatewaysGracefully(Arrays.asList(taskManagerGateway, fakeJobManager2Gateway));
+				ActorUtils.stopActorsGracefully(taskManagerGateway, fakeJobManager2Gateway);
 			}
 		}};
 	}
@@ -675,7 +674,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 					}
 				};
 			} finally {
-				stopActorGracefully(taskManagerGateway);
+				ActorUtils.stopActorsGracefully(taskManagerGateway);
 			}
 		}};
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
@@ -268,8 +269,8 @@ public class TaskManagerTest extends TestLogger {
 			}
 			finally {
 				// shut down the actors
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -409,8 +410,8 @@ public class TaskManagerTest extends TestLogger {
 				fail(e.getMessage());
 			}
 			finally {
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -539,8 +540,8 @@ public class TaskManagerTest extends TestLogger {
 				};
 			}
 			finally {
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -636,8 +637,8 @@ public class TaskManagerTest extends TestLogger {
 			}
 			finally {
 				// shut down the actors
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -775,8 +776,8 @@ public class TaskManagerTest extends TestLogger {
 			}
 			finally {
 				// shut down the actors
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -924,8 +925,8 @@ public class TaskManagerTest extends TestLogger {
 			}
 			finally {
 				// shut down the actors
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -1027,8 +1028,8 @@ public class TaskManagerTest extends TestLogger {
 				fail(e.getMessage());
 			}
 			finally {
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -1148,8 +1149,8 @@ public class TaskManagerTest extends TestLogger {
 				fail(e.getMessage());
 			}
 			finally {
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -1206,8 +1207,8 @@ public class TaskManagerTest extends TestLogger {
 					}
 				};
 			} finally {
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};}
 
@@ -1519,8 +1520,8 @@ public class TaskManagerTest extends TestLogger {
 					}
 				};
 			} finally {
-				TestingUtils.stopActor(taskManagerActorGateway);
-				TestingUtils.stopActor(jobManagerActorGateway);
+				ActorUtils.stopActor(taskManagerActorGateway);
+				ActorUtils.stopActor(jobManagerActorGateway);
 			}
 		}};
 	}
@@ -1618,8 +1619,8 @@ public class TaskManagerTest extends TestLogger {
 
 				assertEquals(true, cancelFuture.get());
 			} finally {
-				TestingUtils.stopActor(taskManager);
-				TestingUtils.stopActor(jobManager);
+				ActorUtils.stopActor(taskManager);
+				ActorUtils.stopActor(jobManager);
 			}
 		}};
 	}
@@ -1679,8 +1680,8 @@ public class TaskManagerTest extends TestLogger {
 				// expected
 			}
 		} finally {
-			TestingUtils.stopActor(jobManager);
-			TestingUtils.stopActor(taskManager);
+			ActorUtils.stopActor(jobManager);
+			ActorUtils.stopActor(taskManager);
 		}
 	}
 
@@ -1748,8 +1749,8 @@ public class TaskManagerTest extends TestLogger {
 				// expected
 			}
 		} finally {
-			TestingUtils.stopActor(jobManager);
-			TestingUtils.stopActor(taskManager);
+			ActorUtils.stopActor(jobManager);
+			ActorUtils.stopActor(taskManager);
 		}
 	}
 
@@ -1795,8 +1796,8 @@ public class TaskManagerTest extends TestLogger {
 				// expected
 			}
 		} finally {
-			TestingUtils.stopActor(jobManager);
-			TestingUtils.stopActor(taskManager);
+			ActorUtils.stopActor(jobManager);
+			ActorUtils.stopActor(taskManager);
 		}
 	}
 
@@ -1866,8 +1867,8 @@ public class TaskManagerTest extends TestLogger {
 				// expected
 			}
 		} finally {
-			TestingUtils.stopActor(jobManager);
-			TestingUtils.stopActor(taskManager);
+			ActorUtils.stopActor(jobManager);
+			ActorUtils.stopActor(taskManager);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaJobManagerRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaJobManagerRetrieverTest.java
@@ -19,12 +19,12 @@
 package org.apache.flink.runtime.webmonitor.retriever.impl;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClientActorTest;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorRef;
@@ -100,7 +100,7 @@ public class AkkaJobManagerRetrieverTest extends TestLogger {
 			settableLeaderRetrievalService.stop();
 
 			if (actorRef != null) {
-				TestingUtils.stopActorGracefully(actorRef);
+				ActorUtils.stopActorGracefully(actorRef);
 			}
 		}
 	}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/FlinkActorTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/FlinkActorTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.akka
 
 import java.util.UUID
 
-import akka.actor.{Props, Kill, ActorRef, ActorSystem}
+import akka.actor.{Props, ActorSystem}
 import akka.testkit.{TestActorRef, TestKit}
 import grizzled.slf4j.Logger
 import org.apache.flink.runtime.akka.FlinkUntypedActorTest.PlainRequiresLeaderSessionID
@@ -82,11 +82,6 @@ class FlinkActorTest(_system: ActorSystem)
           s"leader session ID, even though the message requires a leader session ID.")
     }
   }
-
-  def stopActor(actor: ActorRef): Unit = {
-    actor ! Kill
-  }
-
 }
 
 class PlainFlinkActor(val leaderSessionID: Option[UUID])

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.runtime.akka.AkkaUtils
+import org.apache.flink.runtime.akka.{ActorUtils, AkkaUtils}
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.instance._
 import org.apache.flink.runtime.jobmanager.JobManagerRegistrationTest.PlainForwardingActor
 import org.apache.flink.runtime.messages.JobManagerMessages.LeaderSessionMessage
 import org.apache.flink.runtime.messages.RegistrationMessages.{AcknowledgeRegistration, AlreadyRegistered, RegisterTaskManager}
-import org.apache.flink.runtime.metrics.{MetricRegistryImpl, MetricRegistryConfiguration}
+import org.apache.flink.runtime.metrics.{MetricRegistryConfiguration, MetricRegistryImpl}
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenLeader
 import org.apache.flink.runtime.testingUtils.{TestingJobManager, TestingUtils}
@@ -150,7 +150,7 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with Befor
 
           val response = probe.expectMsgType[LeaderSessionMessage]
           response match {
-            case LeaderSessionMessage(leaderSessionID, AcknowledgeRegistration(id, _)) => id2 = id
+            case LeaderSessionMessage(_, AcknowledgeRegistration(id, _)) => id2 = id
             case _ => fail("Wrong response message: " + response)
           }
         }
@@ -159,10 +159,10 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with Befor
         assertNotNull(id2)
         assertNotEquals(id1, id2)
       } finally {
-        jmOption.foreach(TestingUtils.stopActorGracefully)
-        rmOption.foreach(TestingUtils.stopActorGracefully)
-        tm1Option.foreach(TestingUtils.stopActorGracefully)
-        tm2Option.foreach(TestingUtils.stopActorGracefully)
+        jmOption.foreach(ActorUtils.stopActorGracefully)
+        rmOption.foreach(ActorUtils.stopActorGracefully)
+        tm1Option.foreach(ActorUtils.stopActorGracefully)
+        tm2Option.foreach(ActorUtils.stopActorGracefully)
       }
     }
 
@@ -239,8 +239,8 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with Befor
           }
         }
       } finally {
-        jmOption.foreach(TestingUtils.stopActorGracefully)
-        rmOption.foreach(TestingUtils.stopActorGracefully)
+        jmOption.foreach(ActorUtils.stopActorGracefully)
+        rmOption.foreach(ActorUtils.stopActorGracefully)
       }
     }
   }
@@ -277,8 +277,8 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with Befor
       components._6,
       highAvailabilityServices.getJobManagerLeaderElectionService(
         HighAvailabilityServices.DEFAULT_JOB_ID),
-      highAvailabilityServices.getSubmittedJobGraphStore(),
-      highAvailabilityServices.getCheckpointRecoveryFactory(),
+      highAvailabilityServices.getSubmittedJobGraphStore,
+      highAvailabilityServices.getCheckpointRecoveryFactory,
       components._9,
       components._10,
       None)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -22,8 +22,8 @@ import java.util
 import java.util.concurrent._
 import java.util.{Collections, UUID}
 
-import akka.actor.{ActorRef, ActorSystem, Kill, Props}
-import akka.pattern.{Patterns, ask}
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.pattern.ask
 import com.typesafe.config.ConfigFactory
 import grizzled.slf4j.Logger
 import org.apache.flink.api.common.time.Time
@@ -293,76 +293,6 @@ object TestingUtils {
     }
 
     new AkkaActorGateway(taskManager, leaderId)
-  }
-
-  /** Stops the given actor by sending it a Kill message
-    *
-    * @param actor
-    */
-  def stopActor(actor: ActorRef): Unit = {
-    if (actor != null) {
-      actor ! Kill
-    }
-  }
-
-  /** Stops the given actor by sending it a Kill message
-    *
-    * @param actorGateway
-    */
-  def stopActor(actorGateway: ActorGateway): Unit = {
-    if (actorGateway != null) {
-      stopActor(actorGateway.actor())
-    }
-  }
-
-  def stopActorGracefully(actor: ActorRef): Unit = {
-    val gracefulStopFuture = Patterns.gracefulStop(actor, TestingUtils.TESTING_TIMEOUT)
-
-    Await.result(gracefulStopFuture, TestingUtils.TESTING_TIMEOUT)
-  }
-
-  def stopActorGracefully(actorGateway: ActorGateway): Unit = {
-    stopActorGracefully(actorGateway.actor())
-  }
-
-  def stopActorsGracefully(actors: ActorRef*): Unit = {
-    val gracefulStopFutures = actors.flatMap{
-      actor =>
-        Option(actor) match {
-          case Some(actorRef) => Some(Patterns.gracefulStop(actorRef, TestingUtils.TESTING_TIMEOUT))
-          case None => None
-        }
-    }
-
-    implicit val executionContext = defaultExecutionContext
-
-    val globalStopFuture = scala.concurrent.Future.sequence(gracefulStopFutures)
-
-    Await.result(globalStopFuture, TestingUtils.TESTING_TIMEOUT)
-  }
-
-  def stopActorsGracefully(actors: java.util.List[ActorRef]): Unit = {
-    import scala.collection.JavaConverters._
-
-    stopActorsGracefully(actors.asScala: _*)
-  }
-
-  def stopActorGatewaysGracefully(actorGateways: ActorGateway*): Unit = {
-    val actors = actorGateways.flatMap {
-      actorGateway =>
-        Option(actorGateway) match {
-          case Some(actorGateway) => Some(actorGateway.actor())
-          case None => None
-        }
-    }
-
-    stopActorsGracefully(actors: _*)
-  }
-
-  def stopActorGatewaysGracefully(actorGateways: java.util.List[ActorGateway]): Unit = {
-    import scala.collection.JavaConverters._
-
-    stopActorGatewaysGracefully(actorGateways.asScala: _*)
   }
 
   /** Creates a testing JobManager using the default recovery mode (standalone)


### PR DESCRIPTION
## Brief change log

As discuss at #6678 , we can unify `stopActor` utils. The `MesosResourceManager#stopActor` remains since it customizes the stop logic.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts: **(all no)**

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation **(not applicable)**

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
