### PR TITLE
[FLINK-10396] Remove CodebaseType

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -152,11 +152,7 @@ public class WebFrontendITCase extends TestLogger {
 		if (notFoundJobConnection.getResponseCode() >= 400) {
 			// we don't set the content-encoding header
 			Assert.assertNull(notFoundJobConnection.getContentEncoding());
-			if (CLUSTER.getCodebaseType() == TestBaseUtils.CodebaseType.NEW) {
-				Assert.assertEquals("application/json; charset=UTF-8", notFoundJobConnection.getContentType());
-			} else {
-				Assert.assertEquals("text/plain; charset=UTF-8", notFoundJobConnection.getContentType());
-			}
+			Assert.assertEquals("application/json; charset=UTF-8", notFoundJobConnection.getContentType());
 		} else {
 			throw new RuntimeException("Request for non-existing job did not return an error.");
 		}
@@ -280,23 +276,13 @@ public class WebFrontendITCase extends TestLogger {
 		final Deadline deadline = testTimeout.fromNow();
 
 		try (HttpTestClient client = new HttpTestClient("localhost", CLUSTER.getWebUIPort())) {
-			if (CLUSTER.getCodebaseType() == TestBaseUtils.CodebaseType.NEW) {
-				// stop the job
-				client.sendPatchRequest("/jobs/" + jid + "/?mode=stop", deadline.timeLeft());
-				HttpTestClient.SimpleHttpResponse response = client.getNextResponse(deadline.timeLeft());
+			// stop the job
+			client.sendPatchRequest("/jobs/" + jid + "/?mode=stop", deadline.timeLeft());
+			HttpTestClient.SimpleHttpResponse response = client.getNextResponse(deadline.timeLeft());
 
-				assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
-				assertEquals("application/json; charset=UTF-8", response.getType());
-				assertEquals("{}", response.getContent());
-			} else {
-				// stop the job
-				client.sendDeleteRequest("/jobs/" + jid + "/stop", deadline.timeLeft());
-				HttpTestClient.SimpleHttpResponse response = client.getNextResponse(deadline.timeLeft());
-
-				assertEquals(HttpResponseStatus.OK, response.getStatus());
-				assertEquals("application/json; charset=UTF-8", response.getType());
-				assertEquals("{}", response.getContent());
-			}
+			assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
+			assertEquals("application/json; charset=UTF-8", response.getType());
+			assertEquals("{}", response.getContent());
 		}
 
 		// wait for cancellation to finish
@@ -355,11 +341,7 @@ public class WebFrontendITCase extends TestLogger {
 			HttpTestClient.SimpleHttpResponse response = client
 				.getNextResponse(deadline.timeLeft());
 
-			if (CLUSTER.getCodebaseType() == TestBaseUtils.CodebaseType.NEW) {
-				assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
-			} else {
-				assertEquals(HttpResponseStatus.OK, response.getStatus());
-			}
+			assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
 			assertEquals("application/json; charset=UTF-8", response.getType());
 			assertEquals("{}", response.getContent());
 		}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.ClassRule;
@@ -67,7 +66,6 @@ public class JarRunHandlerTest {
 				.setConfiguration(config)
 				.setNumberTaskManagers(1)
 				.setNumberSlotsPerTaskManager(1)
-				.setCodebaseType(TestBaseUtils.CodebaseType.NEW)
 				.build());
 		clusterResource.before();
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -81,7 +80,6 @@ public class HistoryServerTest extends TestLogger {
 				.setConfiguration(clusterConfig)
 				.setNumberTaskManagers(1)
 				.setNumberSlotsPerTaskManager(1)
-				.setCodebaseType(TestBaseUtils.CodebaseType.NEW)
 				.build());
 		cluster.before();
 	}

--- a/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
+++ b/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
@@ -20,10 +20,9 @@ package org.apache.flink.api.scala
 
 import java.io._
 
-import org.apache.flink.configuration.{Configuration, CoreOptions, RestOptions, TaskManagerOptions}
+import org.apache.flink.configuration.{Configuration, CoreOptions, RestOptions}
 import org.apache.flink.runtime.clusterframework.BootstrapTools
-import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration, StandaloneMiniCluster}
-import org.apache.flink.test.util.TestBaseUtils
+import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
 import org.apache.flink.util.TestLogger
 import org.junit._
 import org.junit.rules.TemporaryFolder
@@ -312,7 +311,7 @@ class ScalaShellITCase extends TestLogger {
 object ScalaShellITCase {
 
   val configuration = new Configuration()
-  var cluster: Option[Either[MiniCluster, StandaloneMiniCluster]] = None
+  var cluster: Option[MiniCluster] = None
 
   var port: Int = _
   var hostname : String = _
@@ -333,7 +332,7 @@ object ScalaShellITCase {
     port = miniCluster.getRestAddress.getPort
     hostname = miniCluster.getRestAddress.getHost
 
-    cluster = Some(Left(miniCluster))
+    cluster = Some(miniCluster)
   }
 
   @AfterClass
@@ -342,8 +341,7 @@ object ScalaShellITCase {
     Thread.currentThread().setContextClassLoader(classOf[ScalaShellITCase].getClassLoader)
 
     cluster.foreach {
-      case Left(miniCluster) => miniCluster.close()
-      case Right(miniCluster) => miniCluster.close()
+      miniCluster => miniCluster.close()
     }
   }
 

--- a/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
+++ b/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
@@ -19,13 +19,11 @@
 package org.apache.flink.api.scala
 
 import java.io._
-import java.util.Objects
 
 import org.apache.flink.configuration.{Configuration, CoreOptions, RestOptions, TaskManagerOptions}
 import org.apache.flink.runtime.clusterframework.BootstrapTools
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration, StandaloneMiniCluster}
-import org.apache.flink.test.util.{MiniClusterResource, TestBaseUtils}
-import org.apache.flink.test.util.TestBaseUtils.CodebaseType
+import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.util.TestLogger
 import org.junit._
 import org.junit.rules.TemporaryFolder
@@ -322,32 +320,20 @@ object ScalaShellITCase {
 
   @BeforeClass
   def beforeAll(): Unit = {
-    val isNew = TestBaseUtils.isNewCodebase()
-    if (isNew) {
-      configuration.setString(CoreOptions.MODE, CoreOptions.NEW_MODE)
-      // set to different than default so not to interfere with ScalaShellLocalStartupITCase
-      configuration.setInteger(RestOptions.PORT, 8082)
-      val miniConfig = new MiniClusterConfiguration.Builder()
-        .setConfiguration(configuration)
-        .setNumSlotsPerTaskManager(parallelism)
-        .build()
+    configuration.setString(CoreOptions.MODE, CoreOptions.NEW_MODE)
+    // set to different than default so not to interfere with ScalaShellLocalStartupITCase
+    configuration.setInteger(RestOptions.PORT, 8082)
+    val miniConfig = new MiniClusterConfiguration.Builder()
+      .setConfiguration(configuration)
+      .setNumSlotsPerTaskManager(parallelism)
+      .build()
 
-      val miniCluster = new MiniCluster(miniConfig)
-      miniCluster.start()
-      port = miniCluster.getRestAddress.getPort
-      hostname = miniCluster.getRestAddress.getHost
+    val miniCluster = new MiniCluster(miniConfig)
+    miniCluster.start()
+    port = miniCluster.getRestAddress.getPort
+    hostname = miniCluster.getRestAddress.getHost
 
-      cluster = Some(Left(miniCluster))
-    } else {
-      configuration.setString(CoreOptions.MODE, CoreOptions.LEGACY_MODE)
-      configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, parallelism)
-      val standaloneCluster = new StandaloneMiniCluster(configuration)
-
-      hostname = standaloneCluster.getHostname
-      port = standaloneCluster.getPort
-
-      cluster = Some(Right(standaloneCluster))
-    }
+    cluster = Some(Left(miniCluster))
   }
 
   @AfterClass

--- a/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellLocalStartupITCase.scala
+++ b/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellLocalStartupITCase.scala
@@ -20,9 +20,8 @@ package org.apache.flink.api.scala
 
 import java.io._
 
-import org.apache.flink.configuration.{Configuration, CoreOptions}
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.clusterframework.BootstrapTools
-import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.util.TestLogger
 import org.junit.rules.TemporaryFolder
 import org.junit.{Assert, Rule, Test}
@@ -86,12 +85,6 @@ class ScalaShellLocalStartupITCase extends TestLogger {
     System.setOut(new PrintStream(baos))
 
     val configuration = new Configuration()
-    val mode = if (TestBaseUtils.isNewCodebase()) {
-      CoreOptions.NEW_MODE
-    } else {
-      CoreOptions.LEGACY_MODE
-    }
-    configuration.setString(CoreOptions.MODE, mode)
 
     val dir = temporaryFolder.newFolder()
     BootstrapTools.writeConfiguration(configuration, new File(dir, "flink-conf.yaml"))

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResourceConfiguration.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResourceConfiguration.java
@@ -37,8 +37,6 @@ public class MiniClusterResourceConfiguration {
 
 	private final Time shutdownTimeout;
 
-	private final TestBaseUtils.CodebaseType codebaseType;
-
 	private final RpcServiceSharing rpcServiceSharing;
 
 	MiniClusterResourceConfiguration(
@@ -46,13 +44,11 @@ public class MiniClusterResourceConfiguration {
 		int numberTaskManagers,
 		int numberSlotsPerTaskManager,
 		Time shutdownTimeout,
-		TestBaseUtils.CodebaseType codebaseType,
 		RpcServiceSharing rpcServiceSharing) {
 		this.configuration = Preconditions.checkNotNull(configuration);
 		this.numberTaskManagers = numberTaskManagers;
 		this.numberSlotsPerTaskManager = numberSlotsPerTaskManager;
 		this.shutdownTimeout = Preconditions.checkNotNull(shutdownTimeout);
-		this.codebaseType = Preconditions.checkNotNull(codebaseType);
 		this.rpcServiceSharing = Preconditions.checkNotNull(rpcServiceSharing);
 	}
 
@@ -72,14 +68,6 @@ public class MiniClusterResourceConfiguration {
 		return shutdownTimeout;
 	}
 
-	/**
-	 * @deprecated Will be irrelevant once the legacy mode has been removed.
-	 */
-	@Deprecated
-	public TestBaseUtils.CodebaseType getCodebaseType() {
-		return codebaseType;
-	}
-
 	public RpcServiceSharing getRpcServiceSharing() {
 		return rpcServiceSharing;
 	}
@@ -93,7 +81,6 @@ public class MiniClusterResourceConfiguration {
 		private int numberTaskManagers = 1;
 		private int numberSlotsPerTaskManager = 1;
 		private Time shutdownTimeout = AkkaUtils.getTimeoutAsTime(configuration);
-		private TestBaseUtils.CodebaseType codebaseType = TestBaseUtils.getCodebaseType();
 
 		private RpcServiceSharing rpcServiceSharing = RpcServiceSharing.SHARED;
 
@@ -117,22 +104,13 @@ public class MiniClusterResourceConfiguration {
 			return this;
 		}
 
-		/**
-		 * @deprecated Will be irrelevant once the legacy mode has been removed.
-		 */
-		@Deprecated
-		public Builder setCodebaseType(TestBaseUtils.CodebaseType codebaseType) {
-			this.codebaseType = codebaseType;
-			return this;
-		}
-
 		public Builder setRpcServiceSharing(RpcServiceSharing rpcServiceSharing) {
 			this.rpcServiceSharing = rpcServiceSharing;
 			return this;
 		}
 
 		public MiniClusterResourceConfiguration build() {
-			return new MiniClusterResourceConfiguration(configuration, numberTaskManagers, numberSlotsPerTaskManager, shutdownTimeout, codebaseType, rpcServiceSharing);
+			return new MiniClusterResourceConfiguration(configuration, numberTaskManagers, numberSlotsPerTaskManager, shutdownTimeout, rpcServiceSharing);
 		}
 	}
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -44,8 +44,6 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -676,26 +674,6 @@ public class TestBaseUtils extends TestLogger {
 		}
 
 		throw new TimeoutException("Could not get HTTP response in time since the service is still unavailable.");
-	}
-
-	@Nonnull
-	public static CodebaseType getCodebaseType() {
-		return Objects.equals(NEW_CODEBASE, System.getProperty(CODEBASE_KEY)) ? CodebaseType.NEW : CodebaseType.LEGACY;
-	}
-
-	public static boolean isNewCodebase() {
-		return CodebaseType.NEW == getCodebaseType();
-	}
-
-	/**
-	 * Type of the mini cluster to start.
-	 *
-	 * @deprecated Will be irrelevant once the legacy mode has been removed.
-	 */
-	@Deprecated
-	public enum CodebaseType {
-		LEGACY,
-		NEW
 	}
 
 	/**

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -58,7 +57,6 @@ public class JobRetrievalITCase extends TestLogger {
 		new MiniClusterResourceConfiguration.Builder()
 			.setNumberTaskManagers(1)
 			.setNumberSlotsPerTaskManager(4)
-			.setCodebaseType(TestBaseUtils.CodebaseType.NEW)
 			.build());
 
 	private RestClusterClient<StandaloneClusterId> client;

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/AutoParallelismITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/AutoParallelismITCase.java
@@ -28,7 +28,6 @@ import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
 import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
@@ -80,9 +79,6 @@ public class AutoParallelismITCase extends TestLogger {
 			assertEquals(PARALLELISM, resultCollection.size());
 		}
 		catch (Exception ex) {
-			if (MINI_CLUSTER_RESOURCE.getCodebaseType() == TestBaseUtils.CodebaseType.LEGACY) {
-				throw ex;
-			}
 			assertTrue(
 				ExceptionUtils.findThrowableWithMessage(ex, ExecutionGraphBuilder.PARALLELISM_AUTO_MAX_ERROR_MESSAGE).isPresent());
 		}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -21,7 +21,6 @@ package org.apache.flink.yarn;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -75,7 +74,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.UUID;
@@ -153,7 +151,7 @@ public abstract class YarnTestBase extends TestLogger {
 
 	protected org.apache.flink.configuration.Configuration flinkConfiguration;
 
-	protected boolean isNewMode;
+	protected final boolean isNewMode = true;
 
 	static {
 		YARN_CONFIGURATION = new YarnConfiguration();
@@ -198,8 +196,6 @@ public abstract class YarnTestBase extends TestLogger {
 		}
 
 		flinkConfiguration = new org.apache.flink.configuration.Configuration(globalConfiguration);
-
-		isNewMode = Objects.equals(TestBaseUtils.CodebaseType.NEW, TestBaseUtils.getCodebaseType());
 	}
 
 	/**
@@ -551,9 +547,6 @@ public abstract class YarnTestBase extends TestLogger {
 			tempConfPathForSecureRun = tmp.newFolder("conf");
 
 			FileUtils.copyDirectory(new File(confDirPath), tempConfPathForSecureRun);
-
-			globalConfiguration.setString(CoreOptions.MODE,
-				Objects.equals(TestBaseUtils.CodebaseType.NEW, TestBaseUtils.getCodebaseType()) ? CoreOptions.NEW_MODE : CoreOptions.LEGACY_MODE);
 
 			BootstrapTools.writeConfiguration(
 				globalConfiguration,


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #6747 and is part of the [removal of Flink's legacy mode].(https://issues.apache.org/jira/browse/FLINK-10392). 

`CodebaseType` was used to distinguish between the legacy and new mode.
This commit removes the `CodebaseType` and the codebase switch in the
`MiniClusterResource`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
