### PR TITLE
[FLINK-10279] [documentation] Make jython limitations more obvious in documentation.

### DIFF
--- a/docs/dev/stream/python.md
+++ b/docs/dev/stream/python.md
@@ -54,7 +54,7 @@ existing Java streaming APIs.
 There are two main constraints for using Jython:
 
 * The latest Python supported version is 2.7
-* It is not straightforward to use Python C extensions, which may prevent reuse of some libraries
+* It is not straightforward to use Python C extensions, which may prevent use of some libraries
 
 (For more information please see <https://wiki.python.org/jython/JythonFaq/GeneralInfo>.)
 

--- a/docs/dev/stream/python.md
+++ b/docs/dev/stream/python.md
@@ -24,6 +24,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+*Note: This API is based on Jython, which is not a full Python replacement and may restrict
+the libraries you are able to use with your application (see below for more information).*
+
 Analysis streaming programs in Flink are regular programs that implement transformations on
 streaming data sets (e.g., filtering, mapping, joining, grouping). The streaming data sets are initially
 created from certain sources (e.g., by reading files, or from collections).
@@ -50,7 +53,12 @@ existing Java streaming APIs.
 There are two main constraints for using Jython:
 
 * The latest Python supported version is 2.7
-* It is not straightforward to use Python C extensions
+* It is not straightforward to use Python C extensions, which may prevent reuse of some libraries
+
+(For more information please see <https://wiki.python.org/jython/JythonFaq/GeneralInfo>.)
+
+One possible alternative for streaming that allows for native Python execution would be the Apache Beam
+portability framework with the Flink runner.
 
 Streaming Program Example
 -------------------------

--- a/docs/dev/stream/python.md
+++ b/docs/dev/stream/python.md
@@ -24,8 +24,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-*Note: This API is based on Jython, which is not a full Python replacement and may restrict
-the libraries you are able to use with your application (see below for more information).*
+<span class="label label-danger">Attention</span> *This API is based on Jython,
+which is not a full Python replacement and may restrict the libraries you are able
+to use with your application (see below for more information).*
 
 Analysis streaming programs in Flink are regular programs that implement transformations on
 streaming data sets (e.g., filtering, mapping, joining, grouping). The streaming data sets are initially
@@ -57,8 +58,8 @@ There are two main constraints for using Jython:
 
 (For more information please see <https://wiki.python.org/jython/JythonFaq/GeneralInfo>.)
 
-One possible alternative for streaming that allows for native Python execution would be the Apache Beam
-portability framework with the Flink runner.
+One possible alternative for streaming that allows for native Python execution would be the [Apache Beam
+portability framework](https://beam.apache.org/contribute/portability/) with the Flink runner.
 
 Streaming Program Example
 -------------------------


### PR DESCRIPTION
Purpose of this change is to better highlight the potential restrictions of the Jython based streaming API to avoid user confusion.
