### PR TITLE
[FLINK-10465][tests] Do not stop sshd if it is supervised by runit.

### DIFF
--- a/flink-jepsen/src/jepsen/flink/utils.clj
+++ b/flink-jepsen/src/jepsen/flink/utils.clj
@@ -86,4 +86,7 @@
   []
   (info "Stop all supervised services.")
   (c/su
-    (c/exec :rm :-f (c/lit (str "/etc/service/*")))))
+    ;; HACK:
+    ;; Remove all symlinks in /etc/service except sshd.
+    ;; This is only relevant when tests are run in Docker because there sshd is started using runit.
+    (c/exec :find (c/lit (str "/etc/service -maxdepth 1 -type l ! -name 'sshd' -delete")))))


### PR DESCRIPTION
## What is the purpose of the change

  * See [FLINK-10465](https://issues.apache.org/jira/browse/FLINK-10465)

## Brief change log

  - *Do not stop sshd if it is supervised by runit.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Tested manually.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

cc: @igalshilman