### PR TITLE
[FLINK-9932] [runtime] fix slot leak when task executor offer slot to job master timeout

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -444,11 +444,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				throw new TaskSubmissionException(message);
 			}
 
-			if (!taskSlotTable.existsActiveSlot(jobId, tdd.getAllocationId())) {
-				final String message = "No task slot allocated for job ID " + jobId +
-					" and allocation ID " + tdd.getAllocationId() + '.';
-				log.debug(message);
-				throw new TaskSubmissionException(message);
+			try {
+				if (!taskSlotTable.markSlotActive(tdd.getAllocationId()) &&
+						!taskSlotTable.isActive(tdd.getTargetSlotNumber(), tdd.getJobId(), tdd.getAllocationId())) {
+					final String message = "No task slot allocated for job ID " + jobId +
+							" and allocation ID " + tdd.getAllocationId() + '.';
+					log.debug(message);
+					throw new TaskSubmissionException(message);
+				}
+			} catch (SlotNotFoundException e) {
+				throw new TaskSubmissionException(e);
 			}
 
 			// re-integrate offloaded data:
@@ -1050,18 +1055,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 				while (reservedSlotsIterator.hasNext()) {
 					SlotOffer offer = reservedSlotsIterator.next().generateSlotOffer();
-					try {
-						if (!taskSlotTable.markSlotActive(offer.getAllocationId())) {
-							// the slot is either free or releasing at the moment
-							final String message = "Could not mark slot " + jobId + " active.";
-							log.debug(message);
-							jobMasterGateway.failSlot(getResourceID(), offer.getAllocationId(), new Exception(message));
-						}
-					} catch (SlotNotFoundException e) {
-						final String message = "Could not mark slot " + jobId + " active.";
-						jobMasterGateway.failSlot(getResourceID(), offer.getAllocationId(), new Exception(message));
-						continue;
-					}
 					reservedSlots.add(offer);
 				}
 
@@ -1076,19 +1069,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 							if (throwable instanceof TimeoutException) {
 								log.info("Slot offering to JobManager did not finish in time. Retrying the slot offering.");
 								// We ran into a timeout. Try again.
-								for (SlotOffer offer : reservedSlots) {
-									try {
-										if (!taskSlotTable.markSlotInactive(offer.getAllocationId(), taskManagerConfiguration.getTimeout())) {
-											// the slot is either free or releasing at the moment
-											final String message = "Could not mark slot " + jobId + " active.";
-											log.debug(message);
-											jobMasterGateway.failSlot(getResourceID(), offer.getAllocationId(), new Exception(message));
-										}
-									} catch (SlotNotFoundException e) {
-										final String message = "Not find slot " + offer.getAllocationId() + " in task executor.";
-										jobMasterGateway.failSlot(getResourceID(), offer.getAllocationId(), new Exception(message));
-									}
-								}
 								offerSlotsToJobManager(jobId);
 							} else {
 								log.warn("Slot offering to JobManager failed. Freeing the slots " +
@@ -1104,7 +1084,20 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 							if (isJobManagerConnectionValid(jobId, jobMasterId)) {
 								// mark accepted slots active
 								for (SlotOffer acceptedSlot : acceptedSlots) {
-									reservedSlots.remove(acceptedSlot);
+									try {
+										if (!taskSlotTable.markSlotActive(acceptedSlot.getAllocationId()) &&
+												!taskSlotTable.isActive(acceptedSlot.getSlotIndex(), jobId, acceptedSlot.getAllocationId())) {
+											// the slot is either free or releasing at the moment
+											final String message = "Could not mark slot " + jobId + " active.";
+											log.debug(message);
+											jobMasterGateway.failSlot(getResourceID(), acceptedSlot.getAllocationId(), new Exception(message));
+										} else {
+											reservedSlots.remove(acceptedSlot);
+										}
+									} catch (SlotNotFoundException e) {
+										final String message = "Not find slot " + acceptedSlot.getAllocationId() + " in task executor.";
+										jobMasterGateway.failSlot(getResourceID(), acceptedSlot.getAllocationId(), new Exception(message));
+									}
 								}
 
 								final Exception e = new Exception("The slot was rejected by the JobManager.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -379,6 +379,20 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	}
 
 	/**
+	 * Check whether the slot for the given index is active for the given job and allocation id.
+	 *
+	 * @param index of the task slot
+	 * @param jobId for which the task slot should be allocated
+	 * @param allocationId which should match the task slot's allocation id
+	 * @return True if the given task slot is active for the given job and allocation id
+	 */
+	public boolean isActive(int index, JobID jobId, AllocationID allocationId) {
+		TaskSlot taskSlot = taskSlots.get(index);
+
+		return taskSlot.isActive(jobId, allocationId);
+	}
+
+	/**
 	 * Check whether there exists an active slot for the given job and allocation id.
 	 *
 	 * @param jobId of the allocated slot

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -744,7 +744,7 @@ public class TaskExecutorTest extends TestLogger {
 		jobManagerTable.put(jobId, jobManagerConnection);
 
 		final TaskSlotTable taskSlotTable = mock(TaskSlotTable.class);
-		when(taskSlotTable.existsActiveSlot(eq(jobId), eq(allocationId))).thenReturn(true);
+		when(taskSlotTable.markSlotActive(eq(allocationId))).thenReturn(true);
 		when(taskSlotTable.addTask(any(Task.class))).thenReturn(true);
 
 		TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();


### PR DESCRIPTION

## What is the purpose of the change

*(For example: This pull request fix that the slots in task executor will leak if task executor fail to offer it to job master due to rpc timeout.)*

## Verifying this change

  - *Add a test in TaskExecutorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
