### PR TITLE
[FLINK-10312] Propagate exception from server to client in REST API

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -376,7 +376,7 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 				(JobSubmitResponseBody jobSubmitResponseBody) -> new JobSubmissionResult(jobGraph.getJobID()))
 			.exceptionally(
 				(Throwable throwable) -> {
-					throw new CompletionException(new JobSubmissionException(jobGraph.getJobID(), "Failed to submit JobGraph.", throwable));
+					throw new CompletionException(new JobSubmissionException(jobGraph.getJobID(), "Failed to submit JobGraph.", ExceptionUtils.stripCompletionException(throwable)));
 				});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -211,7 +211,7 @@ public class FutureUtils {
 									(innerT, innerThrowable) -> scheduledFuture.cancel(false));
 							} else {
 								RetryException retryException = new RetryException(
-									"Could not complete the operation: number of retries has been exhausted.",
+									"Could not complete the operation. Number of retries has been exhausted.",
 									throwable);
 								resultFuture.completeExceptionally(retryException);
 							}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -212,7 +212,7 @@ public class FutureUtils {
 									"Exception is not retryable.";
 								resultFuture.completeExceptionally(new RetryException(
 									"Could not complete the operation. " + errorMsg,
-									throwable));
+									ExceptionUtils.stripCompletionException(throwable)));
 							}
 						}
 					} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -39,6 +39,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 
 import javax.annotation.Nonnull;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -111,10 +112,13 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 	private void processRestHandlerException(ChannelHandlerContext ctx, HttpRequest httpRequest, RestHandlerException rhe) {
 		log.error("Exception occurred in REST handler.", rhe);
 
+		String serverSideExceptionMesssage = "\n<Exception on server side:\n" +
+			ExceptionUtils.stringifyException(rhe) + "\nEnd of exception on server side>";
+
 		HandlerUtils.sendErrorResponse(
 			ctx,
 			httpRequest,
-			new ErrorResponseBody(rhe.getMessage()),
+			new ErrorResponseBody(Arrays.asList(rhe.getMessage(), serverSideExceptionMesssage)),
 			rhe.getHttpResponseStatus(),
 			responseHeaders);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.handler;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rest.AbstractHandler;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
@@ -81,46 +82,26 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 		}
 
 		return response.whenComplete((P resp, Throwable throwable) -> {
-			if (throwable != null) {
-
-				Throwable error = ExceptionUtils.stripCompletionException(throwable);
-
-				if (error instanceof RestHandlerException) {
-					final RestHandlerException rhe = (RestHandlerException) error;
-
-					processRestHandlerException(ctx, httpRequest, rhe);
-				} else {
-					log.error("Implementation error: Unhandled exception.", error);
-					HandlerUtils.sendErrorResponse(
-						ctx,
-						httpRequest,
-						new ErrorResponseBody("Internal server error."),
-						HttpResponseStatus.INTERNAL_SERVER_ERROR,
-						responseHeaders);
-				}
-			} else {
-				HandlerUtils.sendResponse(
-					ctx,
-					httpRequest,
-					resp,
-					messageHeaders.getResponseStatusCode(),
-					responseHeaders);
-			}
+			Tuple2<ResponseBody, HttpResponseStatus> r = throwable != null ?
+				errorResponse(throwable) : Tuple2.of(resp, messageHeaders.getResponseStatusCode());
+			HandlerUtils.sendResponse(ctx, httpRequest, r.f0, r.f1, responseHeaders);
 		}).thenApply(ignored -> null);
 	}
 
-	private void processRestHandlerException(ChannelHandlerContext ctx, HttpRequest httpRequest, RestHandlerException rhe) {
-		log.error("Exception occurred in REST handler.", rhe);
-
-		String serverSideExceptionMesssage = "\n<Exception on server side:\n" +
-			ExceptionUtils.stringifyException(rhe) + "\nEnd of exception on server side>";
-
-		HandlerUtils.sendErrorResponse(
-			ctx,
-			httpRequest,
-			new ErrorResponseBody(Arrays.asList(rhe.getMessage(), serverSideExceptionMesssage)),
-			rhe.getHttpResponseStatus(),
-			responseHeaders);
+	private Tuple2<ResponseBody, HttpResponseStatus> errorResponse(Throwable throwable) {
+		Throwable error = ExceptionUtils.stripCompletionException(throwable);
+		if (error instanceof RestHandlerException) {
+			final RestHandlerException rhe = (RestHandlerException) error;
+			log.error("Exception occurred in REST handler.", rhe);
+			return Tuple2.of(new ErrorResponseBody(rhe.getMessage()), rhe.getHttpResponseStatus());
+		} else {
+			log.error("Implementation error: Unhandled exception.", error);
+			String stackTrace = String.format("<Exception on server side:%n%s%nEnd of exception on server side>",
+				ExceptionUtils.stringifyException(throwable));
+			return Tuple2.of(
+				new ErrorResponseBody(Arrays.asList("Internal server error.", stackTrace)),
+				HttpResponseStatus.INTERNAL_SERVER_ERROR);
+		}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -114,10 +114,7 @@ public final class JobSubmitHandler extends AbstractRestHandler<DispatcherGatewa
 		CompletableFuture<Acknowledge> jobSubmissionFuture = finalizedJobGraphFuture.thenCompose(jobGraph -> gateway.submitJob(jobGraph, timeout));
 
 		return jobSubmissionFuture.thenCombine(jobGraphFuture,
-			(ack, jobGraph) -> new JobSubmitResponseBody("/jobs/" + jobGraph.getJobID()))
-			.exceptionally(exception -> {
-				throw new CompletionException(new RestHandlerException("Job submission failed.", HttpResponseStatus.INTERNAL_SERVER_ERROR, exception));
-			});
+			(ack, jobGraph) -> new JobSubmitResponseBody("/jobs/" + jobGraph.getJobID()));
 	}
 
 	private CompletableFuture<JobGraph> loadJobGraph(JobSubmitRequestBody requestBody, Map<String, Path> nameToFile) throws MissingFileException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -82,7 +82,7 @@ public class FutureUtilsTest extends TestLogger {
 			TestingUtils.defaultExecutor());
 
 		assertTrue(retryFuture.get());
-		assertTrue(retries == atomicInteger.get());
+		assertEquals(retries, atomicInteger.get());
 	}
 
 	/**
@@ -274,7 +274,7 @@ public class FutureUtilsTest extends TestLogger {
 					throwable instanceof RuntimeException && throwable.getMessage().contains(retryableExceptionMessage),
 				new ScheduledExecutorServiceAdapter(retryExecutor)).get();
 		} catch (final ExecutionException e) {
-			assertThat(e.getMessage(), containsString("Could not complete the operation"));
+			assertThat(e.getMessage(), containsString("should propagate"));
 		} finally {
 			retryExecutor.shutdownNow();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -269,11 +269,7 @@ public class JobSubmitHandlerTest extends TestLogger {
 				.get();
 		} catch (Exception e) {
 			Throwable t = ExceptionUtils.stripExecutionException(e);
-			if (t instanceof RestHandlerException){
-				Assert.assertTrue(t.getMessage().equals("Job submission failed."));
-			} else {
-				throw e;
-			}
+			Assert.assertEquals(errorMessage, t.getMessage());
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

If exception currently happens on the server side in REST API handlers, the client side gets error response. The error response contains only an abstract message of the server side exception in the error list and no details. This PR adds also a stringified version of the stack trace of the server side exception. This way the stack trace in logs on the client side will also contain the stack trace of the server side with more details about actual failure.

## Brief change log

  - pack the stringified version of the exception stack trace into the error list of ErrorResponseBody in AbstractRestHandler.processRestHandlerException
  - strip CompletionException in completeExceptionally case of FutureUtils.retryOperationWithDelay to avoid double logging of underlying exception


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
