### PR TITLE
[FLINK-10376] [tests] Replace mkdirTolerateExisting by thread safe Files#createDirectories

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -192,27 +192,9 @@ public class BlobUtils {
 	static File getIncomingDirectory(File storageDir) throws IOException {
 		final File incomingDir = new File(storageDir, "incoming");
 
-		mkdirTolerateExisting(incomingDir);
+		Files.createDirectories(incomingDir.toPath());
 
 		return incomingDir;
-	}
-
-	/**
-	 * Makes sure a given directory exists by creating it if necessary.
-	 *
-	 * @param dir
-	 * 		directory to create
-	 *
-	 * @throws IOException
-	 * 		if creating the directory fails
-	 */
-	private static void mkdirTolerateExisting(final File dir) throws IOException {
-		// note: thread-safe create should try to mkdir first and then ignore the case that the
-		//       directory already existed
-		if (!dir.mkdirs() && !dir.exists()) {
-			throw new IOException(
-				"Cannot create directory '" + dir.getAbsolutePath() + "'.");
-		}
 	}
 
 	/**
@@ -234,7 +216,7 @@ public class BlobUtils {
 			File storageDir, @Nullable JobID jobId, BlobKey key) throws IOException {
 		File file = new File(getStorageLocationPath(storageDir.getAbsolutePath(), jobId, key));
 
-		mkdirTolerateExisting(file.getParentFile());
+		Files.createDirectories(file.getParentFile().toPath());
 
 		return file;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -492,8 +492,7 @@ public class BlobServerPutTest extends TestLogger {
 			rnd.nextBytes(data);
 
 			// upload the file to the server directly
-			exception.expect(IOException.class);
-			exception.expectMessage("Cannot create directory ");
+			exception.expect(AccessDeniedException.class);
 
 			put(server, jobId, data, blobType);
 


### PR DESCRIPTION
## What is the purpose of the change

Mainly to resolve the unstable test `BlobCacheCleanupTest#testPermanentBlobCleanup`. By replace `BlobUtils#mkdirTolerateExisting` with the same functional（but thread-safe) method `java.nio.file.Files#createDirectories`.


## Verifying this change

Verified by passing existing tests, since it is a reinforce.
