### PR TITLE
[FLINK-10395] Remove legacyCode profile from parent pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -674,18 +674,6 @@ under the License.
 		</profile>
 
 		<profile>
-			<id>legacyCode</id>
-			<activation>
-				<property>
-					<name>legacyCode</name>
-				</property>
-			</activation>
-			<properties>
-				<codebase>legacy</codebase>
-			</properties>
-		</profile>
-
-		<profile>
 			<id>spotbugs</id>
 			<activation>
 				<property>


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #6746 and is part of the [removal of Flink's legacy mode](https://issues.apache.org/jira/browse/FLINK-10392).

This PR removes the `legacyCode` profile from the parent `pom.xml` file since it is no longer needed.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
