### PR TITLE
[FLINK-10126] There should be a Scala DataSource

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSource.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSource.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala
+
+import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
+import org.apache.flink.api.common.io.InputFormat
+import org.apache.flink.api.java.io.SplitDataProperties
+import org.apache.flink.api.java.operators.{DataSource => JavaDataSource}
+import org.apache.flink.configuration.Configuration
+
+import scala.reflect.ClassTag
+
+/**
+  * An operation that creates a new data set (data source). The operation acts as the
+  * data set on which to apply further transformations. It encapsulates additional
+  * configuration parameters, to customize the execution.
+  *
+  * @tparam T The type of the elements produced by this data source.
+  */
+@Public
+class DataSource[T: ClassTag](dataSource: JavaDataSource[T]) extends DataSet(dataSource) {
+
+  @PublicEvolving
+  def getSplitDataProperties(): SplitDataProperties[_] = dataSource.getSplitDataProperties()
+
+  @Internal
+  def getInputFormat(): InputFormat[_, _] = dataSource.getInputFormat()
+
+  def getParameters(): Configuration = dataSource.getParameters()
+
+  override def withParameters(parameters: Configuration): DataSource[T] = {
+    dataSource.withParameters(parameters)
+    this
+  }
+
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/DataSourceITCase.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/DataSourceITCase.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala
+
+import org.apache.flink.api.common.io.FileInputFormat
+import org.apache.flink.api.java.io.TextInputFormat
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.fs.Path
+import org.junit.Assert.{assertEquals, assertNotNull, assertTrue}
+import org.junit.Test
+
+/**
+  * Data source IT test case.
+  */
+class DataSourceITCase {
+
+  @throws[Exception]
+  @Test
+  def testWithAndGetParameters(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val ifConf: Configuration = new Configuration
+    ifConf.setString("prepend", "test")
+    val ds: DataSource[String] = env
+      .createInput(new TestInputFormat(new Path("/tmp")))
+      .withParameters(ifConf)
+    val conf = ds.getParameters
+    assertTrue(conf.containsKey("prepend"))
+    assertEquals("test", conf.getString("prepend", null))
+  }
+
+  @Test
+  def testGetSplitDataProperties(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val inputFormat = new Tuple2InputFormat()
+    val ds: DataSource[(String, String)] = env.createInput(inputFormat)
+    assertNotNull(ds.getSplitDataProperties())
+    ds.getSplitDataProperties().splitsGroupedBy(0)
+    val expectedGroupKeys = ds.getSplitDataProperties().getSplitGroupKeys
+    assertEquals(1, expectedGroupKeys.size)
+    assertEquals(0, expectedGroupKeys(0))
+  }
+
+  @Test
+  def testGetInputFormat(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val inputFormat = new TestInputFormat(new Path("/tmp"))
+    inputFormat.setBufferSize(Integer.MAX_VALUE)
+    val ds: DataSource[String] = env.createInput(inputFormat)
+    assertTrue(ds.getInputFormat.isInstanceOf[TestInputFormat])
+    val expectedInputFormat = ds.getInputFormat.asInstanceOf[TestInputFormat]
+    assertEquals(Integer.MAX_VALUE, expectedInputFormat.getBufferSize)
+  }
+
+  private class TestInputFormat(filePath: Path) extends TextInputFormat(filePath) {
+    override def configure(parameters: Configuration): Unit = {
+      super.configure(parameters)
+      assertNotNull(parameters.getString("prepend", null))
+      assertEquals("test", parameters.getString("prepend", null))
+    }
+  }
+
+  private class Tuple2InputFormat extends FileInputFormat[(String, String)] {
+    override def reachedEnd(): Boolean = false
+
+    override def nextRecord(reuse: (String, String)): (String, String) = null
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1613,6 +1613,7 @@ under the License.
 								<exclude>org.apache.flink.api.scala.hadoop.mapred.HadoopOutputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopInputFormat</exclude>
 								<exclude>org.apache.flink.api.scala.hadoop.mapreduce.HadoopOutputFormat</exclude>
+								<exclude>org.apache.flink.api.scala.ExecutionEnvironment</exclude>
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add some APIs which exist flink-java's `DataSource` into flink-scala `DataSet`*


## Brief change log

  - *Add some APIs which exist flink-java's `DataSource` into flink-scala `DataSet`*
 - *Added test case `DataSetITCase`* 

## Verifying this change

This change is already covered by existing tests, such as *DataSetITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
