### PR TITLE
[FLINK-10378] [github] Comment out contribute guide from PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-
+<!--
 *Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
 
 *Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*
@@ -22,6 +22,7 @@
 
 
 **(The sections below can be removed for hotfixes of typos)**
+-->
 
 ## What is the purpose of the change
 


### PR DESCRIPTION
## What is the purpose of the change

Explicitly comment out contribute guide from PULL_REQUEST_TEMPLATE by `<!-- -->`.

This is a hint to contributor that such message is as information and would not appear at the final content, as a side effect also reduce the work the a contributor delete such text every time.
