### PR TITLE
[FLINK-9126] New CassandraPojoInputFormat to output data as a custom annotated Cassandra Pojo

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraInputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraInputFormat.java
@@ -33,6 +33,7 @@ import java.io.IOException;
  */
 public class CassandraInputFormat<OUT extends Tuple> extends CassandraInputFormatBase<OUT> {
 
+	private static final long serialVersionUID = 3642323148032444264L;
 	private transient ResultSet resultSet;
 
 	public CassandraInputFormat(String query, ClusterBuilder builder) {

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraInputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraInputFormatBase.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra;
+
+import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
+import org.apache.flink.api.common.io.NonParallelInput;
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.GenericInputSplit;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * InputFormat to read data from Apache Cassandra and generate a custom Cassandra annotated object.
+ *
+ * @param <OUT> type of inputClass
+ */
+public abstract class CassandraInputFormatBase<OUT> extends RichInputFormat<OUT, InputSplit> implements NonParallelInput {
+	private static final Logger LOG = LoggerFactory.getLogger(CassandraInputFormatBase.class);
+
+	protected final String query;
+	protected final ClusterBuilder builder;
+
+	protected transient Cluster cluster;
+	protected transient Session session;
+
+	public CassandraInputFormatBase(String query, ClusterBuilder builder){
+		Preconditions.checkArgument(!Strings.isNullOrEmpty(query), "Query cannot be null or empty");
+		Preconditions.checkArgument(builder != null, "Builder cannot be null");
+
+		this.query = query;
+		this.builder = builder;
+	}
+
+	@Override
+	public void configure(Configuration parameters) {
+		this.cluster = builder.getCluster();
+	}
+
+	@Override
+	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) {
+		return cachedStatistics;
+	}
+
+	@Override
+	public InputSplit[] createInputSplits(int minNumSplits) {
+		return new GenericInputSplit[]{new GenericInputSplit(0, 1)};
+	}
+
+	@Override
+	public InputSplitAssigner getInputSplitAssigner(InputSplit[] inputSplits) {
+		return new DefaultInputSplitAssigner(inputSplits);
+	}
+
+	/**
+	 * Closes all resources used.
+	 */
+	@Override
+	public void close() {
+		try {
+			if (session != null) {
+				session.close();
+			}
+		} catch (Exception e) {
+			LOG.error("Error while closing session.", e);
+		}
+
+		try {
+			if (cluster != null) {
+				cluster.close();
+			}
+		} catch (Exception e) {
+			LOG.error("Error while closing cluster.", e);
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraInputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraInputFormatBase.java
@@ -36,22 +36,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * InputFormat to read data from Apache Cassandra and generate a custom Cassandra annotated object.
+ * Base class for {@link RichInputFormat} to read data from Apache Cassandra and generate a custom Cassandra annotated object.
  *
  * @param <OUT> type of inputClass
  */
 public abstract class CassandraInputFormatBase<OUT> extends RichInputFormat<OUT, InputSplit> implements NonParallelInput {
-	private static final Logger LOG = LoggerFactory.getLogger(CassandraInputFormatBase.class);
+	private static final long serialVersionUID = -1519372881115104601L;
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
 	protected final String query;
-	protected final ClusterBuilder builder;
+	private final ClusterBuilder builder;
 
 	protected transient Cluster cluster;
 	protected transient Session session;
 
 	public CassandraInputFormatBase(String query, ClusterBuilder builder){
 		Preconditions.checkArgument(!Strings.isNullOrEmpty(query), "Query cannot be null or empty");
-		Preconditions.checkArgument(builder != null, "Builder cannot be null");
+		Preconditions.checkNotNull(builder, "Builder cannot be null");
 
 		this.query = query;
 		this.builder = builder;
@@ -87,7 +88,7 @@ public abstract class CassandraInputFormatBase<OUT> extends RichInputFormat<OUT,
 				session.close();
 			}
 		} catch (Exception e) {
-			LOG.error("Error while closing session.", e);
+			logger.error("Error while closing session.", e);
 		}
 
 		try {
@@ -95,7 +96,7 @@ public abstract class CassandraInputFormatBase<OUT> extends RichInputFormat<OUT,
 				cluster.close();
 			}
 		} catch (Exception e) {
-			LOG.error("Error while closing cluster.", e);
+			logger.error("Error while closing cluster.", e);
 		}
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormatBase.java
@@ -54,7 +54,7 @@ public abstract class CassandraOutputFormatBase<OUT> extends RichOutputFormat<OU
 
 	public CassandraOutputFormatBase(String insertQuery, ClusterBuilder builder) {
 		Preconditions.checkArgument(!Strings.isNullOrEmpty(insertQuery), "Query cannot be null or empty");
-		Preconditions.checkArgument(builder != null, "Builder cannot be null");
+		Preconditions.checkNotNull(builder, "Builder cannot be null");
 
 		this.insertQuery = insertQuery;
 		this.builder = builder;

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/CustomCassandraAnnotatedPojo.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/CustomCassandraAnnotatedPojo.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.Table;
+
+/**
+ * Example of Cassandra Annotated POJO class for use with CassandraInputFormatter.
+ */
+@Table(name = "$TABLE", keyspace = "flink")
+public class CustomCassandraAnnotatedPojo {
+
+	@Column(name = "id")
+	private String id;
+	@Column(name = "counter")
+	private Integer counter;
+	@Column(name = "batch_id")
+	private Integer batchId;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Integer getCounter() {
+		return counter;
+	}
+
+	public void setCounter(Integer counter) {
+		this.counter = counter;
+	}
+
+	public Integer getBatchId() {
+		return batchId;
+	}
+
+	public void setBatchId(Integer batchId) {
+		this.batchId = batchId;
+	}
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/CustomCassandraAnnotatedPojo.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/CustomCassandraAnnotatedPojo.java
@@ -21,10 +21,12 @@ import com.datastax.driver.mapping.annotations.Column;
 import com.datastax.driver.mapping.annotations.Table;
 
 /**
- * Example of Cassandra Annotated POJO class for use with CassandraInputFormatter.
+ * Example of Cassandra Annotated POJO class for use with {@link CassandraPojoInputFormat}.
  */
-@Table(name = "$TABLE", keyspace = "flink")
+@Table(name = CustomCassandraAnnotatedPojo.TABLE_NAME, keyspace = "flink")
 public class CustomCassandraAnnotatedPojo {
+
+	public static final String TABLE_NAME = "batches";
 
 	@Column(name = "id")
 	private String id;
@@ -32,6 +34,17 @@ public class CustomCassandraAnnotatedPojo {
 	private Integer counter;
 	@Column(name = "batch_id")
 	private Integer batchId;
+
+	/**
+	 * Necessary for the driver's mapper instanciation.
+	 */
+	public CustomCassandraAnnotatedPojo(){}
+
+	public CustomCassandraAnnotatedPojo(String id, Integer counter, Integer batchId) {
+		this.id = id;
+		this.counter = counter;
+		this.batchId = batchId;
+	}
 
 	public String getId() {
 		return id;

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/example/BatchPojoExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/example/BatchPojoExample.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra.example;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.batch.connectors.cassandra.CassandraPojoInputFormat;
+import org.apache.flink.batch.connectors.cassandra.CassandraTupleOutputFormat;
+import org.apache.flink.batch.connectors.cassandra.CustomCassandraAnnotatedPojo;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+
+import com.datastax.driver.core.Cluster;
+
+import java.util.ArrayList;
+
+/**
+ * This is an example showing the to use the CassandraPojoInput-/CassandraOutputFormats in the Batch API.
+ *
+ * <p>The example assumes that a table exists in a local cassandra database, according to the following queries:
+ * CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': ‘1’};
+ * CREATE TABLE IF NOT EXISTS test.batches (number int, strings text, PRIMARY KEY(number, strings));
+ */
+public class BatchPojoExample {
+	private static final String INSERT_QUERY = "INSERT INTO test.batches (number, strings) VALUES (?,?);";
+	private static final String SELECT_QUERY = "SELECT number, strings FROM test.batches;";
+
+	/*
+	 *	table script: "CREATE TABLE test.batches (number int, strings text, PRIMARY KEY(number, strings));"
+	 */
+	public static void main(String[] args) throws Exception {
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		ArrayList<Tuple2<Integer, String>> collection = new ArrayList<>(20);
+		for (int i = 0; i < 20; i++) {
+			collection.add(new Tuple2<>(i, "string " + i));
+		}
+
+		DataSet<Tuple2<Integer, String>> dataSet = env.fromCollection(collection);
+
+		dataSet.output(new CassandraTupleOutputFormat<Tuple2<Integer, String>>(INSERT_QUERY, new ClusterBuilder() {
+			@Override
+			protected Cluster buildCluster(Cluster.Builder builder) {
+				return builder.addContactPoints("127.0.0.1").build();
+			}
+		}));
+
+		/*
+		 *	This is for the purpose of showing an example of creating a DataSet using CassandraPojoInputFormat.
+		 */
+		DataSet<CustomCassandraAnnotatedPojo> inputDS = env
+			.createInput(new CassandraPojoInputFormat<>(SELECT_QUERY, new ClusterBuilder() {
+				@Override
+				protected Cluster buildCluster(Cluster.Builder builder) {
+					return builder.addContactPoints("127.0.0.1").build();
+				}
+			}, CustomCassandraAnnotatedPojo.class));
+
+		inputDS.print();
+
+		env.execute("Write");
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Committing the new CassandraPojoInputFormat class. This works similarly to the CassandraInputClass, but allows the data that is read from Cassandra to be output as a custom POJO that the user has created whichhas been annotated using Datastax API.
## Brief change log

- Initial commit of the CassandraPojoInputFormat class and validation test.
## Verifying this change

- CassandraPojoInputFormat can be validated with the testCassandraBatchPojoFormat test in the CassandraConnectorITCaseTest.java file.
## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): don't know
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDocs
