### PR TITLE
[FLINK-10356][network] add sanity checks to SpillingAdaptiveSpanningRecordDeserializer

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/serialization/types/Util.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/serialization/types/Util.java
@@ -51,12 +51,16 @@ public final class Util {
 			@Override
 			protected SerializationTestType getRecord() {
 				// select random test type factory
-				SerializationTestTypeFactory[] types = SerializationTestTypeFactory.values();
-				int i = Util.random.nextInt(types.length);
-
-				return types[i].factory().getRandom(Util.random);
+				return getRandomSerializationTestType().getRandom(Util.random);
 			}
 		};
+	}
+
+	public static SerializationTestType getRandomSerializationTestType() {
+		SerializationTestTypeFactory[] types = SerializationTestTypeFactory.values();
+		int i = Util.random.nextInt(types.length);
+
+		return types[i].factory();
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -204,12 +204,12 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		// -------------------------------------------------------------------------------------------------------------
 
 		@Override
-		public final void readFully(byte[] b) throws IOException {
+		public final void readFully(byte[] b) {
 			readFully(b, 0, b.length);
 		}
 
 		@Override
-		public final void readFully(byte[] b, int off, int len) throws IOException {
+		public final void readFully(byte[] b, int off, int len) {
 			if (off < 0 || len < 0 || off + len > b.length) {
 				throw new IndexOutOfBoundsException();
 			}
@@ -219,78 +219,75 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		}
 
 		@Override
-		public final boolean readBoolean() throws IOException {
+		public final boolean readBoolean() {
 			return readByte() == 1;
 		}
 
 		@Override
-		public final byte readByte() throws IOException {
+		public final byte readByte() {
 			return this.segment.get(this.position++);
 		}
 
 		@Override
-		public final int readUnsignedByte() throws IOException {
+		public final int readUnsignedByte() {
 			return readByte() & 0xff;
 		}
 
 		@Override
-		public final short readShort() throws IOException {
+		public final short readShort() {
 			final short v = this.segment.getShortBigEndian(this.position);
 			this.position += 2;
 			return v;
 		}
 
 		@Override
-		public final int readUnsignedShort() throws IOException {
+		public final int readUnsignedShort() {
 			final int v = this.segment.getShortBigEndian(this.position) & 0xffff;
 			this.position += 2;
 			return v;
 		}
 
 		@Override
-		public final char readChar() throws IOException  {
+		public final char readChar() {
 			final char v = this.segment.getCharBigEndian(this.position);
 			this.position += 2;
 			return v;
 		}
 
 		@Override
-		public final int readInt() throws IOException {
+		public final int readInt() {
 			final int v = this.segment.getIntBigEndian(this.position);
 			this.position += 4;
 			return v;
 		}
 
 		@Override
-		public final long readLong() throws IOException {
+		public final long readLong() {
 			final long v = this.segment.getLongBigEndian(this.position);
 			this.position += 8;
 			return v;
 		}
 
 		@Override
-		public final float readFloat() throws IOException {
+		public final float readFloat() {
 			return Float.intBitsToFloat(readInt());
 		}
 
 		@Override
-		public final double readDouble() throws IOException {
+		public final double readDouble() {
 			return Double.longBitsToDouble(readLong());
 		}
 
 		@Override
-		public final String readLine() throws IOException {
+		public final String readLine() {
 			final StringBuilder bld = new StringBuilder(32);
 
-			try {
-				int b;
-				while ((b = readUnsignedByte()) != '\n') {
-					if (b != '\r') {
-						bld.append((char) b);
-					}
+			int b;
+			while ((b = readUnsignedByte()) != '\n') {
+				if (b != '\r') {
+					bld.append((char) b);
 				}
 			}
-			catch (EOFException ignored) {}
 
 			if (bld.length() == 0) {
 				return null;
@@ -386,7 +383,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		}
 
 		@Override
-		public final int skipBytes(int n) throws IOException {
+		public final int skipBytes(int n) {
 			if (n < 0) {
 				throw new IllegalArgumentException();
 			}
@@ -406,7 +403,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		}
 
 		@Override
-		public int read(byte[] b, int off, int len) throws IOException {
+		public int read(byte[] b, int off, int len) {
 			if (b == null){
 				throw new NullPointerException("Byte array b cannot be null.");
 			}
@@ -427,7 +424,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		}
 
 		@Override
-		public int read(byte[] b) throws IOException {
+		public int read(byte[] b) {
 			return read(b, 0, b.length);
 		}
 	}
@@ -468,7 +465,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		@Nullable
 		private DataInputViewStreamWrapper spillFileReader;
 
-		public SpanningWrapper(String[] tempDirs) {
+		SpanningWrapper(String[] tempDirs) {
 			this.tempDirs = tempDirs;
 
 			this.lengthBuffer = ByteBuffer.allocate(4);
@@ -502,7 +499,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 			this.accumulatedRecordBytes = numBytesChunk;
 		}
 
-		private void initializeWithPartialLength(NonSpanningWrapper partial) throws IOException {
+		private void initializeWithPartialLength(NonSpanningWrapper partial) {
 			// copy what we have to the length buffer
 			partial.segment.get(partial.position, this.lengthBuffer, partial.remaining());
 		}
@@ -621,7 +618,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 			}
 		}
 
-		public DataInputView getInputView() {
+		DataInputView getInputView() {
 			if (spillFileReader == null) {
 				return serializationReadBuffer;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -167,7 +167,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 			try {
 				target.read(this.spanningWrapper.getInputView());
 
-				int remainingSpanningBytes = this.spanningWrapper.getRemainingBytes();
+				int remainingSpanningBytes = this.spanningWrapper.getRemainingBytesOrZero();
 				if (remainingSpanningBytes != 0) {
 					throwDeserializationError(
 						this.spanningWrapper.recordLength,
@@ -615,7 +615,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 			}
 		}
 
-		private int getRemainingBytes() {
+		private int getRemainingBytesOrZero() {
 			if (this.spillFileReader == null) {
 				return this.serializationReadBuffer.available();
 			} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -550,6 +550,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 				}
 				else {
 					spillingChannel.close();
+					spillingChannel = null;
 
 					BufferedInputStream inStream = new BufferedInputStream(new FileInputStream(spillFile), 2 * 1024 * 1024);
 					this.spillFileReader = new DataInputViewStreamWrapper(inStream);
@@ -580,6 +581,8 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 			this.recordLength = -1;
 			this.lengthBuffer.clear();
 			this.leftOverData = null;
+			this.leftOverStart = 0;
+			this.leftOverLimit = 0;
 			this.accumulatedRecordBytes = 0;
 
 			if (spillingChannel != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -27,6 +27,9 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.StringUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.File;
@@ -39,6 +42,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 import java.util.Random;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * @param <T> The type of the record to be deserialized.
@@ -441,6 +446,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 
 		private final ByteBuffer lengthBuffer;
 
+		@Nullable
 		private FileChannel spillingChannel;
 
 		private byte[] buffer;
@@ -449,14 +455,17 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 
 		private int accumulatedRecordBytes;
 
+		@Nullable
 		private MemorySegment leftOverData;
 
 		private int leftOverStart;
 
 		private int leftOverLimit;
 
+		@Nullable
 		private File spillFile;
 
+		@Nullable
 		private DataInputViewStreamWrapper spillFileReader;
 
 		public SpanningWrapper(String[] tempDirs) {
@@ -552,7 +561,10 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 					spillingChannel.close();
 					spillingChannel = null;
 
-					BufferedInputStream inStream = new BufferedInputStream(new FileInputStream(spillFile), 2 * 1024 * 1024);
+					BufferedInputStream inStream =
+						new BufferedInputStream(
+							new FileInputStream(checkNotNull(spillFile)),
+							2 * 1024 * 1024);
 					this.spillFileReader = new DataInputViewStreamWrapper(inStream);
 				}
 			}
@@ -627,6 +639,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 		}
 
 		@SuppressWarnings("resource")
+		@Nonnull
 		private FileChannel createSpillingChannel() throws IOException {
 			if (spillFile != null) {
 				throw new IllegalStateException("Spilling file already exists.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.io.network.api.serialization;
 
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
@@ -25,30 +28,41 @@ import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.serialization.types.LargeObjectType;
 import org.apache.flink.runtime.io.network.util.DeserializationUtils;
 import org.apache.flink.testutils.serialization.types.IntType;
-import org.apache.flink.testutils.serialization.types.SerializationTestType;
 import org.apache.flink.testutils.serialization.types.SerializationTestTypeFactory;
 import org.apache.flink.testutils.serialization.types.Util;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.IntFunction;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSingleBuffer;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createBufferBuilder;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferBuilder;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link SpillingAdaptiveSpanningRecordDeserializer}.
  */
 public class SpanningRecordSerializationTest extends TestLogger {
 	private static final Random RANDOM = new Random(42);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	@Rule
 	public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -90,7 +104,7 @@ public class SpanningRecordSerializationTest extends TestLogger {
 		final int numValues = 99;
 		final int segmentSize = 32 * 1024;
 
-		List<SerializationTestType> originalRecords = new ArrayList<>((numValues + 1) / 2);
+		List<IOReadableWritable> originalRecords = new ArrayList<>((numValues + 1) / 2);
 		LargeObjectType genLarge = new LargeObjectType();
 		Random rnd = new Random();
 
@@ -105,11 +119,235 @@ public class SpanningRecordSerializationTest extends TestLogger {
 		testSerializationRoundTrip(originalRecords, segmentSize);
 	}
 
+	/**
+	 * Non-spanning, deserialization reads one byte too many and succeeds - failure report comes
+	 * from an additional check in {@link SpillingAdaptiveSpanningRecordDeserializer}.
+	 */
+	@Test
+	public void testHandleDeserializingTooMuchNonSpanning1() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingTooMuch.getValue(),
+			32 * 1024);
+	}
+
+	/**
+	 * Non-spanning, deserialization reads one byte too many and fails.
+	 */
+	@Test
+	public void testHandleDeserializingTooMuchNonSpanning2() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingTooMuch.getValue(),
+			(serializedLength) -> serializedLength,
+			isA(IndexOutOfBoundsException.class));
+	}
+
+	/**
+	 * Spanning, deserialization reads one byte too many and fails.
+	 */
+	@Test
+	public void testHandleDeserializingTooMuchSpanning1() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingTooMuch.getValue(),
+			(serializedLength) -> serializedLength - 1,
+			isA(EOFException.class));
+	}
+
+	/**
+	 * Spanning, deserialization reads one byte too many and fails.
+	 */
+	@Test
+	public void testHandleDeserializingTooMuchSpanning2() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingTooMuch.getValue(),
+			(serializedLength) -> 1,
+			isA(EOFException.class));
+	}
+
+	/**
+	 * Spanning, spilling, deserialization reads one byte too many.
+	 */
+	@Test
+	public void testHandleDeserializingTooMuchSpanningLargeRecord() throws Exception {
+		testHandleWrongDeserialization(
+			LargeObjectTypeDeserializingTooMuch.getRandom(),
+			32 * 1024,
+			isA(EOFException.class));
+	}
+
+	/**
+	 * Non-spanning, deserialization forgets to read one byte - failure report comes from an
+	 * additional check in {@link SpillingAdaptiveSpanningRecordDeserializer}.
+	 */
+	@Test
+	public void testHandleDeserializingNotEnoughNonSpanning() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingNotEnough.getValue(),
+			32 * 1024);
+	}
+
+	/**
+	 * Spanning, deserialization forgets to read one byte - failure report comes from an additional
+	 * check in {@link SpillingAdaptiveSpanningRecordDeserializer}.
+	 */
+	@Test
+	public void testHandleDeserializingNotEnoughSpanning1() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingNotEnough.getValue(),
+			(serializedLength) -> serializedLength - 1);
+	}
+
+	/**
+	 * Spanning, serialization length is 17 (including headers), deserialization forgets to read one
+	 * byte - failure report comes from an additional check in {@link SpillingAdaptiveSpanningRecordDeserializer}.
+	 */
+	@Test
+	public void testHandleDeserializingNotEnoughSpanning2() throws Exception {
+		testHandleWrongDeserialization(
+			DeserializingNotEnough.getValue(),
+			1);
+	}
+
+	/**
+	 * Spanning, spilling, deserialization forgets to read one byte - failure report comes from an
+	 * additional check in {@link SpillingAdaptiveSpanningRecordDeserializer}.
+	 */
+	@Test
+	public void testHandleDeserializingNotEnoughSpanningLargeRecord() throws Exception {
+		testHandleWrongDeserialization(
+			LargeObjectTypeDeserializingNotEnough.getRandom(),
+			32 * 1024);
+	}
+
+	private void testHandleWrongDeserialization(
+			WrongDeserializationValue testValue,
+			IntFunction<Integer> segmentSizeProvider,
+			Matcher<? extends Throwable> expectedCause) throws Exception {
+		expectedException.expectCause(expectedCause);
+		testHandleWrongDeserialization(testValue, segmentSizeProvider);
+	}
+
+	private void testHandleWrongDeserialization(
+			WrongDeserializationValue testValue,
+			@SuppressWarnings("SameParameterValue") int segmentSize,
+			Matcher<? extends Throwable> expectedCause) throws Exception {
+		expectedException.expectCause(expectedCause);
+		testHandleWrongDeserialization(testValue, segmentSize);
+	}
+
+	private void testHandleWrongDeserialization(
+			WrongDeserializationValue testValue,
+			IntFunction<Integer> segmentSizeProvider) throws Exception {
+		int serializedBytes = getSerializedBytes(testValue);
+		int segmentSize = segmentSizeProvider.apply(serializedBytes);
+		testHandleWrongDeserialization(testValue, segmentSize);
+	}
+
+	/**
+	 * Executes the de/serialization round trip test with a serializer that consumes more or less
+	 * bytes than what it writes and verifies the expected exception is thrown.
+	 */
+	private void testHandleWrongDeserialization(
+			WrongDeserializationValue testValue,
+			int segmentSize) throws Exception {
+		List<IOReadableWritable> originalRecords = new ArrayList<>(1);
+		originalRecords.add(testValue);
+
+		expectedException.expect(IOException.class);
+		if (testValue instanceof DeserializingTooMuch) {
+			expectedException.expectMessage(" -1 remaining unread byte");
+		} else if (testValue instanceof DeserializingNotEnough) {
+			expectedException.expectMessage(" 1 remaining unread byte");
+		} else {
+			fail("Invalid test value: " + testValue);
+		}
+
+		testSerializationRoundTrip(originalRecords, segmentSize);
+	}
+
+	/**
+	 * Retrieves the number of bytes the serialized representation of the given value takes (by
+	 * doing the serialization).
+	 */
+	private int getSerializedBytes(IOReadableWritable testValue) throws IOException {
+		SpanningRecordSerializer<IOReadableWritable> serializer = new SpanningRecordSerializer<>();
+		serializer.serializeRecord(testValue);
+		BufferBuilder bufferBuilder = createBufferBuilder();
+		assertTrue("Incorrect test setup: buffer not big enough to contain test value",
+			serializer.copyToBufferBuilder(bufferBuilder).isFullRecord());
+		int writtenBytes = bufferBuilder.finish();
+		bufferBuilder.createBufferConsumer().close();
+		return writtenBytes;
+	}
+
+	/**
+	 * Large object that tries to deserialize an additional byte that it has not written during
+	 * serialization.
+	 */
+	public static class LargeObjectTypeDeserializingTooMuch extends LargeObjectType implements DeserializingTooMuch {
+
+		@SuppressWarnings("WeakerAccess")
+		public LargeObjectTypeDeserializingTooMuch() {
+		}
+
+		@SuppressWarnings("WeakerAccess")
+		public LargeObjectTypeDeserializingTooMuch(int len) {
+			super(len);
+		}
+
+		@Override
+		public void read(DataInputView in) throws IOException {
+			super.read(in);
+			in.readUnsignedByte(); // not written by write()
+		}
+
+		@Override
+		public LargeObjectTypeDeserializingTooMuch getRandom(Random rnd) {
+			int length = super.getRandom(rnd).length();
+			return new LargeObjectTypeDeserializingTooMuch(length);
+		}
+
+		static LargeObjectTypeDeserializingTooMuch getRandom() {
+			return (new LargeObjectTypeDeserializingTooMuch()).getRandom(new Random());
+		}
+	}
+
+	/**
+	 * Large object that serializes more bytes than needed and during deserialization will thus
+	 * read one byte too few.
+	 */
+	public static class LargeObjectTypeDeserializingNotEnough extends LargeObjectType implements DeserializingNotEnough {
+
+		@SuppressWarnings("WeakerAccess")
+		public LargeObjectTypeDeserializingNotEnough() {
+		}
+
+		@SuppressWarnings("WeakerAccess")
+		public LargeObjectTypeDeserializingNotEnough(int len) {
+			super(len);
+		}
+
+		@Override
+		public void write(DataOutputView out) throws IOException {
+			super.write(out);
+			out.write(42); // not used in read()
+		}
+
+		@Override
+		public LargeObjectTypeDeserializingNotEnough getRandom(Random rnd) {
+			int length = super.getRandom(rnd).length();
+			return new LargeObjectTypeDeserializingNotEnough(length);
+		}
+
+		static LargeObjectTypeDeserializingNotEnough getRandom() {
+			return (new LargeObjectTypeDeserializingNotEnough()).getRandom(new Random());
+		}
+	}
+
 	// -----------------------------------------------------------------------------------------------------------------
 
-	private void testSerializationRoundTrip(Iterable<SerializationTestType> records, int segmentSize) throws Exception {
-		RecordSerializer<SerializationTestType> serializer = new SpanningRecordSerializer<>();
-		RecordDeserializer<SerializationTestType> deserializer =
+	private void testSerializationRoundTrip(Iterable<? extends IOReadableWritable> records, int segmentSize) throws Exception {
+		RecordSerializer<IOReadableWritable> serializer = new SpanningRecordSerializer<>();
+		RecordDeserializer<IOReadableWritable> deserializer =
 			new SpillingAdaptiveSpanningRecordDeserializer<>(
 				new String[]{ tempFolder.getRoot().getAbsolutePath() });
 
@@ -126,19 +364,19 @@ public class SpanningRecordSerializationTest extends TestLogger {
 	 * @param segmentSize size for the {@link MemorySegment}
 	 */
 	private static void testSerializationRoundTrip(
-			Iterable<SerializationTestType> records,
+			Iterable<? extends IOReadableWritable> records,
 			int segmentSize,
-			RecordSerializer<SerializationTestType> serializer,
-			RecordDeserializer<SerializationTestType> deserializer)
+			RecordSerializer<IOReadableWritable> serializer,
+			RecordDeserializer<IOReadableWritable> deserializer)
 		throws Exception {
-		final ArrayDeque<SerializationTestType> serializedRecords = new ArrayDeque<>();
+		final ArrayDeque<IOReadableWritable> serializedRecords = new ArrayDeque<>();
 
 		// -------------------------------------------------------------------------------------------------------------
 
 		BufferAndSerializerResult serializationResult = setNextBufferForSerializer(serializer, segmentSize);
 
 		int numRecords = 0;
-		for (SerializationTestType record : records) {
+		for (IOReadableWritable record : records) {
 
 			serializedRecords.add(record);
 
@@ -172,7 +410,7 @@ public class SpanningRecordSerializationTest extends TestLogger {
 	}
 
 	private static BufferAndSerializerResult setNextBufferForSerializer(
-			RecordSerializer<SerializationTestType> serializer,
+			RecordSerializer<IOReadableWritable> serializer,
 			int segmentSize) throws IOException {
 		// create a bufferBuilder with some random starting offset to properly test handling buffer slices in the
 		// deserialization code.
@@ -211,6 +449,29 @@ public class SpanningRecordSerializationTest extends TestLogger {
 
 		public boolean isFullBuffer() {
 			return serializationResult.isFullBuffer();
+		}
+	}
+
+	private interface WrongDeserializationValue extends IOReadableWritable {
+	}
+
+	private interface DeserializingTooMuch extends WrongDeserializationValue {
+		/**
+		 * Gets a randomly created value with a serializer that deserializes more bytes than it writes.
+		 */
+		static DeserializingTooMuch getValue() {
+			return new LargeObjectTypeDeserializingTooMuch(
+				ThreadLocalRandom.current().nextInt(0, 1024));
+		}
+	}
+
+	private interface DeserializingNotEnough extends WrongDeserializationValue {
+		/**
+		 * Gets a randomly created value with a serializer that deserializes less bytes than it writes.
+		 */
+		static DeserializingNotEnough getValue() {
+			return new LargeObjectTypeDeserializingNotEnough(
+				ThreadLocalRandom.current().nextInt(0, 1024));
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -150,11 +150,12 @@ public class SpanningRecordSerializationTest extends TestLogger {
 				// buffer is full => start deserializing
 				deserializer.setNextBuffer(serializationResult.buildBuffer());
 
-				numRecords -= DeserializationUtils.deserializeRecords(serializedRecords, deserializer);
+				numRecords -= DeserializationUtils.deserializeRecords(serializedRecords, deserializer, false);
 
-				// move buffers as long as necessary (for long records)
+				// move buffers as long as necessary (for spanning records)
 				while ((serializationResult = setNextBufferForSerializer(serializer, segmentSize)).isFullBuffer()) {
 					deserializer.setNextBuffer(serializationResult.buildBuffer());
+					numRecords -= DeserializationUtils.deserializeRecords(serializedRecords, deserializer, false);
 				}
 			}
 		}
@@ -162,16 +163,7 @@ public class SpanningRecordSerializationTest extends TestLogger {
 		// deserialize left over records
 		deserializer.setNextBuffer(serializationResult.buildBuffer());
 
-		while (!serializedRecords.isEmpty()) {
-			SerializationTestType expected = serializedRecords.poll();
-
-			SerializationTestType actual = expected.getClass().newInstance();
-			RecordDeserializer.DeserializationResult result = deserializer.getNextRecord(actual);
-
-			Assert.assertTrue(result.isFullRecord());
-			Assert.assertEquals(expected, actual);
-			numRecords--;
-		}
+		numRecords -= DeserializationUtils.deserializeRecords(serializedRecords, deserializer, true);
 
 		// assert that all records have been serialized and deserialized
 		Assert.assertEquals(0, numRecords);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -301,8 +301,8 @@ public class SpanningRecordSerializationTest extends TestLogger {
 		}
 
 		@Override
-		public LargeObjectTypeDeserializingTooMuch getRandom(Random rnd) {
-			int length = super.getRandom(rnd).length();
+		public LargeObjectTypeDeserializingTooMuch getRandom(Random random) {
+			int length = super.getRandom(random).length();
 			return new LargeObjectTypeDeserializingTooMuch(length);
 		}
 
@@ -333,8 +333,8 @@ public class SpanningRecordSerializationTest extends TestLogger {
 		}
 
 		@Override
-		public LargeObjectTypeDeserializingNotEnough getRandom(Random rnd) {
-			int length = super.getRandom(rnd).length();
+		public LargeObjectTypeDeserializingNotEnough getRandom(Random random) {
+			int length = super.getRandom(random).length();
 			return new LargeObjectTypeDeserializingNotEnough(length);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -454,7 +454,7 @@ public class RecordWriterTest {
 				Buffer buffer = buildSingleBuffer(queues[i].remove());
 				deserializer.setNextBuffer(buffer);
 
-				assertRecords += DeserializationUtils.deserializeRecords(expectedRecords, deserializer);
+				assertRecords += DeserializationUtils.deserializeRecords(expectedRecords, deserializer, false);
 			}
 			Assert.assertEquals(numValues, assertRecords);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/serialization/types/LargeObjectType.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/serialization/types/LargeObjectType.java
@@ -30,9 +30,9 @@ import java.util.Random;
  */
 public class LargeObjectType implements SerializationTestType {
 
-	private static final int MIN_LEN = 12 * 1000 * 1000;
+	public static final int MIN_LEN = 12 * 1000 * 1000;
 
-	private static final int MAX_LEN = 40 * 1000 * 1000;
+	public static final int MAX_LEN = 40 * 1000 * 1000;
 
 	private int len;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/DeserializationUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/DeserializationUtils.java
@@ -25,6 +25,10 @@ import org.junit.Assert;
 
 import java.util.ArrayDeque;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+
 /**
  * Utility class to help deserialization for testing.
  */
@@ -36,18 +40,25 @@ public final class DeserializationUtils {
 	 *
 	 * @param records records to be deserialized
 	 * @param deserializer the record deserializer
+	 * @param mustBeFullRecords if set, fails if the deserialized records contain partial records
 	 * @return the number of full deserialized records
 	 */
 	public static int deserializeRecords(
 			ArrayDeque<SerializationTestType> records,
-			RecordDeserializer<SerializationTestType> deserializer) throws Exception {
+			RecordDeserializer<SerializationTestType> deserializer,
+			boolean mustBeFullRecords) throws Exception {
 		int deserializedRecords = 0;
 
 		while (!records.isEmpty()) {
 			SerializationTestType expected = records.poll();
 			SerializationTestType actual = expected.getClass().newInstance();
 
-			if (deserializer.getNextRecord(actual).isFullRecord()) {
+			RecordDeserializer.DeserializationResult deserializationResult =
+				deserializer.getNextRecord(actual);
+			if (mustBeFullRecords) {
+				assertThat(deserializationResult, hasProperty("fullRecord", equalTo(true)));
+			}
+			if (deserializationResult.isFullRecord()) {
 				Assert.assertEquals(expected, actual);
 				deserializedRecords++;
 			} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/DeserializationUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/DeserializationUtils.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.io.network.util;
 
+import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
-import org.apache.flink.testutils.serialization.types.SerializationTestType;
 
 import org.junit.Assert;
 
@@ -43,15 +43,16 @@ public final class DeserializationUtils {
 	 * @param mustBeFullRecords if set, fails if the deserialized records contain partial records
 	 * @return the number of full deserialized records
 	 */
-	public static int deserializeRecords(
-			ArrayDeque<SerializationTestType> records,
-			RecordDeserializer<SerializationTestType> deserializer,
+	public static <T extends IOReadableWritable> int deserializeRecords(
+			ArrayDeque<T> records,
+			RecordDeserializer<T> deserializer,
 			boolean mustBeFullRecords) throws Exception {
 		int deserializedRecords = 0;
 
 		while (!records.isEmpty()) {
-			SerializationTestType expected = records.poll();
-			SerializationTestType actual = expected.getClass().newInstance();
+			T expected = records.poll();
+			@SuppressWarnings("unchecked")
+			T actual = (T) expected.getClass().newInstance();
 
 			RecordDeserializer.DeserializationResult deserializationResult =
 				deserializer.getNextRecord(actual);

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.misc;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.DataInputView;
@@ -32,13 +31,17 @@ import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matchers;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.Matchers.hasProperty;
 
 /**
  * Test for proper error messages in case user-defined serialization is broken
@@ -48,6 +51,9 @@ import static org.junit.Assert.fail;
 public class CustomSerializationITCase extends TestLogger {
 
 	private static final int PARLLELISM = 5;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	@ClassRule
 	public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE = new MiniClusterWithClientResource(
@@ -64,127 +70,42 @@ public class CustomSerializationITCase extends TestLogger {
 	}
 
 	@Test
-	public void testIncorrectSerializer1() {
-		try {
-			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
-
-			env
-				.generateSequence(1, 10 * PARLLELISM)
-				.map(new MapFunction<Long, ConsumesTooMuch>() {
-					@Override
-					public ConsumesTooMuch map(Long value) throws Exception {
-						return new ConsumesTooMuch();
-					}
-				})
-				.rebalance()
-				.output(new DiscardingOutputFormat<ConsumesTooMuch>());
-
-			env.execute();
-		}
-		catch (JobExecutionException e) {
-			Throwable rootCause = e.getCause();
-			assertTrue(rootCause instanceof IOException);
-			assertTrue(rootCause.getMessage().contains("broken serialization"));
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+	public void testIncorrectSerializer1() throws Exception {
+		testIncorrectSerializer(value -> new ConsumesTooMuch());
 	}
 
 	@Test
-	public void testIncorrectSerializer2() {
-		try {
-			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
-
-			env
-					.generateSequence(1, 10 * PARLLELISM)
-					.map(new MapFunction<Long, ConsumesTooMuchSpanning>() {
-						@Override
-						public ConsumesTooMuchSpanning map(Long value) throws Exception {
-							return new ConsumesTooMuchSpanning();
-						}
-					})
-					.rebalance()
-					.output(new DiscardingOutputFormat<ConsumesTooMuchSpanning>());
-
-			env.execute();
-		}
-		catch (JobExecutionException e) {
-			Throwable rootCause = e.getCause();
-			assertTrue(rootCause instanceof IOException);
-			assertTrue(rootCause.getMessage().contains("broken serialization"));
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+	public void testIncorrectSerializer2() throws Exception {
+		testIncorrectSerializer(value -> new ConsumesTooMuchSpanning());
 	}
 
 	@Test
-	public void testIncorrectSerializer3() {
-		try {
-			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
-
-			env
-					.generateSequence(1, 10 * PARLLELISM)
-					.map(new MapFunction<Long, ConsumesTooLittle>() {
-						@Override
-						public ConsumesTooLittle map(Long value) throws Exception {
-							return new ConsumesTooLittle();
-						}
-					})
-					.rebalance()
-					.output(new DiscardingOutputFormat<ConsumesTooLittle>());
-
-			env.execute();
-		}
-		catch (JobExecutionException e) {
-			Throwable rootCause = e.getCause();
-			assertTrue(rootCause instanceof IOException);
-			assertTrue(rootCause.getMessage().contains("broken serialization"));
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+	public void testIncorrectSerializer3() throws Exception {
+		testIncorrectSerializer(value -> new ConsumesTooLittle());
 	}
 
 	@Test
-	public void testIncorrectSerializer4() {
-		try {
-			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-			env.setParallelism(PARLLELISM);
-			env.getConfig().disableSysoutLogging();
+	public void testIncorrectSerializer4() throws Exception {
+		testIncorrectSerializer(value -> new ConsumesTooLittleSpanning());
+	}
 
-			env
-					.generateSequence(1, 10 * PARLLELISM)
-					.map(new MapFunction<Long, ConsumesTooLittleSpanning>() {
-						@Override
-						public ConsumesTooLittleSpanning map(Long value) throws Exception {
-							return new ConsumesTooLittleSpanning();
-						}
-					})
-					.rebalance()
-					.output(new DiscardingOutputFormat<ConsumesTooLittleSpanning>());
+	private <T> void testIncorrectSerializer(MapFunction<Long, T> mapper) throws Exception {
+		expectedException.expect(JobExecutionException.class);
+		expectedException.expectCause(
+			Matchers.both(isA(IOException.class))
+				.and(hasProperty("message", containsString("broken serialization"))));
 
-			env.execute();
-		}
-		catch (ProgramInvocationException e) {
-			Throwable rootCause = e.getCause().getCause();
-			assertTrue(rootCause instanceof IOException);
-			assertTrue(rootCause.getMessage().contains("broken serialization"));
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(PARLLELISM);
+		env.getConfig().disableSysoutLogging();
+
+		env
+			.generateSequence(1, 10 * PARLLELISM)
+			.map(mapper)
+			.rebalance()
+			.output(new DiscardingOutputFormat<>());
+
+		env.execute();
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

`SpillingAdaptiveSpanningRecordDeserializer` doesn't have too many consistency checks for usage calls or serializers behaving properly, e.g. to read only as many bytes as available/promised for that record. At least these checks should be added:

1. Check that buffers have not been read from yet before adding them (this is an invariant `SpillingAdaptiveSpanningRecordDeserializer` works with and from what I can see, it is followed now.
2. Check that after deserialization, we actually consumed `recordLength` bytes
   - If not, in the spanning deserializer, we currently simply skip the remaining bytes.
   - But in the non-spanning deserializer, we currently continue from the wrong offset.
3. Protect against `setNextBuffer()` being called before draining all available records

## Brief change log

- add the aforementioned checks
- also add `[FLINK-9812][network][tests] fix SpanningRecordSerializationTest not using deserializer correctly` which was needed to not throw based on the added checks
- fix not resetting all fields correctly in `SpanningWrapper` (to safeguard further usages / future changes)

This PR is based on #6693 

## Verifying this change

This change is already covered by existing tests for the successful de/serializations, e.g. via `SpanningRecordSerializationTest`.

This change added tests and can be verified as follows:

- added misbehaving serialization tests under `SpanningRecordSerializationTest`
- adapted and fixed `CustomSerializationITCase`, working with `ExpectedException` now (please also note that `testIncorrectSerializer4` is not actually verifying behaviour - previously it silently passed although no exception was thrown)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes** (network only!)
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
