### PR TITLE
[FLINK-10371] Allow to enable SSL mutual authentication on REST endpoints by configuration

### DIFF
--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -63,6 +63,11 @@
             <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
         </tr>
         <tr>
+            <td><h5>security.ssl.rest.authentication-enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Turns on mutual SSL authentication for external communication via the REST endpoints.</td>
+        </tr>
+        <tr>
             <td><h5>security.ssl.rest.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Turns on SSL for external communication via the REST endpoints.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -120,6 +120,14 @@ public class SecurityOptions {
 			.defaultValue(false)
 			.withDescription("Turns on SSL for external communication via the REST endpoints.");
 
+	/**
+	 * Enable mututal SSL authentication for external REST endpoints.
+	 */
+	public static final ConfigOption<Boolean> SSL_REST_AUTHENTICATION_ENABLED =
+		key("security.ssl.rest.authentication-enabled")
+			.defaultValue(false)
+			.withDescription("Turns on mutual SSL authentication for external communication via the REST endpoints.");
+
 	// ----------------- certificates (internal + external) -------------------
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -78,6 +78,29 @@ public class SSLUtilsTest extends TestLogger {
 		assertFalse(SSLUtils.isRestSSLEnabled(precedence));
 	}
 
+	/**
+	 * Tests whether activation of REST mutual SSL authentication evaluates the config flags correctly.
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void checkEnableRestSSLAuthentication() {
+		// SSL has to be enabled
+		Configuration noSSLOptions = new Configuration();
+		noSSLOptions.setBoolean(SecurityOptions.SSL_ENABLED, false);
+		noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+		assertFalse(SSLUtils.isRestSSLAuthenticationEnabled(noSSLOptions));
+
+		// authentication is disabled by default
+		Configuration defaultOptions = new Configuration();
+		defaultOptions.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		assertFalse(SSLUtils.isRestSSLAuthenticationEnabled(defaultOptions));
+
+		Configuration options = new Configuration();
+		noSSLOptions.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+		assertTrue(SSLUtils.isRestSSLAuthenticationEnabled(noSSLOptions));
+	}
+
 	@Test
 	public void testSocketFactoriesWhenSslDisabled() throws Exception {
 		Configuration config = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -81,22 +81,21 @@ public class SSLUtilsTest extends TestLogger {
 	/**
 	 * Tests whether activation of REST mutual SSL authentication evaluates the config flags correctly.
 	 */
-	@SuppressWarnings("deprecation")
 	@Test
 	public void checkEnableRestSSLAuthentication() {
 		// SSL has to be enabled
 		Configuration noSSLOptions = new Configuration();
-		noSSLOptions.setBoolean(SecurityOptions.SSL_ENABLED, false);
+		noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
 		noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
 		assertFalse(SSLUtils.isRestSSLAuthenticationEnabled(noSSLOptions));
 
 		// authentication is disabled by default
 		Configuration defaultOptions = new Configuration();
-		defaultOptions.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		defaultOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
 		assertFalse(SSLUtils.isRestSSLAuthenticationEnabled(defaultOptions));
 
 		Configuration options = new Configuration();
-		noSSLOptions.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
 		noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
 		assertTrue(SSLUtils.isRestSSLAuthenticationEnabled(noSSLOptions));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.DecoderException;
+
+import org.junit.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This test validates that connections are failing when mutual auth is enabled but untrusted
+ * keys are used.
+ */
+public class RestServerSSLAuthITCase extends TestLogger {
+
+	private static final String KEY_STORE_FILE = RestServerSSLAuthITCase.class.getResource("/local127.keystore").getFile();
+	private static final String TRUST_STORE_FILE = RestServerSSLAuthITCase.class.getResource("/local127.truststore").getFile();
+	private static final String UNTRUSTED_KEY_STORE_FILE = RestServerSSLAuthITCase.class.getResource("/untrusted.keystore").getFile();
+
+	private static final Time timeout = Time.seconds(10L);
+
+	@Test
+	public void testConnectFailure() throws Exception {
+		RestClient restClient = null;
+		RestServerEndpoint serverEndpoint = null;
+
+		try {
+			final Configuration baseConfig = new Configuration();
+			baseConfig.setInteger(RestOptions.PORT, 0);
+			baseConfig.setString(RestOptions.ADDRESS, "localhost");
+			baseConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+			baseConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+			baseConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+
+			Configuration serverConfig = new Configuration(baseConfig);
+			serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+			serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+			serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
+			serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+			serverConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+
+			Configuration clientConfig = new Configuration(baseConfig);
+			clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, UNTRUSTED_KEY_STORE_FILE);
+			clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+			clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
+			clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+			clientConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+
+			RestServerEndpointConfiguration restServerConfig = RestServerEndpointConfiguration.fromConfiguration(serverConfig);
+			RestClientConfiguration restClientConfig = RestClientConfiguration.fromConfiguration(clientConfig);
+
+			final String restAddress = "http://localhost:1234";
+			RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
+			when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(restAddress));
+
+			final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
+				CompletableFuture.completedFuture(mockRestfulGateway);
+
+			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT);
+
+			serverEndpoint = new RestServerEndpointITCase.TestRestServerEndpoint(
+				restServerConfig,
+				Arrays.asList(Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler)));
+			restClient = new RestServerEndpointITCase.TestRestClient(restClientConfig);
+			serverEndpoint.start();
+
+			CompletableFuture<EmptyResponseBody> response = restClient.sendRequest(
+				serverEndpoint.getServerAddress().getHostName(),
+				serverEndpoint.getServerAddress().getPort(),
+				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
+				EmptyMessageParameters.getInstance(),
+				EmptyRequestBody.getInstance(),
+				Collections.emptyList()
+			);
+			response.get(60, TimeUnit.SECONDS);
+
+			fail("should never complete normally");
+		} catch (ExecutionException executionException) {
+			// that is what we want
+			Throwable exception = executionException.getCause();
+			assertTrue(exception instanceof DecoderException);
+			assertTrue(exception.getCause() instanceof SSLHandshakeException);
+		} finally {
+			if (restClient != null) {
+				restClient.shutdown(timeout);
+			}
+
+			if (serverEndpoint != null) {
+				serverEndpoint.close();
+			}
+		}
+	}
+}


### PR DESCRIPTION
# [[FLINK-10371]: Allow to enable SSL mutual authentication on REST endpoints by configuration](https://issues.apache.org/jira/browse/FLINK-10371)

## What is the purpose of the change

This PR adds a config option to enable SSL mutual authentication on the REST endpoints and clients. 
By default mutual authentication is disabled, so the default behaviour does not changes. 
If `security.ssl.rest.authentication-enabled` is set to `true`, mutual authentication will be enabled and both the `rest.trustore` as well as the `rest.keystore` will be used for the REST endpoint and clients. This is equivalent to the mutual authentication on the internal communication.

## Brief change log
- *Introduce `security.ssl.rest.authentication-enabled` to enable mutual authentication for REST*

## Verifying this change
This change added tests and can be verified as follows:
- *Extended SSLUtil tests to ensure the config option is interpreted correctly*
- *Extended the REST endpoint integration tests to run with mutual auth enabled*
- *Added an integration test to validate the connection denied if the client uses an untrusted certificate*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs