### PR TITLE
[FLINK-10157] [State TTL] Allow `null` user values in map state with TTL

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -350,6 +350,9 @@ will lead to compatibility failure and `StateMigrationException`.
 
 - The TTL configuration is not part of check- or savepoints but rather a way of how Flink treats it in the currently running job.
 
+- The map state with TTL currently supports null user values only if the user value serializer can handle null values. 
+If the serializer does not support null values, it can be wrapped with `NullableSerializer` at the cost of an extra byte in the serialized form.
+
 #### Cleanup of Expired State
 
 Currently, expired values are only removed when they are read out explicitly, 

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MapStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MapStateDescriptor.java
@@ -37,6 +37,12 @@ import java.util.Map;
  * <p>To create keyed map state (on a KeyedStream), use
  * {@link org.apache.flink.api.common.functions.RuntimeContext#getMapState(MapStateDescriptor)}.
  *
+ * <p>Note: The map state with TTL currently supports {@code null} user values
+ * only if the user value serializer can handle {@code null} values.
+ * If the serializer does not support {@code null} values,
+ * it can be wrapped with {@link org.apache.flink.api.java.typeutils.runtime.NullableSerializer}
+ * at the cost of an extra byte in the serialized form.
+ *
  * @param <UK> The type of the keys that can be added to the map state.
  */
 @PublicEvolving

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -33,9 +33,9 @@ import static org.apache.flink.api.common.state.StateTtlConfig.UpdateType.OnCrea
 /**
  * Configuration of state TTL logic.
  *
- * <p>Note: The map state with TTL currently supports null user values
- * only if the user value serializer can handle null values.
- * If the serializer does not support null values,
+ * <p>Note: The map state with TTL currently supports {@code null} user values
+ * only if the user value serializer can handle {@code null} values.
+ * If the serializer does not support {@code null} values,
  * it can be wrapped with {@link org.apache.flink.api.java.typeutils.runtime.NullableSerializer}
  * at the cost of an extra byte in the serialized form.
  */

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -32,6 +32,12 @@ import static org.apache.flink.api.common.state.StateTtlConfig.UpdateType.OnCrea
 
 /**
  * Configuration of state TTL logic.
+ *
+ * <p>Note: The map state with TTL currently supports null user values
+ * only if the user value serializer can handle null values.
+ * If the serializer does not support null values,
+ * it can be wrapped with {@link org.apache.flink.api.java.typeutils.runtime.NullableSerializer}
+ * at the cost of an extra byte in the serialized form.
  */
 public class StateTtlConfig implements Serializable {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.CompatibilityUtil;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeDeserializerAdapter;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Serializer wrapper to add support of null value serialization.
+ *
+ * <p>If the target serializer does not support null values of its type,
+ * you can use this class to wrap this serializer.
+ * This is a generic treatment of null value serialization
+ * which comes with the cost of additional byte in the final serialized value.
+ * The {@code NullableSerializer} will intercept null value serialization case
+ * and prepend the target serialized value with a boolean flag marking whether it is null or not.
+ * <pre> {@code
+ * TypeSerializer<T> originalSerializer = ...;
+ * TypeSerializer<T> serializerWithNullValueSupport = NullableSerializer.wrap(originalSerializer);
+ * // or
+ * TypeSerializer<T> serializerWithNullValueSupport = NullableSerializer.wrapIfNullIsNotSupported(originalSerializer);
+ * }}</pre>
+ *
+ * @param <T> type to serialize
+ */
+public class NullableSerializer<T> extends TypeSerializer<T> {
+	private static final long serialVersionUID = 3335569358214720033L;
+
+	private final TypeSerializer<T> originalSerializer;
+
+	private NullableSerializer(TypeSerializer<T> originalSerializer) {
+		Preconditions.checkNotNull(originalSerializer, "The original serializer cannot be null");
+		this.originalSerializer = originalSerializer;
+	}
+
+	/**
+	 * This method tries to serialize null value with the {@code originalSerializer}
+	 * and wraps it in case of {@link NullPointerException}, otherwise it returns the {@code originalSerializer}.
+	 */
+	public static <T> TypeSerializer<T> wrapIfNullIsNotSupported(TypeSerializer<T> originalSerializer) {
+		return checkIfNullSupported(originalSerializer) ? originalSerializer : wrap(originalSerializer);
+	}
+
+	private static <T> boolean checkIfNullSupported(TypeSerializer<T> originalSerializer) {
+		try {
+			originalSerializer.serialize(null, new DataOutputSerializer(1));
+			Preconditions.checkArgument(originalSerializer.copy(null) == null);
+		} catch (NullPointerException | IOException e) {
+			return false;
+		}
+		return true;
+	}
+
+	/** This method wraps the {@code originalSerializer} with the {@code NullableSerializer} if not already wrapped. */
+	public static <T> TypeSerializer<T> wrap(TypeSerializer<T> originalSerializer) {
+		return originalSerializer instanceof NullableSerializer ?
+			originalSerializer : new NullableSerializer<>(originalSerializer);
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return originalSerializer.isImmutableType();
+	}
+
+	@Override
+	public TypeSerializer<T> duplicate() {
+		return new NullableSerializer<>(originalSerializer.duplicate());
+	}
+
+	@Override
+	public T createInstance() {
+		return originalSerializer.createInstance();
+	}
+
+	@Override
+	public T copy(T from) {
+		return from == null ? null : originalSerializer.copy(from);
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		return from == null ? null :
+			(reuse == null ? originalSerializer.copy(from) : originalSerializer.copy(from, reuse));
+	}
+
+	@Override
+	public int getLength() {
+		int len = originalSerializer.getLength();
+		return len < 0 ? len : len + 1;
+	}
+
+	@Override
+	public void serialize(T record, DataOutputView target) throws IOException {
+		if (record == null) {
+			target.writeBoolean(true);
+		} else {
+			target.writeBoolean(false);
+			originalSerializer.serialize(record, target);
+		}
+	}
+
+	@Override
+	public T deserialize(DataInputView source) throws IOException {
+		boolean isNull = source.readBoolean();
+		return isNull ? null : originalSerializer.deserialize(source);
+	}
+
+	@Override
+	public T deserialize(T reuse, DataInputView source) throws IOException {
+		boolean isNull = source.readBoolean();
+		return isNull ? null : (reuse == null ?
+			originalSerializer.deserialize(source) : originalSerializer.deserialize(reuse, source));
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		boolean isNull = source.readBoolean();
+		target.writeBoolean(isNull);
+		if (!isNull) {
+			originalSerializer.copy(source, target);
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj == this ||
+			(obj != null && obj.getClass() == getClass() &&
+				originalSerializer.equals(((NullableSerializer) originalSerializer).originalSerializer));
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return (obj != null && obj.getClass() == getClass());
+	}
+
+	@Override
+	public int hashCode() {
+		return originalSerializer.hashCode();
+	}
+
+	@Override
+	public NullableSerializerConfigSnapshot<T> snapshotConfiguration() {
+		return new NullableSerializerConfigSnapshot<>(originalSerializer);
+	}
+
+	@Override
+	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+		if (configSnapshot instanceof NullableSerializerConfigSnapshot) {
+			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> previousKvSerializersAndConfigs =
+				((NullableSerializerConfigSnapshot) configSnapshot).getNestedSerializersAndConfigs();
+
+			CompatibilityResult<T> compatResult = CompatibilityUtil.resolveCompatibilityResult(
+				previousKvSerializersAndConfigs.get(0).f0,
+				UnloadableDummyTypeSerializer.class,
+				previousKvSerializersAndConfigs.get(0).f1,
+				originalSerializer);
+
+			if (!compatResult.isRequiresMigration()) {
+				return CompatibilityResult.compatible();
+			} else if (compatResult.getConvertDeserializer() != null) {
+				return CompatibilityResult.requiresMigration(
+					new NullableSerializer<>(
+						new TypeDeserializerAdapter<>(compatResult.getConvertDeserializer())));
+			}
+		}
+
+		return CompatibilityResult.requiresMigration();
+	}
+
+	/**
+	 * Configuration snapshot for serializers of nullable types, containing the
+	 * configuration snapshot of its original serializer.
+	 */
+	@Internal
+	public static class NullableSerializerConfigSnapshot<T> extends CompositeTypeSerializerConfigSnapshot {
+		private static final int VERSION = 1;
+
+		/** This empty nullary constructor is required for deserializing the configuration. */
+		@SuppressWarnings("unused")
+		public NullableSerializerConfigSnapshot() {}
+
+		NullableSerializerConfigSnapshot(TypeSerializer<T> originalSerializer) {
+			super(originalSerializer);
+		}
+
+		@Override
+		public int getVersion() {
+			return VERSION;
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 
 import org.apache.flink.api.java.typeutils.runtime.NullableSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
@@ -430,14 +429,7 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 	public void testNullability() {
 		TypeSerializer<T> serializer = getSerializer();
 		try {
-			int len = serializer.getLength();
-			if (NullableSerializer.checkIfNullSupported(serializer) && len > 0) {
-				DataOutputSerializer dos = new DataOutputSerializer(len);
-				serializer.serialize(null, dos);
-				assertEquals("The serialized form of the null value should have the same length " +
-						"as any other if the length is fixed in the serializer",
-					getLength(), dos.getCopyOfBuffer().length);
-			}
+			NullableSerializer.checkIfNullSupported(serializer);
 		} catch (Throwable t) {
 			System.err.println(t.getMessage());
 			t.printStackTrace();

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
@@ -18,28 +18,41 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.core.memory.DataInputDeserializer;
-import org.apache.flink.core.memory.DataOutputSerializer;
 
 import org.junit.Test;
 
-import java.io.IOException;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link NullableSerializer}. */
-public class NullableSerializerTest {
+public class NullableSerializerTest extends SerializerTestBase<Integer> {
 	private static final TypeSerializer<Integer> originalSerializer = IntSerializer.INSTANCE;
 	private static final TypeSerializer<Integer> nullableSerializer =
 		NullableSerializer.wrapIfNullIsNotSupported(originalSerializer);
-	private static final DataOutputSerializer dov = new DataOutputSerializer(
-		nullableSerializer.getLength() > 0 ? nullableSerializer.getLength() : 0);
-	private static final DataInputDeserializer div = new DataInputDeserializer();
+
+	@Override
+	protected TypeSerializer<Integer> createSerializer() {
+		return NullableSerializer.wrapIfNullIsNotSupported(originalSerializer);
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<Integer> getTypeClass() {
+		return Integer.class;
+	}
+
+	@Override
+	protected Integer[] getTestData() {
+		return new Integer[] { 5, -1, 0, null };
+	}
 
 	@Test
 	public void testWrappingNotNeeded() {
@@ -50,31 +63,5 @@ public class NullableSerializerTest {
 	public void testWrappingNeeded() {
 		assertTrue(nullableSerializer instanceof NullableSerializer);
 		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(nullableSerializer), nullableSerializer);
-	}
-
-	@Test
-	public void testNonNullSerialization() throws IOException {
-		dov.clear();
-		nullableSerializer.serialize(5, dov);
-
-		div.setBuffer(dov.getSharedBuffer());
-		assertEquals((int) nullableSerializer.deserialize(div), 5);
-		div.setBuffer(dov.getSharedBuffer());
-		assertEquals((int) nullableSerializer.deserialize(10, div), 5);
-		div.setBuffer(dov.getSharedBuffer());
-		assertEquals((int) nullableSerializer.deserialize(null, div), 5);
-	}
-
-	@Test
-	public void testNullSerialization() throws IOException {
-		dov.clear();
-		nullableSerializer.serialize(null, dov);
-
-		div.setBuffer(dov.getSharedBuffer());
-		assertNull(nullableSerializer.deserialize(div));
-		div.setBuffer(dov.getSharedBuffer());
-		assertNull(nullableSerializer.deserialize(10, div));
-		div.setBuffer(dov.getSharedBuffer());
-		assertNull(nullableSerializer.deserialize(null, div));
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
@@ -1,0 +1,62 @@
+package org.apache.flink.api.java.typeutils.runtime;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for {@link NullableSerializer}. */
+public class NullableSerializerTest {
+	private static final TypeSerializer<Integer> originalSerializer = IntSerializer.INSTANCE;
+	private static final TypeSerializer<Integer> nullableSerializer =
+		NullableSerializer.wrapIfNullIsNotSupported(originalSerializer);
+	private static final DataOutputSerializer dov = new DataOutputSerializer(
+		nullableSerializer.getLength() > 0 ? nullableSerializer.getLength() : 0);
+	private static final DataInputDeserializer div = new DataInputDeserializer();
+
+	@Test
+	public void testWrappingNotNeeded() {
+		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(StringSerializer.INSTANCE), StringSerializer.INSTANCE);
+	}
+
+	@Test
+	public void testWrappingNeeded() {
+		assertTrue(nullableSerializer instanceof NullableSerializer);
+		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(nullableSerializer), nullableSerializer);
+	}
+
+	@Test
+	public void testNonNullSerialization() throws IOException {
+		dov.clear();
+		nullableSerializer.serialize(5, dov);
+
+		div.setBuffer(dov.getSharedBuffer());
+		assertEquals((int) nullableSerializer.deserialize(div), 5);
+		div.setBuffer(dov.getSharedBuffer());
+		assertEquals((int) nullableSerializer.deserialize(10, div), 5);
+		div.setBuffer(dov.getSharedBuffer());
+		assertEquals((int) nullableSerializer.deserialize(null, div), 5);
+	}
+
+	@Test
+	public void testNullSerialization() throws IOException {
+		dov.clear();
+		nullableSerializer.serialize(null, dov);
+
+		div.setBuffer(dov.getSharedBuffer());
+		assertNull(nullableSerializer.deserialize(div));
+		div.setBuffer(dov.getSharedBuffer());
+		assertNull(nullableSerializer.deserialize(10, div));
+		div.setBuffer(dov.getSharedBuffer());
+		assertNull(nullableSerializer.deserialize(null, div));
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
@@ -23,25 +23,45 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link NullableSerializer}. */
+@RunWith(Parameterized.class)
 public class NullableSerializerTest extends SerializerTestBase<Integer> {
 	private static final TypeSerializer<Integer> originalSerializer = IntSerializer.INSTANCE;
-	private static final TypeSerializer<Integer> nullableSerializer =
-		NullableSerializer.wrapIfNullIsNotSupported(originalSerializer);
+
+	@Parameterized.Parameters(name = "{0}")
+	public static List<Boolean> whetherToPadNullValue() {
+		return Arrays.asList(true, false);
+	}
+
+	@Parameterized.Parameter
+	public boolean padNullValue;
+
+	private TypeSerializer<Integer> nullableSerializer;
+
+	@Before
+	public void init() {
+		nullableSerializer = NullableSerializer.wrapIfNullIsNotSupported(originalSerializer, padNullValue);
+	}
 
 	@Override
 	protected TypeSerializer<Integer> createSerializer() {
-		return NullableSerializer.wrapIfNullIsNotSupported(originalSerializer);
+		return NullableSerializer.wrapIfNullIsNotSupported(originalSerializer, padNullValue);
 	}
 
 	@Override
 	protected int getLength() {
-		return -1;
+		return padNullValue ? 5 : -1;
 	}
 
 	@Override
@@ -56,12 +76,12 @@ public class NullableSerializerTest extends SerializerTestBase<Integer> {
 
 	@Test
 	public void testWrappingNotNeeded() {
-		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(StringSerializer.INSTANCE), StringSerializer.INSTANCE);
+		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(StringSerializer.INSTANCE, padNullValue), StringSerializer.INSTANCE);
 	}
 
 	@Test
 	public void testWrappingNeeded() {
 		assertTrue(nullableSerializer instanceof NullableSerializer);
-		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(nullableSerializer), nullableSerializer);
+		assertEquals(NullableSerializer.wrapIfNullIsNotSupported(nullableSerializer, padNullValue), nullableSerializer);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/AbstractTtlDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/AbstractTtlDecorator.java
@@ -81,6 +81,14 @@ abstract class AbstractTtlDecorator<T> {
 		SupplierWithException<TtlValue<V>, SE> getter,
 		ThrowingConsumer<TtlValue<V>, CE> updater,
 		ThrowingRunnable<CLE> stateClear) throws SE, CE, CLE {
+		TtlValue<V> ttlValue = getWrappedWithTtlCheckAndUpdate(getter, updater, stateClear);
+		return ttlValue == null ? null : ttlValue.getUserValue();
+	}
+
+	<SE extends Throwable, CE extends Throwable, CLE extends Throwable, V> TtlValue<V> getWrappedWithTtlCheckAndUpdate(
+		SupplierWithException<TtlValue<V>, SE> getter,
+		ThrowingConsumer<TtlValue<V>, CE> updater,
+		ThrowingRunnable<CLE> stateClear) throws SE, CE, CLE {
 		TtlValue<V> ttlValue = getter.get();
 		if (ttlValue == null) {
 			return null;
@@ -92,6 +100,6 @@ abstract class AbstractTtlDecorator<T> {
 		} else if (updateTsOnRead) {
 			updater.accept(rewrapWithNewTs(ttlValue));
 		}
-		return ttlValue.getUserValue();
+		return ttlValue;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -54,7 +54,13 @@ class TtlMapState<K, N, UK, UV>
 
 	@Override
 	public UV get(UK key) throws Exception {
-		return getWithTtlCheckAndUpdate(() -> original.get(key), v -> original.put(key, v), () -> original.remove(key));
+		TtlValue<UV> ttlValue = getWrapped(key);
+		return ttlValue == null ? null : ttlValue.getUserValue();
+	}
+
+	private TtlValue<UV> getWrapped(UK key) throws Exception {
+		return getWrappedWithTtlCheckAndUpdate(
+			() -> original.get(key), v -> original.put(key, v), () -> original.remove(key));
 	}
 
 	@Override
@@ -83,7 +89,8 @@ class TtlMapState<K, N, UK, UV>
 
 	@Override
 	public boolean contains(UK key) throws Exception {
-		return get(key) != null;
+		TtlValue<UV> ttlValue = getWrapped(key);
+		return ttlValue != null;
 	}
 
 	@Override
@@ -161,16 +168,16 @@ class TtlMapState<K, N, UK, UV>
 		}
 
 		private Map.Entry<UK, UV> getUnexpiredAndUpdateOrCleanup(Map.Entry<UK, TtlValue<UV>> e) {
-			UV unexpiredValue;
+			TtlValue<UV> unexpiredValue;
 			try {
-				unexpiredValue = getWithTtlCheckAndUpdate(
+				unexpiredValue = getWrappedWithTtlCheckAndUpdate(
 					e::getValue,
 					v -> original.put(e.getKey(), v),
 					originalIterator::remove);
 			} catch (Exception ex) {
 				throw new FlinkRuntimeException(ex);
 			}
-			return unexpiredValue == null ? null : new AbstractMap.SimpleEntry<>(e.getKey(), unexpiredValue);
+			return unexpiredValue == null ? null : new AbstractMap.SimpleEntry<>(e.getKey(), unexpiredValue.getUserValue());
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlUtils.java
@@ -44,6 +44,6 @@ class TtlUtils {
 	}
 
 	static <V> TtlValue<V> wrapWithTs(V value, long ts) {
-		return value == null ? null : new TtlValue<>(value, ts);
+		return new TtlValue<>(value, ts);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateAllEntriesTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStateAllEntriesTestContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,9 +36,9 @@ class TtlMapStateAllEntriesTestContext extends
 	void initTestValues() {
 		emptyValue = Collections.emptySet();
 
-		updateEmpty = mapOf(Tuple2.of(3, "3"), Tuple2.of(5, "5"), Tuple2.of(10, "10"));
-		updateUnexpired = mapOf(Tuple2.of(12, "12"), Tuple2.of(7, "7"));
-		updateExpired = mapOf(Tuple2.of(15, "15"), Tuple2.of(4, "4"));
+		updateEmpty = mapOf(Tuple2.of(3, "3"), Tuple2.of(5, "5"), Tuple2.of(23, null), Tuple2.of(10, "10"));
+		updateUnexpired = mapOf(Tuple2.of(12, "12"), Tuple2.of(24, null), Tuple2.of(7, "7"));
+		updateExpired = mapOf(Tuple2.of(15, "15"), Tuple2.of(25, null), Tuple2.of(4, "4"));
 
 		getUpdateEmpty = updateEmpty.entrySet();
 		getUnexpired = updateUnexpired.entrySet();
@@ -46,7 +47,9 @@ class TtlMapStateAllEntriesTestContext extends
 
 	@SafeVarargs
 	private static <UK, UV> Map<UK, UV> mapOf(Tuple2<UK, UV> ... entries) {
-		return Arrays.stream(entries).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+		Map<UK, UV> map = new HashMap<>();
+		Arrays.stream(entries).forEach(t -> map.put(t.f0, t.f1));
+		return map;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStatePerElementTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStatePerElementTestContext.java
@@ -43,7 +43,10 @@ class TtlMapStatePerElementTestContext extends TtlMapStateTestContext<String, St
 
 	@Override
 	String get() throws Exception {
-		return ttlState.get(TEST_KEY);
+		String value = ttlState.get(TEST_KEY);
+		assert (getOriginal() == null && !ttlState.contains(TEST_KEY)) ||
+			(getOriginal() != null && ttlState.contains(TEST_KEY));
+		return value;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStatePerNullElementTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlMapStatePerNullElementTestContext.java
@@ -18,33 +18,15 @@
 
 package org.apache.flink.runtime.state.ttl;
 
-import javax.annotation.Nullable;
+class TtlMapStatePerNullElementTestContext extends TtlMapStatePerElementTestContext {
+	@Override
+	void initTestValues() {
+		updateEmpty = null;
+		updateUnexpired = null;
+		updateExpired = null;
 
-import java.io.Serializable;
-
-/**
- * This class wraps user value of state with TTL.
- *
- * @param <T> Type of the user value of state with TTL
- */
-class TtlValue<T> implements Serializable {
-	private static final long serialVersionUID = 5221129704201125020L;
-
-	@Nullable
-	private final T userValue;
-	private final long lastAccessTimestamp;
-
-	TtlValue(@Nullable T userValue, long lastAccessTimestamp) {
-		this.userValue = userValue;
-		this.lastAccessTimestamp = lastAccessTimestamp;
-	}
-
-	@Nullable
-	T getUserValue() {
-		return userValue;
-	}
-
-	long getLastAccessTimestamp() {
-		return lastAccessTimestamp;
+		getUpdateEmpty = null;
+		getUnexpired = null;
+		getUpdateExpired = null;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -69,6 +69,7 @@ public abstract class TtlStateTestBase {
 			new TtlListStateTestContext(),
 			new TtlMapStateAllEntriesTestContext(),
 			new TtlMapStatePerElementTestContext(),
+			new TtlMapStatePerNullElementTestContext(),
 			new TtlAggregatingStateTestContext(),
 			new TtlReducingStateTestContext(),
 			new TtlFoldingStateTestContext());


### PR DESCRIPTION
## What is the purpose of the change

This change allows to store null values with TTL and aligns the semantics of map state TTL get/contains methods with the map state w/o TTL.

## Brief change log

  - allow null user value in TtlValue
  - add tests for null user values in Map state
  - add NullableSerializer to wrap serializers w/o null support but where null values are needed in map state
  - doc notes

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
