### PR TITLE
[FLINK-10309][rest] Before shutting down cluster, wait for asynchronous operations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -445,9 +445,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	private CompletableFuture<Void> closeClusterComponent(ApplicationStatus applicationStatus, @Nullable String diagnostics) {
 		synchronized (lock) {
 			if (clusterComponent != null) {
-				return FutureUtils.runAfterwards(
-					clusterComponent.closeAsync(),
-					() -> clusterComponent.deregisterApplication(applicationStatus, diagnostics));
+				return clusterComponent.deregisterApplicationAndClose(applicationStatus, diagnostics);
 			} else {
 				return CompletableFuture.completedFuture(null);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -445,9 +445,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	private CompletableFuture<Void> closeClusterComponent(ApplicationStatus applicationStatus, @Nullable String diagnostics) {
 		synchronized (lock) {
 			if (clusterComponent != null) {
-				final CompletableFuture<Void> deregisterApplicationFuture = clusterComponent.deregisterApplication(applicationStatus, diagnostics);
-
-				return FutureUtils.runAfterwards(deregisterApplicationFuture, clusterComponent::closeAsync);
+				return FutureUtils.runAfterwards(
+					clusterComponent.closeAsync(),
+					() -> clusterComponent.deregisterApplication(applicationStatus, diagnostics));
 			} else {
 				return CompletableFuture.completedFuture(null);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -138,10 +138,10 @@ public class DispatcherResourceManagerComponent<T extends Dispatcher> {
 			final @Nullable String diagnostics) {
 
 		if (isRunning.compareAndSet(true, false)) {
-			final CompletableFuture<Void> closeWebMonitorAndRegisterAppFuture =
+			final CompletableFuture<Void> closeWebMonitorAndDeregisterAppFuture =
 				FutureUtils.composeAfterwards(webMonitorEndpoint.closeAsync(), () -> deregisterApplication(applicationStatus, diagnostics));
 
-			return FutureUtils.composeAfterwards(closeWebMonitorAndRegisterAppFuture, this::closeAsyncInternal);
+			return FutureUtils.composeAfterwards(closeWebMonitorAndDeregisterAppFuture, this::closeAsyncInternal);
 		} else {
 			return terminationFuture;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -679,7 +679,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 				try {
 					checkpointCoordinator.receiveAcknowledgeMessage(ackMessage);
 				} catch (Throwable t) {
-					log.warn("Error while processing checkpoint acknowledgement message");
+					log.warn("Error while processing checkpoint acknowledgement message", t);
 				}
 			});
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
@@ -19,9 +19,11 @@
 package org.apache.flink.runtime.rest;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rest.handler.FileUploads;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.InFlightRequestTracker;
 import org.apache.flink.runtime.rest.handler.RedirectHandler;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
@@ -33,6 +35,7 @@ import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException;
@@ -64,13 +67,19 @@ import java.util.concurrent.CompletableFuture;
  * @param <R> type of the incoming request
  * @param <M> type of the message parameters
  */
-public abstract class AbstractHandler<T extends RestfulGateway, R extends RequestBody, M extends MessageParameters> extends RedirectHandler<T> {
+public abstract class AbstractHandler<T extends RestfulGateway, R extends RequestBody, M extends MessageParameters> extends RedirectHandler<T> implements AutoCloseableAsync {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	protected static final ObjectMapper MAPPER = RestMapperUtils.getStrictObjectMapper();
 
 	private final UntypedResponseMessageHeaders<R, M> untypedResponseMessageHeaders;
+
+	/**
+	 * Used to ensure that the handler is not closed while there are still in-flight requests
+	 * dispatched outside of Netty's {@link org.apache.flink.shaded.netty4.io.netty.util.concurrent.EventExecutor}.
+	 */
+	private final InFlightRequestTracker inFlightRequestTracker;
 
 	protected AbstractHandler(
 			@Nonnull CompletableFuture<String> localAddressFuture,
@@ -81,6 +90,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 		super(localAddressFuture, leaderRetriever, timeout, responseHeaders);
 
 		this.untypedResponseMessageHeaders = Preconditions.checkNotNull(untypedResponseMessageHeaders);
+		this.inFlightRequestTracker = new InFlightRequestTracker();
 	}
 
 	@Override
@@ -92,6 +102,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 		FileUploads uploadedFiles = null;
 		try {
+			inFlightRequestTracker.registerRequest();
 			if (!(httpRequest instanceof FullHttpRequest)) {
 				// The RestServerEndpoint defines a HttpObjectAggregator in the pipeline that always returns
 				// FullHttpRequests.
@@ -154,8 +165,12 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 			final FileUploads finalUploadedFiles = uploadedFiles;
 			requestProcessingFuture
-				.whenComplete((Void ignored, Throwable throwable) -> cleanupFileUploads(finalUploadedFiles));
+				.whenComplete((Void ignored, Throwable throwable) -> {
+					inFlightRequestTracker.deregisterRequest();
+					cleanupFileUploads(finalUploadedFiles);
+				});
 		} catch (RestHandlerException rhe) {
+			inFlightRequestTracker.deregisterRequest();
 			HandlerUtils.sendErrorResponse(
 				ctx,
 				httpRequest,
@@ -164,6 +179,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 				responseHeaders);
 			cleanupFileUploads(uploadedFiles);
 		} catch (Throwable e) {
+			inFlightRequestTracker.deregisterRequest();
 			log.error("Request processing failed.", e);
 			HandlerUtils.sendErrorResponse(
 				ctx,
@@ -173,6 +189,15 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 				responseHeaders);
 			cleanupFileUploads(uploadedFiles);
 		}
+	}
+
+	@Override
+	public final CompletableFuture<Void> closeAsync() {
+		return FutureUtils.composeAfterwards(closeHandlerAsync(), inFlightRequestTracker::awaitAsync);
+	}
+
+	protected CompletableFuture<Void> closeHandlerAsync() {
+		return CompletableFuture.completedFuture(null);
 	}
 
 	private void cleanupFileUploads(@Nullable FileUploads uploadedFiles) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -273,6 +273,7 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 				shutDownFuture.whenComplete(
 					(Void ignored, Throwable throwable) -> {
+						log.info("Shut down complete.");
 						if (throwable != null) {
 							terminationFuture.completeExceptionally(throwable);
 						} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -71,8 +71,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 	private final UntypedResponseMessageHeaders<R, M> untypedResponseMessageHeaders;
 
 	/**
-	 * Used to ensure that the handler is not closed while there are still in-flight requests
-	 * dispatched outside of Netty's {@link org.apache.flink.shaded.netty4.io.netty.util.concurrent.EventExecutor}.
+	 * Used to ensure that the handler is not closed while there are still in-flight requests.
 	 */
 	private final InFlightRequestTracker inFlightRequestTracker;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -16,16 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.handler;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.rest.handler.FileUploads;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.HandlerRequestException;
-import org.apache.flink.runtime.rest.handler.InFlightRequestTracker;
-import org.apache.flink.runtime.rest.handler.RedirectHandler;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.FileUploadHandler;
 import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -53,7 +54,8 @@ import java.util.concurrent.CompletableFuture;
  * @param <P> type of outgoing responses
  */
 @ChannelHandler.Sharable
-public abstract class AbstractRestHandler<T extends RestfulGateway, R extends RequestBody, P extends ResponseBody, M extends MessageParameters> extends AbstractHandler<T, R, M> {
+public abstract class AbstractRestHandler<T extends RestfulGateway, R extends RequestBody, P extends ResponseBody, M extends MessageParameters> extends AbstractHandler<T, R, M>
+	implements AutoCloseableAsync {
 
 	private final MessageHeaders<R, P, M> messageHeaders;
 
@@ -120,4 +122,8 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 	 * @throws RestHandlerException if the handling failed
 	 */
 	protected abstract CompletableFuture<P> handleRequest(@Nonnull HandlerRequest<R, M> request, @Nonnull T gateway) throws RestHandlerException;
+
+	public CompletableFuture<Void> closeAsync() {
+		return CompletableFuture.completedFuture(null);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -80,11 +80,9 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 			response = FutureUtils.completedExceptionally(e);
 		}
 
-		return response.whenComplete((P resp, Throwable throwable) -> {
-			Tuple2<ResponseBody, HttpResponseStatus> r = throwable != null ?
-				errorResponse(throwable) : Tuple2.of(resp, messageHeaders.getResponseStatusCode());
-			HandlerUtils.sendResponse(ctx, httpRequest, r.f0, r.f1, responseHeaders);
-		}).thenApply(ignored -> null);
+		return response.handle((resp, throwable) -> throwable != null ?
+			errorResponse(throwable) : Tuple2.of(resp, messageHeaders.getResponseStatusCode()))
+			.thenCompose(r -> HandlerUtils.sendResponse(ctx, httpRequest, r.f0, r.f1, responseHeaders));
 	}
 
 	private Tuple2<ResponseBody, HttpResponseStatus> errorResponse(Throwable throwable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.rest.handler;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.rest.AbstractHandler;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -123,6 +123,7 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 	 */
 	protected abstract CompletableFuture<P> handleRequest(@Nonnull HandlerRequest<R, M> request, @Nonnull T gateway) throws RestHandlerException;
 
+	@Override
 	public CompletableFuture<Void> closeAsync() {
 		return CompletableFuture.completedFuture(null);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
@@ -26,10 +26,10 @@ import java.util.concurrent.Phaser;
 /**
  * Tracks in-flight client requests.
  *
- * @see AbstractRestHandler
+ * @see org.apache.flink.runtime.rest.AbstractHandler
  */
 @ThreadSafe
-class InFlightRequestTracker {
+public class InFlightRequestTracker {
 
 	private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Phaser;
+
+/**
+ * Tracks in-flight client requests.
+ *
+ * @see AbstractRestHandler
+ */
+@ThreadSafe
+class InFlightRequestTracker {
+
+	private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+
+	private final Phaser phaser = new Phaser(1) {
+		@Override
+		protected boolean onAdvance(final int phase, final int registeredParties) {
+			terminationFuture.complete(null);
+			return true;
+		}
+	};
+
+	/**
+	 * Registers an in-flight request.
+	 */
+	public void registerRequest() {
+		phaser.register();
+	}
+
+	/**
+	 * Deregisters an in-flight request.
+	 */
+	public void deregisterRequest() {
+		phaser.arriveAndDeregister();
+	}
+
+	/**
+	 * Returns a future that completes when the in-flight requests that were registered prior to
+	 * calling this method are deregistered.
+	 */
+	public CompletableFuture<Void> awaitAsync() {
+		phaser.arriveAndDeregister();
+		return terminationFuture;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
@@ -26,10 +26,10 @@ import java.util.concurrent.Phaser;
 /**
  * Tracks in-flight client requests.
  *
- * @see org.apache.flink.runtime.rest.AbstractHandler
+ * @see AbstractHandler
  */
 @ThreadSafe
-public class InFlightRequestTracker {
+class InFlightRequestTracker {
 
 	private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rest.handler.async;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rest.NotFoundException;
@@ -29,24 +28,14 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
-import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.types.Either;
-import org.apache.flink.util.FlinkException;
-
-import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
-import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 /**
  * HTTP handlers for asynchronous operations.
@@ -176,7 +165,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
 			final Either<Throwable, R> operationResultOrError;
 			try {
 				operationResultOrError = completedOperationCache.get(key);
-			} catch (UnknownOperationKey e) {
+			} catch (UnknownOperationKeyException e) {
 				return FutureUtils.completedExceptionally(
 					new NotFoundException("Operation not found under key: " + key, e));
 			}
@@ -192,6 +181,11 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
 			} else {
 				return CompletableFuture.completedFuture(AsynchronousOperationResult.inProgress());
 			}
+		}
+
+		@Override
+		public CompletableFuture<Void> closeAsync() {
+			return completedOperationCache.closeAsync();
 		}
 
 		/**
@@ -218,81 +212,6 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
 		 * @return Operation result
 		 */
 		protected abstract V operationResultResponse(R operationResult);
-	}
-
-	/**
-	 * Cache to manage ongoing operations.
-	 *
-	 * <p>The cache allows to register ongoing operations by calling
-	 * {@link #registerOngoingOperation(K, CompletableFuture)}, where the
-	 * {@code CompletableFuture} contains the operation result. Completed operations will be
-	 * removed from the cache automatically after a fixed timeout.
-	 */
-	@ThreadSafe
-	protected static class CompletedOperationCache<K, R> {
-
-		private static final long COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS = 300L;
-
-		/**
-		 * Stores SavepointKeys of ongoing savepoint.
-		 * If the savepoint completes, it will be moved to {@link #completedOperations}.
-		 */
-		private final Set<K> registeredOperationTriggers = ConcurrentHashMap.newKeySet();
-
-		/** Caches the location of completed operations. */
-		private final Cache<K, Either<Throwable, R>> completedOperations =
-			CacheBuilder.newBuilder()
-				.expireAfterWrite(COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS, TimeUnit.SECONDS)
-				.build();
-
-		/**
-		 * Registers an ongoing operation with the cache.
-		 *
-		 * @param operationResultFuture A future containing the operation result.
-		 */
-		public void registerOngoingOperation(
-			final K operationKey,
-			final CompletableFuture<R> operationResultFuture) {
-			registeredOperationTriggers.add(operationKey);
-			operationResultFuture.whenComplete((savepointLocation, error) -> {
-				if (error == null) {
-					completedOperations.put(operationKey, Either.Right(savepointLocation));
-				} else {
-					completedOperations.put(operationKey, Either.Left(error));
-				}
-				registeredOperationTriggers.remove(operationKey);
-			});
-		}
-
-		/**
-		 * Returns the operation result or a {@code Throwable} if the {@code CompletableFuture}
-		 * finished, otherwise {@code null}.
-		 *
-		 * @throws UnknownOperationKey If the operation is not found, and there is no ongoing
-		 *                                   operation under the provided key.
-		 */
-		@Nullable
-		public Either<Throwable, R> get(
-			final K operationKey) throws UnknownOperationKey {
-			Either<Throwable, R> operationResultOrError = null;
-			if (!registeredOperationTriggers.contains(operationKey)
-				&& (operationResultOrError = completedOperations.getIfPresent(operationKey)) == null) {
-				throw new UnknownOperationKey(operationKey);
-			}
-			return operationResultOrError;
-		}
-	}
-
-	/**
-	 * Exception that indicates that there is no ongoing or completed savepoint for a given
-	 * {@link JobID} and {@link TriggerId} pair.
-	 */
-	static class UnknownOperationKey extends FlinkException {
-		private static final long serialVersionUID = 1L;
-
-		UnknownOperationKey(final Object operationKey) {
-			super("No ongoing operation for " + operationKey);
-		}
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlers.java
@@ -184,7 +184,7 @@ public abstract class AbstractAsynchronousOperationHandlers<K extends OperationK
 		}
 
 		@Override
-		public CompletableFuture<Void> closeAsync() {
+		public CompletableFuture<Void> closeHandlerAsync() {
 			return completedOperationCache.closeAsync();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
@@ -169,7 +169,6 @@ class CompletedOperationCache<K extends OperationKey, R> implements AutoCloseabl
 		/** Future that completes if a non-null {@link #operationResultOrError} is accessed. */
 		private final CompletableFuture<Void> accessed;
 
-
 		private static <R> ResultAccessTracker<R> inProgress() {
 			return new ResultAccessTracker<>();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.async;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.AutoCloseableAsync;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Ticker;
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Cache to manage ongoing operations.
+ *
+ * <p>The cache allows to register ongoing operations by calling
+ * {@link #registerOngoingOperation(K, CompletableFuture)}, where the
+ * {@code CompletableFuture} contains the operation result. Completed operations will be
+ * removed from the cache automatically after a fixed timeout.
+ */
+@ThreadSafe
+class CompletedOperationCache<K extends OperationKey, R> implements AutoCloseableAsync {
+
+	private static final long COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS = 300L;
+
+	/**
+	 * In-progress asynchronous operations.
+	 */
+	private final Map<K, ResultAccessTracker<R>> registeredOperationTriggers = new ConcurrentHashMap<>();
+
+	/**
+	 * Caches the result of completed operations.
+	 */
+	private final Cache<K, ResultAccessTracker<R>> completedOperations;
+
+	CompletedOperationCache() {
+		this(Ticker.systemTicker());
+	}
+
+	@VisibleForTesting
+	CompletedOperationCache(final Ticker ticker) {
+		completedOperations = CacheBuilder.newBuilder()
+			.expireAfterWrite(COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS, TimeUnit.SECONDS)
+			.removalListener((RemovalListener<K, ResultAccessTracker<R>>) removalNotification -> {
+				if (removalNotification.wasEvicted()) {
+					Preconditions.checkState(removalNotification.getValue() != null);
+					removalNotification.getValue().markAccessed();
+				}
+			})
+			.ticker(ticker)
+			.build();
+	}
+
+	/**
+	 * Registers an ongoing operation with the cache.
+	 *
+	 * @param operationResultFuture A future containing the operation result.
+	 */
+	public void registerOngoingOperation(
+			final K operationKey,
+			final CompletableFuture<R> operationResultFuture) {
+		final ResultAccessTracker<R> inProgress = ResultAccessTracker.inProgress();
+		registeredOperationTriggers.put(operationKey, inProgress);
+		operationResultFuture.whenComplete((result, error) -> {
+			if (error == null) {
+				completedOperations.put(operationKey, inProgress.finishOperation(Either.Right(result)));
+			} else {
+				completedOperations.put(operationKey, inProgress.finishOperation(Either.Left(error)));
+			}
+			registeredOperationTriggers.remove(operationKey);
+		});
+	}
+
+	/**
+	 * Returns the operation result or a {@code Throwable} if the {@code CompletableFuture}
+	 * finished, otherwise {@code null}.
+	 *
+	 * @throws UnknownOperationKeyException If the operation is not found, and there is no ongoing
+	 *                                      operation under the provided key.
+	 */
+	@Nullable
+	public Either<Throwable, R> get(
+			final K operationKey) throws UnknownOperationKeyException {
+		ResultAccessTracker<R> operationResultOrError;
+		if ((operationResultOrError = registeredOperationTriggers.get(operationKey)) == null
+			&& (operationResultOrError = completedOperations.getIfPresent(operationKey)) == null) {
+			throw new UnknownOperationKeyException(operationKey);
+		}
+
+		return operationResultOrError.accessOperationResultOrError();
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		return FutureUtils.orTimeout(
+			asyncWaitForResultsToBeAccessed(),
+			COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS,
+			TimeUnit.SECONDS);
+	}
+
+	private CompletableFuture<Void> asyncWaitForResultsToBeAccessed() {
+		return FutureUtils.waitForAll(
+			Stream.concat(registeredOperationTriggers.values().stream(), completedOperations.asMap().values().stream())
+				.map(ResultAccessTracker::getAccessedFuture)
+				.collect(Collectors.toList()));
+	}
+
+	@VisibleForTesting
+	void cleanUp() {
+		completedOperations.cleanUp();
+	}
+
+	/**
+	 * Stores the result of an asynchronous operation, and tracks accesses to it.
+	 */
+	private static class ResultAccessTracker<R> {
+
+		/** Result of an asynchronous operation. Null if operation is in progress. */
+		@Nullable
+		private final Either<Throwable, R> operationResultOrError;
+
+		/** Future that completes if a non-null {@link #operationResultOrError} is accessed. */
+		private final CompletableFuture<Void> accessed;
+
+
+		private static <R> ResultAccessTracker<R> inProgress() {
+			return new ResultAccessTracker<>();
+		}
+
+		private ResultAccessTracker() {
+			this.operationResultOrError = null;
+			this.accessed = new CompletableFuture<>();
+		}
+
+		private ResultAccessTracker(final Either<Throwable, R> operationResultOrError, final CompletableFuture<Void> accessed) {
+			this.operationResultOrError = checkNotNull(operationResultOrError);
+			this.accessed = checkNotNull(accessed);
+		}
+
+		/**
+		 * Creates a new instance of the tracker with the result of the asynchronous operation set.
+		 */
+		public ResultAccessTracker<R> finishOperation(final Either<Throwable, R> operationResultOrError) {
+			checkState(this.operationResultOrError == null);
+
+			return new ResultAccessTracker<>(checkNotNull(operationResultOrError), this.accessed);
+		}
+
+		/**
+		 * If present, returns the result of the asynchronous operation, and marks the result as
+		 * accessed. If the result is not present, this method returns null.
+		 */
+		@Nullable
+		public Either<Throwable, R> accessOperationResultOrError() {
+			if (operationResultOrError != null) {
+				markAccessed();
+			}
+			return operationResultOrError;
+		}
+
+		public CompletableFuture<Void> getAccessedFuture() {
+			return accessed;
+		}
+
+		private void markAccessed() {
+			accessed.complete(null);
+		}
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/UnknownOperationKeyException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/UnknownOperationKeyException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.async;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Exception that indicates that there is no ongoing or completed savepoint for a given
+ * {@link JobID} and {@link TriggerId} pair.
+ */
+class UnknownOperationKeyException extends FlinkException {
+	private static final long serialVersionUID = 1L;
+
+	UnknownOperationKeyException(final Object operationKey) {
+		super("No ongoing operation for " + operationKey);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AsynchronousJobOperationKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AsynchronousJobOperationKey.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * A pair of {@link JobID} and {@link TriggerId} used as a key to a hash based
  * collection.
  *
- * @see AbstractAsynchronousOperationHandlers.CompletedOperationCache
+ * @see AbstractAsynchronousOperationHandlers
  */
 @Immutable
 public class AsynchronousJobOperationKey extends OperationKey {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandler.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.blob.TransientBlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
-import org.apache.flink.runtime.rest.AbstractHandler;
+import org.apache.flink.runtime.rest.handler.AbstractHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerUtils.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
@@ -69,7 +70,7 @@ public class HandlerUtils {
 	 * @param headers additional header values
 	 * @param <P> type of the response
 	 */
-	public static <P extends ResponseBody> void sendResponse(
+	public static <P extends ResponseBody> CompletableFuture<Void> sendResponse(
 			ChannelHandlerContext channelHandlerContext,
 			HttpRequest httpRequest,
 			P response,
@@ -80,15 +81,14 @@ public class HandlerUtils {
 			mapper.writeValue(sw, response);
 		} catch (IOException ioe) {
 			LOG.error("Internal server error. Could not map response to JSON.", ioe);
-			sendErrorResponse(
+			return sendErrorResponse(
 				channelHandlerContext,
 				httpRequest,
 				new ErrorResponseBody("Internal server error. Could not map response to JSON."),
 				HttpResponseStatus.INTERNAL_SERVER_ERROR,
 				headers);
-			return;
 		}
-		sendResponse(
+		return sendResponse(
 			channelHandlerContext,
 			httpRequest,
 			sw.toString(),
@@ -105,14 +105,14 @@ public class HandlerUtils {
 	 * @param statusCode of the message to send
 	 * @param headers additional header values
 	 */
-	public static void sendErrorResponse(
+	public static CompletableFuture<Void> sendErrorResponse(
 			ChannelHandlerContext channelHandlerContext,
 			HttpRequest httpRequest,
 			ErrorResponseBody errorMessage,
 			HttpResponseStatus statusCode,
 			Map<String, String> headers) {
 
-		sendErrorResponse(
+		return sendErrorResponse(
 			channelHandlerContext,
 			HttpHeaders.isKeepAlive(httpRequest),
 			errorMessage,
@@ -129,7 +129,7 @@ public class HandlerUtils {
 	 * @param statusCode of the message to send
 	 * @param headers additional header values
 	 */
-	public static void sendErrorResponse(
+	public static CompletableFuture<Void> sendErrorResponse(
 			ChannelHandlerContext channelHandlerContext,
 			boolean keepAlive,
 			ErrorResponseBody errorMessage,
@@ -142,14 +142,14 @@ public class HandlerUtils {
 		} catch (IOException e) {
 			// this should never happen
 			LOG.error("Internal server error. Could not map error response to JSON.", e);
-			sendResponse(
+			return sendResponse(
 				channelHandlerContext,
 				keepAlive,
 				"Internal server error. Could not map error response to JSON.",
 				HttpResponseStatus.INTERNAL_SERVER_ERROR,
 				headers);
 		}
-		sendResponse(
+		return sendResponse(
 			channelHandlerContext,
 			keepAlive,
 			sw.toString(),
@@ -166,14 +166,14 @@ public class HandlerUtils {
 	 * @param statusCode of the message to send
 	 * @param headers additional header values
 	 */
-	public static void sendResponse(
+	public static CompletableFuture<Void> sendResponse(
 			@Nonnull ChannelHandlerContext channelHandlerContext,
 			@Nonnull HttpRequest httpRequest,
 			@Nonnull String message,
 			@Nonnull HttpResponseStatus statusCode,
 			@Nonnull Map<String, String> headers) {
 
-		sendResponse(
+		return sendResponse(
 			channelHandlerContext,
 			HttpHeaders.isKeepAlive(httpRequest),
 			message,
@@ -190,7 +190,7 @@ public class HandlerUtils {
 	 * @param statusCode of the message to send
 	 * @param headers additional header values
 	 */
-	public static void sendResponse(
+	public static CompletableFuture<Void> sendResponse(
 			@Nonnull ChannelHandlerContext channelHandlerContext,
 			boolean keepAlive,
 			@Nonnull String message,
@@ -223,5 +223,19 @@ public class HandlerUtils {
 		if (!keepAlive) {
 			lastContentFuture.addListener(ChannelFutureListener.CLOSE);
 		}
+
+		return toCompletableFuture(lastContentFuture);
+	}
+
+	private static CompletableFuture<Void> toCompletableFuture(final ChannelFuture channelFuture) {
+		final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+		channelFuture.addListener(future -> {
+			if (future.isSuccess()) {
+				completableFuture.complete(null);
+			} else {
+				completableFuture.completeExceptionally(future.cause());
+			}
+		});
+		return completableFuture;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.ManualTicker;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
@@ -279,20 +280,6 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 			10000L,
 			TestingUtils.defaultScheduledExecutor(),
 			Ticker.systemTicker());
-	}
-
-	private static final class ManualTicker extends Ticker {
-
-		private long currentTime = 0;
-
-		@Override
-		public long read() {
-			return currentTime;
-		}
-
-		void advanceTime(long duration, TimeUnit timeUnit) {
-			currentTime += timeUnit.toNanos(duration);
-		}
 	}
 
 	private static final class PartialArchivedExecutionGraphMatcher extends BaseMatcher<ArchivedExecutionGraph> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -94,9 +94,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -268,33 +270,24 @@ public class RestServerEndpointITCase extends TestLogger {
 	 */
 	@Test
 	public void testRequestInterleaving() throws Exception {
-
-		TestParameters parameters = new TestParameters();
-		parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
-		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
+		final HandlerBlocker handlerBlocker = new HandlerBlocker(timeout);
+		testHandler.handlerBody = id -> {
+			if (id == 1) {
+				handlerBlocker.arriveAndBlock();
+			}
+			return CompletableFuture.completedFuture(new TestResponse(id));
+		};
 
 		// send first request and wait until the handler blocks
-		CompletableFuture<TestResponse> response1;
-
-		response1 = restClient.sendRequest(
-			serverAddress.getHostName(),
-			serverAddress.getPort(),
-			new TestHeaders(),
-			parameters,
-			new TestRequest(1));
-		assertTrue(testHandler.requestArrivedLatch.await(timeout.getSize(), timeout.getUnit()));
+		final CompletableFuture<TestResponse> response1 = sendRequestToTestHandler(new TestRequest(1));
+		handlerBlocker.awaitRequestToArrive();
 
 		// send second request and verify response
-		CompletableFuture<TestResponse> response2 = restClient.sendRequest(
-			serverAddress.getHostName(),
-			serverAddress.getPort(),
-			new TestHeaders(),
-			parameters,
-			new TestRequest(2));
+		final CompletableFuture<TestResponse> response2 = sendRequestToTestHandler(new TestRequest(2));
 		assertEquals(2, response2.get().id);
 
 		// wake up blocked handler
-		testHandler.finishRequestLatch.countDown();
+		handlerBlocker.unblockRequest();
 
 		// verify response to first request
 		assertEquals(1, response1.get().id);
@@ -336,41 +329,34 @@ public class RestServerEndpointITCase extends TestLogger {
 	}
 
 	/**
-	 * Tests that requests and responses larger than {@link #TEST_REST_MAX_CONTENT_LENGTH}
-	 * are rejected by the server and client, respectively.
+	 * Tests that requests larger than {@link #TEST_REST_MAX_CONTENT_LENGTH} are rejected.
 	 */
 	@Test
-	public void testMaxContentLengthLimit() throws Exception {
-		final TestParameters parameters = new TestParameters();
-		parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
-		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
-
-		CompletableFuture<TestResponse> response;
-		response = restClient.sendRequest(
-			serverAddress.getHostName(),
-			serverAddress.getPort(),
-			new TestHeaders(),
-			parameters,
-			new TestRequest(2, createStringOfSize(TEST_REST_MAX_CONTENT_LENGTH)));
+	public void testShouldRespectMaxContentLengthLimitForRequests() throws Exception {
+		testHandler.handlerBody = id -> {
+			throw new AssertionError("Request should not arrive at server.");
+		};
 
 		try {
-			response.get();
+			sendRequestToTestHandler(new TestRequest(2, createStringOfSize(TEST_REST_MAX_CONTENT_LENGTH))).get();
 			fail("Expected exception not thrown");
 		} catch (final ExecutionException e) {
 			final Throwable throwable = ExceptionUtils.stripExecutionException(e);
 			assertThat(throwable, instanceOf(RestClientException.class));
 			assertThat(throwable.getMessage(), containsString("Try to raise"));
 		}
+	}
 
-		response = restClient.sendRequest(
-			serverAddress.getHostName(),
-			serverAddress.getPort(),
-			new TestHeaders(),
-			parameters,
-			new TestRequest(TestHandler.LARGE_RESPONSE_BODY_ID));
+	/**
+	 * Tests that responses larger than {@link #TEST_REST_MAX_CONTENT_LENGTH} are rejected.
+	 */
+	@Test
+	public void testShouldRespectMaxContentLengthLimitForResponses() throws Exception {
+		testHandler.handlerBody = id -> CompletableFuture.completedFuture(
+			new TestResponse(id, createStringOfSize(TEST_REST_MAX_CONTENT_LENGTH)));
 
 		try {
-			response.get();
+			sendRequestToTestHandler(new TestRequest(1)).get();
 			fail("Expected exception not thrown");
 		} catch (final ExecutionException e) {
 			final Throwable throwable = ExceptionUtils.stripExecutionException(e);
@@ -553,33 +539,31 @@ public class RestServerEndpointITCase extends TestLogger {
 	 */
 	@Test
 	public void testShouldWaitForHandlersWhenClosing() throws Exception {
-		final CompletableFuture<Void> closeHandlerFuture = new CompletableFuture<>();
-		testHandler.closeFuture = closeHandlerFuture;
+		testHandler.closeFuture = new CompletableFuture<>();
+		final HandlerBlocker handlerBlocker = new HandlerBlocker(timeout);
+		testHandler.handlerBody = id -> {
+			// Intentionally schedule the work on a different thread. This is to simulate
+			// handlers where the CompletableFuture is finished by the RPC framework.
+			return CompletableFuture.supplyAsync(() -> {
+				handlerBlocker.arriveAndBlock();
+				return new TestResponse(id);
+			});
+		};
 
-		// Initiate closing RestServerEndpoint but the handler should block.
+		// Initiate closing RestServerEndpoint but the test handler should block.
 		final CompletableFuture<Void> closeRestServerEndpointFuture = serverEndpoint.closeAsync();
 		assertThat(closeRestServerEndpointFuture.isDone(), is(false));
 
-		final TestParameters parameters = new TestParameters();
-		parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
-		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
-
-		final CompletableFuture<TestResponse> request;
-		request = restClient.sendRequest(
-			serverAddress.getHostName(),
-			serverAddress.getPort(),
-			new TestHeaders(),
-			parameters,
-			new TestRequest(1));
-		assertTrue(testHandler.requestArrivedLatch.await(timeout.getSize(), timeout.getUnit()));
+		final CompletableFuture<TestResponse> request = sendRequestToTestHandler(new TestRequest(1));
+		handlerBlocker.awaitRequestToArrive();
 
 		// Allow handler to close but there is still one in-flight request which should prevent
 		// the RestServerEndpoint from closing.
-		closeHandlerFuture.complete(null);
+		testHandler.closeFuture.complete(null);
 		assertThat(closeRestServerEndpointFuture.isDone(), is(false));
 
 		// Finish the in-flight request.
-		testHandler.finishRequestLatch.countDown();
+		handlerBlocker.unblockRequest();
 
 		request.get(timeout.getSize(), timeout.getUnit());
 		closeRestServerEndpointFuture.get(timeout.getSize(), timeout.getUnit());
@@ -627,13 +611,9 @@ public class RestServerEndpointITCase extends TestLogger {
 
 	private static class TestHandler extends AbstractRestHandler<RestfulGateway, TestRequest, TestResponse, TestParameters> {
 
-		private final CountDownLatch requestArrivedLatch = new CountDownLatch(1);
-
-		private final CountDownLatch finishRequestLatch = new CountDownLatch(1);
-
-		private static final int LARGE_RESPONSE_BODY_ID = 3;
-
 		private CompletableFuture<Void> closeFuture = CompletableFuture.completedFuture(null);
+
+		private Function<Integer, CompletableFuture<TestResponse>> handlerBody;
 
 		TestHandler(
 				CompletableFuture<String> localAddressFuture,
@@ -648,34 +628,89 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 
 		@Override
-		protected CompletableFuture<TestResponse> handleRequest(@Nonnull HandlerRequest<TestRequest, TestParameters> request, RestfulGateway gateway) throws RestHandlerException {
+		protected CompletableFuture<TestResponse> handleRequest(@Nonnull HandlerRequest<TestRequest, TestParameters> request, RestfulGateway gateway) {
 			assertEquals(request.getPathParameter(JobIDPathParameter.class), PATH_JOB_ID);
 			assertEquals(request.getQueryParameter(JobIDQueryParameter.class).get(0), QUERY_JOB_ID);
 
 			final int id = request.getRequestBody().id;
-			if (id == 1) {
-				// Intentionally schedule the work on a different thread. This is to simulate
-				// handlers where the CompletableFuture is finished by the RPC framework.
-				return CompletableFuture.supplyAsync(() -> {
-					try {
-						requestArrivedLatch.countDown();
-						assertTrue(finishRequestLatch.await(timeout.getSize(), timeout.getUnit()));
-					} catch (InterruptedException ignored) {
-					}
-					return new TestResponse(id);
-				});
-			} else if (id == LARGE_RESPONSE_BODY_ID) {
-				return CompletableFuture.completedFuture(new TestResponse(
-					id,
-					createStringOfSize(TEST_REST_MAX_CONTENT_LENGTH)));
-			} else {
-				return CompletableFuture.completedFuture(new TestResponse(id));
-			}
+			return handlerBody.apply(id);
 		}
 
 		@Override
 		public CompletableFuture<Void> closeHandlerAsync() {
 			return closeFuture;
+		}
+	}
+
+	private CompletableFuture<TestResponse> sendRequestToTestHandler(final TestRequest testRequest) {
+		try {
+			return restClient.sendRequest(
+				serverAddress.getHostName(),
+				serverAddress.getPort(),
+				new TestHeaders(),
+				createTestParameters(),
+				testRequest);
+		} catch (final IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static TestParameters createTestParameters() {
+		final TestParameters parameters = new TestParameters();
+		parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
+		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
+		return parameters;
+	}
+
+	/**
+	 * This is a helper class for tests that require to have fine-grained control over HTTP
+	 * requests so that they are not dispatched immediately.
+	 */
+	private static class HandlerBlocker {
+
+		private final Time timeout;
+
+		private final CountDownLatch requestArrivedLatch = new CountDownLatch(1);
+
+		private final CountDownLatch finishRequestLatch = new CountDownLatch(1);
+
+		private HandlerBlocker(final Time timeout) {
+			this.timeout = checkNotNull(timeout);
+		}
+
+		/**
+		 * Waits until {@link #arriveAndBlock()} is called.
+		 */
+		public void awaitRequestToArrive() {
+			try {
+				assertTrue(requestArrivedLatch.await(timeout.getSize(), timeout.getUnit()));
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		/**
+		 * Signals that the request arrived. This method blocks until {@link #unblockRequest()} is
+		 * called.
+		 */
+		public void arriveAndBlock() {
+			markRequestArrived();
+			try {
+				assertTrue(finishRequestLatch.await(timeout.getSize(), timeout.getUnit()));
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		/**
+		 * @see #arriveAndBlock()
+		 */
+		public void unblockRequest() {
+			finishRequestLatch.countDown();
+		}
+
+		private void markRequestArrived() {
+			requestArrivedLatch.countDown();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.handler;
 
-import org.apache.flink.runtime.rest.handler.FileUploads;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.router.RouteResult;
 import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link InFlightRequestTracker}.
+ */
+public class InFlightRequestTrackerTest {
+
+	private InFlightRequestTracker inFlightRequestTracker;
+
+	@Before
+	public void setUp() {
+		inFlightRequestTracker = new InFlightRequestTracker();
+	}
+
+	@Test
+	public void testShouldFinishAwaitAsyncImmediatelyIfNoRequests() {
+		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
+	}
+
+	@Test
+	public void testShouldFinishAwaitAsyncIffAllRequestsDeregistered() {
+		inFlightRequestTracker.registerRequest();
+
+		final CompletableFuture<Void> closeFuture = inFlightRequestTracker.awaitAsync();
+		assertFalse(closeFuture.isDone());
+
+		inFlightRequestTracker.deregisterRequest();
+		assertTrue(closeFuture.isDone());
+	}
+
+	@Test
+	public void testAwaitAsyncIsIdempotent() {
+		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
+		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
@@ -59,4 +59,10 @@ public class InFlightRequestTrackerTest {
 		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
 		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
 	}
+
+	@Test
+	public void testShouldTolerateRegisterAfterAwaitAsync() {
+		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
+		inFlightRequestTracker.registerRequest();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCacheTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.async;
+
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.util.ManualTicker;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link CompletedOperationCache}.
+ */
+public class CompletedOperationCacheTest extends TestLogger {
+
+	private static final OperationKey TEST_OPERATION_KEY = new OperationKey(new TriggerId());
+
+	private static final CompletableFuture<String> TEST_OPERATION_RESULT = CompletableFuture.completedFuture("foo");
+
+	private ManualTicker manualTicker;
+
+	private CompletedOperationCache<OperationKey, String> completedOperationCache;
+
+	@Before
+	public void setUp() {
+		manualTicker = new ManualTicker();
+		completedOperationCache = new CompletedOperationCache<>(manualTicker);
+	}
+
+	@Test
+	public void testShouldFinishClosingCacheIfAllResultsAreEvicted() {
+		completedOperationCache.registerOngoingOperation(TEST_OPERATION_KEY, TEST_OPERATION_RESULT);
+		final CompletableFuture<Void> closeCacheFuture = completedOperationCache.closeAsync();
+		assertThat(closeCacheFuture.isDone(), is(false));
+
+		manualTicker.advanceTime(300, TimeUnit.SECONDS);
+		completedOperationCache.cleanUp();
+
+		assertThat(closeCacheFuture.isDone(), is(true));
+	}
+
+	@Test
+	public void testShouldFinishClosingCacheIfAllResultsAccessed() throws Exception {
+		completedOperationCache.registerOngoingOperation(TEST_OPERATION_KEY, TEST_OPERATION_RESULT);
+		final CompletableFuture<Void> closeCacheFuture = completedOperationCache.closeAsync();
+		assertThat(closeCacheFuture.isDone(), is(false));
+
+		final Either<Throwable, String> operationResultOrError = completedOperationCache.get(TEST_OPERATION_KEY);
+
+		assertThat(operationResultOrError, is(notNullValue()));
+		assertThat(operationResultOrError.right(), is(equalTo(TEST_OPERATION_RESULT.get())));
+		assertThat(closeCacheFuture.isDone(), is(true));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ManualTicker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ManualTicker.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Ticker;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Controllable {@link Ticker} implementation for tests.
+ */
+public final class ManualTicker extends Ticker {
+
+	private long currentTime;
+
+	@Override
+	public long read() {
+		return currentTime;
+	}
+
+	public void advanceTime(final long duration, final TimeUnit timeUnit) {
+		currentTime += timeUnit.toNanos(duration);
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
@@ -249,7 +250,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 				clusterClient.shutdown();
 			}
 			if (dispatcherResourceManagerComponent != null) {
-				dispatcherResourceManagerComponent.close();
+				dispatcherResourceManagerComponent.deregisterApplicationAndClose(ApplicationStatus.SUCCEEDED, null);
 			}
 
 			fatalErrorHandler.rethrowError();

--- a/flink-yarn-tests/src/test/resources/log4j-test.properties
+++ b/flink-yarn-tests/src/test/resources/log4j-test.properties
@@ -35,7 +35,7 @@ log4j.logger.org.apache.flink.runtime.leaderelection=INFO
 log4j.logger.org.apache.flink.runtime.leaderretrieval=INFO
 
 log4j.logger.org.apache.directory=OFF
-log4j.logger.org.mortbay.log=OFF, testlogger
+log4j.logger.org.mortbay.log=OFF
 log4j.logger.net.sf.ehcache=OFF
 log4j.logger.org.apache.hadoop.metrics2=OFF
 log4j.logger.org.apache.hadoop.conf.Configuration=OFF


### PR DESCRIPTION
## What is the purpose of the change

*Wait for the result of asynchronous operations to be served before shutting down the cluster.  This is necessary for the _"cancel with savepoint"_ operation. If we do not wait for the result to be accessed by the client, we may shutdown the cluster, and the client gets a `ConnectionException`.*

cc: @zentol @tillrohrmann 

## Brief change log

  - *Before shutting down cluster, wait for asynchronous operations.*
  - *Log stacktrace if checkpoint cannot be ack'ed.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test to `RestServerEndpointITCase` to verify that handlers are closed first.*
  - *Added unit tests for `CompletedOperationCache`.*
  - *Verified the changes by submitting and cancelling with savepoint of a job in a loop.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
