### PR TITLE
[FLINK-10134] UTF-16 support for TextInputFormat bug fixed

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -62,6 +62,9 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	// Charset is not serializable
 	private transient Charset charset;
 
+	/** The charset of bom in the file to process. */
+	private String bomCharsetName;
+
 	/**
 	 * The default read buffer size = 1MB.
 	 */
@@ -221,6 +224,11 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 		}
 	}
 
+	@PublicEvolving
+	public String getBomCharsetName() {
+		return this.bomCharsetName;
+	}
+
 	public byte[] getDelimiter() {
 		return delimiter;
 	}
@@ -341,7 +349,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	@Override
 	public FileBaseStatistics getStatistics(BaseStatistics cachedStats) throws IOException {
 		
-		final FileBaseStatistics cachedFileStats = cachedStats instanceof FileBaseStatistics ?
+		final FileBaseStatistics cachedFileStats = cachedStats instanceof FileInputFormat.FileBaseStatistics ?
 				(FileBaseStatistics) cachedStats : null;
 		
 		// store properties
@@ -467,6 +475,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	 */
 	@Override
 	public void open(FileInputSplit split) throws IOException {
+		this.bomCharsetName = split.getBomCharsetName();
 		super.open(split);
 		initBuffers();
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -416,7 +416,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 			while (samplesTaken < numSamples && fileNum < allFiles.size()) {
 				// make a split for the sample and use it to read a record
 				FileStatus file = allFiles.get(fileNum);
-				String bomCharsetName = getBomCharset(file.getPath().getPath());
+				String bomCharsetName = getBomCharset(file);
 
 				FileInputSplit split = new FileInputSplit(0, file.getPath(), offset, file.getLen() - offset, null, bomCharsetName);
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -416,7 +416,9 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 			while (samplesTaken < numSamples && fileNum < allFiles.size()) {
 				// make a split for the sample and use it to read a record
 				FileStatus file = allFiles.get(fileNum);
-				FileInputSplit split = new FileInputSplit(0, file.getPath(), offset, file.getLen() - offset, null);
+				String bomCharsetName = getBomCharset(file.getPath().getPath());
+
+				FileInputSplit split = new FileInputSplit(0, file.getPath(), offset, file.getLen() - offset, null, bomCharsetName);
 
 				// we open the split, read one line, and take its length
 				try {
@@ -745,7 +747,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 		Preconditions.checkNotNull(split, "reopen() cannot be called on a null split.");
 		Preconditions.checkNotNull(state, "reopen() cannot be called with a null initial state.");
 		Preconditions.checkArgument(state == -1 || state >= split.getStart(),
-			" Illegal offset "+ state +", smaller than the splits start=" + split.getStart());
+			" Illegal offset " + state + ", smaller than the splits start=" + split.getStart());
 
 		try {
 			this.open(split);

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -612,6 +612,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		for (final FileStatus file : files) {
 
 			String bomCharsetName = getBomCharset(file.getPath().getPath());
+			System.out.println("bomCharsetName:"+bomCharsetName);
 
 			final FileSystem fs = file.getPath().getFileSystem();
 			final long len = file.getLen();

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -37,8 +37,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,20 +53,20 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link #nextRecord(Object)} and {@link #reachedEnd()} methods need to be implemented.
  * Additionally, one may override {@link #open(FileInputSplit)} and {@link #close()} to
  * change the life cycle behavior.
- * 
+ *
  * <p>After the {@link #open(FileInputSplit)} method completed, the file input data is available
  * from the {@link #stream} field.</p>
  */
 @Public
 public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputSplit> {
-	
+
 	// -------------------------------------- Constants -------------------------------------------
-	
+
 	private static final Logger LOG = LoggerFactory.getLogger(FileInputFormat.class);
-	
+
 	private static final long serialVersionUID = 1L;
-	
-	
+
+
 	/**
 	 * The fraction that the last split may be larger than the others.
 	 */
@@ -84,8 +82,8 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * unsplittable files.
 	 */
 	protected static final Map<String, InflaterInputStreamFactory<?>> INFLATER_INPUT_STREAM_FACTORIES =
-			new HashMap<String, InflaterInputStreamFactory<?>>();
-	
+		new HashMap<String, InflaterInputStreamFactory<?>>();
+
 	/**
 	 * The splitLength is set to -1L for reading the whole split.
 	 */
@@ -100,6 +98,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	/**
 	 * Initialize defaults for input format. Needs to be a static method because it is configured for local
 	 * cluster execution, see LocalFlinkMiniCluster.
+	 *
 	 * @param configuration The configuration to load defaults from
 	 */
 	private static void initDefaultsFromConfiguration(Configuration configuration) {
@@ -118,10 +117,10 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 
 	private static void initDefaultInflaterInputStreamFactories() {
 		InflaterInputStreamFactory<?>[] defaultFactories = {
-				DeflateInflaterInputStreamFactory.getInstance(),
-				GzipInflaterInputStreamFactory.getInstance(),
-				Bzip2InputStreamFactory.getInstance(),
-				XZInputStreamFactory.getInstance(),
+			DeflateInflaterInputStreamFactory.getInstance(),
+			GzipInflaterInputStreamFactory.getInstance(),
+			Bzip2InputStreamFactory.getInstance(),
+			XZInputStreamFactory.getInstance(),
 		};
 		for (InflaterInputStreamFactory<?> inputStreamFactory : defaultFactories) {
 			for (String fileExtension : inputStreamFactory.getCommonFileExtensions()) {
@@ -133,8 +132,9 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	/**
 	 * Registers a decompression algorithm through a {@link org.apache.flink.api.common.io.compression.InflaterInputStreamFactory}
 	 * with a file extension for transparent decompression.
+	 *
 	 * @param fileExtension of the compressed files
-	 * @param factory to create an {@link java.util.zip.InflaterInputStream} that handles the decompression format
+	 * @param factory       to create an {@link java.util.zip.InflaterInputStream} that handles the decompression format
 	 */
 	public static void registerInflaterInputStreamFactory(String fileExtension, InflaterInputStreamFactory<?> factory) {
 		synchronized (INFLATER_INPUT_STREAM_FACTORIES) {
@@ -152,12 +152,13 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 
 	/**
 	 * Returns the extension of a file name (!= a path).
+	 *
 	 * @return the extension of the file name or {@code null} if there is no extension.
 	 */
 	protected static String extractFileExtension(String fileName) {
 		checkNotNull(fileName);
 		int lastPeriodIndex = fileName.lastIndexOf('.');
-		if (lastPeriodIndex < 0){
+		if (lastPeriodIndex < 0) {
 			return null;
 		} else {
 			return fileName.substring(lastPeriodIndex + 1);
@@ -197,7 +198,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * The path to the file that contains the input.
 	 *
 	 * @deprecated Please override {@link FileInputFormat#supportsMultiPaths()} and
-	 *             use {@link FileInputFormat#getFilePaths()} and {@link FileInputFormat#setFilePaths(Path...)}.
+	 * use {@link FileInputFormat#getFilePaths()} and {@link FileInputFormat#setFilePaths(Path...)}.
 	 */
 	@Deprecated
 	protected Path filePath;
@@ -243,7 +244,8 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	//  Constructors
 	// --------------------------------------------------------------------------------------------
 
-	public FileInputFormat() {}
+	public FileInputFormat() {
+	}
 
 	protected FileInputFormat(Path filePath) {
 		if (filePath != null) {
@@ -256,9 +258,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 *
 	 * @return The path of the file to read.
-	 *
 	 * @deprecated Please use getFilePaths() instead.
 	 */
 	@Deprecated
@@ -294,7 +294,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			if (this.filePath == null) {
 				return new Path[0];
 			}
-			return new Path[] {filePath};
+			return new Path[]{filePath};
 		}
 	}
 
@@ -482,13 +482,12 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		} catch (IOException ioex) {
 			if (LOG.isWarnEnabled()) {
 				LOG.warn("Could not determine statistics for paths '" + Arrays.toString(getFilePaths()) + "' due to an io error: "
-						+ ioex.getMessage());
+					+ ioex.getMessage());
 			}
-		}
-		catch (Throwable t) {
+		} catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
 				LOG.error("Unexpected problem while getting the file statistics for paths '" + Arrays.toString(getFilePaths()) + "': "
-						+ t.getMessage(), t);
+					+ t.getMessage(), t);
 			}
 		}
 
@@ -566,7 +565,6 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 *
 	 * @param minNumSplits The minimum desired number of file splits.
 	 * @return The computed file splits.
-	 *
 	 * @see org.apache.flink.api.common.io.InputFormat#createInputSplits(int)
 	 */
 	@Override
@@ -607,15 +605,15 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 				final FileSystem fs = file.getPath().getFileSystem();
 				final BlockLocation[] blocks = fs.getFileBlockLocations(file, 0, file.getLen());
 				Set<String> hosts = new HashSet<String>();
-				for(BlockLocation block : blocks) {
+				for (BlockLocation block : blocks) {
 					hosts.addAll(Arrays.asList(block.getHosts()));
 				}
 				long len = file.getLen();
-				if(testForUnsplittable(file)) {
+				if (testForUnsplittable(file)) {
 					len = READ_WHOLE_SPLIT_FLAG;
 				}
 				FileInputSplit fis = new FileInputSplit(splitNum++, file.getPath(), 0, len,
-						hosts.toArray(new String[hosts.size()]),bomCharsetName);
+					hosts.toArray(new String[hosts.size()]), bomCharsetName);
 				inputSplits.add(fis);
 			}
 			return inputSplits.toArray(new FileInputSplit[inputSplits.size()]);
@@ -637,8 +635,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			final long minSplitSize;
 			if (this.minSplitSize <= blockSize) {
 				minSplitSize = this.minSplitSize;
-			}
-			else {
+			} else {
 				if (LOG.isWarnEnabled()) {
 					LOG.warn("Minimal split size of " + this.minSplitSize + " is larger than the block size of " +
 						blockSize + ". Decreasing minimal split size to block size.");
@@ -667,7 +664,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 					blockIndex = getBlockIndexForPosition(blocks, position, halfSplit, blockIndex);
 					// create a new split
 					FileInputSplit fis = new FileInputSplit(splitNum++, file.getPath(), position, splitSize,
-						blocks[blockIndex].getHosts(),bomCharsetName);
+						blocks[blockIndex].getHosts(), bomCharsetName);
 					inputSplits.add(fis);
 
 					// adjust the positions
@@ -679,7 +676,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 				if (bytesUnassigned > 0) {
 					blockIndex = getBlockIndexForPosition(blocks, position, halfSplit, blockIndex);
 					final FileInputSplit fis = new FileInputSplit(splitNum++, file.getPath(), position,
-						bytesUnassigned, blocks[blockIndex].getHosts(),bomCharsetName);
+						bytesUnassigned, blocks[blockIndex].getHosts(), bomCharsetName);
 					inputSplits.add(fis);
 				}
 			} else {
@@ -691,7 +688,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 				} else {
 					hosts = new String[0];
 				}
-				final FileInputSplit fis = new FileInputSplit(splitNum++, file.getPath(), 0, 0, hosts,bomCharsetName);
+				final FileInputSplit fis = new FileInputSplit(splitNum++, file.getPath(), 0, 0, hosts, bomCharsetName);
 				inputSplits.add(fis);
 			}
 		}
@@ -701,32 +698,32 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 
 	/**
 	 * Enumerate all files in the directory and recursive if enumerateNestedFiles is true.
+	 *
 	 * @return the total length of accepted files.
 	 */
 	private long addFilesInDir(Path path, List<FileStatus> files, boolean logExcludedFiles)
-			throws IOException {
+		throws IOException {
 		final FileSystem fs = path.getFileSystem();
 
 		long length = 0;
 
-		for(FileStatus dir: fs.listStatus(path)) {
+		for (FileStatus dir : fs.listStatus(path)) {
 			if (dir.isDir()) {
 				if (acceptFile(dir) && enumerateNestedFiles) {
 					length += addFilesInDir(dir.getPath(), files, logExcludedFiles);
 				} else {
 					if (logExcludedFiles && LOG.isDebugEnabled()) {
-						LOG.debug("Directory "+dir.getPath().toString()+" did not pass the file-filter and is excluded.");
+						LOG.debug("Directory " + dir.getPath().toString() + " did not pass the file-filter and is excluded.");
 					}
 				}
-			}
-			else {
-				if(acceptFile(dir)) {
+			} else {
+				if (acceptFile(dir)) {
 					files.add(dir);
 					length += dir.getLen();
 					testForUnsplittable(dir);
 				} else {
 					if (logExcludedFiles && LOG.isDebugEnabled()) {
-						LOG.debug("Directory "+dir.getPath().toString()+" did not pass the file-filter and is excluded.");
+						LOG.debug("Directory " + dir.getPath().toString() + " did not pass the file-filter and is excluded.");
 					}
 				}
 			}
@@ -735,7 +732,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	}
 
 	protected boolean testForUnsplittable(FileStatus pathFile) {
-		if(getInflaterInputStreamFactory(pathFile.getPath()) != null) {
+		if (getInflaterInputStreamFactory(pathFile.getPath()) != null) {
 			unsplittable = true;
 			return true;
 		}
@@ -771,8 +768,8 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * Retrieves the index of the <tt>BlockLocation</tt> that contains the part of the file described by the given
 	 * offset.
 	 *
-	 * @param blocks The different blocks of the file. Must be ordered by their offset.
-	 * @param offset The offset of the position in the file.
+	 * @param blocks     The different blocks of the file. Must be ordered by their offset.
+	 * @param offset     The offset of the position in the file.
 	 * @param startIndex The earliest index to look at.
 	 * @return The index of the block containing the given position.
 	 */
@@ -823,10 +820,9 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		try {
 			this.stream = isot.waitForCompletion();
 			this.stream = decorateInputStream(this.stream, fileSplit);
-		}
-		catch (Throwable t) {
+		} catch (Throwable t) {
 			throw new IOException("Error opening the Input Split " + fileSplit.getPath() +
-					" [" + splitStart + "," + splitLength + "]: " + t.getMessage(), t);
+				" [" + splitStart + "," + splitLength + "]: " + t.getMessage(), t);
 		}
 
 		// get FSDataInputStream
@@ -873,7 +869,6 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * When this method will be removed, all FileInputFormats have to support multiple paths.
 	 *
 	 * @return True if the FileInputFormat supports multiple paths, false otherwise.
-	 *
 	 * @deprecated Will be removed for Flink 2.0.
 	 */
 	@Deprecated
@@ -885,11 +880,12 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	public String toString() {
 		return getFilePaths() == null || getFilePaths().length == 0 ?
 			"File Input (unknown file)" :
-			"File Input (" +  Arrays.toString(this.getFilePaths()) + ')';
+			"File Input (" + Arrays.toString(this.getFilePaths()) + ')';
 	}
 
 	/**
 	 * Get file bom encoding
+	 *
 	 * @param fs
 	 * @return
 	 */
@@ -953,12 +949,9 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		/**
 		 * Creates a new statistics object.
 		 *
-		 * @param fileModTime
-		 *        The timestamp of the latest modification of any of the involved files.
-		 * @param fileSize
-		 *        The size of the file, in bytes. <code>-1</code>, if unknown.
-		 * @param avgBytesPerRecord
-		 *        The average number of byte in a record, or <code>-1.0f</code>, if unknown.
+		 * @param fileModTime       The timestamp of the latest modification of any of the involved files.
+		 * @param fileSize          The size of the file, in bytes. <code>-1</code>, if unknown.
+		 * @param avgBytesPerRecord The average number of byte in a record, or <code>-1.0f</code>, if unknown.
 		 */
 		public FileBaseStatistics(long fileModTime, long fileSize, float avgBytesPerRecord) {
 			this.fileModTime = fileModTime;
@@ -1009,35 +1002,35 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		public float getAverageRecordWidth() {
 			return this.avgBytesPerRecord;
 		}
-		
+
 		@Override
 		public String toString() {
 			return "size=" + this.fileSize + ", recWidth=" + this.avgBytesPerRecord + ", modAt=" + this.fileModTime;
 		}
 	}
-	
+
 	// ============================================================================================
-	
+
 	/**
 	 * Obtains a DataInputStream in an thread that is not interrupted.
 	 * This is a necessary hack around the problem that the HDFS client is very sensitive to InterruptedExceptions.
 	 */
 	public static class InputSplitOpenThread extends Thread {
-		
+
 		private final FileInputSplit split;
-		
+
 		private final long timeout;
 
 		private volatile FSDataInputStream fdis;
 
 		private volatile Throwable error;
-		
+
 		private volatile boolean aborted;
 
 		public InputSplitOpenThread(FileInputSplit split, long timeout) {
 			super("Transient InputSplit Opener");
 			setDaemon(true);
-			
+
 			this.split = split;
 			this.timeout = timeout;
 		}
@@ -1047,37 +1040,35 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			try {
 				final FileSystem fs = FileSystem.get(this.split.getPath().toUri());
 				this.fdis = fs.open(this.split.getPath());
-				
+
 				// check for canceling and close the stream in that case, because no one will obtain it
 				if (this.aborted) {
 					final FSDataInputStream f = this.fdis;
 					this.fdis = null;
 					f.close();
 				}
-			}
-			catch (Throwable t) {
+			} catch (Throwable t) {
 				this.error = t;
 			}
 		}
-		
+
 		public FSDataInputStream waitForCompletion() throws Throwable {
 			final long start = System.currentTimeMillis();
 			long remaining = this.timeout;
-			
+
 			do {
 				try {
 					// wait for the task completion
 					this.join(remaining);
-				}
-				catch (InterruptedException iex) {
+				} catch (InterruptedException iex) {
 					// we were canceled, so abort the procedure
 					abortWait();
 					throw iex;
 				}
 			}
 			while (this.error == null && this.fdis == null &&
-					(remaining = this.timeout + start - System.currentTimeMillis()) > 0);
-			
+				(remaining = this.timeout + start - System.currentTimeMillis()) > 0);
+
 			if (this.error != null) {
 				throw this.error;
 			}
@@ -1089,17 +1080,17 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 				// b) the flag was set such that the stream did not see it and we have a valid stream
 				// In any case, close the stream and throw an exception.
 				abortWait();
-				
+
 				final boolean stillAlive = this.isAlive();
 				final StringBuilder bld = new StringBuilder(256);
 				for (StackTraceElement e : this.getStackTrace()) {
 					bld.append("\tat ").append(e.toString()).append('\n');
 				}
-				throw new IOException("Input opening request timed out. Opener was " + (stillAlive ? "" : "NOT ") + 
+				throw new IOException("Input opening request timed out. Opener was " + (stillAlive ? "" : "NOT ") +
 					" alive. Stack of split open thread:\n" + bld.toString());
 			}
 		}
-		
+
 		/**
 		 * Double checked procedure setting the abort flag and closing the stream.
 		 */
@@ -1110,17 +1101,18 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			if (inStream != null) {
 				try {
 					inStream.close();
-				} catch (Throwable t) {}
+				} catch (Throwable t) {
+				}
 			}
 		}
 	}
-	
+
 	// ============================================================================================
 	//  Parameterization via configuration
 	// ============================================================================================
-	
+
 	// ------------------------------------- Config Keys ------------------------------------------
-	
+
 	/**
 	 * The config parameter which defines the input file path.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -612,7 +612,6 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		for (final FileStatus file : files) {
 
 			String bomCharsetName = getBomCharset(file.getPath().getPath());
-			System.out.println("bomCharsetName:"+bomCharsetName);
 
 			final FileSystem fs = file.getPath().getFileSystem();
 			final long len = file.getLen();
@@ -877,7 +876,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	 * @param filePath
 	 * @return
 	 */
-	public  String getBomCharset(String filePath) {
+	public String getBomCharset(String filePath) {
 		FileInputStream is = null;
 		String charset = null;
 		try {

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -906,7 +906,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			if (testFileSystem.equals(fileSystem.getClass().getSimpleName())) {
 				fileSystem = new LocalFileSystem();
 			}
-			
+
 			inStream = fileSystem.open(fs.getPath());
 			inStream.read(bom, 0, bom.length);
 
@@ -921,8 +921,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			} else if ((bom[0] == bytes[2]) && (bom[1] == bytes[1])) {
 				charset = "UTF-16LE";
 			} else {
-				// Unicode BOM mark not found, default encoding is UTF-8
-				charset = "UTF-8";
+				charset = null;
 			}
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Failed to get file bom encoding.");

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -906,14 +906,10 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			if (testFileSystem.equals(fileSystem.getClass().getSimpleName())) {
 				fileSystem = new LocalFileSystem();
 			}
+			
 			inStream = fileSystem.open(fs.getPath());
-
-			InflaterInputStreamFactory<?> inflaterInputStreamFactory = getInflaterInputStreamFactory(fs.getPath());
-			if (inflaterInputStreamFactory != null) {
-				inStream = new InputStreamFSInputWrapper(inflaterInputStreamFactory.create(stream));
-			}
-
 			inStream.read(bom, 0, bom.length);
+
 			if ((bom[0] == bytes[0]) && (bom[1] == bytes[0]) && (bom[2] == bytes[1]) && (bom[3] == bytes[2])) {
 				charset = "UTF-32BE";
 			} else if ((bom[0] == bytes[2]) && (bom[1] == bytes[1]) && (bom[2] == bytes[0]) && (bom[3] == bytes[0])) {

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
@@ -121,7 +121,7 @@ public class FileInputSplit extends LocatableInputSplit {
 	}
 
 	/**
-	 * Return the charset of bom in the file
+	 * Returns the charset of bom in the file.
 	 *
 	 * @return the charset of bom in the file
 	 */

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
@@ -39,6 +39,9 @@ public class FileInputSplit extends LocatableInputSplit {
 	/** The number of bytes in the file to process. */
 	private final long length;
 
+	/** The charset of bom in the file to process. */
+	private String bomCharsetName;
+
 	// --------------------------------------------------------------------------------------------
 
 	/**
@@ -61,6 +64,31 @@ public class FileInputSplit extends LocatableInputSplit {
 		this.file = file;
 		this.start = start;
 		this.length = length;
+	}
+
+	/**
+	 * Constructs a split with host information.
+	 *
+	 * @param num
+	 *        the number of this input split
+	 * @param file
+	 *        the file name
+	 * @param start
+	 *        the position of the first byte in the file to process
+	 * @param length
+	 *        the number of bytes in the file to process (-1 is flag for "read whole file")
+	 * @param hosts
+	 *        the list of hosts containing the block, possibly <code>null</code>
+	 * @param bomCharsetName
+	 *        The charset of bom in the file to process (default is UTF-8)
+	 */
+	public FileInputSplit(int num, Path file, long start, long length, String[] hosts, String bomCharsetName) {
+		super(num, hosts);
+
+		this.file = file;
+		this.start = start;
+		this.length = length;
+		this.bomCharsetName = bomCharsetName;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -91,6 +119,12 @@ public class FileInputSplit extends LocatableInputSplit {
 	public long getLength() {
 		return length;
 	}
+
+	/**
+	 * return the charset of bom in the file
+	 * @return
+	 */
+	public String getBomCharsetName(){return bomCharsetName;}
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
@@ -124,7 +124,9 @@ public class FileInputSplit extends LocatableInputSplit {
 	 * return the charset of bom in the file
 	 * @return
 	 */
-	public String getBomCharsetName(){return bomCharsetName;}
+	public String getBomCharsetName(){
+		return bomCharsetName;
+	}
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileInputSplit.java
@@ -121,8 +121,9 @@ public class FileInputSplit extends LocatableInputSplit {
 	}
 
 	/**
-	 * return the charset of bom in the file
-	 * @return
+	 * Return the charset of bom in the file
+	 *
+	 * @return the charset of bom in the file
 	 */
 	public String getBomCharsetName(){
 		return bomCharsetName;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -60,7 +60,7 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	public String getCharsetName() {
 		String bomCharsetName = getBomCharsetName();
-		if(!bomCharsetName.equals(charsetName)){
+		if(bomCharsetName!=null&&!bomCharsetName.equals(charsetName)){
 			return bomCharsetName;
 		}else{
 			return charsetName;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -90,20 +90,22 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	@Override
 	public String readRecord(String reusable, byte[] bytes, int offset, int numBytes) throws IOException {
+		int step = 0;
+		String charsetName = this.getCharsetName();
+		if (charsetName.contains("UTF-8")) {
+			step = 1;
+		} else if (charsetName.contains("UTF-16")) {
+			step = 2;
+		} else if (charsetName.contains("UTF-32")) {
+			step = 4;
+		}
 		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
 		if (this.getDelimiter() != null && this.getDelimiter().length == 1
-				&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
-				&& bytes[offset + numBytes - 1] == CARRIAGE_RETURN) {
-			numBytes -= 1;
-		} else if (this.getDelimiter() != null && this.getDelimiter().length == 1
-			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 3
-			&& bytes[offset + numBytes - 2] == CARRIAGE_RETURN) {
-			numBytes -= 3;
-		} else if (this.getDelimiter() != null && this.getDelimiter().length == 1
-			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 5
-			&& bytes[offset + numBytes - 4] == CARRIAGE_RETURN) {
-			numBytes -= 5;
+			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= step
+			&& bytes[offset + numBytes - step] == CARRIAGE_RETURN) {
+			numBytes -= step;
 		}
+		numBytes = numBytes - step + 1;
 		return new String(bytes, offset, numBytes, this.getCharsetName());
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -60,9 +60,9 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	public String getCharsetName() {
 		String bomCharsetName = getBomCharsetName();
-		if(bomCharsetName!=null&&!bomCharsetName.equals(charsetName)){
+		if (bomCharsetName!=null&&!bomCharsetName.equals(charsetName)) {
 			return bomCharsetName;
-		}else{
+		} else {
 			return charsetName;
 		}
 	}
@@ -93,15 +93,15 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
 		if (this.getDelimiter() != null && this.getDelimiter().length == 1
 				&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
-				&& bytes[offset + numBytes - 1] == CARRIAGE_RETURN){
+				&& bytes[offset + numBytes - 1] == CARRIAGE_RETURN) {
 			numBytes -= 1;
-		}else if(this.getDelimiter() != null && this.getDelimiter().length == 1
+		} else if (this.getDelimiter() != null && this.getDelimiter().length == 1
 			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
-			&& bytes[offset + numBytes - 2] == CARRIAGE_RETURN){
+			&& bytes[offset + numBytes - 2] == CARRIAGE_RETURN) {
 			numBytes -= 3;
-		} else if(this.getDelimiter() != null && this.getDelimiter().length == 1
+		} else if (this.getDelimiter() != null && this.getDelimiter().length == 1
 			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
-			&& bytes[offset + numBytes - 4] == CARRIAGE_RETURN){
+			&& bytes[offset + numBytes - 4] == CARRIAGE_RETURN) {
 			numBytes -= 5;
 		}
 		return new String(bytes, offset, numBytes, this.getCharsetName());

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -96,11 +96,11 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 				&& bytes[offset + numBytes - 1] == CARRIAGE_RETURN) {
 			numBytes -= 1;
 		} else if (this.getDelimiter() != null && this.getDelimiter().length == 1
-			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
+			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 3
 			&& bytes[offset + numBytes - 2] == CARRIAGE_RETURN) {
 			numBytes -= 3;
 		} else if (this.getDelimiter() != null && this.getDelimiter().length == 1
-			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
+			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 5
 			&& bytes[offset + numBytes - 4] == CARRIAGE_RETURN) {
 			numBytes -= 5;
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -59,7 +59,12 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 	// --------------------------------------------------------------------------------------------
 
 	public String getCharsetName() {
-		return charsetName;
+		String bomCharsetName = getBomCharsetName();
+		if(!bomCharsetName.equals(charsetName)){
+			return bomCharsetName;
+		}else{
+			return charsetName;
+		}
 	}
 
 	public void setCharsetName(String charsetName) {
@@ -90,9 +95,16 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 				&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
 				&& bytes[offset + numBytes - 1] == CARRIAGE_RETURN){
 			numBytes -= 1;
+		}else if(this.getDelimiter() != null && this.getDelimiter().length == 1
+			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
+			&& bytes[offset + numBytes - 2] == CARRIAGE_RETURN){
+			numBytes -= 3;
+		} else if(this.getDelimiter() != null && this.getDelimiter().length == 1
+			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= 1
+			&& bytes[offset + numBytes - 4] == CARRIAGE_RETURN){
+			numBytes -= 5;
 		}
-
-		return new String(bytes, offset, numBytes, this.charsetName);
+		return new String(bytes, offset, numBytes, this.getCharsetName());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -60,7 +60,7 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	public String getCharsetName() {
 		String bomCharsetName = getBomCharsetName();
-		if (bomCharsetName!=null&&!bomCharsetName.equals(charsetName)) {
+		if (bomCharsetName != null && !bomCharsetName.equals(charsetName)) {
 			return bomCharsetName;
 		} else {
 			return charsetName;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -90,22 +90,25 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	@Override
 	public String readRecord(String reusable, byte[] bytes, int offset, int numBytes) throws IOException {
-		int step = 0;
+		String utf8 = "UTF-8";
+		String utf16 = "UTF-16";
+		String utf32 = "UTF-32";
+		int stepSize = 0;
 		String charsetName = this.getCharsetName();
-		if (charsetName.contains("UTF-8")) {
-			step = 1;
-		} else if (charsetName.contains("UTF-16")) {
-			step = 2;
-		} else if (charsetName.contains("UTF-32")) {
-			step = 4;
+		if (charsetName.contains(utf8)) {
+			stepSize = 1;
+		} else if (charsetName.contains(utf16)) {
+			stepSize = 2;
+		} else if (charsetName.contains(utf32)) {
+			stepSize = 4;
 		}
 		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
 		if (this.getDelimiter() != null && this.getDelimiter().length == 1
-			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= step
-			&& bytes[offset + numBytes - step] == CARRIAGE_RETURN) {
-			numBytes -= step;
+			&& this.getDelimiter()[0] == NEW_LINE && offset + numBytes >= stepSize
+			&& bytes[offset + numBytes - stepSize] == CARRIAGE_RETURN) {
+			numBytes -= stepSize;
 		}
-		numBytes = numBytes - step + 1;
+		numBytes = numBytes - stepSize + 1;
 		return new String(bytes, offset, numBytes, this.getCharsetName());
 	}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+
 import org.junit.Test;
 
 import java.io.File;
@@ -32,12 +33,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link TextInputFormat}.
@@ -250,13 +251,13 @@ public class TextInputFormatTest {
 			result = inputFormat.nextRecord("");
 			System.out.println(result);
 			assertNotNull("Expecting first record here", result);
-//			assertEquals(first, result.substring(1));
+			assertEquals(first, result.substring(1));
 
 			assertFalse(inputFormat.reachedEnd());
 			result = inputFormat.nextRecord(result);
 			System.out.println(result);
 			assertNotNull("Expecting second record here", result);
-//			assertEquals(second, result);
+			assertEquals(second, result);
 
 			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -240,17 +240,19 @@ public class TextInputFormatTest {
 
 			String result = "";
 
+			System.out.println("bomCharsetName:"+inputFormat.getBomCharsetName());
+
 			assertFalse(inputFormat.reachedEnd());
 			result = inputFormat.nextRecord("");
 			System.out.println(result);
 			assertNotNull("Expecting first record here", result);
-			assertEquals(first, result.substring(1));
+//			assertEquals(first, result.substring(1));
 
 			assertFalse(inputFormat.reachedEnd());
 			result = inputFormat.nextRecord(result);
 			System.out.println(result);
 			assertNotNull("Expecting second record here", result);
-			assertEquals(second, result);
+//			assertEquals(second, result);
 
 			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -226,7 +226,7 @@ public class TextInputFormatTest {
 			tempFile.deleteOnExit();
 			tempFile.setWritable(true);
 
-			PrintStream ps = new  PrintStream(tempFile, "UTF-16");
+			PrintStream ps = new PrintStream(tempFile, "UTF-16");
 			ps.println(first);
 			ps.println(second);
 			ps.close();
@@ -261,8 +261,7 @@ public class TextInputFormatTest {
 			assertEquals(second, result);
 
 			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
-		}
-		catch (Throwable t) {
+		} catch (Throwable t) {
 			System.err.println("test failed with exception: " + t.getMessage());
 			t.printStackTrace(System.err);
 			fail("Test erroneous");

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -237,7 +237,8 @@ public class TextInputFormatTest {
 			Configuration parameters = new Configuration();
 			inputFormat.configure(parameters);
 
-//			inputFormat.setDelimiter("\n");
+//			inputFormat.setDelimiter("\r");
+//			inputFormat.setDelimiter("i");
 
 			FileInputSplit[] splits = inputFormat.createInputSplits(1);
 			assertTrue("expected at least one input split", splits.length >= 1);

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -32,7 +32,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link TextInputFormat}.
@@ -211,8 +216,8 @@ public class TextInputFormatTest {
 
 	@Test
 	public void testUTF16Read() {
-		final String first = "userId,startTime,startLon,startLat,endTime,endLon,endLat";
-		final String second = "15,2017-08-01 08:03:42,121.553284356451,31.2453823853525,2017-08-01 09:12:45,121.44078692371,31.1641319953861";
+		final String first = "First line";
+		final String second = "Second line";
 
 		try {
 			// create input file
@@ -237,10 +242,9 @@ public class TextInputFormatTest {
 			assertTrue("expected at least one input split", splits.length >= 1);
 			inputFormat.open(splits[0]);
 
-
 			String result = "";
 
-			System.out.println("bomCharsetName:"+inputFormat.getBomCharsetName());
+			System.out.println("bomCharsetName:" + inputFormat.getBomCharsetName());
 
 			assertFalse(inputFormat.reachedEnd());
 			result = inputFormat.nextRecord("");

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -55,7 +55,7 @@ public class TextInputFormatTest {
 			tempFile.deleteOnExit();
 			tempFile.setWritable(true);
 
-			PrintStream ps = new  PrintStream(tempFile);
+			PrintStream ps = new PrintStream(tempFile);
 			ps.println(first);
 			ps.println(second);
 			ps.close();
@@ -83,8 +83,7 @@ public class TextInputFormatTest {
 			assertEquals(second, result);
 
 			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
-		}
-		catch (Throwable t) {
+		} catch (Throwable t) {
 			System.err.println("test failed with exception: " + t.getMessage());
 			t.printStackTrace(System.err);
 			fail("Test erroneous");
@@ -93,11 +92,11 @@ public class TextInputFormatTest {
 
 	@Test
 	public void testNestedFileRead() {
-		String[] dirs = new String[] {"tmp/first/", "tmp/second/"};
+		String[] dirs = new String[]{"tmp/first/", "tmp/second/"};
 		List<String> expectedFiles = new ArrayList<>();
 
 		try {
-			for (String dir: dirs) {
+			for (String dir : dirs) {
 				// create input file
 				File tmpDir = new File(dir);
 				if (!tmpDir.exists()) {
@@ -127,7 +126,7 @@ public class TextInputFormatTest {
 			FileInputSplit[] splits = inputFormat.createInputSplits(expectedFiles.size());
 
 			List<String> paths = new ArrayList<>();
-			for (FileInputSplit split: splits) {
+			for (FileInputSplit split : splits) {
 				paths.add(split.getPath().toString());
 			}
 
@@ -188,7 +187,7 @@ public class TextInputFormatTest {
 
 			String result = "";
 			if ((delimiter.equals("\n") && (lineBreaker.equals("\n") || lineBreaker.equals("\r\n")))
-					|| (lineBreaker.equals(delimiter))){
+				|| (lineBreaker.equals(delimiter))) {
 
 				result = inputFormat.nextRecord("");
 				assertNotNull("Expecting first record here", result);
@@ -207,8 +206,7 @@ public class TextInputFormatTest {
 				assertEquals(content, result);
 			}
 
-		}
-		catch (Throwable t) {
+		} catch (Throwable t) {
 			System.err.println("test failed with exception: " + t.getMessage());
 			t.printStackTrace(System.err);
 			fail("Test erroneous");
@@ -231,8 +229,8 @@ public class TextInputFormatTest {
 			ps.println(second);
 			ps.close();
 
-//			System.out.println(tempFile.toURI().toString());
 			TextInputFormat inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+			inputFormat.setCharsetName("UTF-32");
 
 			Configuration parameters = new Configuration();
 			inputFormat.configure(parameters);
@@ -253,6 +251,56 @@ public class TextInputFormatTest {
 			System.out.println(result);
 			assertNotNull("Expecting first record here", result);
 			assertEquals(first, result.substring(1));
+
+			assertFalse(inputFormat.reachedEnd());
+			result = inputFormat.nextRecord(result);
+			System.out.println(result);
+			assertNotNull("Expecting second record here", result);
+			assertEquals(second, result);
+
+			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
+		} catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			fail("Test erroneous");
+		}
+	}
+
+	@Test
+	public void testUTF32Read() {
+		final String first = "First line";
+		final String second = "Second line";
+
+		try {
+			// create input file
+			File tempFile = File.createTempFile("TextInputFormatTest", "tmp");
+			tempFile.deleteOnExit();
+			tempFile.setWritable(true);
+
+			PrintStream ps = new PrintStream(tempFile, "UTF-32");
+			ps.println(first);
+			ps.println(second);
+			ps.close();
+
+			TextInputFormat inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+			inputFormat.setCharsetName("UTF-32");
+
+			Configuration parameters = new Configuration();
+			inputFormat.configure(parameters);
+
+			FileInputSplit[] splits = inputFormat.createInputSplits(1);
+			assertTrue("expected at least one input split", splits.length >= 1);
+			inputFormat.open(splits[0]);
+
+			String result = "";
+
+			System.out.println("bomCharsetName:" + inputFormat.getBomCharsetName());
+
+			assertFalse(inputFormat.reachedEnd());
+			result = inputFormat.nextRecord("");
+			System.out.println(result);
+			assertNotNull("Expecting first record here", result);
+			assertEquals(first, result);
 
 			assertFalse(inputFormat.reachedEnd());
 			result = inputFormat.nextRecord(result);


### PR DESCRIPTION
## What is the purpose of the change

*(This PR is designed to solve the problem of `TextInputFormat` using UTF-16 encoding to parse files.)*

## Brief change log

*(To solve this bug, I added a file BOM header encoding check to determine the current file encoding, so that when user-defined encoding format and file with a BOM header encoding format conflict processing, specific changes in the following::)*

- *I add `getBomCharset` function to `FileInputFormat. java` to detect the current file BOM header coding judgment, mainly `UTF-16BE`, `UTF-16LE`, `UTF-8 with BOM header`, `UTF-32BE`, `UTF-32LE` these types, default to `UTF-8`.*
- *I added a call to `getBomCharset` in `FileInputFormat`'s `createInputSplits` function and assigned the obtained BOM encoding to FileInputSplit. To copy the BOM encoding to FileInputSplit, I added `bomCharsetName` and `FileInputSplit (int num, Path file, long start, long, String [] hosts ,String  bomCharsetName)` constructor.*
- *I added the `bomCharsetName` variable to the `DelimitedInputFormat`, `this. bomCharsetName = split. getBomCharsetName ()` to the `open` method, and `getBomCharsetName` to get the `bomCharsetName` variable.*
- In `TextInputFormat`, `getCharsetName` adds if there is a BOM header encoding that is inconsistent with the current user-specified encoding format to overwrite the current user-defined encoding format with a BOM header encoding, or if there is no BOM header encoding, a user-defined encoding format or a default encoding format (UTF-8). In the readRecord function, UTF16 and UTF-32 newlines are added. Processing judgment, `this.charsetName` will be replaced by `this.getCharsetName ()`.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *I added `testUTF16Read`  and `testUTF32Read` to `TextInputFormatTest`.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no )
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)