### PR TITLE
[FLINK-10436] Example config uses deprecated key jobmanager.rpc.address

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -30,7 +30,7 @@
 # automatically configure the host name based on the hostname of the node where the
 # JobManager runs.
 
-jobmanager.rpc.address: localhost
+rest.address: localhost
 
 # The RPC port where the JobManager is reachable.
 


### PR DESCRIPTION
## What is the purpose of the change

`flink-conf.yaml` uses deprecated key `jobmanager.rpc.address`, which produces an unexpected warning.

## Brief change log

Use the suggested replacement.

## Verifying this change

Manually, local build and test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive):(**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:(**no**)
  - The S3 file system connector:(**no**)

## Documentation

  - Does this pull request introduce a new feature?(**no**)
  - If yes, how is the feature documented? (**no**)

cc @zentol @StefanRRichter 