### PR TITLE
[FLINK-10400] Fail JobResult if application finished in CANCELED or FAILED state

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
@@ -94,8 +95,8 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 			try {
 				return jobResult.toJobExecutionResult(classLoader);
-			} catch (JobResult.WrappedJobException e) {
-				throw new ProgramInvocationException("Job failed", jobGraph.getJobID(), e.getCause());
+			} catch (JobExecutionException e) {
+				throw new ProgramInvocationException("Job failed", jobGraph.getJobID(), e);
 			} catch (IOException | ClassNotFoundException e) {
 				throw new ProgramInvocationException("Job failed", jobGraph.getJobID(), e);
 			}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -32,6 +32,7 @@ import org.apache.flink.client.program.rest.retry.ExponentialWaitStrategy;
 import org.apache.flink.client.program.rest.retry.WaitStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
@@ -263,8 +264,8 @@ public class RestClusterClient<T> extends ClusterClient<T> implements NewCluster
 			try {
 				this.lastJobExecutionResult = jobResult.toJobExecutionResult(classLoader);
 				return lastJobExecutionResult;
-			} catch (JobResult.WrappedJobException we) {
-				throw new ProgramInvocationException("Job failed.", jobGraph.getJobID(), we.getCause());
+			} catch (JobExecutionException e) {
+				throw new ProgramInvocationException("Job failed.", jobGraph.getJobID(), e);
 			} catch (IOException | ClassNotFoundException e) {
 				throw new ProgramInvocationException("Job failed.", jobGraph.getJobID(), e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -22,11 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
+import org.apache.flink.runtime.client.JobCancellationException;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.jobgraph.JobStatus;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.SerializedValue;
@@ -54,6 +56,8 @@ public class JobResult implements Serializable {
 
 	private final JobID jobId;
 
+	private final ApplicationStatus applicationStatus;
+
 	private final Map<String, SerializedValue<OptionalFailure<Object>>> accumulatorResults;
 
 	private final long netRuntime;
@@ -64,6 +68,7 @@ public class JobResult implements Serializable {
 
 	private JobResult(
 			final JobID jobId,
+			final ApplicationStatus applicationStatus,
 			final Map<String, SerializedValue<OptionalFailure<Object>>> accumulatorResults,
 			final long netRuntime,
 			@Nullable final SerializedThrowable serializedThrowable) {
@@ -71,6 +76,7 @@ public class JobResult implements Serializable {
 		checkArgument(netRuntime >= 0, "netRuntime must be greater than or equals 0");
 
 		this.jobId = requireNonNull(jobId);
+		this.applicationStatus = requireNonNull(applicationStatus);
 		this.accumulatorResults = requireNonNull(accumulatorResults);
 		this.netRuntime = netRuntime;
 		this.serializedThrowable = serializedThrowable;
@@ -80,11 +86,15 @@ public class JobResult implements Serializable {
 	 * Returns {@code true} if the job finished successfully.
 	 */
 	public boolean isSuccess() {
-		return serializedThrowable == null;
+		return applicationStatus == ApplicationStatus.SUCCEEDED || (applicationStatus == ApplicationStatus.UNKNOWN && serializedThrowable == null);
 	}
 
 	public JobID getJobId() {
 		return jobId;
+	}
+
+	public ApplicationStatus getApplicationStatus() {
+		return applicationStatus;
 	}
 
 	public Map<String, SerializedValue<OptionalFailure<Object>>> getAccumulatorResults() {
@@ -108,22 +118,40 @@ public class JobResult implements Serializable {
 	 *
 	 * @param classLoader to use for deserialization
 	 * @return JobExecutionResult
-	 * @throws WrappedJobException if the JobResult contains a serialized exception
+	 * @throws JobCancellationException if the job was cancelled
+	 * @throws JobExecutionException if the job execution did not succeed
 	 * @throws IOException if the accumulator could not be deserialized
 	 * @throws ClassNotFoundException if the accumulator could not deserialized
 	 */
-	public JobExecutionResult toJobExecutionResult(ClassLoader classLoader) throws WrappedJobException, IOException, ClassNotFoundException {
-		if (serializedThrowable != null) {
-			final Throwable throwable = serializedThrowable.deserializeError(classLoader);
-			throw new WrappedJobException(throwable);
-		}
+	public JobExecutionResult toJobExecutionResult(ClassLoader classLoader) throws JobExecutionException, IOException, ClassNotFoundException {
+		if (applicationStatus == ApplicationStatus.SUCCEEDED) {
+			return new JobExecutionResult(
+				jobId,
+				netRuntime,
+				AccumulatorHelper.deserializeAccumulators(
+					accumulatorResults,
+					classLoader));
+		} else {
+			final Throwable cause;
 
-		return new JobExecutionResult(
-			jobId,
-			netRuntime,
-			AccumulatorHelper.deserializeAccumulators(
-				accumulatorResults,
-				classLoader));
+			if (serializedThrowable == null) {
+				cause = null;
+			} else {
+				cause = serializedThrowable.deserializeError(classLoader);
+			}
+
+			final JobExecutionException exception;
+
+			if (applicationStatus == ApplicationStatus.FAILED) {
+				exception = new JobExecutionException(jobId, "Job execution failed.", cause);
+			} else if (applicationStatus == ApplicationStatus.CANCELED) {
+				exception = new JobCancellationException(jobId, "Job was cancelled.", cause);
+			} else {
+				exception = new JobExecutionException(jobId, "Job completed with illegal application status: " + applicationStatus + '.', cause);
+			}
+
+			throw exception;
+		}
 	}
 
 	/**
@@ -134,6 +162,8 @@ public class JobResult implements Serializable {
 
 		private JobID jobId;
 
+		private ApplicationStatus applicationStatus = ApplicationStatus.UNKNOWN;
+
 		private Map<String, SerializedValue<OptionalFailure<Object>>> accumulatorResults;
 
 		private long netRuntime = -1;
@@ -142,6 +172,11 @@ public class JobResult implements Serializable {
 
 		public Builder jobId(final JobID jobId) {
 			this.jobId = jobId;
+			return this;
+		}
+
+		public Builder applicationStatus(final ApplicationStatus applicationStatus) {
+			this.applicationStatus = applicationStatus;
 			return this;
 		}
 
@@ -163,6 +198,7 @@ public class JobResult implements Serializable {
 		public JobResult build() {
 			return new JobResult(
 				jobId,
+				applicationStatus,
 				accumulatorResults == null ? Collections.emptyMap() : accumulatorResults,
 				netRuntime,
 				serializedThrowable);
@@ -188,6 +224,8 @@ public class JobResult implements Serializable {
 		final JobResult.Builder builder = new JobResult.Builder();
 		builder.jobId(jobId);
 
+		builder.applicationStatus(ApplicationStatus.fromJobStatus(accessExecutionGraph.getState()));
+
 		final long netRuntime = accessExecutionGraph.getStatusTimestamp(jobStatus) - accessExecutionGraph.getStatusTimestamp(JobStatus.CREATED);
 		// guard against clock changes
 		final long guardedNetRuntime = Math.max(netRuntime, 0L);
@@ -204,17 +242,4 @@ public class JobResult implements Serializable {
 
 		return builder.build();
 	}
-
-	/**
-	 * Exception which indicates that the job has finished with an {@link Exception}.
-	 */
-	public static final class WrappedJobException extends FlinkException {
-
-		private static final long serialVersionUID = 6535061898650156019L;
-
-		public WrappedJobException(Throwable cause) {
-			super(cause);
-		}
-	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -623,8 +623,6 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 		try {
 			return jobResult.toJobExecutionResult(Thread.currentThread().getContextClassLoader());
-		} catch (JobResult.WrappedJobException e) {
-			throw new JobExecutionException(job.getJobID(), e.getCause());
 		} catch (IOException | ClassNotFoundException e) {
 			throw new JobExecutionException(job.getJobID(), e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializer.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.json;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedThrowable;
@@ -68,6 +69,7 @@ public class JobResultDeserializer extends StdDeserializer<JobResult> {
 	@Override
 	public JobResult deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
 		JobID jobId = null;
+		ApplicationStatus applicationStatus = ApplicationStatus.UNKNOWN;
 		long netRuntime = -1;
 		SerializedThrowable serializedThrowable = null;
 		Map<String, SerializedValue<OptionalFailure<Object>>> accumulatorResults = null;
@@ -84,6 +86,10 @@ public class JobResultDeserializer extends StdDeserializer<JobResult> {
 				case JobResultSerializer.FIELD_NAME_JOB_ID:
 					assertNextToken(p, JsonToken.VALUE_STRING);
 					jobId = jobIdDeserializer.deserialize(p, ctxt);
+					break;
+				case JobResultSerializer.FIELD_NAME_APPLICATION_STATUS:
+					assertNextToken(p, JsonToken.VALUE_STRING);
+					applicationStatus = ApplicationStatus.valueOf(p.getValueAsString().toUpperCase());
 					break;
 				case JobResultSerializer.FIELD_NAME_NET_RUNTIME:
 					assertNextToken(p, JsonToken.VALUE_NUMBER_INT);
@@ -105,6 +111,7 @@ public class JobResultDeserializer extends StdDeserializer<JobResult> {
 		try {
 			return new JobResult.Builder()
 				.jobId(jobId)
+				.applicationStatus(applicationStatus)
 				.netRuntime(netRuntime)
 				.accumulatorResults(accumulatorResults)
 				.serializedThrowable(serializedThrowable)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultSerializer.java
@@ -44,6 +44,8 @@ public class JobResultSerializer extends StdSerializer<JobResult> {
 
 	static final String FIELD_NAME_JOB_ID = "id";
 
+	static final String FIELD_NAME_APPLICATION_STATUS = "application-status";
+
 	static final String FIELD_NAME_NET_RUNTIME = "net-runtime";
 
 	static final String FIELD_NAME_ACCUMULATOR_RESULTS = "accumulator-results";
@@ -75,6 +77,9 @@ public class JobResultSerializer extends StdSerializer<JobResult> {
 
 		gen.writeFieldName(FIELD_NAME_JOB_ID);
 		jobIdSerializer.serialize(result.getJobId(), gen, provider);
+
+		gen.writeFieldName(FIELD_NAME_APPLICATION_STATUS);
+		gen.writeString(result.getApplicationStatus().name());
 
 		gen.writeFieldName(FIELD_NAME_ACCUMULATOR_RESULTS);
 		gen.writeStartObject();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBodyTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 import org.apache.flink.util.OptionalFailure;
@@ -64,12 +65,14 @@ public class JobExecutionResultResponseBodyTest
 		return Arrays.asList(new Object[][] {
 			{JobExecutionResultResponseBody.created(new JobResult.Builder()
 				.jobId(TEST_JOB_ID)
+				.applicationStatus(ApplicationStatus.SUCCEEDED)
 				.netRuntime(TEST_NET_RUNTIME)
 				.accumulatorResults(TEST_ACCUMULATORS)
 				.serializedThrowable(new SerializedThrowable(new RuntimeException("expected")))
 				.build())},
 			{JobExecutionResultResponseBody.created(new JobResult.Builder()
 				.jobId(TEST_JOB_ID)
+				.applicationStatus(ApplicationStatus.FAILED)
 				.netRuntime(TEST_NET_RUNTIME)
 				.accumulatorResults(TEST_ACCUMULATORS)
 				.build())},
@@ -108,6 +111,7 @@ public class JobExecutionResultResponseBodyTest
 			assertNotNull(actualJobExecutionResult);
 
 			assertThat(actualJobExecutionResult.getJobId(), equalTo(expectedJobExecutionResult.getJobId()));
+			assertThat(actualJobExecutionResult.getApplicationStatus(), equalTo(expectedJobExecutionResult.getApplicationStatus()));
 			assertThat(actualJobExecutionResult.getNetRuntime(), equalTo(expectedJobExecutionResult.getNetRuntime()));
 			assertThat(actualJobExecutionResult.getAccumulatorResults(), equalTo(expectedJobExecutionResult.getAccumulatorResults()));
 


### PR DESCRIPTION
## What is the purpose of the change

When generating a `JobExecutionResult` from a `JobResult`, we fail the conversion if the application status was not `SUCCEEDED`.

In case of the CANCELED state, the client will throw an JobCancellationException.
In case of the FAILED state, the client will throw an JobExecutionException.

## Brief change log

- Add `ApplicationStatus` field to `JobResult`
- Throw `JobCancellationException` if `ApplicationStatus` was `CANCELED`
- Throw `JobExecutionException` if `ApplicationStatus` was `FAILED`

## Verifying this change

- Added `JobResultTest#testCancelledJobIsFailureResult`, `#testFailedJobIsFailureResult`, `#testCancelledJobThrowsJobCancellationException` and `#testFailedJobThrowsJobExecutionException`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
