### PR TITLE
[FLINK-9083][Cassandra Connector] Add async backpressure support to Cassandra Connector

### DIFF
--- a/docs/dev/connectors/cassandra.md
+++ b/docs/dev/connectors/cassandra.md
@@ -72,13 +72,16 @@ The following configuration methods can be used:
 4. _setMapperOptions(MapperOptions options)_
     * Sets the mapper options that are used to configure the DataStax ObjectMapper.
     * Only applies when processing __POJO__ data types.
-5. _enableWriteAheadLog([CheckpointCommitter committer])_
+5. _setMaxConcurrentRequests(int maxConcurrentRequests, Duration timeout)_
+    * Sets the maximum allowed number of concurrent requests with a timeout for acquiring permits to execute.
+    * Only applies when __enableWriteAheadLog()__ is not configured.
+6. _enableWriteAheadLog([CheckpointCommitter committer])_
     * An __optional__ setting
     * Allows exactly-once processing for non-deterministic algorithms.
-6. _setFailureHandler([CassandraFailureHandler failureHandler])_
+7. _setFailureHandler([CassandraFailureHandler failureHandler])_
     * An __optional__ setting
     * Sets the custom failure handler.
-7. _build()_
+8. _build()_
     * Finalizes the configuration and constructs the CassandraSink instance.
 
 ### Write-ahead Log

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
@@ -32,8 +32,12 @@ public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<I
 	private final String insertQuery;
 	private transient PreparedStatement ps;
 
-	public AbstractCassandraTupleSink(String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
-		super(builder, failureHandler);
+	public AbstractCassandraTupleSink(
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config,
+			CassandraFailureHandler failureHandler) {
+		super(builder, config, failureHandler);
 		this.insertQuery = insertQuery;
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
@@ -51,24 +51,51 @@ public class CassandraPojoSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 	 *
 	 * @param clazz Class instance
 	 */
-	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder) {
+	public CassandraPojoSink(
+			Class<IN> clazz,
+			ClusterBuilder builder) {
 		this(clazz, builder, null, null);
 	}
 
-	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options) {
+	public CassandraPojoSink(
+			Class<IN> clazz,
+			ClusterBuilder builder,
+			@Nullable MapperOptions options) {
 		this(clazz, builder, options, null);
 	}
 
-	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, String keyspace) {
+	public CassandraPojoSink(
+			Class<IN> clazz,
+			ClusterBuilder builder,
+			String keyspace) {
 		this(clazz, builder, null, keyspace);
 	}
 
-	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options, String keyspace) {
-		this(clazz, builder, options, keyspace, new NoOpCassandraFailureHandler());
+	public CassandraPojoSink(
+			Class<IN> clazz,
+			ClusterBuilder builder,
+			@Nullable MapperOptions options,
+			String keyspace) {
+		this(clazz, builder, options, keyspace, CassandraSinkBaseConfig.newBuilder().build());
 	}
 
-	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options, String keyspace, CassandraFailureHandler failureHandler) {
-		super(builder, failureHandler);
+	CassandraPojoSink(
+			Class<IN> clazz,
+			ClusterBuilder builder,
+			@Nullable MapperOptions options,
+			String keyspace,
+			CassandraSinkBaseConfig config) {
+		this(clazz, builder, options, keyspace, config, new NoOpCassandraFailureHandler());
+	}
+
+	CassandraPojoSink(
+			Class<IN> clazz,
+			ClusterBuilder builder,
+			@Nullable MapperOptions options,
+			String keyspace,
+			CassandraSinkBaseConfig config,
+			CassandraFailureHandler failureHandler) {
+		super(builder, config, failureHandler);
 		this.clazz = clazz;
 		this.options = options;
 		this.keyspace = keyspace;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraRowSink.java
@@ -26,12 +26,28 @@ public class CassandraRowSink extends AbstractCassandraTupleSink<Row> {
 
 	private final int rowArity;
 
-	public CassandraRowSink(int rowArity, String insertQuery, ClusterBuilder builder) {
-		this(rowArity, insertQuery, builder, new NoOpCassandraFailureHandler());
+	public CassandraRowSink(
+			int rowArity,
+			String insertQuery,
+			ClusterBuilder builder) {
+		this(rowArity, insertQuery, builder, CassandraSinkBaseConfig.newBuilder().build());
 	}
 
-	public CassandraRowSink(int rowArity, String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
-		super(insertQuery, builder, failureHandler);
+	CassandraRowSink(
+			int rowArity,
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config) {
+		this(rowArity, insertQuery, builder, config, new NoOpCassandraFailureHandler());
+	}
+
+	CassandraRowSink(
+			int rowArity,
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config,
+			CassandraFailureHandler failureHandler) {
+		super(insertQuery, builder, config, failureHandler);
 		this.rowArity = rowArity;
 	}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
@@ -26,12 +26,25 @@ import scala.Product;
  * @param <IN> Type of the elements emitted by this sink, it must extend {@link Product}
  */
 public class CassandraScalaProductSink<IN extends Product> extends AbstractCassandraTupleSink<IN> {
-	public CassandraScalaProductSink(String insertQuery, ClusterBuilder builder) {
-		this(insertQuery, builder, new NoOpCassandraFailureHandler());
+	public CassandraScalaProductSink(
+			String insertQuery,
+			ClusterBuilder builder) {
+		this(insertQuery, builder, CassandraSinkBaseConfig.newBuilder().build());
 	}
 
-	public CassandraScalaProductSink(String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
-		super(insertQuery, builder, failureHandler);
+	CassandraScalaProductSink(
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config) {
+		this(insertQuery, builder, config, new NoOpCassandraFailureHandler());
+	}
+
+	CassandraScalaProductSink(
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config,
+			CassandraFailureHandler failureHandler) {
+		super(insertQuery, builder, config, failureHandler);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.util.Preconditions;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
@@ -33,9 +34,10 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * CassandraSinkBase is the common abstract class of {@link CassandraPojoSink} and {@link
@@ -49,16 +51,19 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 	protected transient Cluster cluster;
 	protected transient Session session;
 
-	protected transient volatile Throwable exception;
-	protected transient FutureCallback<V> callback;
-	private final AtomicInteger updatesPending = new AtomicInteger();
+	private AtomicReference<Throwable> throwable;
+	private FutureCallback<V> callback;
+	private Semaphore semaphore;
 
 	private final ClusterBuilder builder;
+	private final CassandraSinkBaseConfig config;
+
 	private final CassandraFailureHandler failureHandler;
 
-	CassandraSinkBase(ClusterBuilder builder, CassandraFailureHandler failureHandler) {
+	CassandraSinkBase(ClusterBuilder builder, CassandraSinkBaseConfig config, CassandraFailureHandler failureHandler) {
 		this.builder = builder;
-		this.failureHandler = checkNotNull(failureHandler);
+		this.config = config;
+		this.failureHandler = Preconditions.checkNotNull(failureHandler);
 		ClosureCleaner.clean(builder, true);
 	}
 
@@ -67,36 +72,28 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 		this.callback = new FutureCallback<V>() {
 			@Override
 			public void onSuccess(V ignored) {
-				int pending = updatesPending.decrementAndGet();
-				if (pending == 0) {
-					synchronized (updatesPending) {
-						updatesPending.notifyAll();
-					}
-				}
+				semaphore.release();
 			}
 
 			@Override
 			public void onFailure(Throwable t) {
-				int pending = updatesPending.decrementAndGet();
-				if (pending == 0) {
-					synchronized (updatesPending) {
-						updatesPending.notifyAll();
-					}
-				}
-				exception = t;
-
+				throwable.compareAndSet(null, t);
 				log.error("Error while sending value.", t);
+				semaphore.release();
 			}
 		};
 		this.cluster = builder.getCluster();
 		this.session = createSession();
+
+		throwable = new AtomicReference<>();
+		semaphore = new Semaphore(config.getMaxConcurrentRequests());
 	}
 
 	@Override
 	public void close() throws Exception {
 		try {
 			checkAsyncErrors();
-			waitForPendingUpdates();
+			flush();
 			checkAsyncErrors();
 		} finally {
 			try {
@@ -123,15 +120,15 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 	@Override
 	public void snapshotState(FunctionSnapshotContext ctx) throws Exception {
 		checkAsyncErrors();
-		waitForPendingUpdates();
+		flush();
 		checkAsyncErrors();
 	}
 
 	@Override
 	public void invoke(IN value) throws Exception {
 		checkAsyncErrors();
-		ListenableFuture<V> result = send(value);
-		updatesPending.incrementAndGet();
+		tryAcquire();
+		final ListenableFuture<V> result = send(value);
 		Futures.addCallback(result, callback);
 	}
 
@@ -141,25 +138,37 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 
 	public abstract ListenableFuture<V> send(IN value);
 
-	private void waitForPendingUpdates() throws InterruptedException {
-		synchronized (updatesPending) {
-			while (updatesPending.get() > 0) {
-				updatesPending.wait();
-			}
+	private void tryAcquire() throws InterruptedException, TimeoutException {
+		if (!semaphore.tryAcquire(config.getMaxConcurrentRequestsTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
+			throw new TimeoutException(
+				String.format(
+					"Failed to acquire 1 permit of %d to send value in %s.",
+					config.getMaxConcurrentRequests(),
+					config.getMaxConcurrentRequestsTimeout()
+				)
+			);
 		}
 	}
 
 	private void checkAsyncErrors() throws Exception {
-		Throwable error = exception;
-		if (error != null) {
-			// prevent throwing duplicated error
-			exception = null;
-			failureHandler.onFailure(error);
+		final Throwable currentError = throwable.getAndSet(null);
+		if (currentError != null) {
+			failureHandler.onFailure(currentError);
 		}
 	}
 
+	private void flush() {
+		semaphore.acquireUninterruptibly(config.getMaxConcurrentRequests());
+		semaphore.release(config.getMaxConcurrentRequests());
+	}
+
 	@VisibleForTesting
-	int getNumOfPendingRecords() {
-		return updatesPending.get();
+	int getAvailablePermits() {
+		return semaphore.availablePermits();
+	}
+
+	@VisibleForTesting
+	int getAcquiredPermits() {
+		return config.getMaxConcurrentRequests() - semaphore.availablePermits();
 	}
 }

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseConfig.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+/**
+ * Configuration for {@link CassandraSinkBase}.
+ */
+public final class CassandraSinkBaseConfig implements Serializable  {
+	// ------------------------ Default Configurations ------------------------
+
+	/**
+	 * The default maximum number of concurrent requests. By default, {@code Integer.MAX_VALUE}.
+	 */
+	public static final int DEFAULT_MAX_CONCURRENT_REQUESTS = Integer.MAX_VALUE;
+
+	/**
+	 * The default timeout duration when acquiring a permit to execute. By default, {@code Long.MAX_VALUE}.
+	 */
+	public static final Duration DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT = Duration.ofMillis(Long.MAX_VALUE);
+
+	// ------------------------- Configuration Fields -------------------------
+
+	/** Maximum number of concurrent requests allowed. */
+	private final int maxConcurrentRequests;
+
+	/** Timeout duration when acquiring a permit to execute. */
+	private final Duration maxConcurrentRequestsTimeout;
+
+	private CassandraSinkBaseConfig(
+			int maxConcurrentRequests,
+			Duration maxConcurrentRequestsTimeout) {
+		Preconditions.checkArgument(maxConcurrentRequests > 0,
+			"Max concurrent requests is expected to be positive");
+		Preconditions.checkNotNull(maxConcurrentRequestsTimeout,
+			"Max concurrent requests timeout cannot be null");
+		Preconditions.checkArgument(!maxConcurrentRequestsTimeout.isNegative(),
+			"Max concurrent requests timeout is expected to be positive");
+		this.maxConcurrentRequests = maxConcurrentRequests;
+		this.maxConcurrentRequestsTimeout = maxConcurrentRequestsTimeout;
+	}
+
+	public int getMaxConcurrentRequests() {
+		return maxConcurrentRequests;
+	}
+
+	public Duration getMaxConcurrentRequestsTimeout() {
+		return maxConcurrentRequestsTimeout;
+	}
+
+	@Override
+	public String toString() {
+		return "CassandraSinkBaseConfig{" +
+			"maxConcurrentRequests=" + maxConcurrentRequests +
+			", maxConcurrentRequestsTimeout=" + maxConcurrentRequestsTimeout +
+			'}';
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for the {@link CassandraSinkBaseConfig}.
+	 */
+	public static class Builder {
+		private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
+		private Duration maxConcurrentRequestsTimeout = DEFAULT_MAX_CONCURRENT_REQUESTS_TIMEOUT;
+
+		Builder() { }
+
+		public Builder setMaxConcurrentRequests(int maxConcurrentRequests) {
+			this.maxConcurrentRequests = maxConcurrentRequests;
+			return this;
+		}
+
+		public Builder setMaxConcurrentRequestsTimeout(Duration timeout) {
+			this.maxConcurrentRequestsTimeout = timeout;
+			return this;
+		}
+
+		public CassandraSinkBaseConfig build() {
+			return new CassandraSinkBaseConfig(
+				maxConcurrentRequests,
+				maxConcurrentRequestsTimeout);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleSink.java
@@ -25,12 +25,25 @@ import org.apache.flink.api.java.tuple.Tuple;
  * @param <IN> Type of the elements emitted by this sink, it must extend {@link Tuple}
  */
 public class CassandraTupleSink<IN extends Tuple> extends AbstractCassandraTupleSink<IN> {
-	public CassandraTupleSink(String insertQuery, ClusterBuilder builder) {
-		this(insertQuery, builder, new NoOpCassandraFailureHandler());
+	public CassandraTupleSink(
+			String insertQuery,
+			ClusterBuilder builder) {
+		this(insertQuery, builder, CassandraSinkBaseConfig.newBuilder().build());
 	}
 
-	public CassandraTupleSink(String insertQuery, ClusterBuilder builder, CassandraFailureHandler failureHandler) {
-		super(insertQuery, builder, failureHandler);
+	CassandraTupleSink(
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config) {
+		this(insertQuery, builder, config, new NoOpCassandraFailureHandler());
+	}
+
+	CassandraTupleSink(
+			String insertQuery,
+			ClusterBuilder builder,
+			CassandraSinkBaseConfig config,
+			CassandraFailureHandler failureHandler) {
+		super(insertQuery, builder, config, failureHandler);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This pull requests rewrites `CassandraSinkBase` to use a `Phaser` and `Semaphore` to provide proper synchronization to support `maxConcurrentRequests` as a new configuration. This improves the reliability of the Cassandra Connector as it can currently overwhelm a weak Cassandra cluster if the upstream source has very high throughput.

## Brief change log

  - Rewrote `CassandraSinkBase` to use a `Phaser` and `Semaphore`.
  - Expose `public void setMaxConcurrentRequests(int maxConcurrentRequests, long timeout, TimeUnit unit)` on `CassandraSinkBase`.
  - Modify `CassandraSink` with the new configuration. **It currently does not support the WAL.**
  - Updated the documentation about the new configuration.

## Verifying this change

This change is already covered by existing tests, such as `CassandraSinkBaseTest` and `CassandraConnectorITCase`.

This change added tests and can be verified as follows:

  - Added tests for acquiring permits from the `Semaphore` and releasing permits from the `Semaphore` when a write succeeds or fails.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
