### PR TITLE
[FLINK-10417][cep] Added option to throw exception on pattern variable mis…

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1385,6 +1385,23 @@ Pattern.begin("patternName", skipStrategy)
 </div>
 </div>
 
+{% warn Attention %} For SKIP_TO_FIRST/LAST there are two options how to handle cases when there are no elements mapped to
+the specified variable. By default a NO_SKIP strategy will be used in this case. The other option is to throw exception in such situation.
+One can enable this option by:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+AfterMatchSkipStrategy.skipToFirst(patternName).throwExceptionOnMiss()
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+AfterMatchSkipStrategy.skipToFirst(patternName).throwExceptionOnMiss()
+{% endhighlight %}
+</div>
+</div>
+
 ## Detecting Patterns
 
 After specifying the pattern sequence you are looking for, it is time to apply it to your input stream to detect

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
@@ -43,7 +43,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	 * @param patternName the pattern name to skip to
 	 * @return the created AfterMatchSkipStrategy
 	 */
-	public static AfterMatchSkipStrategy skipToFirst(String patternName) {
+	public static SkipToFirstStrategy skipToFirst(String patternName) {
 		return new SkipToFirstStrategy(patternName);
 	}
 
@@ -53,7 +53,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	 * @param patternName the pattern name to skip to
 	 * @return the created AfterMatchSkipStrategy
 	 */
-	public static AfterMatchSkipStrategy skipToLast(String patternName) {
+	public static SkipToLastStrategy skipToLast(String patternName) {
 		return new SkipToLastStrategy(patternName);
 	}
 
@@ -62,7 +62,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	 *
 	 * @return the created AfterMatchSkipStrategy
 	 */
-	public static AfterMatchSkipStrategy skipPastLastEvent() {
+	public static SkipPastLastStrategy skipPastLastEvent() {
 		return SkipPastLastStrategy.INSTANCE;
 	}
 
@@ -71,7 +71,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	 *
 	 * @return the created AfterMatchSkipStrategy
 	 */
-	public static AfterMatchSkipStrategy noSkip() {
+	public static NoSkipStrategy noSkip() {
 		return NoSkipStrategy.INSTANCE;
 	}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
@@ -44,7 +44,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	 * @return the created AfterMatchSkipStrategy
 	 */
 	public static SkipToFirstStrategy skipToFirst(String patternName) {
-		return new SkipToFirstStrategy(patternName);
+		return new SkipToFirstStrategy(patternName, false);
 	}
 
 	/**
@@ -54,7 +54,7 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
 	 * @return the created AfterMatchSkipStrategy
 	 */
 	public static SkipToLastStrategy skipToLast(String patternName) {
-		return new SkipToLastStrategy(patternName);
+		return new SkipToLastStrategy(patternName, false);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToElementStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToElementStrategy.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.nfa.aftermatch;
+
+import org.apache.flink.cep.nfa.sharedbuffer.EventId;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+abstract class SkipToElementStrategy extends AfterMatchSkipStrategy {
+	private static final long serialVersionUID = 7127107527654629026L;
+	private final String patternName;
+	private final boolean shouldThrowException;
+
+	SkipToElementStrategy(String patternName, boolean shouldThrowException) {
+		this.patternName = checkNotNull(patternName);
+		this.shouldThrowException = shouldThrowException;
+	}
+
+	@Override
+	public boolean isSkipStrategy() {
+		return true;
+	}
+
+	@Override
+	protected boolean shouldPrune(EventId startEventID, EventId pruningId) {
+		return startEventID != null && startEventID.compareTo(pruningId) < 0;
+	}
+
+	@Override
+	protected EventId getPruningId(Collection<Map<String, List<EventId>>> match) {
+		EventId pruningId = null;
+		for (Map<String, List<EventId>> resultMap : match) {
+			List<EventId> pruningPattern = resultMap.get(patternName);
+			if (pruningPattern == null || pruningPattern.isEmpty()) {
+				if (shouldThrowException) {
+					throw new FlinkRuntimeException(String.format(
+						"Could not skip to %s. No such element in the found match %s",
+						patternName,
+						resultMap));
+				}
+			} else {
+				pruningId = max(pruningId, pruningPattern.get(getIndex(pruningPattern.size())));
+			}
+		}
+
+		return pruningId;
+	}
+
+	@Override
+	public Optional<String> getPatternName() {
+		return Optional.of(patternName);
+	}
+
+	/**
+	 * Tells which element from the list of events mapped to *PatternName* to use.
+	 *
+	 * @param size number of elements mapped to the *PatternName*
+	 * @return index of event mapped to *PatternName* to use for pruning
+	 */
+	abstract int getIndex(int size);
+
+	/**
+	 * Enables throwing exception if no events mapped to the *PatternName*. If not enabled and no events were mapped,
+	 * {@link NoSkipStrategy} will be used
+	 */
+	public abstract SkipToElementStrategy throwExceptionOnMiss();
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToFirstStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToFirstStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.flink.cep.nfa.aftermatch;
 
 import org.apache.flink.cep.nfa.sharedbuffer.EventId;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +35,7 @@ public class SkipToFirstStrategy extends AfterMatchSkipStrategy {
 
 	private static final long serialVersionUID = 7127107527654629026L;
 	private final String patternName;
+	private boolean shouldThrowException = false;
 
 	SkipToFirstStrategy(String patternName) {
 		this.patternName = checkNotNull(patternName);
@@ -54,7 +56,14 @@ public class SkipToFirstStrategy extends AfterMatchSkipStrategy {
 		EventId pruniningId = null;
 		for (Map<String, List<EventId>> resultMap : match) {
 			List<EventId> pruningPattern = resultMap.get(patternName);
-			if (pruningPattern != null && !pruningPattern.isEmpty()) {
+			if (pruningPattern == null || pruningPattern.isEmpty()) {
+				if (shouldThrowException) {
+					throw new FlinkRuntimeException(String.format(
+						"Could not skip to %s. No such element in the found match %s",
+						patternName,
+						resultMap));
+				}
+			} else {
 				pruniningId = max(pruniningId, pruningPattern.get(0));
 			}
 		}
@@ -65,6 +74,15 @@ public class SkipToFirstStrategy extends AfterMatchSkipStrategy {
 	@Override
 	public Optional<String> getPatternName() {
 		return Optional.of(patternName);
+	}
+
+	/**
+	 * Enables throwing exception if no events mapped to the *PatternName*. If not enabled and no events were mapped,
+	 * {@link NoSkipStrategy} will be used
+	 */
+	public SkipToFirstStrategy throwExceptionOnMiss() {
+		this.shouldThrowException = true;
+		return this;
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToFirstStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToFirstStrategy.java
@@ -18,77 +18,30 @@
 
 package org.apache.flink.cep.nfa.aftermatch;
 
-import org.apache.flink.cep.nfa.sharedbuffer.EventId;
-import org.apache.flink.util.FlinkRuntimeException;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * Discards every partial match that contains event of the match preceding the first of *PatternName*.
  */
-public class SkipToFirstStrategy extends AfterMatchSkipStrategy {
-
+public final class SkipToFirstStrategy extends SkipToElementStrategy {
 	private static final long serialVersionUID = 7127107527654629026L;
-	private final String patternName;
-	private boolean shouldThrowException = false;
 
-	SkipToFirstStrategy(String patternName) {
-		this.patternName = checkNotNull(patternName);
+	SkipToFirstStrategy(String patternName, boolean shouldThrowException) {
+		super(patternName, shouldThrowException);
 	}
 
 	@Override
-	public boolean isSkipStrategy() {
-		return true;
+	public SkipToElementStrategy throwExceptionOnMiss() {
+		return new SkipToFirstStrategy(getPatternName().get(), true);
 	}
 
 	@Override
-	protected boolean shouldPrune(EventId startEventID, EventId pruningId) {
-		return startEventID != null && startEventID.compareTo(pruningId) < 0;
-	}
-
-	@Override
-	protected EventId getPruningId(Collection<Map<String, List<EventId>>> match) {
-		EventId pruniningId = null;
-		for (Map<String, List<EventId>> resultMap : match) {
-			List<EventId> pruningPattern = resultMap.get(patternName);
-			if (pruningPattern == null || pruningPattern.isEmpty()) {
-				if (shouldThrowException) {
-					throw new FlinkRuntimeException(String.format(
-						"Could not skip to %s. No such element in the found match %s",
-						patternName,
-						resultMap));
-				}
-			} else {
-				pruniningId = max(pruniningId, pruningPattern.get(0));
-			}
-		}
-
-		return pruniningId;
-	}
-
-	@Override
-	public Optional<String> getPatternName() {
-		return Optional.of(patternName);
-	}
-
-	/**
-	 * Enables throwing exception if no events mapped to the *PatternName*. If not enabled and no events were mapped,
-	 * {@link NoSkipStrategy} will be used
-	 */
-	public SkipToFirstStrategy throwExceptionOnMiss() {
-		this.shouldThrowException = true;
-		return this;
+	int getIndex(int size) {
+		return 0;
 	}
 
 	@Override
 	public String toString() {
 		return "SkipToFirstStrategy{" +
-			"patternName='" + patternName + '\'' +
+			"patternName='" + getPatternName().get() + '\'' +
 			'}';
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToLastStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/SkipToLastStrategy.java
@@ -18,76 +18,30 @@
 
 package org.apache.flink.cep.nfa.aftermatch;
 
-import org.apache.flink.cep.nfa.sharedbuffer.EventId;
-import org.apache.flink.util.FlinkRuntimeException;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * Discards every partial match that contains event of the match preceding the last of *PatternName*.
  */
-public class SkipToLastStrategy extends AfterMatchSkipStrategy {
+public final class SkipToLastStrategy extends SkipToElementStrategy {
 	private static final long serialVersionUID = 7585116990619594531L;
-	private final String patternName;
-	private boolean shouldThrowException = false;
 
-	SkipToLastStrategy(String patternName) {
-		this.patternName = checkNotNull(patternName);
+	SkipToLastStrategy(String patternName, boolean shouldThrowException) {
+		super(patternName, shouldThrowException);
 	}
 
 	@Override
-	public boolean isSkipStrategy() {
-		return true;
+	public SkipToElementStrategy throwExceptionOnMiss() {
+		return new SkipToLastStrategy(getPatternName().get(), true);
 	}
 
 	@Override
-	protected boolean shouldPrune(EventId startEventID, EventId pruningId) {
-		return startEventID != null && startEventID.compareTo(pruningId) < 0;
-	}
-
-	@Override
-	protected EventId getPruningId(Collection<Map<String, List<EventId>>> match) {
-		EventId pruningId = null;
-		for (Map<String, List<EventId>> resultMap : match) {
-			List<EventId> pruningPattern = resultMap.get(patternName);
-			if (pruningPattern == null || pruningPattern.isEmpty()) {
-				if (shouldThrowException) {
-					throw new FlinkRuntimeException(String.format(
-						"Could not skip to %s. No such element in the found match %s",
-						patternName,
-						resultMap));
-				}
-			} else {
-				pruningId = max(pruningId, pruningPattern.get(pruningPattern.size() - 1));
-			}
-		}
-
-		return pruningId;
-	}
-
-	@Override
-	public Optional<String> getPatternName() {
-		return Optional.of(patternName);
-	}
-
-	/**
-	 * Enables throwing exception if no events mapped to the *PatternName*. If not enabled and no events were mapped,
-	 * {@link NoSkipStrategy} will be used
-	 */
-	public SkipToLastStrategy throwExceptionOnMiss() {
-		this.shouldThrowException = true;
-		return this;
+	int getIndex(int size) {
+		return size - 1;
 	}
 
 	@Override
 	public String toString() {
 		return "SkipToLastStrategy{" +
-			"patternName='" + patternName + '\'' +
+			"patternName='" + getPatternName().get() + '\'' +
 			'}';
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Add option to throw exception when found match does not have any events mapped to variable that is used in SKIP_TO_FIRST/LAST. This is to conform with SQL standard for MATCH_RECOGNIZE.

## Brief change log

* throwing exception when there is no events mapped to variable used in SKIP_TO_FIRST/LAST
* added option to enable/disable this feature

## Verifying this change
This change added tests and can be verified as follows:
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSkipToFirstNonExistentPosition`
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSkipToFirstNonExistentPositionWithoutException`
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSkipToLastNonExistentPosition`
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSkipToLastNonExistentPositionWithoutException`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
