### PR TITLE
[FLINK-10354] Revert "[FLINK-6328] [chkPts] Don't add savepoints to CompletedCheckpointStore"

### DIFF
--- a/docs/ops/state/savepoints.md
+++ b/docs/ops/state/savepoints.md
@@ -106,6 +106,11 @@ Please follow <a href="https://issues.apache.org/jira/browse/FLINK-5778">FLINK-5
 
 Note that if you use the `MemoryStateBackend`, metadata *and* savepoint state will be stored in the `_metadata` file. Since it is self-contained, you may move the file and restore from any location.
 
+<div class="alert alert-warning">
+  <strong>Attention:</strong> It is discouraged to move or delete last savepoint of a running job, cause this might interfere with failure-recovery. Savepoints have side-effects on exactly-once sinks, therefore 
+  to ensure exactly-once semantics, if there is no checkpoint after the last savepoint, the savepoint will be used for recovery. 
+</div>
+
 #### Trigger a Savepoint
 
 {% highlight shell %}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -839,28 +839,22 @@ public class CheckpointCoordinator {
 			// the pending checkpoint must be discarded after the finalization
 			Preconditions.checkState(pendingCheckpoint.isDiscarded() && completedCheckpoint != null);
 
-			// TODO: add savepoints to completed checkpoint store once FLINK-4815 has been completed
-			if (!completedCheckpoint.getProperties().isSavepoint()) {
-				try {
-					completedCheckpointStore.addCheckpoint(completedCheckpoint);
-				} catch (Exception exception) {
-					// we failed to store the completed checkpoint. Let's clean up
-					executor.execute(new Runnable() {
-						@Override
-						public void run() {
-							try {
-								completedCheckpoint.discardOnFailedStoring();
-							} catch (Throwable t) {
-								LOG.warn("Could not properly discard completed checkpoint {} of job {}.", completedCheckpoint.getCheckpointID(), job, t);
-							}
+			try {
+				completedCheckpointStore.addCheckpoint(completedCheckpoint);
+			} catch (Exception exception) {
+				// we failed to store the completed checkpoint. Let's clean up
+				executor.execute(new Runnable() {
+					@Override
+					public void run() {
+						try {
+							completedCheckpoint.discardOnFailedStoring();
+						} catch (Throwable t) {
+							LOG.warn("Could not properly discard completed checkpoint {}.", completedCheckpoint.getCheckpointID(), t);
 						}
-					});
+					}
+				});
 
-					throw new CheckpointException("Could not complete the pending checkpoint " + checkpointId + '.', exception);
-				}
-
-				// drop those pending checkpoints that are at prior to the completed one
-				dropSubsumedCheckpoints(checkpointId);
+				throw new CheckpointException("Could not complete the pending checkpoint " + checkpointId + '.', exception);
 			}
 		} finally {
 			pendingCheckpoints.remove(checkpointId);
@@ -869,6 +863,9 @@ public class CheckpointCoordinator {
 		}
 
 		rememberRecentCheckpointId(checkpointId);
+
+		// drop those pending checkpoints that are at prior to the completed one
+		dropSubsumedCheckpoints(checkpointId);
 
 		// record the time when this was completed, to calculate
 		// the 'min delay between checkpoints'


### PR DESCRIPTION
## What is the purpose of the change

This reverts commit 6f570e7b6810e1645a4f7094f17ab9e8559fa139. 

Savepoints are once again counted as checkpoint, so that if failure happens between savepoint and next checkpoint, side effects on exactly one sinks manifested during savepoint, are taken into account.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
