### PR TITLE
[FLINK-10394][build] Remove legacy mode from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,27 +64,27 @@ matrix:
     - jdk: "openjdk8"
       env:
         - TEST="core"
-        - PROFILE="-Dhadoop.version=2.4.1 -DlegacyCode"
+        - PROFILE="-Dhadoop.version=2.4.1"
         - CACHE_NAME=JDK8_H241_CO
     - jdk: "openjdk8"
       env:
         - TEST="libraries"
-        - PROFILE="-Dhadoop.version=2.4.1 -DlegacyCode"
+        - PROFILE="-Dhadoop.version=2.4.1"
         - CACHE_NAME=JDK8_H241_L
     - jdk: "openjdk8"
       env:
         - TEST="connectors"
-        - PROFILE="-Dhadoop.version=2.4.1 -DlegacyCode -Pinclude-kinesis"
+        - PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
         - CACHE_NAME=JDK8_H241_CN
     - jdk: "openjdk8"
       env:
         - TEST="tests"
-        - PROFILE="-Dhadoop.version=2.4.1 -DlegacyCode"
+        - PROFILE="-Dhadoop.version=2.4.1"
         - CACHE_NAME=JDK8_H241_T
     - jdk: "openjdk8"
       env:
         - TEST="misc"
-        - PROFILE="-Dhadoop.version=2.4.1 -DlegacyCode"
+        - PROFILE="-Dhadoop.version=2.4.1"
         - CACHE_NAME=JDK8_H241_M
 
 git:


### PR DESCRIPTION
## What is the purpose of the change

This PR is part of the [removal of Flink's legacy mode](https://issues.apache.org/jira/browse/FLINK-10392).

Remove legacy mode from Travis build matrix.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
