### PR TITLE
[FLINK-10339][network] Use off-heap memory for SpillReadBufferPool

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -75,6 +75,19 @@ public final class MemorySegmentFactory {
 	}
 
 	/**
+	 * Allocates some unpooled off-heap memory and creates a new memory segment that
+	 * represents that memory.
+	 *
+	 * @param size The size of the off-heap memory segment to allocate.
+	 * @param owner The owner to associate with the off-heap memory segment.
+	 * @return A new memory segment, backed by unpooled off-heap memory.
+	 */
+	public static MemorySegment allocateUnpooledOffHeapMemory(int size, Object owner) {
+		ByteBuffer memory = ByteBuffer.allocateDirect(size);
+		return wrapPooledOffHeapMemory(memory, owner);
+	}
+
+	/**
 	 * Creates a memory segment that wraps the given byte array.
 	 *
 	 * <p>This method is intended to be used for components which pool memory and create

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -89,8 +88,7 @@ public class NetworkBufferPool implements BufferPoolFactory {
 
 		try {
 			for (int i = 0; i < numberOfSegmentsToAllocate; i++) {
-				ByteBuffer memory = ByteBuffer.allocateDirect(segmentSize);
-				availableMemorySegments.add(MemorySegmentFactory.wrapPooledOffHeapMemory(memory, null));
+				availableMemorySegments.add(MemorySegmentFactory.allocateUnpooledOffHeapMemory(segmentSize, null));
 			}
 		}
 		catch (OutOfMemoryError err) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -36,7 +36,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -258,8 +257,8 @@ class SpilledSubpartitionView implements ResultSubpartitionView, NotificationLis
 
 			synchronized (buffers) {
 				for (int i = 0; i < numberOfBuffers; i++) {
-					ByteBuffer memory = ByteBuffer.allocateDirect(memorySegmentSize);
-					buffers.add(new NetworkBuffer(MemorySegmentFactory.wrapPooledOffHeapMemory(memory, null), this));
+					buffers.add(new NetworkBuffer(MemorySegmentFactory.allocateUnpooledOffHeapMemory(
+						memorySegmentSize, null), this));
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -257,7 +258,8 @@ class SpilledSubpartitionView implements ResultSubpartitionView, NotificationLis
 
 			synchronized (buffers) {
 				for (int i = 0; i < numberOfBuffers; i++) {
-					buffers.add(new NetworkBuffer(MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize), this));
+					ByteBuffer memory = ByteBuffer.allocateDirect(memorySegmentSize);
+					buffers.add(new NetworkBuffer(MemorySegmentFactory.wrapPooledOffHeapMemory(memory, null), this));
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -675,8 +675,7 @@ public class MemoryManager {
 
 		@Override
 		MemorySegment allocateNewSegment(Object owner) {
-			ByteBuffer memory = ByteBuffer.allocateDirect(segmentSize);
-			return MemorySegmentFactory.wrapPooledOffHeapMemory(memory, owner);
+			return MemorySegmentFactory.allocateUnpooledOffHeapMemory(segmentSize, owner);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Currently the `NetworkBufferPool` already uses off-heap memory directly. But the `BufferPool` for `SpilledSubpartitionView` still uses heap memory by default. It should keep the same behavior with `NetworkBufferPool` and it may get benefit for reusing this off-heap memory in netty stack during transporting.

## Brief change log

  - *Use off-heap memory directly for `SpillReadBufferPool` in `SpilledSubpartitionView`.*

## Verifying this change

This change is already covered by existing tests, such as *SpillableSubpartitionTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
