### PR TITLE
[FLINK-8577][table] Implement proctime DataStream to Table upsert conversion

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -458,7 +458,7 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 
 		DataStreamSource<Row> source = env.fromCollection(rowCollection);
 
-		tEnv.registerDataStreamInternal("testFlinkTable", source);
+		tEnv.registerAppendStreamInternal("testFlinkTable", source);
 		tEnv.registerTableSink(
 			"cassandraTable",
 			new String[]{"f0", "f1", "f2"},

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -54,9 +54,9 @@ object StreamSQLExample {
       Order(4L, "beer", 1)))
 
     // convert DataStream to Table
-    var tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
+    var tableA = tEnv.fromAppendStream(orderA, 'user, 'product, 'amount)
     // register DataStream as Table
-    tEnv.registerDataStream("OrderB", orderB, 'user, 'product, 'amount)
+    tEnv.registerAppendStream("OrderB", orderB, 'user, 'product, 'amount)
 
     // union the two tables
     val result = tEnv.sqlQuery(

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamTableExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamTableExample.scala
@@ -44,12 +44,12 @@ object StreamTableExample {
     val orderA = env.fromCollection(Seq(
       Order(1L, "beer", 3),
       Order(1L, "diaper", 4),
-      Order(3L, "rubber", 2))).toTable(tEnv)
+      Order(3L, "rubber", 2))).toTableFromAppendStream(tEnv)
 
     val orderB = env.fromCollection(Seq(
       Order(2L, "pen", 3),
       Order(2L, "rubber", 3),
-      Order(4L, "beer", 1))).toTable(tEnv)
+      Order(4L, "beer", 1))).toTableFromAppendStream(tEnv)
 
     // union the two tables
     val result: DataStream[Order] = orderA.unionAll(orderB)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -505,14 +505,14 @@ abstract class StreamTableEnvironment(
   }
 
   /**
-    * Registers a [[DataStream]] as a table under a given name in the [[TableEnvironment]]'s
+    * Registers an append [[DataStream]] as a table under a given name in the [[TableEnvironment]]'s
     * catalog.
     *
     * @param name The name under which the table is registered in the catalog.
     * @param dataStream The [[DataStream]] to register as table in the catalog.
     * @tparam T the type of the [[DataStream]].
     */
-  protected def registerDataStreamInternal[T](
+  protected def registerAppendStreamInternal[T](
     name: String,
     dataStream: DataStream[T]): Unit = {
 
@@ -526,15 +526,15 @@ abstract class StreamTableEnvironment(
   }
 
   /**
-    * Registers a [[DataStream]] as a table under a given name with field names as specified by
-    * field expressions in the [[TableEnvironment]]'s catalog.
+    * Registers an append [[DataStream]] as a table under a given name with field names as specified
+    * by field expressions in the [[TableEnvironment]]'s catalog.
     *
     * @param name The name under which the table is registered in the catalog.
     * @param dataStream The [[DataStream]] to register as table in the catalog.
     * @param fields The field expressions to define the field names of the table.
     * @tparam T The type of the [[DataStream]].
     */
-  protected def registerDataStreamInternal[T](
+  protected def registerAppendStreamInternal[T](
       name: String,
       dataStream: DataStream[T],
       fields: Array[Expression])

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -47,7 +47,7 @@ import org.apache.flink.table.plan.schema._
 import org.apache.flink.table.plan.util.UpdatingPlanChecker
 import org.apache.flink.table.runtime.conversion._
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
-import org.apache.flink.table.runtime.{CRowMapRunner, OutputRowtimeProcessFunction}
+import org.apache.flink.table.runtime.OutputRowtimeProcessFunction
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.sources.{StreamTableSource, TableSource, TableSourceUtil}
 import org.apache.flink.table.typeutils.{TimeIndicatorTypeInfo, TypeCheckUtils}
@@ -426,7 +426,7 @@ abstract class StreamTableEnvironment(
     converterFunction match {
 
       case Some(func) =>
-        new CRowMapRunner[OUT](func.name, func.code, func.returnType)
+        new CRowToExternalTypeMapRunner[OUT](func.name, func.code, func.returnType)
 
       case _ =>
         new CRowToRowMapFunction().asInstanceOf[MapFunction[CRow, OUT]]

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -578,7 +578,7 @@ abstract class TableEnvironment(val config: TableConfig) {
 
   /**
     * Replaces a registered Table with another Table under the same name.
-    * We use this method to replace a [[org.apache.flink.table.plan.schema.DataStreamTable]]
+    * We use this method to replace a [[org.apache.flink.table.plan.schema.AppendStreamTable]]
     * with a [[org.apache.calcite.schema.TranslatableTable]].
     *
     * @param name Name of the table to replace.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
@@ -48,7 +48,7 @@ class StreamTableEnvironment(
   extends org.apache.flink.table.api.StreamTableEnvironment(execEnv, config) {
 
   /**
-    * Converts the given [[DataStream]] into a [[Table]].
+    * Converts the given append [[DataStream]] into a [[Table]].
     *
     * The field names of the [[Table]] are automatically derived from the type of the
     * [[DataStream]].
@@ -57,15 +57,11 @@ class StreamTableEnvironment(
     * @tparam T The type of the [[DataStream]].
     * @return The converted [[Table]].
     */
-  def fromDataStream[T](dataStream: DataStream[T]): Table = {
-
-    val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream)
-    scan(name)
-  }
+  @Deprecated
+  def fromDataStream[T](dataStream: DataStream[T]): Table = fromAppendStream(dataStream)
 
   /**
-    * Converts the given [[DataStream]] into a [[Table]] with specified field names.
+    * Converts the given append [[DataStream]] into a [[Table]] with specified field names.
     *
     * Example:
     *
@@ -79,18 +75,54 @@ class StreamTableEnvironment(
     * @tparam T The type of the [[DataStream]].
     * @return The converted [[Table]].
     */
-  def fromDataStream[T](dataStream: DataStream[T], fields: String): Table = {
+  @Deprecated
+  def fromDataStream[T](dataStream: DataStream[T], fields: String): Table =
+    fromAppendStream(dataStream, fields)
+
+  /**
+    * Converts the given append [[DataStream]] into a [[Table]].
+    *
+    * The field names of the [[Table]] are automatically derived from the type of the
+    * [[DataStream]].
+    *
+    * @param dataStream The [[DataStream]] to be converted.
+    * @tparam T The type of the [[DataStream]].
+    * @return The converted [[Table]].
+    */
+  def fromAppendStream[T](dataStream: DataStream[T]): Table = {
+
+    val name = createUniqueTableName()
+    registerAppendStreamInternal(name, dataStream)
+    scan(name)
+  }
+
+  /**
+    * Converts the given append [[DataStream]] into a [[Table]] with specified field names.
+    *
+    * Example:
+    *
+    * {{{
+    *   DataStream<Tuple2<String, Long>> stream = ...
+    *   Table tab = tableEnv.fromAppendStream(stream, "a, b")
+    * }}}
+    *
+    * @param dataStream The [[DataStream]] to be converted.
+    * @param fields The field names of the resulting [[Table]].
+    * @tparam T The type of the [[DataStream]].
+    * @return The converted [[Table]].
+    */
+  def fromAppendStream[T](dataStream: DataStream[T], fields: String): Table = {
     val exprs = ExpressionParser
       .parseExpressionList(fields)
       .toArray
 
     val name = createUniqueTableName()
-    registerDataStreamInternal(name, dataStream, exprs)
+    registerAppendStreamInternal(name, dataStream, exprs)
     scan(name)
   }
 
   /**
-    * Registers the given [[DataStream]] as table in the
+    * Registers the given append [[DataStream]] as table in the
     * [[TableEnvironment]]'s catalog.
     * Registered tables can be referenced in SQL queries.
     *
@@ -101,14 +133,12 @@ class StreamTableEnvironment(
     * @param dataStream The [[DataStream]] to register.
     * @tparam T The type of the [[DataStream]] to register.
     */
-  def registerDataStream[T](name: String, dataStream: DataStream[T]): Unit = {
-
-    checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream)
-  }
+  @Deprecated
+  def registerDataStream[T](name: String, dataStream: DataStream[T]): Unit =
+    registerAppendStream(name, dataStream)
 
   /**
-    * Registers the given [[DataStream]] as table with specified field names in the
+    * Registers the given append [[DataStream]] as table with specified field names in the
     * [[TableEnvironment]]'s catalog.
     * Registered tables can be referenced in SQL queries.
     *
@@ -124,13 +154,52 @@ class StreamTableEnvironment(
     * @param fields The field names of the registered table.
     * @tparam T The type of the [[DataStream]] to register.
     */
-  def registerDataStream[T](name: String, dataStream: DataStream[T], fields: String): Unit = {
+  @Deprecated
+  def registerDataStream[T](name: String, dataStream: DataStream[T], fields: String): Unit =
+    registerAppendStream(name, dataStream, fields)
+
+  /**
+    * Registers the given append [[DataStream]] as table in the
+    * [[TableEnvironment]]'s catalog.
+    * Registered tables can be referenced in SQL queries.
+    *
+    * The field names of the [[Table]] are automatically derived
+    * from the type of the [[DataStream]].
+    *
+    * @param name The name under which the [[DataStream]] is registered in the catalog.
+    * @param dataStream The [[DataStream]] to register.
+    * @tparam T The type of the [[DataStream]] to register.
+    */
+  def registerAppendStream[T](name: String, dataStream: DataStream[T]): Unit = {
+
+    checkValidTableName(name)
+    registerAppendStreamInternal(name, dataStream)
+  }
+
+  /**
+    * Registers the given append [[DataStream]] as table with specified field names in the
+    * [[TableEnvironment]]'s catalog.
+    * Registered tables can be referenced in SQL queries.
+    *
+    * Example:
+    *
+    * {{{
+    *   DataStream<Tuple2<String, Long>> set = ...
+    *   tableEnv.registerAppendStream("myTable", set, "a, b")
+    * }}}
+    *
+    * @param name The name under which the [[DataStream]] is registered in the catalog.
+    * @param dataStream The [[DataStream]] to register.
+    * @param fields The field names of the registered table.
+    * @tparam T The type of the [[DataStream]] to register.
+    */
+  def registerAppendStream[T](name: String, dataStream: DataStream[T], fields: String): Unit = {
     val exprs = ExpressionParser
       .parseExpressionList(fields)
       .toArray
 
     checkValidTableName(name)
-    registerDataStreamInternal(name, dataStream, exprs)
+    registerAppendStreamInternal(name, dataStream, exprs)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/DataStreamConversions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/DataStreamConversions.scala
@@ -53,9 +53,9 @@ class DataStreamConversions[T](dataStream: DataStream[T], inputType: TypeInforma
     */
   def toTable(tableEnv: StreamTableEnvironment, fields: Expression*): Table = {
     if (fields.isEmpty) {
-      tableEnv.fromDataStream(dataStream)
+      tableEnv.fromAppendStream(dataStream)
     } else {
-      tableEnv.fromDataStream(dataStream, fields:_*)
+      tableEnv.fromAppendStream(dataStream, fields:_*)
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/DataStreamConversions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/DataStreamConversions.scala
@@ -88,5 +88,38 @@ class DataStreamConversions[T](dataStream: DataStream[T], inputType: TypeInforma
     }
   }
 
+  /**
+    * Converts the upsert [[DataStream]] with upsert messages into a [[Table]] with keys.
+    *
+    * The incoming messages from the source DataStream are expected to be encoded as [[Tuple2]].
+    * The first field is a [[Boolean]] flag, the second field holds the record. A true [[Boolean]]
+    * flag indicates an update message, a false flag indicates a delete message.
+    *
+    * The field name and key of the new [[Table]] can be specified like this:
+    *
+    * {{{
+    *   val env = StreamExecutionEnvironment.getExecutionEnvironment
+    *   val tEnv = TableEnvironment.getTableEnvironment(env)
+    *
+    *   val stream: DataStream[(Boolean, (String, Int))] = ...
+    *   val table = stream.toTableFromUpsertStream(tEnv, 'name.key, 'amount)
+    * }}}
+    *
+    * If field names are not explicitly specified, names are automatically extracted from the type
+    * of the [[DataStream]].
+    * If keys are not explicitly specified, an empty key will be used and the table will be a
+    * single row table.
+    *
+    * @param tableEnv The [[StreamTableEnvironment]] in which the new [[Table]] is created.
+    * @param fields The field names of the new [[Table]] (optional).
+    * @return The resulting [[Table]].
+    */
+  def toTableFromUpsertStream(tableEnv: StreamTableEnvironment, fields: Expression*): Table = {
+    if (fields.isEmpty) {
+      tableEnv.fromUpsertStream(dataStream)
+    } else {
+      tableEnv.fromUpsertStream(dataStream, fields:_*)
+    }
+  }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/DataStreamConversions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/DataStreamConversions.scala
@@ -51,7 +51,36 @@ class DataStreamConversions[T](dataStream: DataStream[T], inputType: TypeInforma
     * @param fields The field names of the new [[Table]] (optional).
     * @return The resulting [[Table]].
     */
+  @deprecated("In order to make it more explicit, use toTableFromAppendStream instead.")
   def toTable(tableEnv: StreamTableEnvironment, fields: Expression*): Table = {
+    if (fields.isEmpty) {
+      tableEnv.fromAppendStream(dataStream)
+    } else {
+      tableEnv.fromAppendStream(dataStream, fields:_*)
+    }
+  }
+
+  /**
+    * Converts the append [[DataStream]] into a [[Table]].
+    *
+    * The field name of the new [[Table]] can be specified like this:
+    *
+    * {{{
+    *   val env = StreamExecutionEnvironment.getExecutionEnvironment
+    *   val tEnv = TableEnvironment.getTableEnvironment(env)
+    *
+    *   val stream: DataStream[(String, Int)] = ...
+    *   val table = stream.toTableFromAppendStream(tEnv, 'name, 'amount)
+    * }}}
+    *
+    * If not explicitly specified, field names are automatically extracted from the type of
+    * the [[DataStream]].
+    *
+    * @param tableEnv The [[StreamTableEnvironment]] in which the new [[Table]] is created.
+    * @param fields The field names of the new [[Table]] (optional).
+    * @return The resulting [[Table]].
+    */
+  def toTableFromAppendStream(tableEnv: StreamTableEnvironment, fields: Expression*): Table = {
     if (fields.isEmpty) {
       tableEnv.fromAppendStream(dataStream)
     } else {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
@@ -121,6 +121,53 @@ class StreamTableEnvironment(
   }
 
   /**
+    * Converts the given upsert [[DataStream]] into a single row [[Table]].
+    *
+    * The field names of the [[Table]] are automatically derived from the type of the
+    * [[DataStream]]. Since the key has not been specified, an empty key will be used and the table
+    * will be a single row [[Table]].
+    *
+    * @param dataStream The [[DataStream]] to be converted.
+    * @tparam T The type of the [[DataStream]].
+    * @return The converted [[Table]].
+    */
+  def fromUpsertStream[T](dataStream: DataStream[T]): Table = {
+
+    val name = createUniqueTableName()
+    registerUpsertStreamInternal(name, dataStream.javaStream)
+    scan(name)
+  }
+
+  /**
+    * Converts the given upsert [[DataStream]] into a [[Table]] with specified field names and keys.
+    *
+    * The message will be encoded as [[Tuple2]]. The first field is a [[Boolean]] flag, the second
+    * field holds the record of the specified type [[T]]. A true [[Boolean]] flag indicates an
+    * update message, a false flag indicates a delete message.
+    *
+    * Example:
+    *
+    * {{{
+    *   val stream: DataStream[(Boolean, Row)] = ...
+    *   val tab: Table = tableEnv.fromUpsertStream(stream, 'a.key, 'b)
+    * }}}
+    *
+    * If keys are not explicitly specified, an empty key will be used and the table will be a
+    * single row [[Table]].
+    *
+    * @param dataStream The [[DataStream]] to be converted.
+    * @param fields The field names of the resulting [[Table]].
+    * @tparam T The type of the [[DataStream]].
+    * @return The converted [[Table]].
+    */
+  def fromUpsertStream[T](dataStream: DataStream[T], fields: Expression*): Table = {
+
+    val name = createUniqueTableName()
+    registerUpsertStreamInternal(name, dataStream.javaStream, fields.toArray)
+    scan(name)
+  }
+
+  /**
     * Registers the given append [[DataStream]] as table in the
     * [[TableEnvironment]]'s catalog.
     * Registered tables can be referenced in SQL queries.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -869,6 +869,17 @@ trait ImplicitExpressionOperations {
     */
   def proctime = ProctimeAttribute(expr)
 
+  /**
+    * Declares a field as the unique key attribute for source Table.
+    */
+  def key: Expression = {
+    expr match {
+      case u: UnresolvedFieldReference => new UnresolvedKeyFieldReference(u.name)
+      case _ => throw new TableException(
+        "The key method can only be used on a source field.")
+    }
+  }
+
   // Hash functions
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/UpsertToRetractionConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/UpsertToRetractionConverter.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import org.apache.calcite.rel.core._
+import org.apache.calcite.rel.{RelHomogeneousShuttle, RelNode}
+import org.apache.calcite.rex._
+import org.apache.flink.table.plan.logical.rel.LogicalUpsertToRetraction
+import org.apache.flink.table.plan.schema.UpsertStreamTable
+
+import scala.collection.JavaConversions._
+
+/**
+  * Traverses a [[RelNode]] tree and add [[LogicalUpsertToRetraction]] node after the upsert source.
+  */
+class UpsertToRetractionConverter(rexBuilder: RexBuilder) extends RelHomogeneousShuttle {
+
+  override def visit(other: RelNode): RelNode = {
+    other match {
+      case scan: TableScan => {
+          scan.getTable.unwrap(classOf[UpsertStreamTable[_]]) match {
+          case upsertStreamTable: UpsertStreamTable[_] =>
+            LogicalUpsertToRetraction.create(
+              scan.getCluster,
+              scan.getTraitSet,
+              scan,
+              upsertStreamTable.uniqueKeys)
+          case _ => scan
+        }
+      }
+      case _ => other.copy(other.getTraitSet, other.getInputs.map(_.accept(this)))
+    }
+  }
+}
+
+object UpsertToRetractionConverter {
+
+  def convert(rootRel: RelNode, rexBuilder: RexBuilder): RelNode = {
+    val converter = new UpsertToRetractionConverter(rexBuilder)
+    rootRel.accept(converter)
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -93,6 +93,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   lazy val UNBOUNDED_RANGE: Keyword = Keyword("unbounded_range")
   lazy val ROWTIME: Keyword = Keyword("rowtime")
   lazy val PROCTIME: Keyword = Keyword("proctime")
+  lazy val KEY: Keyword = Keyword("key")
   lazy val TRUE: Keyword = Keyword("true")
   lazy val FALSE: Keyword = Keyword("false")
   lazy val PRIMITIVE_ARRAY: Keyword = Keyword("PRIMITIVE_ARRAY")
@@ -357,7 +358,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     // function call must always be at the end
     suffixFunctionCall | suffixFunctionCallOneArg |
     // rowtime or proctime
-    timeIndicator
+    timeIndicator |
+    key
 
   // prefix operators
 
@@ -533,6 +535,11 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
   lazy val rowtime: PackratParser[Expression] = fieldReference ~ "." ~ ROWTIME ^^ {
     case f ~ _ ~ _ => RowtimeAttribute(f)
+  }
+
+  lazy val key: PackratParser[Expression] = fieldReference ~ "." ~ KEY ^^ {
+    case f ~ _ ~ _ =>
+      new UnresolvedKeyFieldReference(f.asInstanceOf[UnresolvedFieldReference].name)
   }
 
   // alias

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/fieldExpression.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/fieldExpression.scala
@@ -52,6 +52,8 @@ case class UnresolvedFieldReference(name: String) extends Attribute {
     ValidationFailure(s"Unresolved reference $name.")
 }
 
+class UnresolvedKeyFieldReference(name: String) extends UnresolvedFieldReference(name) {}
+
 case class ResolvedFieldReference(
     name: String,
     resultType: TypeInformation[_]) extends Attribute {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalUpsertToRetraction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalUpsertToRetraction.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.logical.rel
+
+import java.util
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, SingleRel}
+
+/**
+  * Represent a relnode which convert upsert to retraction.
+  */
+class LogicalUpsertToRetraction(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    child: RelNode,
+    val upsertKeyNames: Array[String])
+  extends SingleRel(cluster, traitSet, child) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new LogicalUpsertToRetraction(cluster, traitSet, inputs.get(0), upsertKeyNames)
+  }
+}
+
+object LogicalUpsertToRetraction {
+
+  def create(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    child: RelNode,
+    keyIndexes: Array[String]): LogicalUpsertToRetraction = {
+
+    new LogicalUpsertToRetraction(cluster, traitSet, child, keyIndexes)
+  }
+}
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/AppendStreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/AppendStreamScan.scala
@@ -16,20 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.schema
+package org.apache.flink.table.plan.nodes.datastream
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.table.api.TableEnvironment
-import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.flink.table.plan.schema.RowSchema
 
 /**
-  * Base class for Table that to be registered in the [[TableEnvironment]]'s catalog.
+  * [[DataStreamScan]] which used to handle append streams from source.
   */
-abstract class DataStreamTable[T](
-    val dataStream: DataStream[T],
-    override val typeInfo: TypeInformation[T],
-    override val fieldIndexes: Array[Int],
-    override val fieldNames: Array[String],
-    override val statistic: FlinkStatistic = FlinkStatistic.UNKNOWN)
-  extends InlineTable[T](typeInfo, fieldIndexes, fieldNames, statistic)
+class AppendStreamScan(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    table: RelOptTable,
+    schema: RowSchema)
+  extends DataStreamScan(cluster, traitSet, table, schema)
+  with StreamScan {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new AppendStreamScan(
+      cluster,
+      traitSet,
+      getTable,
+      schema
+    )
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
@@ -19,15 +19,13 @@
 package org.apache.flink.table.plan.nodes.datastream
 
 import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
 import org.apache.calcite.rex.RexNode
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
 import org.apache.flink.table.expressions.Cast
-import org.apache.flink.table.plan.schema.RowSchema
-import org.apache.flink.table.plan.schema.DataStreamTable
+import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema}
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
@@ -36,7 +34,7 @@ import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
   * It ensures that types without deterministic field order (e.g. POJOs) are not part of
   * the plan translation.
   */
-class DataStreamScan(
+abstract class DataStreamScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
@@ -47,15 +45,6 @@ class DataStreamScan(
   val dataStreamTable: DataStreamTable[Any] = getTable.unwrap(classOf[DataStreamTable[Any]])
 
   override def deriveRowType(): RelDataType = schema.relDataType
-
-  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
-    new DataStreamScan(
-      cluster,
-      traitSet,
-      getTable,
-      schema
-    )
-  }
 
   override def translateToPlan(
       tableEnv: StreamTableEnvironment,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
@@ -25,7 +25,7 @@ import org.apache.calcite.rex.RexNode
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
 import org.apache.flink.table.expressions.Cast
-import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema}
+import org.apache.flink.table.plan.schema.{AppendStreamTable, DataStreamTable, RowSchema, UpsertStreamTable}
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
@@ -68,7 +68,11 @@ abstract class DataStreamScan(
       }
 
     // convert DataStream
-    convertToInternalRow(schema, inputDataStream, fieldIdxs, config, rowtimeExpr)
+    dataStreamTable match {
+      case _: AppendStreamTable[_] =>
+        convertToInternalRow(schema, inputDataStream, fieldIdxs, config, rowtimeExpr)
+      case _: UpsertStreamTable[_] =>
+        convertUpsertToInternalRow(schema, inputDataStream, fieldIdxs, config, rowtimeExpr)
+    }
   }
-
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamUpsertToRetraction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamUpsertToRetraction.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import java.util
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
+import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.runtime.types.CRow
+
+import scala.collection.JavaConversions._
+
+/**
+  * Flink RelNode for ingesting upsert stream from source.
+  */
+class DataStreamUpsertToRetraction(
+   cluster: RelOptCluster,
+   traitSet: RelTraitSet,
+   input: RelNode,
+   inputSchema: RowSchema,
+   schema: RowSchema,
+   val keyNames: Seq[String])
+  extends SingleRel(cluster, traitSet, input)
+  with DataStreamRel{
+
+  lazy val keyIndexes = getRowType.getFieldNames.zipWithIndex
+    .filter(e => keyNames.contains(e._1))
+    .map(_._2).toArray
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new DataStreamUpsertToRetraction(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      inputSchema,
+      schema,
+      keyNames)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter ={
+    super.explainTerms(pw)
+      .itemIf("keys", keyNames.mkString(", "), keyNames.nonEmpty)
+      .item("select", input.getRowType.getFieldNames.toArray.mkString(", "))
+  }
+
+  override def toString: String = {
+    s"UpsertToRetractionConverter(${
+      if (keyNames.nonEmpty) {
+        s"keys:(${keyNames.mkString(", ")}), "
+      } else {
+        ""
+      }
+    }select:(${input.getRowType.getFieldNames.toArray.mkString(", ")}))"
+  }
+
+  override def producesUpdates: Boolean = true
+
+  override def translateToPlan(
+      tableEnv: StreamTableEnvironment,
+      queryConfig: StreamQueryConfig): DataStream[CRow] = {
+
+    // todo: return inputDS for plan test. The detailed code will be ready in the next commit
+    throw new NotImplementedError
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
@@ -29,14 +29,12 @@ import org.apache.flink.api.java.functions.NullByteKeySelector
 import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.api.java.tuple.Tuple
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
-import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.streaming.api.functions.co.CoProcessFunction
 import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment, TableException}
 import org.apache.flink.table.plan.nodes.CommonJoin
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.plan.util.UpdatingPlanChecker
-import org.apache.flink.table.runtime.{CRowKeySelector, CRowWrappingCollector}
+import org.apache.flink.table.runtime.CRowKeySelector
 import org.apache.flink.table.runtime.join.{OuterJoinPaddingUtil, ProcTimeBoundedStreamJoin, RowTimeBoundedStreamJoin, WindowJoinUtil}
 import org.apache.flink.table.runtime.operators.KeyedCoProcessOperatorWithWatermarkDelay
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/UpsertStreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/UpsertStreamScan.scala
@@ -16,20 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.schema
+package org.apache.flink.table.plan.nodes.datastream
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.table.api.TableEnvironment
-import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.flink.table.plan.schema.RowSchema
 
 /**
-  * Base class for Table that to be registered in the [[TableEnvironment]]'s catalog.
+  * [[DataStreamScan]] which used to handle upsert streams from source.
   */
-abstract class DataStreamTable[T](
-    val dataStream: DataStream[T],
-    override val typeInfo: TypeInformation[T],
-    override val fieldIndexes: Array[Int],
-    override val fieldNames: Array[String],
-    override val statistic: FlinkStatistic = FlinkStatistic.UNKNOWN)
-  extends InlineTable[T](typeInfo, fieldIndexes, fieldNames, statistic)
+class UpsertStreamScan(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    table: RelOptTable,
+    schema: RowSchema)
+  extends DataStreamScan(cluster, traitSet, table, schema)
+  with StreamScan {
+
+  override def producesUpdates: Boolean = true
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new UpsertStreamScan(
+      cluster,
+      traitSet,
+      getTable,
+      schema
+    )
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalUpsertToRetraction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalUpsertToRetraction.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.logical
+
+import java.util.{List => JList}
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.flink.table.plan.logical.rel.LogicalUpsertToRetraction
+import org.apache.flink.table.plan.nodes.FlinkConventions
+
+class FlinkLogicalUpsertToRetraction(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    child: RelNode,
+    val keyNames: Seq[String])
+  extends SingleRel(cluster, traitSet, child)
+  with FlinkLogicalRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: JList[RelNode]): RelNode = {
+    new FlinkLogicalUpsertToRetraction(cluster, traitSet, inputs.get(0), keyNames)
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    val child = this.getInput
+    val rowCnt = mq.getRowCount(child)
+    // take rowCnt and fieldCnt into account, so that cost will be smaller when generate
+    // UpsertToRetractionConverter after Calc.
+    planner.getCostFactory.makeCost(rowCnt, rowCnt, rowCnt * estimateRowSize(child.getRowType))
+  }
+}
+
+private class FlinkLogicalUpsertToRetractionConverter
+  extends ConverterRule(
+    classOf[LogicalUpsertToRetraction],
+    Convention.NONE,
+    FlinkConventions.LOGICAL,
+    "FlinkLogicalUpsertToRetractionConverter") {
+
+  override def convert(rel: RelNode): RelNode = {
+    val upsertToRetraction = rel.asInstanceOf[LogicalUpsertToRetraction]
+    val traitSet = rel.getTraitSet.replace(FlinkConventions.LOGICAL)
+    val newInput = RelOptRule.convert(upsertToRetraction.getInput, FlinkConventions.LOGICAL)
+
+    new FlinkLogicalUpsertToRetraction(
+      rel.getCluster,
+      traitSet,
+      newInput,
+      upsertToRetraction.upsertKeyNames
+    )
+  }
+}
+
+object FlinkLogicalUpsertToRetraction {
+  val CONVERTER: ConverterRule = new FlinkLogicalUpsertToRetractionConverter()
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.plan.rules
 import org.apache.calcite.rel.core.RelFactories
 import org.apache.calcite.rel.rules._
 import org.apache.calcite.tools.{RuleSet, RuleSets}
-import org.apache.flink.table.plan.nodes.logical
 import org.apache.flink.table.plan.rules.common._
 import org.apache.flink.table.plan.rules.logical._
 import org.apache.flink.table.plan.rules.dataSet._
@@ -140,7 +139,8 @@ object FlinkRuleSets {
     FlinkLogicalTableSourceScan.CONVERTER,
     FlinkLogicalTableFunctionScan.CONVERTER,
     FlinkLogicalNativeTableScan.CONVERTER,
-    FlinkLogicalMatch.CONVERTER
+    FlinkLogicalMatch.CONVERTER,
+    FlinkLogicalUpsertToRetraction.CONVERTER
   )
 
   /**
@@ -228,7 +228,8 @@ object FlinkRuleSets {
     DataStreamJoinRule.INSTANCE,
     DataStreamTemporalTableJoinRule.INSTANCE,
     StreamTableSourceScanRule.INSTANCE,
-    DataStreamMatchRule.INSTANCE
+    DataStreamMatchRule.INSTANCE,
+    DataStreamUpsertToRetractionRule.INSTANCE
   )
 
   /**
@@ -238,7 +239,9 @@ object FlinkRuleSets {
     // retraction rules
     DataStreamRetractionRules.DEFAULT_RETRACTION_INSTANCE,
     DataStreamRetractionRules.UPDATES_AS_RETRACTION_INSTANCE,
-    DataStreamRetractionRules.ACCMODE_INSTANCE
+    DataStreamRetractionRules.ACCMODE_INSTANCE,
+    // remove DataStreamUpsertToRetraction under AccMode.
+    RemoveDataStreamUpsertToRetractionRule.INSTANCE
   )
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -119,6 +119,7 @@ object FlinkRuleSets {
     // scan optimization
     PushProjectIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoTableSourceScanRule.INSTANCE,
+    CalcUpsertToRetractionTransposeRule.INSTANCE,
 
     // unnest rule
     LogicalUnnestRule.INSTANCE,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamUpsertToRetractionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamUpsertToRetractionRule.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.datastream.DataStreamUpsertToRetraction
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalUpsertToRetraction
+import org.apache.flink.table.plan.schema.RowSchema
+
+class DataStreamUpsertToRetractionRule
+  extends ConverterRule(
+    classOf[FlinkLogicalUpsertToRetraction],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.DATASTREAM,
+    "DataStreamUpsertToRetractionRule") {
+
+  override def convert(rel: RelNode): RelNode = {
+    val upsertToRetraction = rel.asInstanceOf[FlinkLogicalUpsertToRetraction]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASTREAM)
+    val convInput: RelNode =
+      RelOptRule.convert(upsertToRetraction.getInput, FlinkConventions.DATASTREAM)
+
+    new DataStreamUpsertToRetraction(
+      upsertToRetraction.getCluster,
+      traitSet,
+      convInput,
+      new RowSchema(convInput.getRowType),
+      new RowSchema(rel.getRowType),
+      upsertToRetraction.keyNames)
+  }
+}
+
+object DataStreamUpsertToRetractionRule {
+  val INSTANCE = new DataStreamUpsertToRetractionRule
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/RemoveDataStreamUpsertToRetractionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/RemoveDataStreamUpsertToRetractionRule.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.flink.table.plan.nodes.datastream.{AccMode, DataStreamUpsertToRetraction}
+
+/**
+  * Rule to remove [[DataStreamUpsertToRetraction]] under [[AccMode.Acc]]. In this case, it is a
+  * no-op node.
+  */
+class RemoveDataStreamUpsertToRetractionRule extends RelOptRule(
+  operand(
+    classOf[DataStreamUpsertToRetraction], none()),
+  "RemoveDataStreamUpsertToRetractionRule") {
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val rel = call.rel(0).asInstanceOf[DataStreamUpsertToRetraction]
+    val input = rel.getInput.asInstanceOf[HepRelVertex].getCurrentRel
+
+    if (!DataStreamRetractionRules.isAccRetract(rel)) {
+      call.transformTo(input)
+    }
+  }
+}
+
+object RemoveDataStreamUpsertToRetractionRule {
+  val INSTANCE: RemoveDataStreamUpsertToRetractionRule = new RemoveDataStreamUpsertToRetractionRule
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/logical/CalcUpsertToRetractionTransposeRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/logical/CalcUpsertToRetractionTransposeRule.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.calcite.plan.RelOptRule.{none, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalUpsertToRetraction}
+
+import scala.collection.JavaConversions._
+
+/**
+  * Use this rule to transpose Calc through UpsertToRetraction relnode. It is beneficial if we get
+  * smaller state size in upsertToRetraction.
+  */
+class CalcUpsertToRetractionTransposeRule extends RelOptRule(
+  operand(classOf[FlinkLogicalCalc],
+    operand(classOf[FlinkLogicalUpsertToRetraction], none)),
+  "CalcUpsertToRetractionTransposeRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val upsertToRetraction = call.rel(1).asInstanceOf[FlinkLogicalUpsertToRetraction]
+
+    fieldsRemainAfterCalc(upsertToRetraction.keyNames, calc)
+  }
+
+  override def onMatch(call: RelOptRuleCall) {
+    val calc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val upsertToRetraction = call.rel(1).asInstanceOf[FlinkLogicalUpsertToRetraction]
+    call.transformTo(getNewUpsertToRetraction(calc, upsertToRetraction))
+  }
+
+  private def getNewUpsertToRetraction(
+    calc: FlinkLogicalCalc,
+    upsertToRetraction: FlinkLogicalUpsertToRetraction): FlinkLogicalUpsertToRetraction = {
+
+    val newCalc = calc.copy(calc.getTraitSet, upsertToRetraction.getInput, calc.getProgram)
+
+    val oldKeyNames = upsertToRetraction.keyNames
+    val newKeyNames = getNamesAfterCalc(oldKeyNames, calc)
+    new FlinkLogicalUpsertToRetraction(
+      upsertToRetraction.getCluster,
+      upsertToRetraction.getTraitSet,
+      newCalc,
+      newKeyNames)
+  }
+
+  private def fieldsRemainAfterCalc(fields: Seq[String], calc: FlinkLogicalCalc): Boolean = {
+    calc.getRowType.getFieldNames
+      .flatMap(calc.getInputFromOutputName(calc, _))
+      .containsAll(fields)
+  }
+
+  private def getNamesAfterCalc(names: Seq[String], calc: FlinkLogicalCalc): Seq[String] = {
+    calc.getRowType.getFieldNames
+      .filter{ outputName =>
+        val inputName = calc.getInputFromOutputName(calc, outputName)
+        inputName.isDefined && names.contains(inputName.get)
+      }
+  }
+}
+
+object CalcUpsertToRetractionTransposeRule {
+  val INSTANCE = new CalcUpsertToRetractionTransposeRule()
+}
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/AppendStreamTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/AppendStreamTable.scala
@@ -18,18 +18,22 @@
 
 package org.apache.flink.table.plan.schema
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.plan.stats.FlinkStatistic
 
 /**
-  * Base class for Table that to be registered in the [[TableEnvironment]]'s catalog.
+  * Table that to be registered in the [[TableEnvironment]]'s catalog. The dataStream is an append
+  * stream, while [[UpsertStreamTable]] contains an upsert stream.
   */
-abstract class DataStreamTable[T](
-    val dataStream: DataStream[T],
-    override val typeInfo: TypeInformation[T],
+class AppendStreamTable[T](
+    override val dataStream: DataStream[T],
     override val fieldIndexes: Array[Int],
     override val fieldNames: Array[String],
     override val statistic: FlinkStatistic = FlinkStatistic.UNKNOWN)
-  extends InlineTable[T](typeInfo, fieldIndexes, fieldNames, statistic)
+  extends DataStreamTable[T](
+    dataStream,
+    dataStream.getType,
+    fieldIndexes,
+    fieldNames,
+    statistic)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowProcessRunner.scala
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.table.runtime.conversion.CRowWrappingCollector
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/UpsertToRetractionProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/UpsertToRetractionProcessFunction.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime
+
+import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.runtime.aggregate.ProcessFunctionWithCleanupState
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.table.util.Logging
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+/**
+  * Function used to convert upsert to retractions.
+  *
+  * @param rowTypeInfo the output row type info.
+  * @param queryConfig the configuration for the query.
+  */
+class UpsertToRetractionProcessFunction(
+    private val rowTypeInfo: RowTypeInfo,
+    private val queryConfig: StreamQueryConfig)
+  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+    with Logging {
+
+  @transient private var prevRow: CRow = _
+  // stores the accumulators
+  @transient private var state: ValueState[Row] = _
+
+  override def open(config: Configuration) {
+
+    prevRow = new CRow(new Row(rowTypeInfo.getArity), false)
+
+    val stateDescriptor: ValueStateDescriptor[Row] =
+      new ValueStateDescriptor[Row]("UpsertToRetractionState", rowTypeInfo)
+    state = getRuntimeContext.getState(stateDescriptor)
+
+    initCleanupTimeState("UpsertToRetractionCleanupTime")
+    LOG.info("Init UpsertToRetractionProcessFunction.")
+  }
+
+  override def processElement(
+      inputC: CRow,
+      ctx: ProcessFunction[CRow, CRow]#Context,
+      out: Collector[CRow]): Unit = {
+
+    val currentTime = ctx.timerService().currentProcessingTime()
+    // register state-cleanup timer
+    processCleanupTimer(ctx, currentTime)
+
+    val pre = state.value()
+    val current = inputC.row
+
+    if (inputC.change) {
+      // ignore same record
+      if (!stateCleaningEnabled && pre != null && pre.equals(current)) {
+        return
+      }
+      state.update(current)
+      // retract prevRow
+      if (pre != null) {
+        prevRow.row = pre
+        out.collect(prevRow)
+      }
+      // output currentRow
+      out.collect(inputC)
+    } else {
+      state.clear()
+      if (pre != null) {
+        prevRow.row = pre
+        out.collect(prevRow)
+      } else {
+        // else input is a delete row we ignore it, since delete on nothing means nothing.
+      }
+    }
+  }
+
+  override def onTimer(
+      timestamp: Long,
+      ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+      out: Collector[CRow]): Unit = {
+
+    if (stateCleaningEnabled) {
+      cleanupState(state)
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/CRowWrappingCollector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/CRowWrappingCollector.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime
+package org.apache.flink.table.runtime.conversion
 
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.types.Row

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/JavaTupleToCRowProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/JavaTupleToCRowProcessRunner.scala
@@ -16,46 +16,65 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime
+package org.apache.flink.table.runtime.conversion
+
+import _root_.java.lang.{Boolean => JBool}
 
 import org.apache.flink.api.common.functions.util.FunctionUtils
-import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.codegen.Compiler
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
 
 /**
-  * MapRunner with [[CRow]] input.
+  * ProcessRunner with [[CRow]] output.
   */
-class CRowMapRunner[OUT](
+class JavaTupleToCRowProcessRunner(
     name: String,
     code: String,
-    @transient var returnType: TypeInformation[OUT])
-  extends RichMapFunction[CRow, OUT]
-  with ResultTypeQueryable[OUT]
-  with Compiler[MapFunction[Row, OUT]]
+    @transient var returnType: TypeInformation[CRow])
+  extends ProcessFunction[JTuple2[JBool, Any], CRow]
+  with ResultTypeQueryable[CRow]
+  with Compiler[ProcessFunction[Any, Row]]
   with Logging {
 
-  private var function: MapFunction[Row, OUT] = _
+  private var function: ProcessFunction[Any, Row] = _
+  private var cRowWrapper: CRowWrappingCollector = _
 
   override def open(parameters: Configuration): Unit = {
-    LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
+    LOG.debug(s"Compiling ProcessFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
-    LOG.debug("Instantiating MapFunction.")
+    LOG.debug("Instantiating ProcessFunction.")
     function = clazz.newInstance()
     FunctionUtils.setFunctionRuntimeContext(function, getRuntimeContext)
     FunctionUtils.openFunction(function, parameters)
+
+    this.cRowWrapper = new CRowWrappingCollector()
+    this.cRowWrapper.setChange(true)
   }
 
-  override def map(in: CRow): OUT = {
-    function.map(in.row)
+  override def processElement(
+      in: JTuple2[JBool, Any],
+      ctx: ProcessFunction[JTuple2[JBool, Any], CRow]#Context,
+      out: Collector[CRow]): Unit = {
+
+    // remove timestamp from stream record
+    val tc = out.asInstanceOf[TimestampedCollector[_]]
+    tc.eraseTimestamp()
+
+    cRowWrapper.out = out
+    cRowWrapper.setChange(in.f0)
+    function.processElement(in.f1, ctx.asInstanceOf[ProcessFunction[Any, Row]#Context], cRowWrapper)
   }
 
-  override def getProducedType: TypeInformation[OUT] = returnType
+  override def getProducedType: TypeInformation[CRow] = returnType
 
   override def close(): Unit = {
     FunctionUtils.closeFunction(function)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/ScalaTupleToCRowProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/ScalaTupleToCRowProcessRunner.scala
@@ -16,79 +16,64 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime
+package org.apache.flink.table.runtime.conversion
 
 import org.apache.flink.api.common.functions.util.FunctionUtils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.codegen.Compiler
-import org.apache.flink.table.runtime.conversion.CRowWrappingCollector
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 
 /**
-  * A CorrelateProcessRunner with [[CRow]] input and [[CRow]] output.
+  * ProcessRunner with [[CRow]] output.
   */
-class CRowCorrelateProcessRunner(
-    processName: String,
-    processCode: String,
-    collectorName: String,
-    collectorCode: String,
+class ScalaTupleToCRowProcessRunner(
+    name: String,
+    code: String,
     @transient var returnType: TypeInformation[CRow])
-  extends ProcessFunction[CRow, CRow]
+  extends ProcessFunction[(Boolean, Any), CRow]
   with ResultTypeQueryable[CRow]
-  with Compiler[Any]
+  with Compiler[ProcessFunction[Any, Row]]
   with Logging {
 
-  private var function: ProcessFunction[Row, Row] = _
-  private var collector: TableFunctionCollector[_] = _
+  private var function: ProcessFunction[Any, Row] = _
   private var cRowWrapper: CRowWrappingCollector = _
 
   override def open(parameters: Configuration): Unit = {
-    LOG.debug(s"Compiling TableFunctionCollector: $collectorName \n\n Code:\n$collectorCode")
-    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, collectorName, collectorCode)
-    LOG.debug("Instantiating TableFunctionCollector.")
-    collector = clazz.newInstance().asInstanceOf[TableFunctionCollector[_]]
-    this.cRowWrapper = new CRowWrappingCollector()
-
-    LOG.debug(s"Compiling ProcessFunction: $processName \n\n Code:\n$processCode")
-    val processClazz = compile(getRuntimeContext.getUserCodeClassLoader, processName, processCode)
-    val constructor = processClazz.getConstructor(classOf[TableFunctionCollector[_]])
+    LOG.debug(s"Compiling ProcessFunction: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating ProcessFunction.")
-    function = constructor.newInstance(collector).asInstanceOf[ProcessFunction[Row, Row]]
-    FunctionUtils.setFunctionRuntimeContext(collector, getRuntimeContext)
+    function = clazz.newInstance()
     FunctionUtils.setFunctionRuntimeContext(function, getRuntimeContext)
-    FunctionUtils.openFunction(collector, parameters)
     FunctionUtils.openFunction(function, parameters)
+
+    this.cRowWrapper = new CRowWrappingCollector()
+    this.cRowWrapper.setChange(true)
   }
 
   override def processElement(
-      in: CRow,
-      ctx: ProcessFunction[CRow, CRow]#Context,
-      out: Collector[CRow])
-    : Unit = {
+      in: (Boolean, Any),
+      ctx: ProcessFunction[(Boolean, Any), CRow]#Context,
+      out: Collector[CRow]): Unit = {
+
+    // remove timestamp from stream record
+    val tc = out.asInstanceOf[TimestampedCollector[_]]
+    tc.eraseTimestamp()
 
     cRowWrapper.out = out
-    cRowWrapper.setChange(in.change)
-
-    collector.setCollector(cRowWrapper)
-    collector.setInput(in.row)
-    collector.reset()
-
-    function.processElement(
-      in.row,
-      ctx.asInstanceOf[ProcessFunction[Row, Row]#Context],
-      cRowWrapper)
+    cRowWrapper.setChange(in._1)
+    function.processElement(in._2, ctx.asInstanceOf[ProcessFunction[Any, Row]#Context], cRowWrapper)
   }
 
   override def getProducedType: TypeInformation[CRow] = returnType
 
   override def close(): Unit = {
-    FunctionUtils.closeFunction(collector)
     FunctionUtils.closeFunction(function)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TemporalProcessTimeJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TemporalProcessTimeJoin.scala
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.operators.{InternalTimer, TimestampedColle
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.Compiler
-import org.apache.flink.table.runtime.CRowWrappingCollector
+import org.apache.flink.table.runtime.conversion.CRowWrappingCollector
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.typeutils.TypeCheckUtils._
 import org.apache.flink.table.util.Logging

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TemporalRowtimeJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TemporalRowtimeJoin.scala
@@ -31,7 +31,7 @@ import org.apache.flink.streaming.api.operators._
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.Compiler
-import org.apache.flink.table.runtime.CRowWrappingCollector
+import org.apache.flink.table.runtime.conversion.CRowWrappingCollector
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.typeutils.TypeCheckUtils._
 import org.apache.flink.table.util.Logging

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/match/PatternProcessFunctionRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/match/PatternProcessFunctionRunner.scala
@@ -25,7 +25,7 @@ import org.apache.flink.cep.functions.PatternProcessFunction
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.codegen.Compiler
-import org.apache.flink.table.runtime.CRowWrappingCollector
+import org.apache.flink.table.runtime.conversion.CRowWrappingCollector
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -64,7 +64,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 
 		DataStream<Row> ds = env.fromCollection(data).returns(typeInfo);
 
-		Table in = tableEnv.fromDataStream(ds, "a,b,c");
+		Table in = tableEnv.fromAppendStream(ds, "a,b,c");
 		tableEnv.registerTable("MyTableRow", in);
 
 		String sqlQuery = "SELECT a,c FROM MyTableRow";
@@ -89,7 +89,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 		StreamITCase.clear();
 
 		DataStream<Tuple3<Integer, Long, String>> ds = JavaStreamTestData.getSmall3TupleDataSet(env);
-		Table in = tableEnv.fromDataStream(ds, "a,b,c");
+		Table in = tableEnv.fromAppendStream(ds, "a,b,c");
 		tableEnv.registerTable("MyTable", in);
 
 		String sqlQuery = "SELECT * FROM MyTable";
@@ -114,7 +114,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 		StreamITCase.clear();
 
 		DataStream<Tuple5<Integer, Long, Integer, String, Long>> ds = JavaStreamTestData.get5TupleDataStream(env);
-		tableEnv.registerDataStream("MyTable", ds, "a, b, c, d, e");
+		tableEnv.registerAppendStream("MyTable", ds, "a, b, c, d, e");
 
 		String sqlQuery = "SELECT a, b, e FROM MyTable WHERE c < 4";
 		Table result = tableEnv.sqlQuery(sqlQuery);
@@ -139,11 +139,11 @@ public class JavaSqlITCase extends AbstractTestBase {
 		StreamITCase.clear();
 
 		DataStream<Tuple3<Integer, Long, String>> ds1 = JavaStreamTestData.getSmall3TupleDataSet(env);
-		Table t1 = tableEnv.fromDataStream(ds1, "a,b,c");
+		Table t1 = tableEnv.fromAppendStream(ds1, "a,b,c");
 		tableEnv.registerTable("T1", t1);
 
 		DataStream<Tuple5<Integer, Long, Integer, String, Long>> ds2 = JavaStreamTestData.get5TupleDataStream(env);
-		tableEnv.registerDataStream("T2", ds2, "a, b, d, c, e");
+		tableEnv.registerAppendStream("T2", ds2, "a, b, d, c, e");
 
 		String sqlQuery = "SELECT * FROM T1 " +
 							"UNION ALL " +

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
@@ -36,7 +36,7 @@ class ExplainTest extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     val table = env.fromElements((1, "hello"))
-      .toTable(tEnv, 'a, 'b)
+      .toTableFromAppendStream(tEnv, 'a, 'b)
       .filter("a % 2 = 0")
 
     val result = replaceString(tEnv.explain(table))
@@ -52,8 +52,8 @@ class ExplainTest extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
-    val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
+    val table1 = env.fromElements((1, "hello")).toTableFromAppendStream(tEnv, 'count, 'word)
+    val table2 = env.fromElements((1, "hello")).toTableFromAppendStream(tEnv, 'count, 'word)
     val table = table1.unionAll(table2)
 
     val result = replaceString(tEnv.explain(table))

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -184,5 +184,4 @@ class StreamTableEnvironmentTest extends TableTestBase {
 
     (jTEnv, ds)
   }
-
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment =>
 import org.apache.flink.table.api.java.{StreamTableEnvironment => JStreamTableEnv}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{TableEnvironment, Types}
-import org.apache.flink.table.utils.TableTestUtil.{binaryNode, streamTableNode, term, unaryNode}
+import org.apache.flink.table.utils.TableTestUtil.{binaryNode, AppendTableNode, term, unaryNode}
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
 import org.mockito.Mockito.{mock, when}
@@ -45,7 +45,7 @@ class StreamTableEnvironmentTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a, b, c"),
       term("where", ">(b, 12)"))
 
@@ -58,8 +58,8 @@ class StreamTableEnvironmentTest extends TableTestBase {
 
     val expected2 = binaryNode(
       "DataStreamUnion",
-      streamTableNode(1),
-      streamTableNode(0),
+      AppendTableNode(1),
+      AppendTableNode(0),
       term("all", "true"),
       term("union all", "d, e, f"))
 
@@ -143,31 +143,31 @@ class StreamTableEnvironmentTest extends TableTestBase {
   @Test
   def testProctimeAttributeParsed(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a, b, c, d, e, pt.proctime")
+    jTEnv.fromAppendStream(ds, "a, b, c, d, e, pt.proctime")
   }
 
   @Test
   def testReplacingRowtimeAttributeParsed(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a.rowtime, b, c, d, e")
+    jTEnv.fromAppendStream(ds, "a.rowtime, b, c, d, e")
   }
 
   @Test
   def testAppedingRowtimeAttributeParsed(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a, b, c, d, e, rt.rowtime")
+    jTEnv.fromAppendStream(ds, "a, b, c, d, e, rt.rowtime")
   }
 
   @Test
   def testRowtimeAndProctimeAttributeParsed1(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a, b, c, d, e, pt.proctime, rt.rowtime")
+    jTEnv.fromAppendStream(ds, "a, b, c, d, e, pt.proctime, rt.rowtime")
   }
 
   @Test
   def testRowtimeAndProctimeAttributeParsed2(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "rt.rowtime, b, c, d, e, pt.proctime")
+    jTEnv.fromAppendStream(ds, "rt.rowtime, b, c, d, e, pt.proctime")
   }
 
   private def prepareSchemaExpressionParser:

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentValidationTest.scala
@@ -132,7 +132,7 @@ class StreamTableEnvironmentValidationTest extends TableTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    stream.toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/AggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/AggregateTest.scala
@@ -26,11 +26,11 @@ import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.AggFunctionCall
 import org.apache.flink.table.functions.AggregateFunction
-import org.apache.flink.table.utils.TableTestUtil.{streamTableNode, term, unaryNode}
+import org.apache.flink.table.utils.TableTestUtil.{AppendTableNode, term, unaryNode}
 import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
 import org.apache.flink.types.Row
 import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 class AggregateTest extends TableTestBase {
 
@@ -49,7 +49,7 @@ class AggregateTest extends TableTestBase {
           "DataStreamGroupAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "b", "a")
           ),
           term("groupBy", "b"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/CorrelateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/CorrelateTest.scala
@@ -42,7 +42,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func1($cor0.c)"),
         term("correlate", s"table(func1($$cor0.c))"),
         term("select", "a", "b", "c", "f0"),
@@ -63,7 +63,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func1($cor0.c, '$')"),
         term("correlate", s"table(func1($$cor0.c, '$$'))"),
         term("select", "a", "b", "c", "f0"),
@@ -90,7 +90,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func1($cor0.c)"),
         term("correlate", s"table(func1($$cor0.c))"),
         term("select", "a", "b", "c", "f0"),
@@ -122,12 +122,12 @@ class CorrelateTest extends TableTestBase {
 
     val expected = binaryNode(
       "DataStreamJoin",
-      streamTableNode(1),
+      AppendTableNode(1),
       unaryNode(
         "DataStreamCalc",
         unaryNode(
           "DataStreamCorrelate",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("invocation", "func1($cor0.c)"),
           term("correlate", "table(func1($cor0.c))"),
           term("select", "a", "b", "c", "f0"),
@@ -157,7 +157,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func2($cor0.c)"),
         term("correlate", s"table(func2($$cor0.c))"),
         term("select", "a", "b", "c", "f0", "f1"),
@@ -185,7 +185,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "hierarchy($cor0.c)"),
         term("correlate", s"table(hierarchy($$cor0.c))"),
         term("select", "a", "b", "c", "f0", "f1", "f2"),
@@ -213,7 +213,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "pojo($cor0.c)"),
         term("correlate", s"table(pojo($$cor0.c))"),
         term("select", "a", "b", "c", "age", "name"),
@@ -242,7 +242,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "tableFunc5($cor0.c)"),
         term("correlate", "table(tableFunc5($cor0.c))"),
         term("select", "a", "b", "c", "f0", "f1", "f2"),
@@ -275,7 +275,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func2($cor0.c)"),
         term("correlate", s"table(func2($$cor0.c))"),
         term("select", "a", "b", "c", "f0", "f1"),
@@ -304,7 +304,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func1(SUBSTRING($cor0.c, 2))"),
         term("correlate", s"table(func1(SUBSTRING($$cor0.c, 2)))"),
         term("select", "a", "b", "c", "f0"),
@@ -331,7 +331,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func1('hello', 'world', $cor0.c)"),
         term("correlate", s"table(func1('hello', 'world', $$cor0.c))"),
         term("select", "a", "b", "c", "f0"),
@@ -354,7 +354,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", "func2('hello', 'world', $cor0.c)"),
         term("correlate", s"table(func2('hello', 'world', $$cor0.c))"),
         term("select", "a", "b", "c", "f0"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/DistinctAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/DistinctAggregateTest.scala
@@ -41,7 +41,7 @@ class DistinctAggregateTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a, b, c")
         ),
         term("groupBy", "a, b, c"),
@@ -62,7 +62,7 @@ class DistinctAggregateTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a")
         ),
         term("groupBy", "a"),
@@ -83,7 +83,7 @@ class DistinctAggregateTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "c", "a", "b")
         ),
         term("groupBy", "c"),
@@ -104,7 +104,7 @@ class DistinctAggregateTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "rowtime", "a")
       ),
       term("window", TumblingGroupWindow('w$, 'rowtime, 900000.millis)),
@@ -126,7 +126,7 @@ class DistinctAggregateTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "rowtime", "a")
       ),
       term("window", SlidingGroupWindow('w$, 'rowtime, 3600000.millis, 900000.millis)),
@@ -149,7 +149,7 @@ class DistinctAggregateTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "a", "rowtime", "c")
       ),
       term("groupBy", "a"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/FromUpsertStreamTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/FromUpsertStreamTest.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.sql
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.java.typeutils.{RowTypeInfo, TupleTypeInfo}
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestUtil.{UpsertTableNode, term, unaryNode}
+import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
+import org.apache.flink.types.Row
+import org.junit.Test
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import java.lang.{Boolean => JBool}
+
+class FromUpsertStreamTest extends TableTestBase {
+
+  private val streamUtil: StreamTableTestUtil = streamTestUtil()
+
+  @Test
+  def testRemoveUpsertToRetraction() = {
+    streamUtil.addTableFromUpsert[(Boolean, (Int, String, Long))](
+      "MyTable", 'a, 'b.key, 'c, 'proctime.proctime, 'rowtime.rowtime)
+
+    val sql = "SELECT a, b, c, proctime, rowtime FROM MyTable"
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        UpsertTableNode(0),
+        term("select", "a", "b", "c", "PROCTIME(proctime) AS proctime",
+          "CAST(rowtime) AS rowtime")
+      )
+    streamUtil.verifySql(sql, expected)
+  }
+
+  @Test
+  def testMaterializeTimeIndicator() = {
+    streamUtil.addTableFromUpsert[(Boolean, (Int, String, Long))](
+      "MyTable", 'a, 'b.key, 'c, 'proctime.proctime, 'rowtime.rowtime)
+
+    val sql = "SELECT b as b1, c, proctime as proctime1, rowtime as rowtime1 FROM MyTable"
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamUpsertToRetraction",
+          unaryNode(
+            "DataStreamCalc",
+            UpsertTableNode(0),
+            term("select", "a", "b", "c", "PROCTIME(proctime) AS proctime",
+              "CAST(rowtime) AS rowtime")
+          ),
+          term("keys", "b"),
+          term("select", "a", "b", "c", "proctime", "rowtime")
+        ),
+        term("select", "b AS b1", "c", "proctime AS proctime1", "rowtime AS rowtime1"))
+    streamUtil.verifySql(sql, expected, true)
+  }
+
+  @Test
+  def testSingleRowUpsert() = {
+    streamUtil.addTableFromUpsert[(Boolean, (Int, String, Long))]("MyTable", 'a, 'b, 'c)
+    val sql = "SELECT a, b FROM MyTable"
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamUpsertToRetraction",
+          UpsertTableNode(0),
+          term("select", "a", "b", "c")
+        ),
+        term("select", "a", "b")
+      )
+    streamUtil.verifySql(sql, expected, true)
+  }
+
+  @Test
+  def testFromUpsertForJavaTableEnvironment() = {
+    val typeInfo = new RowTypeInfo(Seq(Types.INT, Types.STRING, Types.LONG): _*)
+    val tupleTypeInfo = new TupleTypeInfo(
+      BasicTypeInfo.BOOLEAN_TYPE_INFO, typeInfo).asInstanceOf[TupleTypeInfo[JTuple2[JBool, Row]]]
+    streamUtil.addJavaTableFromUpsert[Row](tupleTypeInfo, "MyTable", "a, b.key, c")
+
+    val sql = "SELECT a, b as bb FROM MyTable"
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamUpsertToRetraction",
+          UpsertTableNode(0),
+          term("keys", "b"),
+          term("select", "a", "b", "c")
+        ),
+        term("select", "a", "b AS bb")
+      )
+
+    streamUtil.verifyJavaSql(sql, expected, true)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
@@ -49,7 +49,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "rowtime", "c", "a")
           ),
           term("window", TumblingGroupWindow('w$, 'rowtime, 900000.millis)),
@@ -83,7 +83,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "proctime", "c", "a")
           ),
           term("window", SlidingGroupWindow('w$, 'proctime, 3600000.millis, 900000.millis)),
@@ -118,7 +118,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "proctime", "c", "a")
           ),
           term("window", SessionGroupWindow('w$, 'proctime, 900000.millis)),
@@ -150,7 +150,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "rowtime")
           ),
           term("window", TumblingGroupWindow('w$, 'rowtime, 900000.millis)),
@@ -186,7 +186,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "rowtime, a")
           ),
           term("window", SlidingGroupWindow('w$, 'rowtime, 60000.millis, 900000.millis)),
@@ -234,7 +234,7 @@ class GroupWindowTest extends TableTestBase {
               "DataStreamGroupWindowAggregate",
               unaryNode(
                 "DataStreamCalc",
-                streamTableNode(0),
+                AppendTableNode(0),
                 term("select", "rowtime, a")
               ),
               term("window", TumblingGroupWindow('w$, 'rowtime, 2.millis)),
@@ -278,7 +278,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "rowtime", "c",
               "*(c, c) AS $f2", "*(c, c) AS $f3", "*(c, c) AS $f4", "*(c, c) AS $f5")
           ),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
@@ -57,12 +57,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "proctime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "proctime")
           ),
           term("where",
@@ -95,12 +95,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where",
@@ -133,12 +133,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "proctime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "proctime")
           ),
           term("where",
@@ -171,12 +171,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where",
@@ -205,11 +205,11 @@ class JoinTest extends TableTestBase {
       unaryNode("DataStreamCalc",
         binaryNode("DataStreamWindowJoin",
           unaryNode("DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "proctime")
           ),
           unaryNode("DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "proctime")
           ),
           term("where", "AND(=(a, a0), =(PROCTIME(proctime), PROCTIME(proctime0)))"),
@@ -235,11 +235,11 @@ class JoinTest extends TableTestBase {
       unaryNode("DataStreamCalc",
         binaryNode("DataStreamWindowJoin",
           unaryNode("DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c")
           ),
           unaryNode("DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where", "AND(=(a, a0), =(CAST(c), CAST(c0)))"),
@@ -277,11 +277,11 @@ class JoinTest extends TableTestBase {
       unaryNode("DataStreamCalc",
         binaryNode("DataStreamWindowJoin",
           unaryNode("DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime", "null AS nullField")
           ),
           unaryNode("DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "c", "proctime", "12 AS nullField")
           ),
           term("where", "AND(=(a, a0), =(nullField, nullField0), >=(PROCTIME(proctime), " +
@@ -315,12 +315,12 @@ class JoinTest extends TableTestBase {
             "DataStreamWindowJoin",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(0),
+              AppendTableNode(0),
               term("select", "a", "b", "c")
             ),
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(1),
+              AppendTableNode(1),
               term("select", "a", "b", "c")
             ),
             term("where",
@@ -360,12 +360,12 @@ class JoinTest extends TableTestBase {
             "DataStreamWindowJoin",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(0),
+              AppendTableNode(0),
               term("select", "a", "b", "c")
             ),
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(1),
+              AppendTableNode(1),
               term("select", "a", "b", "c")
             ),
             term("where",
@@ -403,12 +403,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "proctime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "proctime")
           ),
           term("where",
@@ -441,12 +441,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where",
@@ -480,12 +480,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "proctime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "proctime")
           ),
           term("where",
@@ -518,12 +518,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where",
@@ -557,12 +557,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "proctime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "proctime")
           ),
           term("where",
@@ -595,12 +595,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where",
@@ -635,12 +635,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "b", "c")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "a", "b", "c")
           ),
           term("where",
@@ -805,12 +805,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "y", "z")
         ),
         term("where", "=(a, z)"),
@@ -838,12 +838,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b", "<(b, 2) AS $f3")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "y", "z")
         ),
         term("where", "AND(=(a, z), $f3)"),
@@ -871,10 +871,10 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
-        streamTableNode(1),
+        AppendTableNode(1),
         term("where", "AND(=(a, z), <(b, x))"),
         term("join", "a", "b", "x", "y", "z"),
         term("joinType", "LeftOuterJoin")
@@ -900,12 +900,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "y", "z")
         ),
         term("where", "=(a, z)"),
@@ -933,12 +933,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "x", "z", "<(x, 2) AS $f3")
         ),
         term("where", "AND(=(a, z), $f3)"),
@@ -966,10 +966,10 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
-        streamTableNode(1),
+        AppendTableNode(1),
         term("where", "AND(=(a, z), <(b, x))"),
         term("join", "a", "b", "x", "y", "z"),
         term("joinType", "RightOuterJoin")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/MatchRecognizeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/MatchRecognizeTest.scala
@@ -45,7 +45,7 @@ class MatchRecognizeTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamMatch",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("orderBy", "proctime ASC"),
       term("measures", "FINAL(A.a) AS aa"),
       term("rowsPerMatch", "ONE ROW PER MATCH"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
@@ -62,7 +62,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "b", "c", "proctime")
           ),
           term("partitionBy", "b"),
@@ -103,7 +103,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "c"),
@@ -143,7 +143,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "c"),
@@ -180,7 +180,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "a"),
@@ -225,7 +225,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -260,7 +260,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -304,7 +304,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "c"),
@@ -337,7 +337,7 @@ class OverWindowTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamOverAggregate",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("partitionBy", "c"),
           term("orderBy", "proctime"),
           term("rows", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
@@ -371,7 +371,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -403,7 +403,7 @@ class OverWindowTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamOverAggregate",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("orderBy", "proctime"),
           term("rows", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "b", "c", "proctime", "rowtime", "COUNT(a) AS w0$o0")
@@ -428,7 +428,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "c"),
@@ -456,7 +456,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "c"),
@@ -484,7 +484,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -511,7 +511,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -545,7 +545,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "c"),
@@ -573,7 +573,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "c"),
@@ -614,7 +614,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -641,7 +641,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -690,7 +690,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "a"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
@@ -33,7 +33,7 @@ class SetOperatorsTest extends TableTestBase {
     val resultStr = (1 to 30).mkString(", ")
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", s"IN(b, $resultStr)")
     )
@@ -51,7 +51,7 @@ class SetOperatorsTest extends TableTestBase {
     val resultStr = (1 to 30).mkString(", ")
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", s"NOT IN(b, $resultStr)")
     )
@@ -78,12 +78,12 @@ class SetOperatorsTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          streamTableNode(0),
+          AppendTableNode(0),
           unaryNode(
             "DataStreamGroupAggregate",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(1),
+              AppendTableNode(1),
               term("select", "x")
             ),
             term("groupBy", "x"),
@@ -116,7 +116,7 @@ class SetOperatorsTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          streamTableNode(0),
+          AppendTableNode(0),
           unaryNode(
             "DataStreamGroupAggregate",
             unaryNode(
@@ -125,7 +125,7 @@ class SetOperatorsTest extends TableTestBase {
                 "DataStreamGroupAggregate",
                 unaryNode(
                   "DataStreamCalc",
-                  streamTableNode(1),
+                  AppendTableNode(1),
                   term("select", "x", "y"),
                   term("where", "LIKE(y, '%Hanoi%')")
                 ),
@@ -170,12 +170,12 @@ class SetOperatorsTest extends TableTestBase {
             "DataStreamCalc",
             binaryNode(
               "DataStreamJoin",
-              streamTableNode(0),
+              AppendTableNode(0),
               unaryNode(
                 "DataStreamGroupAggregate",
                 unaryNode(
                   "DataStreamCalc",
-                  streamTableNode(1),
+                  AppendTableNode(1),
                   term("select", "x")
                 ),
                 term("groupBy", "x"),
@@ -191,7 +191,7 @@ class SetOperatorsTest extends TableTestBase {
             "DataStreamGroupAggregate",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(2),
+              AppendTableNode(2),
               term("select", "w")
             ),
             term("groupBy", "w"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SortTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SortTest.scala
@@ -39,7 +39,7 @@ class SortTest extends TableTestBase {
       unaryNode(
         "DataStreamCalc",
         unaryNode("DataStreamSort",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("orderBy", "proctime ASC", "c ASC")),
         term("select", "a", "PROCTIME(proctime) AS proctime", "c"))
 
@@ -55,7 +55,7 @@ class SortTest extends TableTestBase {
       unaryNode(
         "DataStreamCalc",
         unaryNode("DataStreamSort",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("orderBy", "rowtime ASC, c ASC")),
         term("select", "a", "rowtime", "c"))
        

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
@@ -38,12 +38,12 @@ class UnionTest extends TableTestBase {
       "DataStreamUnion",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "a")
       ),
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "CASE(>(c, 0), b, null) AS EXPR$0")
       ),
       term("all", "true"),
@@ -68,12 +68,12 @@ class UnionTest extends TableTestBase {
       "DataStreamUnion",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "a")
       ),
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "b")
       ),
       term("all", "true"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/InsertIntoValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/InsertIntoValidationTest.scala
@@ -33,7 +33,8 @@ class InsertIntoValidationTest {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e")
@@ -52,7 +53,8 @@ class InsertIntoValidationTest {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")
@@ -71,7 +73,8 @@ class InsertIntoValidationTest {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/AggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/AggregateTest.scala
@@ -43,7 +43,7 @@ class AggregateTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamGroupAggregate",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("groupBy", "b"),
           term("select", "b", "SUM(DISTINCT a) AS TMP_0", "COUNT(DISTINCT c) AS TMP_1")
         ),
@@ -67,7 +67,7 @@ class AggregateTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamGroupAggregate",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("groupBy", "c"),
           term(
             "select",
@@ -96,7 +96,7 @@ class AggregateTest extends TableTestBase {
           "DataStreamGroupAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "b")
           ),
           term("groupBy", "b"),
@@ -124,7 +124,7 @@ class AggregateTest extends TableTestBase {
           "DataStreamGroupAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "4 AS four", "b", "a")
           ),
           term("groupBy", "four", "a"),
@@ -152,7 +152,7 @@ class AggregateTest extends TableTestBase {
           "DataStreamGroupAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "4 AS four", "a", "b")
           ),
           term("groupBy", "four", "b"),
@@ -180,7 +180,7 @@ class AggregateTest extends TableTestBase {
           "DataStreamGroupAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "MOD(b, 3) AS d", "c")
           ),
           term("groupBy", "d"),
@@ -206,7 +206,7 @@ class AggregateTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "b", "a"),
           term("where", "=(b, 2)")
         ),
@@ -230,7 +230,7 @@ class AggregateTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "b", "a", "CAST(a) AS a0")
         ),
         term("groupBy", "b"),
@@ -254,7 +254,7 @@ class AggregateTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "a", "rowtime")
       ),
       term("window", TumblingGroupWindow('w, 'rowtime, 900000.millis)),
@@ -278,7 +278,7 @@ class AggregateTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "a", "rowtime")
       ),
       term("window", SlidingGroupWindow('w, 'rowtime, 3600000.millis, 900000.millis)),
@@ -303,7 +303,7 @@ class AggregateTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "a", "c", "rowtime")
       ),
       term("groupBy", "a"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/CalcTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/CalcTest.scala
@@ -48,7 +48,7 @@ class CalcTest extends TableTestBase {
         "DataStreamGroupWindowAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "c", "a", "rowtime", "UPPER(c) AS $f3")
         ),
         term("window",
@@ -78,7 +78,7 @@ class CalcTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "c", "a", "b", "rowtime", "UPPER(c) AS $f4")
           ),
           term("groupBy", "b"),
@@ -106,7 +106,7 @@ class CalcTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b"),
       term("where", "AND(AND(>(a, 0), <(b, 2)), =(MOD(a, 2), 1))")
     )
@@ -123,7 +123,7 @@ class CalcTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", s"AND(IN(b, ${(1 to 30).mkString(", ")}), =(c, 'xx'))")
     )
@@ -140,7 +140,7 @@ class CalcTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", s"OR(NOT IN(b, ${(1 to 30).mkString(", ")}), <>(c, 'xx'))")
     )

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/CorrelateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/CorrelateTest.scala
@@ -44,7 +44,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", s"${function.functionIdentifier}($$2)"),
         term("correlate", s"table(${function.getClass.getSimpleName}(c))"),
         term("select", "a", "b", "c", "s"),
@@ -65,7 +65,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", s"${function.functionIdentifier}($$2, '$$')"),
         term("correlate", s"table(${function.getClass.getSimpleName}(c, '$$'))"),
         term("select", "a", "b", "c", "s"),
@@ -91,7 +91,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", s"${function.functionIdentifier}($$2)"),
         term("correlate", s"table(${function.getClass.getSimpleName}(c))"),
         term("select", "a", "b", "c", "s"),
@@ -118,7 +118,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation",
              s"${function.functionIdentifier}(${scalarFunc.functionIdentifier}($$2))"),
         term("correlate", s"table(${function.getClass.getSimpleName}(Func13(c)))"),
@@ -144,7 +144,7 @@ class CorrelateTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCorrelate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("invocation", s"${function.functionIdentifier}($$2)"),
       term("correlate", "table(HierarchyTableFunction(c))"),
       term("select", "a", "b", "c", "name", "adult", "len"),
@@ -167,7 +167,7 @@ class CorrelateTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCorrelate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("invocation", s"${function.functionIdentifier}($$2)"),
       term("correlate", s"table(${function.getClass.getSimpleName}(c))"),
       term("select", "a", "b", "c", "age", "name"),
@@ -195,7 +195,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", s"${function.functionIdentifier}($$2)"),
         term("correlate", s"table(${function.getClass.getSimpleName}(c))"),
         term("select", "a", "b", "c", "name", "len"),
@@ -221,7 +221,7 @@ class CorrelateTest extends TableTestBase {
 
     val expected = unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation",  s"${function.functionIdentifier}(SUBSTRING($$2, 2, CHAR_LENGTH($$2)))"),
         term("correlate",
              s"table(${function.getClass.getSimpleName}(SUBSTRING(c, 2, CHAR_LENGTH(c))))"),
@@ -251,7 +251,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", s"${function.functionIdentifier}($$2)"),
         term("correlate", s"table(${function.getClass.getSimpleName}(c))"),
         term("select", "a", "b", "c", "d", "e"),
@@ -297,7 +297,7 @@ class CorrelateTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation", s"${function.functionIdentifier}($$2)"),
         term("correlate", s"table(${function.getClass.getSimpleName}(c))"),
         term("select", "a", "b", "c", "d", "e"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTest.scala
@@ -50,7 +50,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "string", "int", "proctime")
           ),
           term("groupBy", "string"),
@@ -90,7 +90,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "proctime")
       ),
       term("groupBy", "string"),
@@ -120,7 +120,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "proctime")
       ),
       term("groupBy", "string"),
@@ -145,7 +145,7 @@ class GroupWindowTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamGroupWindowAggregate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("groupBy", "string"),
       term(
         "window",
@@ -173,7 +173,7 @@ class GroupWindowTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamGroupWindowAggregate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("groupBy", "string"),
       term(
         "window",
@@ -201,7 +201,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "proctime")
       ),
       term("groupBy", "string"),
@@ -232,7 +232,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "proctime")
       ),
       term("groupBy", "string"),
@@ -263,7 +263,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "rowtime")
       ),
       term("groupBy", "string"),
@@ -287,7 +287,7 @@ class GroupWindowTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamGroupWindowAggregate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("groupBy", "string"),
       term(
         "window",
@@ -316,7 +316,7 @@ class GroupWindowTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamGroupWindowAggregate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("groupBy", "string"),
       term("window", SlidingGroupWindow(WindowReference("w"), 'rowtime, 8.milli, 10.milli)),
       term("select", "string", "myWeightedAvg(long, int) AS TMP_0")
@@ -337,7 +337,7 @@ class GroupWindowTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamGroupWindowAggregate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("groupBy", "string"),
       term("window", SessionGroupWindow(WindowReference("w"), 'long, 7.milli)),
       term("select", "string", "COUNT(int) AS TMP_0")
@@ -360,7 +360,7 @@ class GroupWindowTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamGroupWindowAggregate",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("groupBy", "string"),
       term("window", SessionGroupWindow(WindowReference("w"), 'rowtime, 7.milli)),
       term("select", "string", "myWeightedAvg(long, int) AS TMP_0")
@@ -383,7 +383,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "proctime")
       ),
       term("groupBy", "string"),
@@ -413,7 +413,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "proctime")
       ),
       term(
@@ -442,7 +442,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "rowtime")
       ),
       term("window", TumblingGroupWindow(WindowReference("w"), 'rowtime, 5.milli)),
@@ -467,7 +467,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "long")
       ),
       term(
@@ -496,7 +496,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "proctime")
       ),
       term(
@@ -526,7 +526,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "proctime")
       ),
       term(
@@ -556,7 +556,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "rowtime")
       ),
       term("window", SlidingGroupWindow(WindowReference("w"), 'rowtime, 8.milli, 10.milli)),
@@ -581,7 +581,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "long")
       ),
       term("window", SlidingGroupWindow(WindowReference("w"), 'long, 8.milli, 10.milli)),
@@ -605,7 +605,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "int", "long")
       ),
       term(
@@ -634,7 +634,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "rowtime")
       ),
       term("groupBy", "string"),
@@ -672,7 +672,7 @@ class GroupWindowTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamGroupWindowAggregate",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("groupBy", "string, int2, int3"),
           term("window", SlidingGroupWindow(WindowReference("w"), 'proctime,  2.rows, 1.rows)),
           term(
@@ -702,7 +702,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamGroupWindowAggregate",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "string", "int", "rowtime")
       ),
       term("groupBy", "string"),
@@ -731,7 +731,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamGroupWindowAggregate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("groupBy", "string"),
         term("window", SessionGroupWindow(WindowReference("w"), 'long, 3.milli)),
         term("select",
@@ -761,7 +761,7 @@ class GroupWindowTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamGroupWindowAggregate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("groupBy", "string"),
         term("window", TumblingGroupWindow(WindowReference("w"), 'long, 5.millis)),
         term("select",
@@ -800,7 +800,7 @@ class GroupWindowTest extends TableTestBase {
           "DataStreamGroupWindowAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "c", "rowtime",
               "*(c, c) AS $f2", "*(c, c) AS $f3", "*(c, c) AS $f4", "*(c, c) AS $f5")
           ),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/JoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/JoinTest.scala
@@ -49,12 +49,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lrtime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
           term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
@@ -84,12 +84,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lptime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rptime")
           ),
           term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
@@ -119,12 +119,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lptime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rptime")
           ),
           term("where", "AND(=(a, d), =(PROCTIME(lptime), PROCTIME(rptime)))"),
@@ -151,8 +151,8 @@ class JoinTest extends TableTestBase {
     val expected =
       binaryNode(
         "DataStreamWindowJoin",
-        streamTableNode(0),
-        streamTableNode(1),
+        AppendTableNode(0),
+        AppendTableNode(1),
         term("where",
           "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000)), " +
             "<(CAST(lrtime), CAST(rrtime)), >(CAST(lrtime), f))"),
@@ -182,12 +182,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lrtime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
           term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
@@ -217,12 +217,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lptime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rptime")
           ),
           term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
@@ -255,12 +255,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lrtime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
           term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
@@ -290,12 +290,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lptime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rptime")
           ),
           term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
@@ -328,12 +328,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lrtime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
           term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
@@ -363,12 +363,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lptime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rptime")
           ),
           term("where", "AND(=(a, d), >=(PROCTIME(lptime), -(PROCTIME(rptime), 1000)), " +
@@ -399,12 +399,12 @@ class JoinTest extends TableTestBase {
           "DataStreamWindowJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "lrtime")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "d", "e", "rrtime")
           ),
           term("where", "AND(=(a, d), >=(CAST(lrtime), -(CAST(rrtime), 300000))," +
@@ -433,12 +433,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "y", "z")
         ),
         term("where", "=(a, z)"),
@@ -465,12 +465,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "y", "z")
         ),
         term("where", "AND(=(a, z), <(b, 2))"),
@@ -497,10 +497,10 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
-        streamTableNode(1),
+        AppendTableNode(1),
         term("where", "AND(=(a, z), <(b, x))"),
         term("join", "a", "b", "x", "y", "z"),
         term("joinType", "LeftOuterJoin")
@@ -525,12 +525,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "y", "z")
         ),
         term("where", "=(a, z)"),
@@ -557,12 +557,12 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "x", "z")
         ),
         term("where", "AND(=(a, z), <(x, 2))"),
@@ -589,10 +589,10 @@ class JoinTest extends TableTestBase {
         "DataStreamJoin",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "a", "b")
         ),
-        streamTableNode(1),
+        AppendTableNode(1),
         term("where", "AND(=(a, z), <(b, x))"),
         term("join", "a", "b", "x", "y", "z"),
         term("joinType", "RightOuterJoin")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
@@ -52,7 +52,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "b", "c", "proctime")
           ),
           term("partitionBy", "b"),
@@ -88,7 +88,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "b", "c", "proctime")
           ),
           term("partitionBy", "b"),
@@ -117,7 +117,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "a"),
@@ -150,7 +150,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -176,7 +176,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -210,7 +210,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "c"),
@@ -252,7 +252,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("partitionBy", "c"),
@@ -282,7 +282,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -321,7 +321,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "proctime")
           ),
           term("orderBy", "proctime"),
@@ -350,7 +350,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "b", "c", "rowtime")
           ),
           term("partitionBy", "b"),
@@ -382,7 +382,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "a"),
@@ -416,7 +416,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -442,7 +442,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -477,7 +477,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "c"),
@@ -520,7 +520,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("partitionBy", "c"),
@@ -550,7 +550,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),
@@ -589,7 +589,7 @@ class OverWindowTest extends TableTestBase {
           "DataStreamOverAggregate",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("select", "a", "c", "rowtime")
           ),
           term("orderBy", "rowtime"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.stream.table
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.TableTestBase
-import org.apache.flink.table.utils.TableTestUtil.{binaryNode, streamTableNode, term, unaryNode}
+import org.apache.flink.table.utils.TableTestUtil.{binaryNode, AppendTableNode, term, unaryNode}
 import org.junit.Test
 
 class SetOperatorsTest extends TableTestBase {
@@ -45,13 +45,13 @@ class SetOperatorsTest extends TableTestBase {
             "DataStreamUnion",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(0),
+              AppendTableNode(0),
               term("select", "a", "b", "c"),
               term("where", ">(a, 0)")
             ),
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(1),
+              AppendTableNode(1),
               term("select", "a", "b", "c"),
               term("where", ">(a, 0)")
             ),
@@ -81,12 +81,12 @@ class SetOperatorsTest extends TableTestBase {
       "DataStreamUnion",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "b", "c")
       ),
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(1),
+        AppendTableNode(1),
         term("select", "b", "c")
       ),
       term("all", "true"),
@@ -109,12 +109,12 @@ class SetOperatorsTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          streamTableNode(0),
+          AppendTableNode(0),
           unaryNode(
             "DataStreamGroupAggregate",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(1),
+              AppendTableNode(1),
               term("select", "x")
             ),
             term("groupBy", "x"),
@@ -144,7 +144,7 @@ class SetOperatorsTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          streamTableNode(0),
+          AppendTableNode(0),
           unaryNode(
             "DataStreamGroupAggregate",
             unaryNode(
@@ -153,7 +153,7 @@ class SetOperatorsTest extends TableTestBase {
                 "DataStreamGroupAggregate",
                 unaryNode(
                   "DataStreamCalc",
-                  streamTableNode(1),
+                  AppendTableNode(1),
                   term("select", "x", "y"),
                   term("where", "LIKE(y, '%Hanoi%')")
                 ),
@@ -194,12 +194,12 @@ class SetOperatorsTest extends TableTestBase {
             "DataStreamCalc",
             binaryNode(
               "DataStreamJoin",
-              streamTableNode(0),
+              AppendTableNode(0),
               unaryNode(
                 "DataStreamGroupAggregate",
                 unaryNode(
                   "DataStreamCalc",
-                  streamTableNode(1),
+                  AppendTableNode(1),
                   term("select", "x")
                 ),
                 term("groupBy", "x"),
@@ -215,7 +215,7 @@ class SetOperatorsTest extends TableTestBase {
             "DataStreamGroupAggregate",
             unaryNode(
               "DataStreamCalc",
-              streamTableNode(2),
+              AppendTableNode(2),
               term("select", "w")
             ),
             term("groupBy", "w"),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
@@ -179,8 +179,8 @@ object TemporalTableJoinTest {
       "DataStreamCalc",
       binaryNode(
         "DataStreamTemporalTableJoin",
-        streamTableNode(0),
-        streamTableNode(1),
+        AppendTableNode(0),
+        AppendTableNode(1),
         term("where",
           "AND(" +
             s"${TEMPORAL_JOIN_CONDITION.getName}(o_rowtime, rowtime, currency), " +
@@ -197,10 +197,10 @@ object TemporalTableJoinTest {
       "DataStreamCalc",
       binaryNode(
         "DataStreamTemporalTableJoin",
-        streamTableNode(2),
+        AppendTableNode(2),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(3),
+          AppendTableNode(3),
           term("select", "currency, rate")),
         term("where",
           "AND(" +
@@ -222,12 +222,12 @@ object TemporalTableJoinTest {
           "DataStreamTemporalTableJoin",
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(1),
+            AppendTableNode(1),
             term("select", "o_rowtime, o_amount, o_currency, o_secondary_key")
           ),
           unaryNode(
             "DataStreamCalc",
-            streamTableNode(2),
+            AppendTableNode(2),
             term("select", "rowtime, currency, rate, secondary_key"),
             term("where", ">(rate, 110)")
           ),
@@ -248,7 +248,7 @@ object TemporalTableJoinTest {
         ),
         term("select", "*(o_amount, rate) AS rate", "secondary_key")
       ),
-      streamTableNode(0),
+      AppendTableNode(0),
       term("where", "=(t3_secondary_key, secondary_key)"),
       term("join", "rate, secondary_key, t3_comment, t3_secondary_key"),
       term("joinType", "InnerJoin")
@@ -260,10 +260,10 @@ object TemporalTableJoinTest {
       "DataStreamCalc",
       binaryNode(
         "DataStreamTemporalTableJoin",
-        streamTableNode(0),
+        AppendTableNode(0),
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(1),
+          AppendTableNode(1),
           term("select", "currency", "*(rate, 2) AS rate", "rowtime"),
           term("where", ">(rate, 100)")),
         term("where",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/FromUpsertStreamValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/FromUpsertStreamValidationTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.table.validation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{TableEnvironment, TableException}
+import org.apache.flink.table.utils.TableTestBase
+import org.junit.Test
+
+class FromUpsertStreamValidationTest extends TableTestBase {
+
+  @Test(expected = classOf[TableException])
+  def testInvalidKeyOnAppendStream(): Unit = {
+    val util = streamTestUtil()
+    // can not apply key on append stream
+    util.addTable[(Int, Long, String)]('a.key, 'b, 'c)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testInvalidToTableOnUpsertStream(): Unit = {
+    val data = List((true, (1L, 1, 1d)))
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val stream = env
+      .fromCollection(data)
+    stream.toTableFromAppendStream(tEnv, 'long, 'int, 'double)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testInvalidInputType(): Unit = {
+    val util = streamTestUtil()
+    // throw exception. Can only upsert from a datastream of type Tuple2
+    util.addTableFromUpsert[(Long, Int, String)]('long, 'int, 'string)
+  }
+}
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/InsertIntoValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/InsertIntoValidationTest.scala
@@ -33,7 +33,8 @@ class InsertIntoValidationTest {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "f")
@@ -52,7 +53,8 @@ class InsertIntoValidationTest {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
@@ -38,7 +38,7 @@ class JoinValidationTest extends TableTestBase {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
     val tenv = TableEnvironment.getTableEnvironment(env)
     val ds = env.fromElements(new WithoutEqualsHashCode) // no equals/hashCode
-    val t = tenv.fromDataStream(ds)
+    val t = tenv.fromAppendStream(ds)
 
     val left = t.select('f0 as 'l)
     val right = t.select('f0 as 'r)
@@ -209,8 +209,8 @@ class JoinValidationTest extends TableTestBase {
     val tEnv2 = TableEnvironment.getTableEnvironment(env)
     val ds1 = StreamTestData.get3TupleDataStream(env)
     val ds2 = StreamTestData.get5TupleDataStream(env)
-    val in1 = tEnv1.fromDataStream(ds1, 'a, 'b, 'c)
-    val in2 = tEnv2.fromDataStream(ds2, 'd, 'e, 'f, 'g, 'c)
+    val in1 = tEnv1.fromAppendStream(ds1, 'a, 'b, 'c)
+    val in2 = tEnv2.fromAppendStream(ds2, 'd, 'e, 'f, 'g, 'c)
 
     // Must fail. Tables are bound to different TableEnvironments.
     in1.join(in2).where('b === 'e).select('c, 'g)
@@ -223,8 +223,8 @@ class JoinValidationTest extends TableTestBase {
     val tEnv2 = TableEnvironment.getTableEnvironment(env)
     val ds1 = StreamTestData.get3TupleDataStream(env)
     val ds2 = StreamTestData.get5TupleDataStream(env)
-    val in1 = tEnv1.fromDataStream(ds1, 'a, 'b, 'c)
-    val in2 = tEnv2.fromDataStream(ds2, 'd, 'e, 'f, 'g, 'c)
+    val in1 = tEnv1.fromAppendStream(ds1, 'a, 'b, 'c)
+    val in2 = tEnv2.fromAppendStream(ds2, 'd, 'e, 'f, 'g, 'c)
     // Must fail. Tables are bound to different TableEnvironments.
     in1.join(in2).where("a === d").select("g.count")
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/SetOperatorsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/SetOperatorsValidationTest.scala
@@ -38,8 +38,10 @@ class SetOperatorsValidationTest extends TableTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'd, 'c, 'e)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'd, 'c, 'e)
 
     val unionDs = ds1.unionAll(ds2)
 
@@ -56,8 +58,10 @@ class SetOperatorsValidationTest extends TableTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
       .select('a, 'b, 'c)
 
     val unionDs = ds1.unionAll(ds2)
@@ -75,8 +79,10 @@ class SetOperatorsValidationTest extends TableTestBase {
     val tEnv1 = TableEnvironment.getTableEnvironment(env)
     val tEnv2 = TableEnvironment.getTableEnvironment(env)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv1, 'a, 'b, 'c)
-    val ds2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv2, 'a, 'b, 'c)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv1, 'a, 'b, 'c)
+    val ds2 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv2, 'a, 'b, 'c)
 
     // Must fail. Tables are bound to different TableEnvironments.
     ds1.unionAll(ds2)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
@@ -34,7 +34,8 @@ class TableSinkValidationTest extends TableTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'id, 'num, 'text)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text)
     tEnv.registerTableSink("testSink", new TestAppendSink)
 
     t.groupBy('text)
@@ -53,7 +54,7 @@ class TableSinkValidationTest extends TableTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text)
     tEnv.registerTableSink("testSink", new TestUpsertSink(Array("len", "cTrue"), false))
 
     t.select('id, 'num, 'text.charLength() as 'len, ('id > 0) as 'cTrue)
@@ -70,8 +71,10 @@ class TableSinkValidationTest extends TableTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTableSink("testSink", new TestAppendSink)
 
     ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 'h)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
@@ -31,15 +31,15 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testSort(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).orderBy('_1.desc)
+    StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv).orderBy('_1.desc)
   }
 
   @Test(expected = classOf[ValidationException])
   def testJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.join(t2)
   }
 
@@ -47,8 +47,8 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testUnion(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.union(t2)
   }
 
@@ -56,8 +56,8 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testIntersect(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.intersect(t2)
   }
 
@@ -65,8 +65,8 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testIntersectAll(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.intersectAll(t2)
   }
 
@@ -74,8 +74,8 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testMinus(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.minus(t2)
   }
 
@@ -83,8 +83,8 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testMinusAll(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.minusAll(t2)
   }
 
@@ -92,7 +92,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testOffset(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.offset(5)
   }
 
@@ -100,7 +100,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   def testFetch(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTableFromAppendStream(tEnv)
     t1.fetch(5)
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironm
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{TableConfig, TableEnvironment}
 import org.apache.flink.table.calcite.FlinkPlannerImpl
-import org.apache.flink.table.plan.nodes.datastream.{DataStreamMatch, DataStreamScan}
+import org.apache.flink.table.plan.nodes.datastream.{AppendStreamScan, DataStreamMatch}
 import org.apache.flink.types.Row
 import org.apache.flink.util.TestLogger
 import org.junit.Assert._
@@ -85,7 +85,7 @@ abstract class PatternTranslatorTestBase extends TestLogger{
     val optimized = env.optimize(converted, updatesAsRetraction = false)
 
     // throw exception if plan contains more than a match
-    if (!optimized.getInput(0).isInstanceOf[DataStreamScan]) {
+    if (!optimized.getInput(0).isInstanceOf[AppendStreamScan]) {
       fail("Expression is converted into more than a Match operation. Use a different test method.")
     }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -249,7 +249,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select",
         "+(7, a) AS EXPR$0",
         "+(b, 3) AS EXPR$1",
@@ -294,7 +294,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select",
         "+(7, a) AS EXPR$0",
         "+(b, 3) AS EXPR$1",
@@ -326,7 +326,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", ">(a, 8)")
     )
@@ -353,7 +353,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select",
         "13 AS _c0",
         "'b' AS _c1",
@@ -389,7 +389,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select",
         "13 AS _c0",
         "'b' AS _c1",
@@ -416,7 +416,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", ">(a, 8)")
     )
@@ -437,7 +437,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
     val sqlQuery = "SELECT a FROM NewTable"
 
     // 1+1 should be normalized to 2
-    val expected = unaryNode("DataStreamCalc", streamTableNode(0), term("select", "+(2, a) AS a"))
+    val expected = unaryNode("DataStreamCalc", AppendTableNode(0), term("select", "+(2, a) AS a"))
 
     util.verifySql(sqlQuery, expected)
   }
@@ -472,7 +472,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
       .where("d.isNull")
       .select('a, 'b, 'c)
 
-    val expected: String = streamTableNode(0)
+    val expected: String = AppendTableNode(0)
 
     util.verifyTable(result, expected)
   }
@@ -489,7 +489,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "a", "b", "c"),
       term("where", s"IS NULL(NonDeterministicNullFunc$$())")
     )

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/RetractionRulesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/RetractionRulesTest.scala
@@ -42,7 +42,7 @@ class RetractionRulesTest extends TableTestBase {
 
     val resultTable = table.select('word, 'number)
 
-    val expected = s"DataStreamScan(false, Acc)"
+    val expected = s"AppendStreamScan(false, Acc)"
 
     util.verifyTableTrait(resultTable, expected)
   }
@@ -63,7 +63,7 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamGroupAggregate",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           s"$defaultStatus"
         ),
         s"$defaultStatus"
@@ -92,7 +92,7 @@ class RetractionRulesTest extends TableTestBase {
           "DataStreamCalc",
           unaryNode(
             "DataStreamGroupAggregate",
-            "DataStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
             "true, AccRetract"
           ),
           "true, AccRetract"
@@ -120,7 +120,7 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamGroupWindowAggregate",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           s"$defaultStatus"
         ),
         s"$defaultStatus"
@@ -153,7 +153,7 @@ class RetractionRulesTest extends TableTestBase {
             "DataStreamCalc",
             unaryNode(
               "DataStreamGroupAggregate",
-              "DataStreamScan(true, Acc)",
+              "AppendStreamScan(true, Acc)",
               "true, AccRetract"
             ),
             "true, AccRetract"
@@ -185,7 +185,7 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         unaryNode(
           "DataStreamOverAggregate",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           s"$defaultStatus"
         ),
         s"$defaultStatus"
@@ -220,7 +220,7 @@ class RetractionRulesTest extends TableTestBase {
             "DataStreamCalc",
             unaryNode(
               "DataStreamGroupAggregate",
-              "DataStreamScan(true, Acc)",
+              "AppendStreamScan(true, Acc)",
               "true, AccRetract"
             ),
             "true, AccRetract"
@@ -257,14 +257,14 @@ class RetractionRulesTest extends TableTestBase {
             "DataStreamCalc",
             unaryNode(
               "DataStreamGroupAggregate",
-              "DataStreamScan(true, Acc)",
+              "AppendStreamScan(true, Acc)",
               "true, AccRetract"
             ),
             "true, AccRetract"
           ),
           unaryNode(
             "DataStreamCalc",
-            "DataStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
             "true, Acc"
           ),
           "true, AccRetract"
@@ -297,10 +297,10 @@ class RetractionRulesTest extends TableTestBase {
           "DataStreamJoin",
           unaryNode(
             "DataStreamGroupAggregate",
-            "DataStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
             "true, AccRetract"
           ),
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           "false, AccRetract"
         ),
         "false, AccRetract"
@@ -324,8 +324,8 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          "DataStreamScan(true, Acc)",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           "false, Acc"
         ),
         "false, Acc"
@@ -348,8 +348,8 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          "DataStreamScan(true, Acc)",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           "false, AccRetract"
         ),
         "false, AccRetract"
@@ -377,8 +377,8 @@ class RetractionRulesTest extends TableTestBase {
           "DataStreamCalc",
           binaryNode(
             "DataStreamJoin",
-            "DataStreamScan(true, Acc)",
-            "DataStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
             "true, AccRetract"
           ),
           "true, AccRetract"
@@ -403,8 +403,8 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          "DataStreamScan(true, Acc)",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           "false, AccRetract"
         ),
         "false, AccRetract"
@@ -432,8 +432,8 @@ class RetractionRulesTest extends TableTestBase {
           "DataStreamCalc",
           binaryNode(
             "DataStreamJoin",
-            "DataStreamScan(true, Acc)",
-            "DataStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
             "true, AccRetract"
           ),
           "true, AccRetract"
@@ -458,8 +458,8 @@ class RetractionRulesTest extends TableTestBase {
         "DataStreamCalc",
         binaryNode(
           "DataStreamJoin",
-          "DataStreamScan(true, Acc)",
-          "DataStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
+          "AppendStreamScan(true, Acc)",
           "false, AccRetract"
         ),
         "false, AccRetract"
@@ -487,8 +487,8 @@ class RetractionRulesTest extends TableTestBase {
           "DataStreamCalc",
           binaryNode(
             "DataStreamJoin",
-            "DataStreamScan(true, Acc)",
-            "DataStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
+            "AppendStreamScan(true, Acc)",
             "true, AccRetract"
           ),
           "true, AccRetract"

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
@@ -47,7 +47,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "FLOOR(CAST(rowtime)", "FLAG(DAY)) AS rowtime"),
       term("where", ">(long, 0)")
     )
@@ -64,7 +64,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "rowtime", "long", "int",
         "PROCTIME(proctime) AS proctime")
     )
@@ -83,7 +83,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamCalc",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("select", "rowtime"),
       term("where", ">(CAST(rowtime), 1990-12-02 12:11:11)")
     )
@@ -106,7 +106,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "long", "CAST(rowtime) AS rowtime")
         ),
         term("groupBy", "rowtime"),
@@ -133,7 +133,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "CAST(rowtime) AS rowtime", "long")
         ),
         term("groupBy", "long"),
@@ -157,7 +157,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("invocation",
           s"${func.functionIdentifier}(CAST($$0):TIMESTAMP(3) NOT NULL, PROCTIME($$3), '')"),
         term("correlate", s"table(TableFunc(CAST(rowtime), PROCTIME(proctime), ''))"),
@@ -186,7 +186,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamGroupWindowAggregate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("groupBy", "long"),
         term(
           "window",
@@ -213,12 +213,12 @@ class TimeIndicatorConversionTest extends TableTestBase {
       "DataStreamUnion",
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "rowtime")
       ),
       unaryNode(
         "DataStreamCalc",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("select", "rowtime")
       ),
       term("all", "true"),
@@ -249,7 +249,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
           "DataStreamCalc",
           unaryNode(
             "DataStreamGroupWindowAggregate",
-            streamTableNode(0),
+            AppendTableNode(0),
             term("groupBy", "long"),
             term(
               "window",
@@ -289,7 +289,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "PROCTIME(proctime) AS proctime", "long")
         ),
         term("groupBy", "proctime"),
@@ -314,7 +314,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         "DataStreamGroupAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "long", "PROCTIME(proctime) AS proctime")
         ),
         term("groupBy", "long"),
@@ -340,7 +340,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamGroupWindowAggregate",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("groupBy", "long"),
         term(
           "window",
@@ -376,7 +376,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         "DataStreamGroupWindowAggregate",
         unaryNode(
           "DataStreamCalc",
-          streamTableNode(0),
+          AppendTableNode(0),
           term("select", "long", "rowtime", "CAST(rowtime) AS rowtime0")
         ),
         term("groupBy", "long"),
@@ -536,7 +536,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val expected = unaryNode(
       "DataStreamMatch",
-      streamTableNode(0),
+      AppendTableNode(0),
       term("partitionBy", "symbol"),
       term("orderBy", "rowtime ASC"),
       term("measures",
@@ -587,7 +587,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
       "DataStreamCalc",
       unaryNode(
         "DataStreamMatch",
-        streamTableNode(0),
+        AppendTableNode(0),
         term("partitionBy", "symbol"),
         term("orderBy", "rowtime ASC"),
         term("measures",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/UpdatingPlanCheckerTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/UpdatingPlanCheckerTest.scala
@@ -29,6 +29,34 @@ import org.junit.Test
 class UpdatingPlanCheckerTest {
 
   @Test
+  def testTableFromUpsert(): Unit = {
+    val util = new UpdatePlanCheckerUtil()
+    val table = util.addTableFromUpsert[(Boolean, (String, Int))]("MyTable", 'a.key, 'b)
+    val resultTable = table.select('a, 'b)
+
+    util.verifyTableUniqueKey(resultTable, Seq("a"))
+  }
+
+  @Test
+  def testMultiKeysTableFromUpsert(): Unit = {
+    val util = new UpdatePlanCheckerUtil()
+    val table =
+      util.addTableFromUpsert[(Boolean, (String, Int, Int))]("MyTable", 'a.key, 'b.key, 'c)
+    val resultTable = table.select('a, 'b, 'c)
+
+    util.verifyTableUniqueKey(resultTable, Seq("a", "b"))
+  }
+
+  @Test
+  def testSingleRowTableFromUpsert(): Unit = {
+    val util = new UpdatePlanCheckerUtil()
+    val table = util.addTableFromUpsert[(Boolean, (String, Int))]("MyTable", 'a, 'b)
+    val resultTable = table.select('a, 'b)
+
+    util.verifyTableUniqueKey(resultTable, Nil)
+  }
+
+  @Test
   def testSelect(): Unit = {
     val util = new UpdatePlanCheckerUtil()
     val table = util.addTable[(String, Int)]('a, 'b)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/TimeAttributesITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/TimeAttributesITCase.scala
@@ -68,7 +68,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(Seq(1L, 2L, 3L, 4L, 7L, 8L, 16L))
       .assignTimestampsAndWatermarks(new AtomicTimestampWithEqualWatermark())
-    val table = stream.toTable(
+    val table = stream.toTableFromAppendStream(
       tEnv, 'rowtime.rowtime, 'proctime.proctime)
 
     val t = table
@@ -100,7 +100,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(Seq(1L, 2L, 3L, 4L, 7L, 8L, 16L))
       .assignTimestampsAndWatermarks(new AtomicTimestampWithEqualWatermark())
-    val table = stream.toTable(
+    val table = stream.toTableFromAppendStream(
       tEnv, 'l, 'rowtime.rowtime, 'proctime.proctime)
 
     val t = table
@@ -132,7 +132,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(
+    val table = stream.toTableFromAppendStream(
       tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string, 'proctime.proctime)
 
     val t = table.select('rowtime.cast(Types.STRING))
@@ -162,7 +162,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val t = table
       .filter('rowtime.cast(Types.LONG) > 4)
@@ -196,7 +197,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    stream.toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
       .filter('rowtime.cast(Types.LONG) > 4)
       .select(
         'rowtime,
@@ -223,7 +224,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(
+    val table = stream.toTableFromAppendStream(
       tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string, 'proctime.proctime)
     val func = new TableFunc
 
@@ -261,7 +262,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(
+    val table = stream.toTableFromAppendStream(
       tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string, 'proctime.proctime)
     val func = new TableFunc
 
@@ -292,7 +293,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(
+    val table = stream.toTableFromAppendStream(
       tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val t = table.unionAll(table).select('rowtime)
@@ -329,7 +330,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
     tEnv.registerTable("MyTable", table)
 
     val t = tEnv.sqlQuery("SELECT COUNT(`rowtime`) FROM MyTable " +
@@ -358,7 +360,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val t = table
       .window(Tumble over 2.millis on 'rowtime as 'w)
@@ -391,7 +394,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val window1 = tEnv.sqlQuery(
       s"""SELECT
@@ -430,7 +434,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val window = tEnv.sqlQuery(
       s"""SELECT
@@ -469,7 +474,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime1.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime1.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val window = tEnv.sqlQuery(
       s"""SELECT
@@ -508,7 +514,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
     tEnv.registerTable("T1", table)
     val querySql = "select rowtime as ts, string as msg from T1"
 
@@ -549,20 +556,21 @@ class TimeAttributesITCase extends AbstractTestBase {
       .fromElements(p1, p2)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermarkPojo)
     // use aliases, swap all attributes, and skip b2
-    val table = stream.toTable(tEnv, 'b.rowtime as 'b, 'c as 'c, 'a as 'a)
+    val table = stream.toTableFromAppendStream(tEnv, 'b.rowtime as 'b, 'c as 'c, 'a as 'a)
     // no aliases, no swapping
-    val table2 = stream.toTable(tEnv, 'a, 'b.rowtime, 'c)
+    val table2 = stream.toTableFromAppendStream(tEnv, 'a, 'b.rowtime, 'c)
     // use proctime, no skipping
-    val table3 = stream.toTable(tEnv, 'a, 'b.rowtime, 'c, 'b2, 'proctime.proctime)
+    val table3 = stream
+      .toTableFromAppendStream(tEnv, 'a, 'b.rowtime, 'c, 'b2, 'proctime.proctime)
 
     // Java expressions
 
     // use aliases, swap all attributes, and skip b2
-    val table4 = stream.toTable(
+    val table4 = stream.toTableFromAppendStream(
       tEnv,
       ExpressionParser.parseExpressionList("b.rowtime as b, c as c, a as a"): _*)
     // no aliases, no swapping
-    val table5 = stream.toTable(
+    val table5 = stream.toTableFromAppendStream(
       tEnv,
       ExpressionParser.parseExpressionList("a, b.rowtime, c"): _*)
 
@@ -644,7 +652,8 @@ class TimeAttributesITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
-    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'rowtime.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
     tEnv.registerTable("MyTable", table)
 
     val t = tEnv.sqlQuery("SELECT TUMBLE_ROWTIME(rowtime, INTERVAL '0.003' SECOND) FROM MyTable " +
@@ -679,7 +688,7 @@ class TimeAttributesITCase extends AbstractTestBase {
 
     val t = env.fromCollection(data)
       .assignAscendingTimestamps(e => e._2.toInstant.toEpochMilli)
-      .toTable(tEnv, 'symbol, 'tstamp.rowtime, 'price)
+      .toTableFromAppendStream(tEnv, 'symbol, 'tstamp.rowtime, 'price)
     tEnv.registerTable("Ticker", t)
 
     val sqlQuery =

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/FromUpsertStreamITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/FromUpsertStreamITCase.scala
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
+import org.apache.flink.types.Row
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.table.runtime.stream.sql.FromUpsertStreamITCase.{TestPojo, TimestampWithEqualWatermark}
+import org.apache.flink.table.runtime.stream.table.{RowCollector, TestUpsertSink}
+import org.junit.Assert._
+import org.junit._
+
+class FromUpsertStreamITCase extends StreamingWithStateTestBase {
+
+  /** test upsert stream registered table **/
+  @Test
+  def testRegisterUpsertStream(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    // set parallelism to 1 to ensure data input order, since it is processing time
+    env.setParallelism(1)
+    StreamITCase.clear
+
+    val ds = StreamTestData.get3TupleUpsertStream(env)
+    val t = tEnv.fromUpsertStream(ds, 'a, 'b.key, 'c)
+    tEnv.registerTable("MyTableRow", t)
+    val sqlQuery = "SELECT a, b, c FROM MyTableRow"
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    result.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("6,3,Luke Skywalker", "15,5,Comment#9", "21,6,Comment#15")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testUpsertSinkFromUpsertSource(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    // set parallelism to 1 to ensure data input order, since it is processing time
+    env.setParallelism(1)
+    StreamITCase.clear
+
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(Array("b"), false).configure(
+        Array[String]("a", "b", "c"),
+        Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING)))
+
+    val ds = StreamTestData.get3TupleUpsertStream(env)
+    val t = ds.toTableFromUpsertStream(tEnv, 'a, 'b.key, 'c)
+    tEnv.registerTable("MyTableRow", t)
+    val sqlQuery = "SELECT a, b, c FROM MyTableRow"
+    tEnv.sqlQuery(sqlQuery).insertInto("upsertSink")
+    env.execute()
+
+    val results = RowCollector.getAndClearValues
+    val upserted = RowCollector.upsertResults(results, Array(1))
+    val expected = List("6,3,Luke Skywalker", "15,5,Comment#9", "21,6,Comment#15")
+    assertEquals(expected.sorted, upserted.sorted)
+  }
+
+  /** test upsert stream registered single row table **/
+  @Test
+  def testRegisterSingleRowTableFromUpsertStream(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    env.setParallelism(1)
+    StreamITCase.clear
+
+    val sqlQuery = "SELECT a, b, c FROM MyTableRow WHERE c < 3"
+
+    val data = List(
+      (true, ("Hello", "Worlds", 1)),
+      (true, ("Hello", "Hiden", 5)),
+      (true, ("Hello again", "Worlds", 2)))
+
+    val ds = env.fromCollection(data)
+      .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())
+
+    val t = tEnv.fromUpsertStream(ds, 'a, 'b, 'c, 'proctime.proctime)
+    tEnv.registerTable("MyTableRow", t)
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    result.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("Hello again,Worlds,2")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  /** test upsert stream registered table without schema **/
+  @Test
+  def testRegisterUpsertStreamWithoutSchema(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    env.setParallelism(1)
+    StreamITCase.clear
+
+    val sqlQuery = "SELECT _1, _2, _3 FROM MyTableRow WHERE _3 < 3"
+
+    val data = List(
+      (true, ("Hello", "Worlds", 1)),
+      (true, ("Hello", "Hiden", 5)),
+      (true, ("Hello again", "Worlds", 2)))
+
+    val ds = env.fromCollection(data)
+    val t = tEnv.fromUpsertStream(ds)
+    tEnv.registerTable("MyTableRow", t)
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    result.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("Hello again,Worlds,2")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testCalcTransposeUpsertToRetract(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    env.setParallelism(1)
+    StreamITCase.clear
+
+    val ds = StreamTestData.get3TupleUpsertStream(env)
+    val t = tEnv.fromUpsertStream(ds, 'a, 'b.key, 'c)
+    tEnv.registerTable("MyTableRow", t)
+    val sqlQuery = "SELECT a, count(b) FROM (SELECT a, b, c FROM MyTableRow) GROUP BY a"
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    result.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("6,1", "15,1", "21,1")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testPojoAndUpsertSink(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    env.setParallelism(1)
+
+    val p1 = new TestPojo
+    p1.a = 12
+    p1.b = 42L
+    p1.c = "Test 1."
+
+    val p2 = new TestPojo
+    p2.a = 12
+    p2.b = 43L
+    p2.c = "Test 2."
+
+    val p3 = new TestPojo
+    p3.a = 13
+    p3.b = 44L
+    p3.c = "Test 3."
+
+    val data = List(
+      (true, p1),
+      (true, p2),
+      (true, p3)
+    )
+
+    val ds = env.fromCollection(data)
+    // use aliases, swap all attributes, and skip b2
+    val t = tEnv.fromUpsertStream(ds, 'b, 'c as 'c, 'a.key as 'a)
+    tEnv.registerTable("MyTableRow", t)
+
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(Array("a"), false).configure(
+        Array[String]("a", "b", "c"),
+        Array[TypeInformation[_]](Types.INT, Types.LONG, Types.STRING)))
+
+    val sqlQuery = "SELECT a, b, c FROM MyTableRow"
+    tEnv.sqlQuery(sqlQuery).insertInto("upsertSink")
+    env.execute()
+
+    val results = RowCollector.getAndClearValues
+    val upserted = RowCollector.upsertResults(results, Array(0))
+    val expected = List("12,43,Test 2.", "13,44,Test 3.")
+    assertEquals(expected.sorted, upserted.sorted)
+  }
+}
+
+object FromUpsertStreamITCase {
+
+  class TimestampWithEqualWatermark
+    extends AssignerWithPunctuatedWatermarks[(Boolean, (String, String, Int))] {
+
+    override def checkAndGetNextWatermark(
+        lastElement: (Boolean, (String, String, Int)),
+        extractedTimestamp: Long)
+    : Watermark = {
+      new Watermark(extractedTimestamp)
+    }
+
+    override def extractTimestamp(
+        element: (Boolean, (String, String, Int)),
+        previousElementTimestamp: Long): Long = {
+      element._2._3
+    }
+  }
+
+  class TestPojo() {
+    var a: Int = _
+    var b: Long = _
+    var b2: String = "skip me"
+    var c: String = _
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
@@ -68,9 +68,9 @@ class JoinITCase extends StreamingWithStateTestBase {
     data2.+=((1, 1L, "HiHi"))
     data2.+=((2, 2L, "HeHe"))
 
-    val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data1).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select(('a === 1)?(Null(Types.INT), 'a) as 'a, 'b, 'c, 'proctime) // test null values
-    val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t2 = env.fromCollection(data2).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select(('a === 1)?(Null(Types.INT), 'a) as 'a, 'b, 'c, 'proctime) // test null values
 
     tEnv.registerTable("T1", t1)
@@ -116,8 +116,8 @@ class JoinITCase extends StreamingWithStateTestBase {
     data1.+=((null.asInstanceOf[String], 20L, "leftNull"))
     data2.+=((null.asInstanceOf[String], 20L, "rightNull"))
 
-    val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
-    val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data1).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t2 = env.fromCollection(data2).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -168,10 +168,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -219,10 +219,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row4WatermarkExtractor)
-      .toTable(tEnv, 'id, 'tm, 'key, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'tm, 'key, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -278,10 +278,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row4WatermarkExtractor)
-      .toTable(tEnv, 'a, 'b, 'c, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row4WatermarkExtractor)
-      .toTable(tEnv, 'a, 'b, 'c, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -334,10 +334,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row4WatermarkExtractor)
-      .toTable(tEnv, 'a, 'b, 'c, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row4WatermarkExtractor)
-      .toTable(tEnv, 'a, 'b, 'c, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -390,10 +390,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -445,10 +445,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -491,9 +491,11 @@ class JoinITCase extends StreamingWithStateTestBase {
     data2.+=((1, 1L, "HiHi"))
     data2.+=((2, 2L, "HeHe"))
 
-    val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data1)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select('a, 'b, 'c, 'proctime)
-    val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t2 = env.fromCollection(data2)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select('a, 'b, 'c, 'proctime)
 
     tEnv.registerTable("T1", t1)
@@ -542,10 +544,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -599,10 +601,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -645,9 +647,11 @@ class JoinITCase extends StreamingWithStateTestBase {
     data2.+=((1, 1L, "HiHi"))
     data2.+=((2, 2L, "HeHe"))
 
-    val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data1)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select('a, 'b, 'c, 'proctime)
-    val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t2 = env.fromCollection(data2)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select('a, 'b, 'c, 'proctime)
 
     tEnv.registerTable("T1", t1)
@@ -695,10 +699,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -749,10 +753,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -795,9 +799,11 @@ class JoinITCase extends StreamingWithStateTestBase {
     data2.+=((1, 1L, "HiHi"))
     data2.+=((2, 2L, "HeHe"))
 
-    val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data1)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select('a, 'b, 'c, 'proctime)
-    val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t2 = env.fromCollection(data2)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
       .select('a, 'b, 'c, 'proctime)
 
     tEnv.registerTable("T1", t1)
@@ -846,10 +852,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -902,10 +908,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val t1 = env.fromCollection(data1)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
     val t2 = env.fromCollection(data2)
       .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
-      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+      .toTableFromAppendStream(tEnv, 'key, 'id, 'rt.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)
@@ -946,9 +952,9 @@ class JoinITCase extends StreamingWithStateTestBase {
     data2.+=((2, 2L, "HeHe"))
     data2.+=((3, 2L, "HeHe"))
 
-    val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c)
+    val t1 = env.fromCollection(data1).toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .select(('a === 3) ? (Null(Types.INT), 'a) as 'a, 'b, 'c)
-    val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c)
+    val t2 = env.fromCollection(data2).toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .select(('a === 3) ? (Null(Types.INT), 'a) as 'a, 'b, 'c)
 
     tEnv.registerTable("T1", t1)
@@ -986,8 +992,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     env.setStateBackend(getStateBackend)
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e"
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1009,8 +1017,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND b < 2"
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1032,8 +1042,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6 AND h < b"
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1055,8 +1067,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE a = d AND b = h"
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1082,8 +1096,10 @@ class JoinITCase extends StreamingWithStateTestBase {
       "SELECT Table5.c, T.`1-_./Ü` FROM (SELECT a, b, c AS `1-_./Ü` FROM Table3) AS T, Table5 " +
         "WHERE a = d AND a < 4"
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'c)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'c)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1107,8 +1123,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT COUNT(g), COUNT(b) FROM Table3, Table5 WHERE a = d"
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1130,8 +1148,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT c, g FROM Table5 LEFT OUTER JOIN Table3 ON b = e"
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1156,8 +1176,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e"
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -1183,8 +1205,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     val sqlQuery =
       "SELECT a, cnt FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt = a"
 
-    val ds1 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
-    val ds2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val ds2 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'f, 'g, 'h)
     tEnv.registerTable("A", ds1)
     tEnv.registerTable("B", ds2)
 
@@ -1208,8 +1232,10 @@ class JoinITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT c, g FROM Table3 FULL OUTER JOIN Table5 ON b = e"
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.stream.sql
 
 import java.sql.Timestamp
-import java.time.{ZoneId, ZonedDateTime}
 import java.util.TimeZone
 
 import org.apache.flink.api.common.time.Time
@@ -59,7 +58,8 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     data.+=((8, "c"))
     data.+=((9, "h"))
 
-    val t = env.fromCollection(data).toTable(tEnv,'id, 'name, 'proctime.proctime)
+    val t = env.fromCollection(data)
+      .toTableFromAppendStream(tEnv,'id, 'name, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery =
@@ -106,7 +106,8 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     data.+=((8, "c", null))
     data.+=((9, null, null))
 
-    val t = env.fromCollection(data).toTable(tEnv,'id, 'name, 'nullField, 'proctime.proctime)
+    val t = env.fromCollection(data)
+      .toTableFromAppendStream(tEnv,'id, 'name, 'nullField, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery =
@@ -157,7 +158,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     data.+=((9, "f", "key", "second_key"))
 
     val t = env.fromCollection(data)
-      .toTable(tEnv, 'id, 'name, 'key1, 'key2, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'id, 'name, 'key1, 'key2, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery =
@@ -219,7 +220,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     )
 
     val t = env.addSource(new EventTimeSourceFunction[(Int, Int, String, Int)](data))
-      .toTable(tEnv, 'secondaryOrder, 'ternaryOrder, 'name, 'id,'tstamp.rowtime)
+      .toTableFromAppendStream(tEnv,'secondaryOrder, 'ternaryOrder, 'name, 'id,'tstamp.rowtime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery =
@@ -276,7 +277,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
 
     val t = env.fromCollection(data)
       .assignAscendingTimestamps(e => e._2)
-      .toTable(tEnv, 'symbol, 'tstamp.rowtime, 'price, 'tax)
+      .toTableFromAppendStream(tEnv, 'symbol, 'tstamp.rowtime, 'price, 'tax)
     tEnv.registerTable("Ticker", t)
 
     val sqlQuery =
@@ -331,7 +332,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
 
     val tickerEvents = env.fromCollection(data)
       .assignAscendingTimestamps(tickerEvent => tickerEvent._2)
-      .toTable(tEnv, 'symbol, 'rowtime.rowtime, 'price, 'tax)
+      .toTableFromAppendStream(tEnv, 'symbol, 'rowtime.rowtime, 'price, 'tax)
 
     tEnv.registerTable("Ticker", tickerEvents)
 
@@ -386,7 +387,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     data.+=(("ACME", 8L, 25, 8))
 
     val t = env.fromCollection(data)
-      .toTable(tEnv, 'symbol, 'tstamp, 'price, 'tax, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'symbol, 'tstamp, 'price, 'tax, 'proctime.proctime)
     tEnv.registerTable("Ticker", t)
 
     val sqlQuery =
@@ -436,7 +437,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     data.+=((8, "ACME", 8L, 20))
 
     val t = env.fromCollection(data)
-      .toTable(tEnv, 'id, 'symbol, 'tstamp, 'price, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'id, 'symbol, 'tstamp, 'price, 'proctime.proctime)
     tEnv.registerTable("Ticker", t)
 
     val sqlQuery =
@@ -493,7 +494,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     data.+=(("ACME", 4L, 20, 4))
 
     val t = env.fromCollection(data)
-      .toTable(tEnv, 'symbol, 'tstamp, 'price, 'tax, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'symbol, 'tstamp, 'price, 'tax, 'proctime.proctime)
     tEnv.registerTable("Ticker", t)
 
     val sqlQuery =
@@ -659,7 +660,8 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     val data = new mutable.MutableList[(Int, String)]
     data.+=((1, "a"))
 
-    val t = env.fromCollection(data).toTable(tEnv,'id, 'name, 'proctime.proctime)
+    val t = env.fromCollection(data)
+      .toTableFromAppendStream(tEnv,'id, 'name, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery =

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/OverWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/OverWindowITCase.scala
@@ -62,7 +62,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = "SELECT a, " +
@@ -105,7 +105,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = "SELECT a, " +
@@ -147,7 +147,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     // for sum aggregation ensure that every time the order of each element is consistent
     env.setParallelism(1)
 
-    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
 
     tEnv.registerTable("T1", t1)
 
@@ -175,7 +175,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
 
     tEnv.registerTable("T1", t1)
 
@@ -210,7 +210,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     // for sum aggregation ensure that every time the order of each element is consistent
     env.setParallelism(1)
 
-    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
 
     tEnv.registerTable("T1", t1)
 
@@ -237,7 +237,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val t1 = env.fromCollection(data).toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
 
     tEnv.registerTable("T1", t1)
 
@@ -295,7 +295,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource[(Long, Int, String)](new EventTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerFunction("LTCNT", new LargerThanCount)
@@ -360,7 +360,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource[(Long, Int, String)](new EventTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerFunction("LTCNT", new LargerThanCount)
@@ -431,7 +431,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource[(Long, Int, String)](new EventTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
 
@@ -494,7 +494,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource[(Long, Int, String)](new EventTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
 
@@ -563,7 +563,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource(new EventTimeSourceFunction[(Int, Long, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerFunction("LTCNT", new LargerThanCount)
@@ -632,7 +632,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       Right(14000030L))
 
     val t1 = env.addSource(new EventTimeSourceFunction[(Int, Long, String)](data))
-             .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+             .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
     tEnv.registerFunction("LTCNT", new LargerThanCount)
@@ -695,7 +695,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource(new EventTimeSourceFunction[(Int, Long, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
 
@@ -756,7 +756,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val t1 = env
       .addSource(new EventTimeSourceFunction[(Int, Long, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
 
@@ -828,7 +828,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     )
 
     val t1 = env.addSource(new EventTimeSourceFunction[(Int, Long, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
 
@@ -865,7 +865,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = "SELECT a, " +
@@ -910,7 +910,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
     tEnv.registerTable("MyTable", t)
     tEnv.registerFunction("myCount", new MultiArgCount)
 
@@ -975,7 +975,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val table = env.fromCollection(data)
       .assignAscendingTimestamps(_._1)
-      .toTable(tEnv, 'a, 'b, 'c, 'rtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rtime.rowtime)
 
     tEnv.registerTable("MyTable", table)
     tEnv.registerFunction("CntNullNonNull", new CountNullNonNull)
@@ -1027,7 +1027,8 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     env.setParallelism(1)
     StreamITCase.clear
 
-    val table = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'proctime.proctime)
+    val table = env.fromCollection(data)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'proctime.proctime)
     tEnv.registerTable("MyTable", table)
     tEnv.registerFunction("PairCount", new CountPairs)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
@@ -58,10 +58,10 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("tableA",
-      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(dataA).toTableFromAppendStream(tEnv).as('a, 'b, 'c))
 
     tEnv.registerTable("tableB",
-      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+      env.fromCollection(dataB).toTableFromAppendStream(tEnv).as('x, 'y))
 
     val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink)
@@ -107,13 +107,13 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("tableA",
-      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(dataA).toTableFromAppendStream(tEnv).as('a, 'b, 'c))
 
     tEnv.registerTable("tableB",
-      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+      env.fromCollection(dataB).toTableFromAppendStream(tEnv).as('x, 'y))
 
     tEnv.registerTable("tableC",
-      env.fromCollection(dataC).toTable(tEnv).as('w, 'z))
+      env.fromCollection(dataC).toTableFromAppendStream(tEnv).as('w, 'z))
 
     val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink)
@@ -152,10 +152,10 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("tableA",
-      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(dataA).toTableFromAppendStream(tEnv).as('a, 'b, 'c))
 
     tEnv.registerTable("tableB",
-      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+      env.fromCollection(dataB).toTableFromAppendStream(tEnv).as('x, 'y))
 
     val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala
@@ -82,7 +82,7 @@ class SortITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val t1 = env.addSource(new EventTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
       
     tEnv.registerTable("T1", t1)
 
@@ -117,7 +117,7 @@ class SortITCase extends StreamingWithStateTestBase {
 
     val t = StreamTestData.getSmall3TupleDataStream(env)
       .assignAscendingTimestamps(x => x._2)
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f", "t")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -75,7 +75,7 @@ class SqlITCase extends StreamingWithStateTestBase {
         new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
 
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    val table = stream.toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+    val table = stream.toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
     tEnv.registerTable("MyTable", table)
     tEnv.registerFunction("myCount", new MultiArgCount)
 
@@ -111,7 +111,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env).assignAscendingTimestamps(x => x._2)
-      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e, 'rowtime.rowtime)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = "SELECT a, " +
@@ -149,7 +149,7 @@ class SqlITCase extends StreamingWithStateTestBase {
                  .fromCollection(data)
                  .assignTimestampsAndWatermarks(
                    new TimestampAndWatermarkWithOffset[(Long, String, String)](0L))
-    val table = stream.toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+    val table = stream.toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", table)
 
@@ -175,7 +175,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     env.setParallelism(1)
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'a, 'b, 'c)
+    val table = stream.toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
     tEnv.registerTable("T1", table)
 
@@ -211,7 +211,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     
     val ds = env.fromCollection(data)
     
-    val t = ds.toTable(tEnv).as('a, 'b, 'c)
+    val t = ds.toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTableRow", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -232,7 +232,8 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT b, COUNT(a) FROM MyTable GROUP BY b"
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
@@ -258,7 +259,8 @@ class SqlITCase extends StreamingWithStateTestBase {
       "FROM MyTable " +
       "GROUP BY b"
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
@@ -288,7 +290,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     data.+=((4, 1L, "Hi World"))
     data.+=((4, 1L, "Test"))
 
-    val t = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+    val t = env.fromCollection(data).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     // "1,1,3", "2,1,2", "3,1,1", "4,1,2"
@@ -316,7 +318,8 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT b, COLLECT(a) FROM MyTable GROUP BY b"
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
@@ -352,7 +355,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("MyTable",
-      env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(data).toTableFromAppendStream(tEnv).as('a, 'b, 'c))
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     result.addSink(new StreamITCase.RetractingSink).setParallelism(1)
@@ -375,7 +378,8 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT * FROM MyTable"
 
-    val t = StreamTestData.getSmallNestedTupleDataStream(env).toTable(tEnv).as('a, 'b)
+    val t = StreamTestData.getSmallNestedTupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -396,7 +400,8 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT a * 2, b - 1 FROM MyTable"
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -417,7 +422,8 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT a * 2, b - 1 FROM MyTable"
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -438,7 +444,8 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT * FROM MyTable WHERE a = 3"
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -481,9 +488,11 @@ class SqlITCase extends StreamingWithStateTestBase {
       "UNION ALL " +
       "SELECT * FROM T2"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T2", t2)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -508,9 +517,11 @@ class SqlITCase extends StreamingWithStateTestBase {
       "UNION ALL " +
       "SELECT * FROM T2 WHERE a = 2"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T2", t2)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -534,7 +545,8 @@ class SqlITCase extends StreamingWithStateTestBase {
       "UNION ALL " +
       "SELECT c FROM T2 WHERE a = 2"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
     val t2 = StreamTestData.get3TupleDataStream(env)
     tEnv.registerAppendStream("T2", t2, 'a, 'b, 'c)
@@ -646,7 +658,8 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, 2, (13, "41.6")),
       (4, 3, (14, "45.2136")),
       (5, 3, (18, "42.6")))
-    tEnv.registerTable("t1", env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c))
+    tEnv.registerTable("t1", env.fromCollection(data)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c))
 
     val t2 = tEnv.sqlQuery("SELECT b, COLLECT(c) as `set` FROM t1 GROUP BY b")
     tEnv.registerTable("t2", t2)
@@ -682,7 +695,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t1 = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = env.fromCollection(data).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("t1", t1)
 
     val t2 = tEnv.sqlQuery("SELECT a, COLLECT(b) as `set` FROM t1 GROUP BY a")
@@ -738,7 +751,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     )
 
     val t1 = env.addSource(new EventTimeSourceFunction[(Int, Long, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     tEnv.registerTable("T1", t1)
 
@@ -773,7 +786,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val t = StreamTestData.getSmall3TupleDataStream(env)
       .assignAscendingTimestamps(x => x._2)
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
     tEnv.registerTable("sourceTable", t)
 
     tEnv.registerTableSource("targetTable",
@@ -804,7 +817,8 @@ class SqlITCase extends StreamingWithStateTestBase {
     val parameters = "c," + (0 until 300).map(_ => "a").mkString(",")
     val sqlQuery = s"SELECT func15($parameters) FROM T1"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -830,7 +844,8 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = s"SELECT T1.a, T2.x FROM T1 " +
       s"JOIN LATERAL TABLE(udtf($parameters)) as T2(x) ON TRUE"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -851,7 +866,8 @@ class SqlITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.getSingletonDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSingletonDataStream(env)
+      .toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = new StringBuilder

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -207,7 +207,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     implicit val tpe: TypeInformation[Row] = new RowTypeInfo(
       BasicTypeInfo.STRING_TYPE_INFO,
       BasicTypeInfo.STRING_TYPE_INFO,
-      BasicTypeInfo.INT_TYPE_INFO) // tpe is automatically 
+      BasicTypeInfo.INT_TYPE_INFO) // tpe is automatically
     
     val ds = env.fromCollection(data)
     
@@ -221,7 +221,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val expected = List("Hello,Worlds,1","Hello again,Worlds,2")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
-    
+
   /** test unbounded groupBy (without window) **/
   @Test
   def testUnboundedGroupBy(): Unit = {
@@ -460,7 +460,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = "SELECT * FROM MyTable WHERE _1 = 3"
 
     val t = StreamTestData.getSmall3TupleDataStream(env)
-    tEnv.registerDataStream("MyTable", t)
+    tEnv.registerAppendStream("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])
@@ -537,7 +537,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
     val t2 = StreamTestData.get3TupleDataStream(env)
-    tEnv.registerDataStream("T2", t2, 'a, 'b, 'c)
+    tEnv.registerAppendStream("T2", t2, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])
@@ -559,7 +559,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, Array(18, 42), Array(Array(1), Array(45)))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'a, 'b, 'c)
+    tEnv.registerAppendStream("T", stream, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT a, b, s FROM T, UNNEST(T.b) AS A (s)"
 
@@ -590,7 +590,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, Array(18, 42), Array(Array(1), Array(45)))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'a, 'b, 'c)
+    tEnv.registerAppendStream("T", stream, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) AS A (s)"
 
@@ -619,7 +619,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, Array((18, "42.6")))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'a, 'b)
+    tEnv.registerAppendStream("T", stream, 'a, 'b)
 
     val sqlQuery = "SELECT a, b, s, t FROM T, UNNEST(T.b) AS A (s, t) WHERE s > 13"
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
@@ -76,10 +76,10 @@ class TemporalJoinITCase extends StreamingWithStateTestBase {
 
     val orders = env
       .fromCollection(ordersData)
-      .toTable(tEnv, 'amount, 'currency, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'amount, 'currency, 'proctime.proctime)
     val ratesHistory = env
       .fromCollection(ratesHistoryData)
-      .toTable(tEnv, 'currency, 'rate, 'proctime.proctime)
+      .toTableFromAppendStream(tEnv, 'currency, 'rate, 'proctime.proctime)
 
     tEnv.registerTable("Orders", orders)
     tEnv.registerTable("RatesHistory", ratesHistory)
@@ -132,11 +132,11 @@ class TemporalJoinITCase extends StreamingWithStateTestBase {
     val orders = env
       .fromCollection(ordersData)
       .assignTimestampsAndWatermarks(new TimestampExtractor[Long, String]())
-      .toTable(tEnv, 'amount, 'currency, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'amount, 'currency, 'rowtime.rowtime)
     val ratesHistory = env
       .fromCollection(ratesHistoryData)
       .assignTimestampsAndWatermarks(new TimestampExtractor[String, Long]())
-      .toTable(tEnv, 'currency, 'rate, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'currency, 'rate, 'rowtime.rowtime)
 
     tEnv.registerTable("Orders", orders)
     tEnv.registerTable("RatesHistory", ratesHistory)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -49,7 +49,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val testAgg = new DataViewTestAgg
-    val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val t = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e)
       .select('e, testAgg.distinct('d, 'e))
 
@@ -69,7 +70,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
 
     val testAgg = new WeightedAvg
-    val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val t = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e)
       .select('e, testAgg.distinct('a, 'a), testAgg('a, 'a))
 
@@ -102,7 +104,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
     data.+=((3, 2, "B"))
 
     val testAgg = new WeightedAvg
-    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    val t = env.fromCollection(data).toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .groupBy('c)
       .select('c, 'a.count.distinct, 'a.sum.distinct,
               testAgg.distinct('a, 'b), testAgg.distinct('b, 'a), testAgg('a, 'b))
@@ -122,7 +124,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val t = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e)
       .select('e, 'a.count.distinct, 'b.count)
 
@@ -141,7 +144,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .select('b, Null(Types.LONG)).distinct()
 
     val results = t.toRetractStream[Row](queryConfig)
@@ -159,7 +163,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val t = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e).select('e, 'a.count).distinct()
 
     val results = t.toRetractStream[Row](queryConfig)
@@ -177,8 +182,9 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-            .select('a.sum, 'b.sum)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+      .select('a.sum, 'b.sum)
 
     val results = t.toRetractStream[Row](queryConfig)
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
@@ -195,7 +201,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .groupBy('b)
       .select('b, 'a.sum)
 
@@ -214,7 +221,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .groupBy('b)
       .select('a.count as 'cnt, 'b)
       .groupBy('cnt)
@@ -235,7 +243,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val t = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e, 'b % 3)
       .select('c.min, 'e, 'a.avg, 'd.count)
 
@@ -257,7 +266,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .groupBy('b)
       .select('b, 'a.collect)
 
@@ -294,7 +304,8 @@ class AggregateITCase extends StreamingWithStateTestBase {
 
     val distinct = new CountDistinct
     val testAgg = new DataViewTestAgg
-    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    val t = env.fromCollection(data)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .groupBy('b)
       .select('b, distinct('c), testAgg('c, 'b))
 
@@ -328,9 +339,10 @@ class AggregateITCase extends StreamingWithStateTestBase {
       new TestUpsertSink(Array("c"), false).configure(
         Array[String]("c", "bMax"), Array[TypeInformation[_]](Types.STRING, Types.LONG)))
 
-    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
-            .groupBy('c)
-            .select('c, 'b.max)
+    val t = env.fromCollection(data)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+      .groupBy('c)
+      .select('c, 'b.max)
 
     t.insertInto("testSink")
     env.execute()

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
@@ -40,7 +40,8 @@ class CalcITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).select('_1, '_2, '_3)
+    val ds = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).select('_1, '_2, '_3)
 
     val results = ds.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
@@ -59,7 +60,8 @@ class CalcITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmallNestedTupleDataStream(env).toTable(tEnv).select('*)
+    val ds = StreamTestData.getSmallNestedTupleDataStream(env)
+      .toTableFromAppendStream(tEnv).select('*)
 
     val results = ds.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
@@ -75,7 +77,8 @@ class CalcITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).select('_1)
+    val ds = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv).select('_1)
 
     val results = ds.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
@@ -92,7 +95,8 @@ class CalcITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv)
+    val ds = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv)
       .select('_1 as 'a, '_2 as 'b, '_1 as 'c)
       .select('a, 'b)
 
@@ -113,7 +117,8 @@ class CalcITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .select('a, 'b, 'c)
 
     val results = ds.toAppendStream[Row]
@@ -136,7 +141,8 @@ class CalcITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter('a === 3)
     val results = filterDs.toAppendStream[Row]
@@ -156,7 +162,8 @@ class CalcITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter( Literal(false) )
     val results = filterDs.toAppendStream[Row]
@@ -175,7 +182,8 @@ class CalcITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter( Literal(true) )
     val results = filterDs.toAppendStream[Row]
@@ -198,7 +206,8 @@ class CalcITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter( 'a % 2 === 0 )
       .where("b = 3 || b = 4 || b = 5")
@@ -221,7 +230,8 @@ class CalcITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter( 'a % 2 !== 0)
       .where("b != 1 && b != 2 && b != 3")
@@ -245,7 +255,7 @@ class CalcITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val result = StreamTestData.get3TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .where("RichFunc2(c)='ABC#Hello'")
       .select('c)
 
@@ -268,7 +278,7 @@ class CalcITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val result = StreamTestData.get3TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .where("RichFunc2(c)='Abc#Hello' || RichFunc1(a)=3 && b=2")
       .select('c)
 
@@ -293,7 +303,7 @@ class CalcITCase extends AbstractTestBase {
     testData.+=((3, 2L, "Anna#44"))
     testData.+=((4, 3L, "nosharp"))
 
-    val t = env.fromCollection(testData).toTable(tEnv).as('a, 'b, 'c)
+    val t = env.fromCollection(testData).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new Func13("default")
     val func1 = new Func13("Sunny")
     val func2 = new Func13("kevin2")
@@ -319,7 +329,7 @@ class CalcITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.get3TupleDataStream(env)
-      .toTable(tEnv)
+      .toTableFromAppendStream(tEnv)
       .select(map('_1, '_3))
 
     val results = ds.toAppendStream[Row]

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -45,7 +45,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testCrossJoin(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
     val pojoFunc0 = new PojoTableFunc()
 
@@ -66,7 +66,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testLeftOuterJoinWithoutPredicates(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
     val result = t
@@ -88,7 +88,7 @@ class CorrelateITCase extends AbstractTestBase {
     */
   @Test (expected = classOf[ValidationException])
   def testLeftOuterJoinWithPredicates(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
     val result = t
@@ -106,7 +106,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testUserDefinedTableFunctionWithScalarFunction(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
     val result = t
@@ -130,7 +130,7 @@ class CorrelateITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val result = StreamTestData.getSmall3TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .join(tableFunc1('c) as 's)
       .select('a, 's)
 
@@ -154,7 +154,7 @@ class CorrelateITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val result = StreamTestData.getSmall3TupleDataStream(env)
-      .toTable(tEnv, 'a, 'b, 'c)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .join(tableFunc1(richFunc2('c)) as 's)
       .select('a, 's)
 
@@ -174,7 +174,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testTableFunctionConstructorWithParams(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val config = Map("key1" -> "value1", "key2" -> "value2")
     val func30 = new TableFunc3(null)
     val func31 = new TableFunc3("OneConf_")
@@ -209,7 +209,7 @@ class CorrelateITCase extends AbstractTestBase {
     tEnv.registerFunction("VarArgsFunc0", varArgsFunc0)
 
     val result = testData(env)
-      .toTable(tEnv, 'a, 'b, 'c)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .select('c)
       .join(varArgsFunc0("1", "2", 'c))
 
@@ -241,7 +241,7 @@ class CorrelateITCase extends AbstractTestBase {
     )
 
     val rowType = Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
-    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as('a, 'b, 'c)
+    val in = env.fromElements(row, row)(rowType).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
 
     val tableFunc5 = new TableFunc5()
     val result = in
@@ -259,7 +259,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testTableFunctionCollectorOpenClose(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
     val func20 = new Func20
 
@@ -286,7 +286,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testTableFunctionCollectorInit(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTableFromAppendStream(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
     // this case will generate 'timestamp' member field and 'DateFormatter'

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
@@ -72,7 +72,7 @@ class GroupWindowITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'proctime.proctime)
+    val table = stream.toTableFromAppendStream(tEnv, 'long, 'int, 'string, 'proctime.proctime)
 
     val countFun = new CountAggFunction
     val weightAvgFun = new WeightedAvg
@@ -120,7 +120,7 @@ class GroupWindowITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(sessionWindowTestdata)
       .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
+    val table = stream.toTableFromAppendStream(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
 
     val windowedTable = table
       .window(Session withGap 5.milli on 'rowtime as 'w)
@@ -145,7 +145,7 @@ class GroupWindowITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'proctime.proctime)
+    val table = stream.toTableFromAppendStream(tEnv, 'long, 'int, 'string, 'proctime.proctime)
     val countFun = new CountAggFunction
     val weightAvgFun = new WeightedAvg
     val countDistinct = new CountDistinct
@@ -176,7 +176,7 @@ class GroupWindowITCase extends AbstractTestBase {
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](0L))
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
+    val table = stream.toTableFromAppendStream(tEnv, 'long, 'int, 'string, 'rowtime.rowtime)
     val countFun = new CountAggFunction
     val weightAvgFun = new WeightedAvg
     val countDistinct = new CountDistinct
@@ -215,7 +215,8 @@ class GroupWindowITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'long, 'int, 'string, 'int2, 'int3, 'proctime.proctime)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'long, 'int, 'string, 'int2, 'int3, 'proctime.proctime)
 
     val weightAvgFun = new WeightedAvg
     val countDistinct = new CountDistinct
@@ -249,7 +250,8 @@ class GroupWindowITCase extends AbstractTestBase {
       .fromCollection(data2)
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
-    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val windowedTable = table
       .window(Slide over 5.milli every 2.milli on 'long as 'w)
@@ -288,7 +290,8 @@ class GroupWindowITCase extends AbstractTestBase {
       .fromCollection(data2)
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
-    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream
+      .toTableFromAppendStream(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val windowedTable = table
       .window(Slide over 10.milli every 5.milli on 'long as 'w)
@@ -328,7 +331,8 @@ class GroupWindowITCase extends AbstractTestBase {
       .fromCollection(data2)
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
-    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream.
+      toTableFromAppendStream(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val windowedTable = table
       .window(Slide over 5.milli every 4.milli on 'long as 'w)
@@ -365,7 +369,8 @@ class GroupWindowITCase extends AbstractTestBase {
       .fromCollection(data2)
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
-    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream.
+      toTableFromAppendStream(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val windowedTable = table
       .window(Slide over 5.milli every 10.milli on 'long as 'w)
@@ -396,7 +401,8 @@ class GroupWindowITCase extends AbstractTestBase {
       .fromCollection(data2)
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
-    val table = stream.toTable(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
+    val table = stream.
+      toTableFromAppendStream(tEnv, 'long.rowtime, 'int, 'double, 'float, 'bigdec, 'string)
 
     val windowedTable = table
       .window(Slide over 3.milli every 10.milli on 'long as 'w)
@@ -426,7 +432,7 @@ class GroupWindowITCase extends AbstractTestBase {
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, Double, Float, BigDecimal, String)](0L))
       .map(t => (t._2, t._6))
-    val table = stream.toTable(tEnv, 'int, 'string, 'rowtime.rowtime)
+    val table = stream.toTableFromAppendStream(tEnv, 'int, 'string, 'rowtime.rowtime)
 
     val windowedTable = table
       .window(Slide over 3.milli every 10.milli on 'rowtime as 'w)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
@@ -76,8 +76,8 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val leftTable = env.fromCollection(data1).toTable(tEnv, 'a, 'b)
-    val rightTable = env.fromCollection(data2).toTable(tEnv, 'bb, 'c)
+    val leftTable = env.fromCollection(data1).toTableFromAppendStream(tEnv, 'a, 'b)
+    val rightTable = env.fromCollection(data2).toTableFromAppendStream(tEnv, 'bb, 'c)
 
     tEnv.registerTableSink(
       "upsertSink",
@@ -140,8 +140,8 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val leftTable = env.fromCollection(data1).toTable(tEnv, 'a, 'b)
-    val rightTable = env.fromCollection(data2).toTable(tEnv, 'bb, 'c, 'd)
+    val leftTable = env.fromCollection(data1).toTableFromAppendStream(tEnv, 'a, 'b)
+    val rightTable = env.fromCollection(data2).toTableFromAppendStream(tEnv, 'bb, 'c, 'd)
 
     tEnv.registerTableSink(
       "retractSink",
@@ -192,8 +192,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     val stream2 = env
       .fromCollection(data2)
 
-    val table1 = stream1.toTable(tEnv, 'long_l, 'int_l, 'string_l, 'proctime_l.proctime)
-    val table2 = stream2.toTable(tEnv, 'long_r, 'int_r, 'string_r)
+    val table1 = stream1
+      .toTableFromAppendStream(tEnv, 'long_l, 'int_l, 'string_l, 'proctime_l.proctime)
+    val table2 = stream2
+      .toTableFromAppendStream(tEnv, 'long_r, 'int_r, 'string_r)
     val countFun = new CountAggFunction
     val weightAvgFun = new WeightedAvg
     val countDistinct = new CountDistinct
@@ -223,8 +225,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val testOpenCall = new Func20
 
@@ -247,8 +251,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).where('b === 'e && 'b < 2).select('c, 'g)
 
@@ -266,8 +272,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).where('b === 'e && 'a < 6).select('c, 'g)
 
@@ -287,8 +295,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).where('b === 'e && 'a < 6 && 'h < 'b).select('c, 'g)
 
@@ -307,8 +317,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).filter('a === 'd && 'b === 'h).select('c, 'g)
 
@@ -330,8 +342,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).where('a === 'd).select('g.count)
 
@@ -351,8 +365,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2)
       .where('a === 'd)
@@ -374,9 +390,12 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
-    val ds3 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'j, 'k, 'l)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds3 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'j, 'k, 'l)
 
     val joinT = ds1.join(ds2)
       .where(Literal(true))
@@ -399,8 +418,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).filter('a === 'd && ('b === 'e || 'b === 'e - 10)).select('c, 'g)
 
@@ -419,8 +440,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).filter('b === 'h + 1 && 'a - 1 === 'd + 2).select('c, 'g)
 
@@ -440,9 +463,11 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
       .select(('a === 21) ? (Null(Types.INT), 'a) as 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
       .select(('e === 15) ? (Null(Types.INT), 'd) as 'd,  'e, 'f, 'g, 'h)
 
     val joinT = ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 'h).select('c, 'g)
@@ -468,8 +493,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.leftOuterJoin(ds2, 'a === 'd && 'b <= 'h).select('c, 'g)
 
@@ -494,8 +521,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 2).select('c, 'g)
 
@@ -519,8 +548,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
-    val ds2 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds1 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds2 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
     val leftT = ds1.groupBy('e).select('e, 'd.count as 'd)
     val rightT = ds2.groupBy('b).select('b, 'a.count as 'a)
 
@@ -541,8 +572,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.rightOuterJoin(ds2, 'a === 'd && 'b === 'h).select('c, 'g)
 
@@ -564,8 +597,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds2 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds1 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds2 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds1 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.rightOuterJoin(ds2, 'a === 'd && 'b <= 'h).select('c, 'g)
 
@@ -589,8 +624,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds2 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds1 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds2 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds1 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.rightOuterJoin(ds2, 'a === 'd && 'b === 2).select('c, 'g)
 
@@ -614,8 +651,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.fullOuterJoin(ds2, 'a === 'd && 'b === 'h).select('c, 'g)
 
@@ -642,8 +681,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.fullOuterJoin(ds2, 'a === 'd && 'b <= 'h).select('c, 'g)
 
@@ -672,8 +713,10 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
-    val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.get3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.fullOuterJoin(ds2, 'a === 'd && 'b >= 2 && 'h === 1).select('c, 'g)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
@@ -61,7 +61,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     StreamITCase.testResults = mutable.MutableList()
     StreamITCase.clear
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val table = stream.toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
     val countFun = new CountAggFunction
     val weightAvgFun = new WeightedAvg
     val countDist = new CountDistinct
@@ -107,7 +107,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     StreamITCase.testResults = mutable.MutableList()
     StreamITCase.clear
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+    val table = stream.toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'proctime.proctime)
     val weightAvgFun = new WeightedAvg
 
     val windowedTable = table
@@ -154,7 +154,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     )
     val table = env
       .addSource(new RowTimeSourceFunction[(Int, Long, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
     val countFun = new CountAggFunction
     val weightAvgFun = new WeightedAvg
     val plusOne = new JavaFunc0
@@ -229,7 +229,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val countDist = new CountDistinctWithRetractAndReset
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+    val table = stream.toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
 
     val windowedTable = table
       .window(Over partitionBy 'a orderBy 'proctime preceding 4.rows following CURRENT_ROW as 'w)
@@ -292,7 +292,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val countDist = new CountDistinctWithRetractAndReset
     val table = env.addSource[(Long, Int, String)](
       new RowTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     val windowedTable = table
       .window(Over partitionBy 'c orderBy 'rowtime preceding 2.rows following CURRENT_ROW as 'w)
@@ -356,7 +356,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val countDist = new CountDistinctWithRetractAndReset
     val table = env.addSource[(Long, Int, String)](
       new RowTimeSourceFunction[(Long, Int, String)](data))
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
 
     val windowedTable = table
       .window(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/RetractionITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/RetractionITCase.scala
@@ -55,7 +55,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
     env.setStateBackend(getStateBackend)
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'word, 'num)
+    val table = stream.toTableFromAppendStream(tEnv, 'word, 'num)
     val resultTable = table
       .groupBy('word)
       .select('num.sum as 'count)
@@ -79,7 +79,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
     env.setStateBackend(getStateBackend)
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'word, 'num)
+    val table = stream.toTableFromAppendStream(tEnv, 'word, 'num)
     val resultTable = table
       .groupBy('word)
       .select('word as 'word, 'num.sum as 'cnt)
@@ -104,7 +104,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
     env.setStateBackend(getStateBackend)
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'word, 'num)
+    val table = stream.toTableFromAppendStream(tEnv, 'word, 'num)
     val resultTable = table
       .select('num.sum as 'count)
       .groupBy('count)
@@ -145,7 +145,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
     env.setParallelism(1)
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'pk, 'value)
+    val table = stream.toTableFromAppendStream(tEnv, 'pk, 'value)
     val resultTable = table
       .groupBy('pk)
       .select('pk as 'pk, 'value.sum as 'sum)
@@ -173,7 +173,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
     val func0 = new TableFunc0
 
     val stream = env.fromCollection(data)
-    val table = stream.toTable(tEnv, 'word, 'num)
+    val table = stream.toTableFromAppendStream(tEnv, 'word, 'num)
     val resultTable = table
       .groupBy('word)
       .select('word as 'word, 'num.sum as 'cnt)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
@@ -39,8 +39,10 @@ class SetOperatorsITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f)
 
     val unionDs = ds1.unionAll(ds2).select('c)
 
@@ -59,8 +61,10 @@ class SetOperatorsITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'd, 'c, 'e)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'd, 'c, 'e)
 
     val unionDs = ds1.unionAll(ds2.select('a, 'b, 'c)).filter('b < 2).select('c)
 
@@ -78,8 +82,10 @@ class SetOperatorsITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val s1 = env.fromElements((1, new NonPojo), (2, new NonPojo)).toTable(tEnv, 'a, 'b)
-    val s2 = env.fromElements((3, new NonPojo), (4, new NonPojo)).toTable(tEnv, 'a, 'b)
+    val s1 = env.fromElements((1, new NonPojo), (2, new NonPojo))
+      .toTableFromAppendStream(tEnv, 'a, 'b)
+    val s2 = env.fromElements((3, new NonPojo), (4, new NonPojo))
+      .toTableFromAppendStream(tEnv, 'a, 'b)
 
     val result = s1.unionAll(s2).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])
@@ -96,9 +102,9 @@ class SetOperatorsITCase extends AbstractTestBase {
 
     StreamITCase.testResults = mutable.MutableList()
     val s1 = env.fromElements((1, (1, "a")), (2, (2, "b")))
-      .toTable(tEnv, 'a, 'b)
+      .toTableFromAppendStream(tEnv, 'a, 'b)
     val s2 = env.fromElements(((3, "c"), 3), ((4, "d"), 4))
-      .toTable(tEnv, 'a, 'b)
+      .toTableFromAppendStream(tEnv, 'a, 'b)
 
     val result = s1.unionAll(s2.select('b, 'a)).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])
@@ -127,9 +133,9 @@ class SetOperatorsITCase extends AbstractTestBase {
       (4, "hello")
     )
 
-    val tableA = env.fromCollection(dataA).toTable(tEnv, 'a, 'b, 'c)
+    val tableA = env.fromCollection(dataA).toTableFromAppendStream(tEnv, 'a, 'b, 'c)
 
-    val tableB = env.fromCollection(dataB).toTable(tEnv, 'x, 'y)
+    val tableB = env.fromCollection(dataB).toTableFromAppendStream(tEnv, 'x, 'y)
 
     val result = tableA.where('a.in(tableB.select('x)))
 
@@ -166,9 +172,9 @@ class SetOperatorsITCase extends AbstractTestBase {
       (-1, "Hanoi-1")
     )
 
-    val tableA = env.fromCollection(dataA).toTable(tEnv,'a, 'b, 'c)
+    val tableA = env.fromCollection(dataA).toTableFromAppendStream(tEnv,'a, 'b, 'c)
 
-    val tableB = env.fromCollection(dataB).toTable(tEnv,'x, 'y)
+    val tableB = env.fromCollection(dataB).toTableFromAppendStream(tEnv,'x, 'y)
 
     val result = tableA
       .where('a.in(tableB.where('y.like("%Hanoi%")).groupBy('y).select('x.sum)))
@@ -209,11 +215,11 @@ class SetOperatorsITCase extends AbstractTestBase {
       (2L, "Cool")
     )
 
-    val tableA = env.fromCollection(dataA).toTable(tEnv,'a, 'b, 'c)
+    val tableA = env.fromCollection(dataA).toTableFromAppendStream(tEnv,'a, 'b, 'c)
 
-    val tableB = env.fromCollection(dataB).toTable(tEnv,'x, 'y)
+    val tableB = env.fromCollection(dataB).toTableFromAppendStream(tEnv,'x, 'y)
 
-    val tableC = env.fromCollection(dataC).toTable(tEnv,'w, 'z)
+    val tableC = env.fromCollection(dataC).toTableFromAppendStream(tEnv,'w, 'z)
 
     val result = tableA
       .where('a.in(tableB.select('x)) && 'b.in(tableC.select('w)))

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -63,7 +63,7 @@ class TableSinkITCase extends AbstractTestBase {
     val sink = new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink
     tEnv.registerTableSink("targetTable", fieldNames, fieldTypes, sink)
 
-    input.toTable(tEnv, 'a, 'b, 'c, 't.rowtime)
+    input.toTableFromAppendStream(tEnv, 'a, 'b, 'c, 't.rowtime)
       .where('a < 3 || 'a > 19)
       .select('c, 't, 'b)
       .insertInto("targetTable")
@@ -102,7 +102,7 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._2)
       .map(x => x).setParallelism(4) // increase DOP to 4
 
-    input.toTable(tEnv, 'a, 'b.rowtime, 'c)
+    input.toTableFromAppendStream(tEnv, 'a, 'b.rowtime, 'c)
       .where('a < 5 || 'a > 17)
       .select('c, 'b)
       .insertInto("csvSink")
@@ -131,7 +131,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
         .assignAscendingTimestamps(_._1.toLong)
-        .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+        .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     tEnv.registerTableSink(
       "appendSink",
@@ -164,8 +164,10 @@ class TableSinkITCase extends AbstractTestBase {
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'a, 'b, 'c)
+    val ds2 = StreamTestData.get5TupleDataStream(env)
+      .toTableFromAppendStream(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     tEnv.registerTableSink(
       "appendSink",
@@ -193,7 +195,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text)
 
     tEnv.registerTableSink(
       "retractSink",
@@ -231,7 +233,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     tEnv.registerTableSink(
       "retractSink",
@@ -272,7 +274,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text)
 
     tEnv.registerTableSink(
       "upsertSink",
@@ -313,7 +315,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     tEnv.registerTableSink(
       "upsertSink",
@@ -357,7 +359,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     tEnv.registerTableSink(
       "upsertSink",
@@ -402,7 +404,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     tEnv.registerTableSink(
       "upsertSink",
@@ -446,7 +448,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     tEnv.registerTableSink(
       "upsertSink",
@@ -491,7 +493,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     val r = t
       .window(Tumble over 5.milli on 'rowtime as 'w)
@@ -538,7 +540,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     val r = t
       .window(Tumble over 5.milli on 'rowtime as 'w)
@@ -585,7 +587,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     val r = t
       .window(Tumble over 5.milli on 'rowtime as 'w)
@@ -604,7 +606,7 @@ class TableSinkITCase extends AbstractTestBase {
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
-      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+      .toTableFromAppendStream(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
     val r = t
       .window(Tumble over 5.milli on 'rowtime as 'w)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/StreamTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/StreamTestData.scala
@@ -95,4 +95,32 @@ object StreamTestData {
     data.+=(((3, 3), "three"))
     env.fromCollection(data)
   }
+
+  def get3TupleUpsertStream(env: StreamExecutionEnvironment):
+  DataStream[(Boolean, (Int, Long, String))] = {
+    val data = new mutable.MutableList[(Boolean, (Int, Long, String))]
+    // false as a delete message, true as an add message
+    data.+=((false, (1, 1L, "Hi")))
+    data.+=((true, (2, 2L, "Hello")))
+    data.+=((false, (3, 2L, "Hello world")))
+    data.+=((true, (4, 3L, "Hello world, how are you?")))
+    data.+=((true, (5, 3L, "I am fine.")))
+    data.+=((true, (6, 3L, "Luke Skywalker")))
+    data.+=((true, (7, 4L, "Comment#1")))
+    data.+=((true, (8, 4L, "Comment#2")))
+    data.+=((true, (9, 4L, "Comment#3")))
+    data.+=((false, (10, 4L, "Comment#4")))
+    data.+=((true, (11, 5L, "Comment#5")))
+    data.+=((true, (12, 5L, "Comment#6")))
+    data.+=((true, (13, 5L, "Comment#7")))
+    data.+=((true, (14, 5L, "Comment#8")))
+    data.+=((true, (15, 5L, "Comment#9")))
+    data.+=((true, (16, 6L, "Comment#10")))
+    data.+=((true, (17, 6L, "Comment#11")))
+    data.+=((true, (18, 6L, "Comment#12")))
+    data.+=((true, (19, 6L, "Comment#13")))
+    data.+=((true, (20, 6L, "Comment#14")))
+    data.+=((true, (21, 6L, "Comment#15")))
+    env.fromCollection(data)
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -20,12 +20,12 @@ package org.apache.flink.table.utils
 
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.RelNode
+import org.apache.flink.api.java.LocalEnvironment
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.{LocalEnvironment, DataSet => JDataSet, ExecutionEnvironment => JExecutionEnvironment}
+import org.apache.flink.api.java.{DataSet => JDataSet}
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
-import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment => JStreamExecutionEnvironment}
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
@@ -180,8 +180,8 @@ object TableTestUtil {
     s"DataSetScan(table=[[_DataSetTable_$idx]])"
   }
 
-  def streamTableNode(idx: Int): String = {
-    s"DataStreamScan(table=[[_DataStreamTable_$idx]])"
+  def AppendTableNode(idx: Int): String = {
+    s"AppendStreamScan(table=[[_DataStreamTable_$idx]])"
   }
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -282,14 +282,14 @@ case class StreamTableTestUtil() extends TableTestUtil {
       fields: Expression*)
     : Table = {
 
-    val table = env.fromElements().toTable(tableEnv, fields: _*)
+    val table = env.fromElements().toTableFromAppendStream(tableEnv, fields: _*)
     tableEnv.registerTable(name, table)
     table
   }
 
   def addJavaTable[T](typeInfo: TypeInformation[T], name: String, fields: String): Table = {
     val stream = javaEnv.addSource(new EmptySource[T], typeInfo)
-    val table = javaTableEnv.fromDataStream(stream, fields)
+    val table = javaTableEnv.fromAppendStream(stream, fields)
     javaTableEnv.registerTable(name, table)
     table
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -293,7 +293,8 @@ case class StreamTableTestUtil() extends TableTestUtil {
     table
   }
 
-  def addJavaTable[T](typeInfo: TypeInformation[T], name: String, fields: String): Table = {
+  def addJavaTable[T](
+      typeInfo: TypeInformation[T], name: String, fields: String): Table = {
     val stream = javaEnv.addSource(new EmptySource[T], typeInfo)
     val table = javaTableEnv.fromAppendStream(stream, fields)
     javaTableEnv.registerTable(name, table)

--- a/flink-libraries/flink-table/src/test/scala/resources/testFilterStream0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testFilterStream0.out
@@ -4,7 +4,7 @@ LogicalFilter(condition=[=(MOD($0, 2), 0)])
 
 == Optimized Logical Plan ==
 DataStreamCalc(select=[a, b], where=[=(MOD(a, 2), 0)])
-  DataStreamScan(table=[[_DataStreamTable_0]])
+  AppendStreamScan(table=[[_DataStreamTable_0]])
 
 == Physical Execution Plan ==
 Stage 1 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnionStream0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnionStream0.out
@@ -5,8 +5,8 @@ LogicalUnion(all=[true])
 
 == Optimized Logical Plan ==
 DataStreamUnion(all=[true], union all=[count, word])
-  DataStreamScan(table=[[_DataStreamTable_0]])
-  DataStreamScan(table=[[_DataStreamTable_1]])
+  AppendStreamScan(table=[[_DataStreamTable_0]])
+  AppendStreamScan(table=[[_DataStreamTable_1]])
 
 == Physical Execution Plan ==
 Stage 1 : Data Source


### PR DESCRIPTION

## What is the purpose of the change

Currently, only append stream can be ingested as a stream table. This pull request implement proctime DataStream to Table upsert conversion.

Api looks like:

```
DataStream[(Boolean, (String, Long, Int))] input = ???
// upsert with keyedTable 
table = tEnv.fromUpsertStream(input, 'a, 'b, 'c.key)
// upsert without key -> single row tableTable 
table = tEnv.fromUpsertFromStream(input, 'a, 'b, 'c) 
```

A simple design doc can be fond [here](https://docs.google.com/document/d/1yMEi9xkm3pNYNmmZykbLzqtKjFVezaWe0y7Xqd0c1zE/edit?usp=sharing).


## Brief change log

  - Add `fromUpsertStream()` and `fromAppendStream()` in  java and scala `StreamTableEnvironment` and deprecate `fromDataStream`.
  - Add key support in the source definition including parse `key` keyword. 
  - Add `DataStreamLastRowRule` and `DataStreamLastRowAfterCalcRule`. Both rules generate `DataStreamLastRow` to handle upsert stream. The differences between the two rule is `DataStreamLastRowAfterCalcRule` will take calc into consideration and generate LastRow DataStreamRel node after calc. This can decrease state size in LastRow.
  - Add `LastRowProcessFunction` to handle upsert messages and generate retractions if there is an update.


## Verifying this change

This change added tests and can be verified as follows:

  - Add java api test in `JavaSqlITCase`
  - Add IT test cases in `FromUpsertStreamITCase`
  - Add sql plan tests in `FromUpsertStreamTest`
  - Add key extract in `UpdatingPlanCheckerTest`
  - Add validation test in `StreamTableEnvironmentValidationTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented, documents will be added in the later pr)
