### PR TITLE
[FLINK-10310] Cassandra Sink - Handling failing requests.

### DIFF
--- a/docs/dev/connectors/cassandra.md
+++ b/docs/dev/connectors/cassandra.md
@@ -75,7 +75,10 @@ The following configuration methods can be used:
 5. _enableWriteAheadLog([CheckpointCommitter committer])_
     * An __optional__ setting
     * Allows exactly-once processing for non-deterministic algorithms.
-6. _build()_
+6. _setFailureHandler([CassandraFailureHandler failureHandler])_
+    * An __optional__ setting
+    * Sets the custom failur handler.
+7. _build()_
     * Finalizes the configuration and constructs the CassandraSink instance.
 
 ### Write-ahead Log

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
@@ -32,8 +32,8 @@ public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<I
 	private final String insertQuery;
 	private transient PreparedStatement ps;
 
-	public AbstractCassandraTupleSink(String insertQuery, ClusterBuilder builder) {
-		super(builder);
+	public AbstractCassandraTupleSink(String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
+		super(builder, failureHandler);
 		this.insertQuery = insertQuery;
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraFailureHandler.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraFailureHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * An implementation of {@link CassandraFailureHandler} is provided by the user to define how
+ * {@link Throwable Throwable} should be handled, e.g. dropping them if the failure is only temporary.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ *
+ * 	private static class ExampleFailureHandler implements CassandraFailureHandler {
+ *
+ * 		@Override
+ * 		void onFailure(Throwable failure) throws IOException {
+ * 			if (ExceptionUtils.containsThrowable(failure, WriteTimeoutException.class)) {
+ * 				// drop exception
+ * 			} else {
+ * 				// for all other failures, fail the sink;
+ * 				// here the failure is simply rethrown, but users can also choose to throw custom exceptions
+ * 				throw failure;
+ * 			}
+ * 		}
+ * 	}
+ *
+ * }</pre>
+ *
+ * <p>The above example will let the sink ignore the WriteTimeoutException, without failing the sink. For all other
+ * failures, the sink will fail.
+ */
+@PublicEvolving
+public interface CassandraFailureHandler extends Serializable {
+
+	/**
+	 * Handle a failed {@link Throwable}.
+	 *
+	 * @param failure the cause of failure
+	 * @throws IOException if the sink should fail on this failure, the implementation should rethrow the throwable or a custom one
+	 */
+	void onFailure(Throwable failure) throws IOException;
+
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
@@ -64,7 +64,11 @@ public class CassandraPojoSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 	}
 
 	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options, String keyspace) {
-		super(builder);
+		this(clazz, builder, options, keyspace, new NoOpCassandraFailureHandler());
+	}
+
+	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options, String keyspace, CassandraFailureHandler failureHandler) {
+		super(builder, failureHandler);
 		this.clazz = clazz;
 		this.options = options;
 		this.keyspace = keyspace;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowSink.java
@@ -27,7 +27,11 @@ public class CassandraRowSink extends AbstractCassandraTupleSink<Row> {
 	private final int rowArity;
 
 	public CassandraRowSink(int rowArity, String insertQuery, ClusterBuilder builder) {
-		super(insertQuery, builder);
+		this(rowArity, insertQuery, builder, new NoOpCassandraFailureHandler());
+	}
+
+	public CassandraRowSink(int rowArity, String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
+		super(insertQuery, builder, failureHandler);
 		this.rowArity = rowArity;
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
@@ -27,7 +27,11 @@ import scala.Product;
  */
 public class CassandraScalaProductSink<IN extends Product> extends AbstractCassandraTupleSink<IN> {
 	public CassandraScalaProductSink(String insertQuery, ClusterBuilder builder) {
-		super(insertQuery, builder);
+		this(insertQuery, builder, new NoOpCassandraFailureHandler());
+	}
+
+	public CassandraScalaProductSink(String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
+		super(insertQuery, builder, failureHandler);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/NoOpCassandraFailureHandler.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/NoOpCassandraFailureHandler.java
@@ -17,28 +17,22 @@
 
 package org.apache.flink.streaming.connectors.cassandra;
 
-	import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
 
 /**
- * Sink to write Flink {@link Tuple}s into a Cassandra cluster.
- *
- * @param <IN> Type of the elements emitted by this sink, it must extend {@link Tuple}
+ * A {@link CassandraFailureHandler} that simply fails the sink on any failures.
  */
-public class CassandraTupleSink<IN extends Tuple> extends AbstractCassandraTupleSink<IN> {
-	public CassandraTupleSink(String insertQuery, ClusterBuilder builder) {
-		this(insertQuery, builder, new NoOpCassandraFailureHandler());
-	}
+@Internal
+public class NoOpCassandraFailureHandler implements CassandraFailureHandler {
 
-	public CassandraTupleSink(String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
-		super(insertQuery, builder, failureHandler);
-	}
+	private static final long serialVersionUID = 737941343410827885L;
 
 	@Override
-	protected Object[] extract(IN record) {
-		Object[] al = new Object[record.getArity()];
-		for (int i = 0; i < record.getArity(); i++) {
-			al[i] = record.getField(i);
-		}
-		return al;
+	public void onFailure(Throwable failure) throws IOException {
+		// simply fail the sink
+		throw new IOException("Error while sending value.", failure);
 	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request provides support to optionally handle cassandra sink errors. A user may choose to ignore an exception instead of allowing the sink to fail. The handler is similar to `ActionRequestFailureHandler` in Elastic Sink.


## Brief change log

  - *Added interface `CassandraFailureHandler` and a no-op implementation `NoOpCassandraFailureHandler`*
  - *`CassandraSinkBase` has a new field `failureHandler` and updated constructor*
  - *`checkAsyncErrors` method in `CassandraSinkBase` calls the `failureHandler` instead of throwing an `IOException`*
  - *`CassandraSinkBuilder` has a new optional field `failureHandler` and updated setter. Uses no-op implementation as default*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test in class `CassandraSinkBaseTest` that validates that failureHandler is called and the error is ignored*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs**
