### PR TITLE
[FLINK-10316][kinesis] bug was preventing FlinkKinesisProducer to connect to Kinesalite

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -87,6 +87,12 @@ public class KinesisConfigUtil {
 
 		validateAwsConfiguration(config);
 
+		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) ^ config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
+			// per validation in AwsClientBuilder
+			throw new IllegalArgumentException(String.format("For FlinkKinesisConsumer either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
+					AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT));
+		}
+
 		if (config.containsKey(ConsumerConfigConstants.STREAM_INITIAL_POSITION)) {
 			String initPosType = config.getProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION);
 
@@ -213,6 +219,11 @@ public class KinesisConfigUtil {
 
 		validateAwsConfiguration(config);
 
+		if (!config.containsKey(AWSConfigConstants.AWS_REGION)) {
+			// per requirement in Amazon Kinesis Producer Library
+			throw new IllegalArgumentException(String.format("For FlinkKinesisProducer AWS region ('%s') must be set in the config.", AWSConfigConstants.AWS_REGION));
+		}
+
 		KinesisProducerConfiguration kpc = KinesisProducerConfiguration.fromProperties(config);
 		kpc.setRegion(config.getProperty(AWSConfigConstants.AWS_REGION));
 
@@ -264,12 +275,6 @@ public class KinesisConfigUtil {
 						"and Secret Key ('" + AWSConfigConstants.AWS_SECRET_ACCESS_KEY + "') when using the BASIC AWS credential provider type.");
 				}
 			}
-		}
-
-		if (!(config.containsKey(AWSConfigConstants.AWS_REGION) ^ config.containsKey(ConsumerConfigConstants.AWS_ENDPOINT))) {
-			// per validation in AwsClientBuilder
-			throw new IllegalArgumentException(String.format("Either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
-				AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_REGION));
 		}
 
 		if (config.containsKey(AWSConfigConstants.AWS_REGION)) {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -125,14 +125,10 @@ public class KinesisConfigUtilTest {
 		assertEquals("incorrect region", region, kpc.getRegion());
 	}
 
-	// ----------------------------------------------------------------------
-	// validateAwsConfiguration() tests
-	// ----------------------------------------------------------------------
-
 	@Test
-	public void testMissingAwsRegionInConfig() {
-		String expectedMessage = String.format("Either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
-			AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_REGION);
+	public void testMissingAwsRegionInProducerConfig() {
+		String expectedMessage = String.format("For FlinkKinesisProducer AWS region ('%s') must be set in the config.",
+				AWSConfigConstants.AWS_REGION);
 		exception.expect(IllegalArgumentException.class);
 		exception.expectMessage(expectedMessage);
 
@@ -140,8 +136,12 @@ public class KinesisConfigUtilTest {
 		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
 		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
 
-		KinesisConfigUtil.validateAwsConfiguration(testConfig);
+		KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
 	}
+
+	// ----------------------------------------------------------------------
+	// validateAwsConfiguration() tests
+	// ----------------------------------------------------------------------
 
 	@Test
 	public void testUnrecognizableAwsRegionInConfig() {
@@ -151,22 +151,6 @@ public class KinesisConfigUtilTest {
 		Properties testConfig = new Properties();
 		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "wrongRegionId");
 		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-		KinesisConfigUtil.validateAwsConfiguration(testConfig);
-	}
-
-	@Test
-	public void testAwsRegionOrEndpointInConfig() {
-		String expectedMessage = String.format("Either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
-			AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_REGION);
-		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(expectedMessage);
-
-		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east");
-		testConfig.setProperty(AWSConfigConstants.AWS_ENDPOINT, "fake");
-		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
 		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
 
 		KinesisConfigUtil.validateAwsConfiguration(testConfig);
@@ -199,6 +183,22 @@ public class KinesisConfigUtilTest {
 	// ----------------------------------------------------------------------
 	// validateConsumerConfiguration() tests
 	// ----------------------------------------------------------------------
+
+	@Test
+	public void testAwsRegionOrEndpointInConsumerConfig() {
+		String expectedMessage = String.format("For FlinkKinesisConsumer either AWS region ('%s') or AWS endpoint ('%s') must be set in the config.",
+				AWSConfigConstants.AWS_REGION, AWSConfigConstants.AWS_ENDPOINT);
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage(expectedMessage);
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ENDPOINT, "fake");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKey");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+	}
 
 	@Test
 	public void testUnrecognizableStreamInitPositionTypeInConfig() {


### PR DESCRIPTION
## What is the purpose of the change
- Some time ago [FLINK-4197](https://issues.apache.org/jira/browse/FLINK-4197) added the ability to connect to a local Kinesis endpoint but also introduced some bugs
- Some time ago [FLINK-9402](https://issues.apache.org/jira/browse/FLINK-9402) added some fixes for those bugs but for FlinkKinesisConsumer only
- This PR addresses [FLINK-10316](https://issues.apache.org/jira/browse/FLINK-10316) to fix the remaining bugs to allow FlinkKinesisProducer also to connect to a local Kinesis endpoint

## Brief change log

  - The method `KinesisConfigUtil.validateAwsConfiguration(Properties config)` is used by both `FlinkKinesisConsumer` and `FlinkKinesisProducer` but AWS_REGION/AWS_ENDPOINT validation was performed only for Consumer who needs only one of them to be set. On the other side Producer requires AWS_REGION to be set even if AWS_ENDPOINT is defined to connect to local Kinesis. Since this validation code is not common for Consumer and Producer the change in this PR is moving out of this method the AWS_REGION/AWS_ENDPOINT validation which is now handled by `validateConsumerConfiguration(...)` and `getValidatedProducerConfiguration(...)` (per suggestion in comments below by @tweise)
  - Changed the Unit Tests accordingly 

## Jira Note
There are 2 other tickets that could be closed along with this one since they all refer to the same issue: [FLINK-9618](https://issues.apache.org/jira/browse/FLINK-9618) and [FLINK-8936](https://issues.apache.org/jira/browse/FLINK-8936)

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
  - KinesisConfigUtilTest. testMissingAwsRegionInProducerConfig
  - KinesisConfigUtilTest. testAwsRegionOrEndpointInConsumerConfig

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
