### PR TITLE
[FLINK-8424] update cassandra and driver version to latest

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<cassandra.version>2.2.5</cassandra.version>
-		<driver.version>3.0.0</driver.version>
+		<cassandra.version>3.11.3</cassandra.version>
+		<driver.version>3.6.0</driver.version>
 	</properties>
 
 	<build>

--- a/flink-connectors/flink-connector-cassandra/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-cassandra/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
-- com.datastax.cassandra:cassandra-driver-core:3.0.0
-- com.datastax.cassandra:cassandra-driver-mapping:3.0.0
+- com.datastax.cassandra:cassandra-driver-core:3.6.0
+- com.datastax.cassandra:cassandra-driver-mapping:3.6.0
 - com.google.guava:guava:18.0
-- io.netty:netty-handler:4.0.33.Final
-- io.netty:netty-buffer:4.0.33.Final
-- io.netty:netty-common:4.0.33.Final
-- io.netty:netty-transport:4.0.33.Final
-- io.netty:netty-codec:4.0.33.Final
+- io.netty:netty-handler:4.0.56.Final
+- io.netty:netty-buffer:4.0.56.Final
+- io.netty:netty-common:4.0.56.Final
+- io.netty:netty-transport:4.0.56.Final
+- io.netty:netty-codec:4.0.56.Final

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -144,8 +144,7 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 
 		public void start() throws IOException {
 			this.cassandraDaemon = new CassandraDaemon();
-			this.cassandraDaemon.init(null);
-			this.cassandraDaemon.start();
+			this.cassandraDaemon.activate();
 		}
 
 		public void stop() {

--- a/flink-connectors/flink-connector-cassandra/src/test/resources/cassandra.yaml
+++ b/flink-connectors/flink-connector-cassandra/src/test/resources/cassandra.yaml
@@ -21,9 +21,11 @@ commitlog_sync_period_in_ms: 10000
 commitlog_segment_size_in_mb: 16
 partitioner: 'org.apache.cassandra.dht.RandomPartitioner'
 endpoint_snitch: 'org.apache.cassandra.locator.SimpleSnitch'
+cdc_raw_directory: $PATH/cdc'
 commitlog_directory: $PATH/commit'
 data_file_directories:
     - $PATH/data'
+hints_directory: $PATH/hints'
 saved_caches_directory: $PATH/cache'
 listen_address: '127.0.0.1'
 seed_provider:


### PR DESCRIPTION
## What is the purpose of the change

*Update the cassandra and driver version of the cassandra connector*


## Brief change log

*Update the cassandra driver version to 3.6.0*
```
+- com.datastax.cassandra:cassandra-driver-core:jar:3.6.0:compile
|  +- io.netty:netty-handler:jar:4.0.56.Final:compile
|  |  +- io.netty:netty-buffer:jar:4.0.56.Final:compile
|  |  |  \- io.netty:netty-common:jar:4.0.56.Final:compile
|  |  +- io.netty:netty-transport:jar:4.0.56.Final:compile
|  |  \- io.netty:netty-codec:jar:4.0.56.Final:compile
|  +- io.dropwizard.metrics:metrics-core:jar:3.2.2:compile
|  +- com.github.jnr:jnr-ffi:jar:2.1.7:compile
|  |  +- com.github.jnr:jffi:jar:1.2.16:compile
|  |  +- com.github.jnr:jffi:jar:native:1.2.16:runtime
|  |  +- org.ow2.asm:asm-commons:jar:5.0.3:compile
|  |  +- org.ow2.asm:asm-analysis:jar:5.0.3:compile
|  |  +- org.ow2.asm:asm-tree:jar:5.0.3:compile
|  |  +- org.ow2.asm:asm-util:jar:5.0.3:compile
|  |  \- com.github.jnr:jnr-x86asm:jar:1.0.2:compile
|  \- com.github.jnr:jnr-posix:jar:3.0.44:compile
|     \- com.github.jnr:jnr-constants:jar:0.9.9:compile
+- com.datastax.cassandra:cassandra-driver-mapping:jar:3.6.0:compile
```
*Update the cassandra version to 3.11.3*
```
+- org.apache.cassandra:cassandra-all:jar:3.11.3:test
|  +- net.jpountz.lz4:lz4:jar:1.3.0:test
|  +- com.ning:compress-lzf:jar:0.8.4:test
|  +- commons-codec:commons-codec:jar:1.10:test
|  +- com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:jar:1.4:test
|  +- org.antlr:antlr:jar:3.5.2:test
|  |  \- org.antlr:ST4:jar:4.0.8:test
|  +- org.antlr:antlr-runtime:jar:3.5.2:test
|  +- org.slf4j:jcl-over-slf4j:jar:1.7.7:test
|  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:test
|  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:test
|  +- com.googlecode.json-simple:json-simple:jar:1.1:test
|  +- com.boundary:high-scale-lib:jar:1.0.6:test
|  +- org.yaml:snakeyaml:jar:1.11:test
|  +- org.mindrot:jbcrypt:jar:0.3m:test
|  +- io.airlift:airline:jar:0.6:test
|  |  \- javax.inject:javax.inject:jar:1:test
|  +- io.dropwizard.metrics:metrics-jvm:jar:3.1.5:test
|  +- com.addthis.metrics:reporter-config3:jar:3.0.3:test
|  |  +- com.addthis.metrics:reporter-config-base:jar:3.0.3:test
|  |  \- org.hibernate:hibernate-validator:jar:4.3.0.Final:test
|  |     +- javax.validation:validation-api:jar:1.0.0.GA:test
|  |     \- org.jboss.logging:jboss-logging:jar:3.1.0.CR2:test
|  +- com.thinkaurelius.thrift:thrift-server:jar:0.3.7:test
|  |  \- com.lmax:disruptor:jar:3.0.1:test
|  +- com.clearspring.analytics:stream:jar:2.5.2:test
|  |  \- it.unimi.dsi:fastutil:jar:6.5.7:test
|  +- ch.qos.logback:logback-core:jar:1.1.3:test
|  +- org.apache.thrift:libthrift:jar:0.9.2:test
|  |  +- org.apache.httpcomponents:httpclient:jar:4.5.3:test
|  |  \- org.apache.httpcomponents:httpcore:jar:4.4.6:test
|  +- org.apache.cassandra:cassandra-thrift:jar:3.11.3:test
|  |  +- com.carrotsearch:hppc:jar:0.5.4:test
|  |  +- de.jflex:jflex:jar:1.6.0:test
|  |  |  \- org.apache.ant:ant:jar:1.7.0:test
|  |  |     \- org.apache.ant:ant-launcher:jar:1.7.0:test
|  |  +- com.github.rholder:snowball-stemmer:jar:1.3.0.581.1:test
|  |  \- com.googlecode.concurrent-trees:concurrent-trees:jar:2.4.0:test
|  +- net.java.dev.jna:jna:jar:4.2.2:test
|  +- com.github.jbellis:jamm:jar:0.3.0:test
|  +- io.netty:netty-all:jar:4.0.44.Final:test
|  +- joda-time:joda-time:jar:2.5:test
|  +- org.fusesource:sigar:jar:1.6.4:test
|  +- org.eclipse.jdt.core.compiler:ecj:jar:4.4.2:test
|  +- org.caffinitas.ohc:ohc-core:jar:0.4.4:test
|  +- org.caffinitas.ohc:ohc-core-j8:jar:0.4.4:test
|  +- com.github.ben-manes.caffeine:caffeine:jar:2.2.6:test
|  +- org.jctools:jctools-core:jar:1.2.1:test
|  \- org.ow2.asm:asm:jar:5.0.4:compile
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
