### PR TITLE
[FLINK-10399] Refactor ParameterTool#fromArgs

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -70,8 +70,6 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	public static ParameterTool fromArgs(String[] args) {
 		final Map<String, String> map = new HashMap<>(args.length / 2);
 
-		final String errorMessage = "Error parsing arguments '%s' on '%s'.";
-
 		int i = 0;
 		while (i < args.length) {
 			final String key;
@@ -82,14 +80,13 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 				key = args[i].substring(1);
 			} else {
 				throw new IllegalArgumentException(
-					String.format(errorMessage + " Please prefix keys with -- or -.",
+					String.format("Error parsing arguments '%s' on '%s'. Please prefix keys with -- or -.",
 						Arrays.toString(args), args[i]));
 			}
 
 			if (key.length() == 0) {
 				throw new IllegalArgumentException(
-					String.format(errorMessage + " Keys should never be empty",
-						Arrays.toString(args), args[i]));
+					"The input " + Arrays.toString(args) + " contains an empty argument");
 			}
 
 			i += 1; // try to find the value
@@ -99,9 +96,9 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 			} else if (NumberUtils.isNumber(args[i])) {
 				map.put(key, args[i]);
 				i += 1;
-			} else if (args[i].startsWith("--")) {
-				map.put(key, NO_VALUE_KEY);
-			} else if (args[i].startsWith("-")) { // negate number guarded by precondition
+			} else if (args[i].startsWith("--") || args[i].startsWith("-")) {
+				// the argument cannot be a negative number because we checked earlier
+				// -> the next argument is a parameter name
 				map.put(key, NO_VALUE_KEY);
 			} else {
 				map.put(key, args[i]);

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -87,7 +87,9 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 			}
 
 			if (key.length() == 0) {
-				throw new IllegalArgumentException(errorMessage + " Keys should never be empty");
+				throw new IllegalArgumentException(
+					String.format(errorMessage + " Keys should never be empty",
+						Arrays.toString(args), args[i]));
 			}
 
 			i += 1; // try to find the value

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -68,80 +68,43 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	 * @return A {@link ParameterTool}
 	 */
 	public static ParameterTool fromArgs(String[] args) {
-		Map<String, String> map = new HashMap<String, String>(args.length / 2);
+		final Map<String, String> map = new HashMap<>(args.length / 2);
 
-		String key = null;
-		String value = null;
-		boolean expectValue = false;
-		for (String arg : args) {
-			// check for -- argument
-			if (arg.startsWith("--")) {
-				if (expectValue) {
-					// we got into a new key, even though we were a value --> current key is one without value
-					if (value != null) {
-						throw new IllegalStateException("Unexpected state");
-					}
-					map.put(key, NO_VALUE_KEY);
-					// key will be overwritten in the next step
-				}
-				key = arg.substring(2);
-				expectValue = true;
-			} // check for - argument
-			else if (arg.startsWith("-")) {
-				// we are waiting for a value, so this is a - prefixed value (negative number)
-				if (expectValue) {
+		final String errorMessage = "Error parsing arguments '%s' on '%s'.";
 
-					if (NumberUtils.isNumber(arg)) {
-						// negative number
-						value = arg;
-						expectValue = false;
-					} else {
-						if (value != null) {
-							throw new IllegalStateException("Unexpected state");
-						}
-						// We waited for a value but found a new key. So the previous key doesnt have a value.
-						map.put(key, NO_VALUE_KEY);
-						key = arg.substring(1);
-						expectValue = true;
-					}
-				} else {
-					// we are not waiting for a value, so its an argument
-					key = arg.substring(1);
-					expectValue = true;
-				}
+		int i = 0;
+		while (i < args.length) {
+			final String key;
+
+			if (args[i].startsWith("--")) {
+				key = args[i].substring(2);
+			} else if (args[i].startsWith("-")) {
+				key = args[i].substring(1);
 			} else {
-				if (expectValue) {
-					value = arg;
-					expectValue = false;
-				} else {
-					throw new RuntimeException("Error parsing arguments '" + Arrays.toString(args) + "' on '" + arg + "'. Unexpected value. Please prefix values with -- or -.");
-				}
+				throw new IllegalArgumentException(
+					String.format(errorMessage + " Please prefix keys with -- or -.",
+						Arrays.toString(args), args[i]));
 			}
 
-			if (value == null && key == null) {
-				throw new IllegalStateException("Value and key can not be null at the same time");
-			}
-			if (key != null && value == null && !expectValue) {
-				throw new IllegalStateException("Value expected but flag not set");
-			}
-			if (key != null && value != null) {
-				map.put(key, value);
-				key = null;
-				value = null;
-				expectValue = false;
-			}
-			if (key != null && key.length() == 0) {
-				throw new IllegalArgumentException("The input " + Arrays.toString(args) + " contains an empty argument");
+			if (key.length() == 0) {
+				throw new IllegalArgumentException(errorMessage + " Keys should never be empty");
 			}
 
-			if (key != null && !expectValue) {
+			i += 1; // try to find the value
+
+			if (i >= args.length) {
 				map.put(key, NO_VALUE_KEY);
-				key = null;
-				expectValue = false;
+			} else if (NumberUtils.isNumber(args[i])) {
+				map.put(key, args[i]);
+				i += 1;
+			} else if (args[i].startsWith("--")) {
+				map.put(key, NO_VALUE_KEY);
+			} else if (args[i].startsWith("-")) { // negate number guarded by precondition
+				map.put(key, NO_VALUE_KEY);
+			} else {
+				map.put(key, args[i]);
+				i += 1;
 			}
-		}
-		if (key != null) {
-			map.put(key, NO_VALUE_KEY);
 		}
 
 		return fromMap(map);
@@ -497,7 +460,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	// --------------- Internals
 
 	protected void addToDefaults(String key, String value) {
-		String currentValue = defaultData.get(key);
+		final String currentValue = defaultData.get(key);
 		if (currentValue == null) {
 			if (value == null) {
 				value = DEFAULT_UNDEFINED;
@@ -520,7 +483,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	 * @return A {@link Configuration}
 	 */
 	public Configuration getConfiguration() {
-		Configuration conf = new Configuration();
+		final Configuration conf = new Configuration();
 		for (Map.Entry<String, String> entry : data.entrySet()) {
 			conf.setString(entry.getKey(), entry.getValue());
 		}
@@ -559,7 +522,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	 * @throws IOException If overwrite is not allowed and the file exists
 	 */
 	public void createPropertiesFile(String pathToFile, boolean overwrite) throws IOException {
-		File file = new File(pathToFile);
+		final File file = new File(pathToFile);
 		if (file.exists()) {
 			if (overwrite) {
 				file.delete();
@@ -567,7 +530,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 				throw new RuntimeException("File " + pathToFile + " exists and overwriting is not allowed");
 			}
 		}
-		Properties defaultProps = new Properties();
+		final Properties defaultProps = new Properties();
 		defaultProps.putAll(this.defaultData);
 		try (final OutputStream out = new FileOutputStream(file)) {
 			defaultProps.store(out, "Default file created by Flink's ParameterUtil.createPropertiesFile()");
@@ -588,11 +551,11 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	 * @return The Merged {@link ParameterTool}
 	 */
 	public ParameterTool mergeWith(ParameterTool other) {
-		Map<String, String> resultData = new HashMap<>(data.size() + other.data.size());
+		final Map<String, String> resultData = new HashMap<>(data.size() + other.data.size());
 		resultData.putAll(data);
 		resultData.putAll(other.data);
 
-		ParameterTool ret = new ParameterTool(resultData);
+		final ParameterTool ret = new ParameterTool(resultData);
 
 		final HashSet<String> requestedParametersLeft = new HashSet<>(data.keySet());
 		requestedParametersLeft.removeAll(unrequestedParameters);

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
@@ -30,8 +30,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-import static org.junit.Assert.fail;
-
 /**
  * Base class for tests for {@link ParameterTool}.
  */
@@ -45,14 +43,14 @@ public abstract class AbstractParameterToolTest {
 		internalValidate(parameter);
 
 		// -------- test behaviour after serialization ------------
-		ParameterTool copy = null;
 		try {
 			byte[] b = InstantiationUtil.serializeObject(parameter);
-			copy = InstantiationUtil.deserializeObject(b, getClass().getClassLoader());
+			final ParameterTool copy = InstantiationUtil.deserializeObject(b, getClass().getClassLoader());
+			internalValidate(copy);
 		} catch (Exception e) {
-			fail();
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
 		}
-		internalValidate(copy);
 	}
 
 	private void internalValidate(ParameterTool parameter) {
@@ -84,8 +82,8 @@ public abstract class AbstractParameterToolTest {
 			Assert.assertTrue(defaultProps.containsKey("input"));
 
 		} catch (IOException e) {
-			Assert.fail(e.getMessage());
 			e.printStackTrace();
+			Assert.fail(e.getMessage());
 		}
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractParameterToolTest {
 
 	protected void validate(ParameterTool parameter) {
 		ClosureCleaner.ensureSerializable(parameter);
-		validatePrivate(parameter);
+		internalValidate(parameter);
 
 		// -------- test behaviour after serialization ------------
 		ParameterTool copy = null;
@@ -52,30 +52,29 @@ public abstract class AbstractParameterToolTest {
 		} catch (Exception e) {
 			fail();
 		}
-		validatePrivate(copy);
+		internalValidate(copy);
 	}
 
-	private void validatePrivate(ParameterTool parameter) {
+	private void internalValidate(ParameterTool parameter) {
 		Assert.assertEquals("myInput", parameter.getRequired("input"));
 		Assert.assertEquals("myDefaultValue", parameter.get("output", "myDefaultValue"));
-		Assert.assertEquals(null, parameter.get("whatever"));
+		Assert.assertNull(parameter.get("whatever"));
 		Assert.assertEquals(15L, parameter.getLong("expectedCount", -1L));
 		Assert.assertTrue(parameter.getBoolean("thisIsUseful", true));
 		Assert.assertEquals(42, parameter.getByte("myDefaultByte", (byte) 42));
 		Assert.assertEquals(42, parameter.getShort("myDefaultShort", (short) 42));
 
-		Configuration config = parameter.getConfiguration();
+		final Configuration config = parameter.getConfiguration();
 		Assert.assertEquals(15L, config.getLong("expectedCount", -1L));
 
-		Properties props = parameter.getProperties();
+		final Properties props = parameter.getProperties();
 		Assert.assertEquals("myInput", props.getProperty("input"));
-		props = null;
 
 		// -------- test the default file creation ------------
 		try {
-			String pathToFile = tmp.newFile().getAbsolutePath();
+			final String pathToFile = tmp.newFile().getAbsolutePath();
 			parameter.createPropertiesFile(pathToFile);
-			Properties defaultProps = new Properties();
+			final Properties defaultProps = new Properties();
 			try (FileInputStream fis = new FileInputStream(pathToFile)) {
 				defaultProps.load(fis);
 			}

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -57,9 +57,12 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 	// ----- Parser tests -----------------
 
-	@Test(expected = RuntimeException.class)
-	public void testIllegalArgs() {
-		ParameterTool.fromArgs(new String[]{"berlin"});
+	@Test
+	public void testThrowExceptionIfParameterIsNotPrefixed() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Error parsing arguments '[a]' on 'a'. Please prefix keys with -- or -.");
+
+		ParameterTool.fromArgs(new String[]{"a"});
 	}
 
 	@Test
@@ -100,13 +103,19 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		Assert.assertTrue(parameter.has("f"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testEmptyVal() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("The input [--a, -b, --] contains an empty argument");
+
 		ParameterTool.fromArgs(new String[]{"--a", "-b", "--"});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testEmptyValShort() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("The input [--a, -b, -] contains an empty argument");
+
 		ParameterTool.fromArgs(new String[]{"--a", "-b", "-"});
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request is about a refractor of `ParameterTool#fromArgs`.

Current `ParameterTool#fromArgs` uses a weird implement by which flink developer would fail to parse it fast.

The main problem is that, when parse args, we always try to get a key-value pair, but the implement iterate by a for loop, thus introduce weird flag/mutable variable and branches.

## Brief change log

Refractor `ParameterTool#fromArgs`. Use a index(int iterator) and while loop to replace the original for loop. Make it more clear for the purpose and reduce weird branches and flags.

Place some `final` modifier where I cannot get the idea that the variable is `final` when look at it.

## Verifying this change

`ParameterToolTest` should guard the refractor.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes**, but only the implementation, the interface and behavior kept.)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  (**no**)
  - The S3 file system connector:  (**no**)

## Documentation

  - Does this pull request introduce a new feature?  (**no**)
  - If yes, how is the feature documented? (**no**)
