### PR TITLE
[FLINK-10414][cep] Added skip to next strategy

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1289,6 +1289,15 @@ For example, for a given pattern `b+ c` and a data stream `b1 b2 b3 c`, the diff
         <td>After found matching <code>b1 b2 b3 c</code>, the match process will not discard any result.</td>
     </tr>
     <tr>
+        <td><strong>SKIP_TO_NEXT</strong></td>
+        <td>
+            <code>b1 b2 b3 c</code><br>
+            <code>b2 b3 c</code><br>
+            <code>b3 c</code><br>
+        </td>
+        <td>After found matching <code>b1 b2 b3 c</code>, the match process will not discard any result, because no other match could start at b1.</td>
+    </tr>
+    <tr>
         <td><strong>SKIP_PAST_LAST_EVENT</strong></td>
         <td>
             <code>b1 b2 b3 c</code><br>
@@ -1296,7 +1305,7 @@ For example, for a given pattern `b+ c` and a data stream `b1 b2 b3 c`, the diff
         <td>After found matching <code>b1 b2 b3 c</code>, the match process will discard all started partial matches.</td>
     </tr>
     <tr>
-        <td><strong>SKIP_TO_FIRST</strong>[<code>b*</code>]</td>
+        <td><strong>SKIP_TO_FIRST</strong>[<code>b</code>]</td>
         <td>
             <code>b1 b2 b3 c</code><br>
             <code>b2 b3 c</code><br>
@@ -1340,7 +1349,35 @@ Pattern: `(a | c) (b | c) c+.greedy d` and sequence: `a b c1 c2 c3 d` Then the r
             <code>a b c1 c2 c3 d</code><br>
             <code>c1 c2 c3 d</code><br>
         </td>
-        <td>After found matching <code>a b c1 c2 c3 d</code>, the match process will try to discard all partial matches started before <code>c1</code>. There is one such match <code>b c1 c2 c3 d</code>.</td>
+        <td>After found matching <code>a b c1 c2 c3 d</code>, the match process will discard all partial matches started before <code>c1</code>. There is one such match <code>b c1 c2 c3 d</code>.</td>
+    </tr>
+</table>
+
+To better understand the difference between NO_SKIP and SKIP_TO_NEXT take a look at following example:
+Pattern: `a b+` and sequence: `a b1 b2 b3` Then the results will be:
+
+
+<table class="table table-bordered">
+    <tr>
+        <th class="text-left" style="width: 25%">Skip Strategy</th>
+        <th class="text-center" style="width: 25%">Result</th>
+        <th class="text-center"> Description</th>
+    </tr>
+    <tr>
+        <td><strong>NO_SKIP</strong></td>
+        <td>
+            <code>a b1</code><br>
+            <code>a b1 b2</code><br>
+            <code>a b1 b2 b3</code><br>
+        </td>
+        <td>After found matching <code>a b1</code>, the match process will not discard any result.</td>
+    </tr>
+    <tr>
+        <td><strong>SKIP_TO_NEXT</strong>[<code>b*</code>]</td>
+        <td>
+            <code>a b1</code><br>
+        </td>
+        <td>After found matching <code>a b1</code>, the match process will discard all partial matches started at <code>a</code>. This means neither <code>a b1 b2</code> nor <code>a b1 b2 b3</code> could be generated.</td>
     </tr>
 </table>
 
@@ -1353,6 +1390,10 @@ To specify which skip strategy to use, just create an `AfterMatchSkipStrategy` b
     <tr>
         <td><code>AfterMatchSkipStrategy.noSkip()</code></td>
         <td>Create a <strong>NO_SKIP</strong> skip strategy </td>
+    </tr>
+    <tr>
+        <td><code>AfterMatchSkipStrategy.skipToNext()</code></td>
+        <td>Create a <strong>SKIP_TO_NEXT</strong> skip strategy </td>
     </tr>
     <tr>
         <td><code>AfterMatchSkipStrategy.skipPastLastEvent()</code></td>

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
@@ -38,7 +38,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	private static final long serialVersionUID = -4048930333619068531L;
 
 	/**
-	 * Discards every partial match that contains event of the match preceding the first of *PatternName*.
+	 * Discards every partial match that started before the first event of emitted match mapped to *PatternName*.
 	 *
 	 * @param patternName the pattern name to skip to
 	 * @return the created AfterMatchSkipStrategy
@@ -48,7 +48,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	}
 
 	/**
-	 * Discards every partial match that contains event of the match preceding the last of *PatternName*.
+	 * Discards every partial match that started before the last event of emitted match mapped to *PatternName*.
 	 *
 	 * @param patternName the pattern name to skip to
 	 * @return the created AfterMatchSkipStrategy
@@ -58,12 +58,21 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	}
 
 	/**
-	 * Discards every partial match that contains event of the match.
+	 * Discards every partial match that started before emitted match ended.
 	 *
 	 * @return the created AfterMatchSkipStrategy
 	 */
 	public static SkipPastLastStrategy skipPastLastEvent() {
 		return SkipPastLastStrategy.INSTANCE;
+	}
+
+	/**
+	 * Discards every partial match that started with the same event, emitted match was started.
+	 *
+	 * @return the created AfterMatchSkipStrategy
+	 */
+	public static AfterMatchSkipStrategy skipToNext() {
+		return SkipToNextStrategy.INSTANCE;
 	}
 
 	/**
@@ -143,6 +152,22 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 		}
 
 		if (o1.compareTo(o2) >= 0) {
+			return o1;
+		} else {
+			return o2;
+		}
+	}
+
+	static EventId min(EventId o1, EventId o2) {
+		if (o2 == null) {
+			return o1;
+		}
+
+		if (o1 == null) {
+			return o2;
+		}
+
+		if (o1.compareTo(o2) <= 0) {
 			return o1;
 		} else {
 			return o2;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipPastLastStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipPastLastStrategy.java
@@ -27,23 +27,13 @@ import java.util.Map;
 /**
  * Discards every partial match that started before emitted match ended.
  */
-public class SkipPastLastStrategy extends AfterMatchSkipStrategy {
+public final class SkipPastLastStrategy extends SkipRelativeToWholeMatchStrategy {
 
 	public static final SkipPastLastStrategy INSTANCE = new SkipPastLastStrategy();
 
 	private static final long serialVersionUID = -8450320065949093169L;
 
 	private SkipPastLastStrategy() {
-	}
-
-	@Override
-	public boolean isSkipStrategy() {
-		return true;
-	}
-
-	@Override
-	protected boolean shouldPrune(EventId startEventID, EventId pruningId) {
-		return startEventID != null && startEventID.compareTo(pruningId) <= 0;
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipRelativeToWholeMatchStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipRelativeToWholeMatchStrategy.java
@@ -20,36 +20,16 @@ package org.apache.flink.cep.nfa.aftermatch;
 
 import org.apache.flink.cep.nfa.sharedbuffer.EventId;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+abstract class SkipRelativeToWholeMatchStrategy extends AfterMatchSkipStrategy {
+	private static final long serialVersionUID = -3214720554878479037L;
 
-/**
- * Discards every partial match that started with the same event, emitted match was started.
- */
-public final class SkipToNextStrategy extends SkipRelativeToWholeMatchStrategy {
-
-	public static final SkipToNextStrategy INSTANCE = new SkipToNextStrategy();
-
-	private static final long serialVersionUID = -6490314998588752621L;
-
-	private SkipToNextStrategy() {
+	@Override
+	public final boolean isSkipStrategy() {
+		return true;
 	}
 
 	@Override
-	protected EventId getPruningId(final Collection<Map<String, List<EventId>>> match) {
-		EventId pruningId = null;
-		for (Map<String, List<EventId>> resultMap : match) {
-			for (List<EventId> eventList : resultMap.values()) {
-				pruningId = min(pruningId, eventList.get(0));
-			}
-		}
-
-		return pruningId;
-	}
-
-	@Override
-	public String toString() {
-		return "SkipToNextStrategy{}";
+	protected final boolean shouldPrune(EventId startEventID, EventId pruningId) {
+		return startEventID != null && startEventID.compareTo(pruningId) <= 0;
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToFirstStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToFirstStrategy.java
@@ -19,7 +19,7 @@
 package org.apache.flink.cep.nfa.aftermatch;
 
 /**
- * Discards every partial match that contains event of the match preceding the first of *PatternName*.
+ * Discards every partial match that started before the first event of emitted match mapped to *PatternName*.
  */
 public final class SkipToFirstStrategy extends SkipToElementStrategy {
 	private static final long serialVersionUID = 7127107527654629026L;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToLastStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToLastStrategy.java
@@ -19,7 +19,7 @@
 package org.apache.flink.cep.nfa.aftermatch;
 
 /**
- * Discards every partial match that contains event of the match preceding the last of *PatternName*.
+ * Discards every partial match that started before the last event of emitted match mapped to *PatternName*.
  */
 public final class SkipToLastStrategy extends SkipToElementStrategy {
 	private static final long serialVersionUID = 7585116990619594531L;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToNextStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToNextStrategy.java
@@ -25,15 +25,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Discards every partial match that started before emitted match ended.
+ * Discards every partial match that started with the same event, emitted match was started.
  */
-public class SkipPastLastStrategy extends AfterMatchSkipStrategy {
+public class SkipToNextStrategy extends AfterMatchSkipStrategy {
 
-	public static final SkipPastLastStrategy INSTANCE = new SkipPastLastStrategy();
+	public static final SkipToNextStrategy INSTANCE = new SkipToNextStrategy();
 
 	private static final long serialVersionUID = -8450320065949093169L;
 
-	private SkipPastLastStrategy() {
+	private SkipToNextStrategy() {
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public class SkipPastLastStrategy extends AfterMatchSkipStrategy {
 		EventId pruningId = null;
 		for (Map<String, List<EventId>> resultMap : match) {
 			for (List<EventId> eventList : resultMap.values()) {
-				pruningId = max(pruningId, eventList.get(eventList.size() - 1));
+				pruningId = min(pruningId, eventList.get(0));
 			}
 		}
 
@@ -60,6 +60,6 @@ public class SkipPastLastStrategy extends AfterMatchSkipStrategy {
 
 	@Override
 	public String toString() {
-		return "SkipPastLastStrategy{}";
+		return "SkipToNextStrategy{}";
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support of SKIP_TO_NEXT, which will fully cover all variants of AFTER MATCH clause in SQL. This clause is important for e.g. reluctant quantifiers at the end, as after first, shortest match, all others started at the same element will be discarded.

## Brief change log

  * Added `SkipToNextStrategy`
  * Extended documentation with SKIP_TO_NEXT description

## Verifying this change

This change added tests and can be verified as follows:
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testNoSkipWithQuantifierAtTheEnd`
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSkipToNextWithQuantifierAtTheEnd`
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testNoSkipWithFollowedByAny`
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSkipToNextWithFollowedByAny`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
