### PR TITLE
[FLINK-10380] Add precondition for assignToKeyGroup method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
@@ -56,7 +56,12 @@ public final class KeyGroupRangeAssignment {
 	 * @return the key-group to which the given key is assigned
 	 */
 	public static int assignToKeyGroup(Object key, int maxParallelism) {
-		return computeKeyGroupForKeyHash(key.hashCode(), maxParallelism);
+		try {
+			return computeKeyGroupForKeyHash(key.hashCode(), maxParallelism);
+		} catch (NullPointerException e){
+			throw new RuntimeException("Stream partition key must not be null. " +
+				"Ensure that a key provided for partitioning operator state is not null.", e);
+		}
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -278,7 +278,7 @@ public class DataStream<T> {
 	}
 
 	/**
-	 * It creates a new {@link KeyedStream} that uses the provided key for partitioning
+	 * It creates a new {@link KeyedStream} that uses the provided not null key for partitioning
 	 * its operator states.
 	 *
 	 * @param key
@@ -294,7 +294,7 @@ public class DataStream<T> {
 	 * It creates a new {@link KeyedStream} that uses the provided key with explicit type information
 	 * for partitioning its operator states.
 	 *
-	 * @param key The KeySelector to be used for extracting the key for partitioning.
+	 * @param key The KeySelector to be used for extracting the not null key for partitioning.
 	 * @param keyType The type information describing the key type.
 	 * @return The {@link DataStream} with partitioned state (i.e. KeyedStream)
 	 */
@@ -308,7 +308,7 @@ public class DataStream<T> {
 	 * Partitions the operator state of a {@link DataStream} by the given key positions.
 	 *
 	 * @param fields
-	 *            The position of the fields on which the {@link DataStream}
+	 *            The position of the not null fields on which the {@link DataStream}
 	 *            will be grouped.
 	 * @return The {@link DataStream} with partitioned state (i.e. KeyedStream)
 	 */
@@ -327,7 +327,7 @@ public class DataStream<T> {
 	 * down into objects, as in {@code "field1.getInnerField2()" }.
 	 *
 	 * @param fields
-	 *            One or more field expressions on which the state of the {@link DataStream} operators will be
+	 *            One or more not null field expressions on which the state of the {@link DataStream} operators will be
 	 *            partitioned.
 	 * @return The {@link DataStream} with partitioned state (i.e. KeyedStream)
 	 **/


### PR DESCRIPTION
## Contribution Checklist
  
## What is the purpose of the change

This pull request checks add a is not null precondition to providing a better feedback for the user. Without it, Flink cluster throws obscure NullPointerException at runtime.

```
Exception in thread "main" org.apache.flink.runtime.client.JobExecutionException: java.lang.RuntimeException
 at org.apache.flink.runtime.minicluster.MiniCluster.executeJobBlocking(MiniCluster.java:623)
 at org.apache.flink.streaming.api.environment.LocalStreamEnvironment.execute(LocalStreamEnvironment.java:123)
 at org.myorg.quickstart.BuggyKeyedStream.main(BuggyKeyedStream.java:61)
Caused by: java.lang.RuntimeException
 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.pushToRecordWriter(RecordWriterOutput.java:110)
 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.collect(RecordWriterOutput.java:89)16:26:43,110 INFO org.apache.flink.runtime.rpc.akka.AkkaRpcService - Stopped Akka RPC service.
at org.apache.flink.streaming.runtime.io.RecordWriterOutput.collect(RecordWriterOutput.java:45)
 at org.apache.flink.streaming.api.operators.AbstractStreamOperator$CountingOutput.collect(AbstractStreamOperator.java:689)
 at org.apache.flink.streaming.api.operators.AbstractStreamOperator$CountingOutput.collect(AbstractStreamOperator.java:667)
 at org.apache.flink.streaming.api.operators.StreamMap.processElement(StreamMap.java:41)
 at org.apache.flink.streaming.runtime.io.StreamInputProcessor.processInput(StreamInputProcessor.java:202)
 at org.apache.flink.streaming.runtime.tasks.OneInputStreamTask.run(OneInputStreamTask.java:105)
 at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:300)
 at org.apache.flink.runtime.taskmanager.Task.run(Task.java:711)
 at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
 at org.apache.flink.runtime.state.KeyGroupRangeAssignment.assignToKeyGroup(KeyGroupRangeAssignment.java:59)
 at org.apache.flink.runtime.state.KeyGroupRangeAssignment.assignKeyToParallelOperator(KeyGroupRangeAssignment.java:48)
 at org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner.selectChannels(KeyGroupStreamPartitioner.java:63)
 at org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner.selectChannels(KeyGroupStreamPartitioner.java:32)
 at org.apache.flink.runtime.io.network.api.writer.RecordWriter.emit(RecordWriter.java:104)
 at org.apache.flink.streaming.runtime.io.StreamRecordWriter.emit(StreamRecordWriter.java:81)
 at org.apache.flink.streaming.runtime.io.RecordWriterOutput.pushToRecordWriter(RecordWriterOutput.java:107)
```

## Brief changelog
  - *Add notNull precondition check for KeyGroupRangeAssignment#assignToKeyGroup*

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)