### PR TITLE
[FLINK-10487] [table] fix invalid Flink SQL example and add runnable SQL example for Java API

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -48,7 +48,7 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 DataStream<Tuple3<Long, String, Integer>> ds = env.addSource(...);
 
 // SQL query with an inlined (unregistered) table
-Table table = tableEnv.toTable(ds, "user, product, amount");
+Table table = tableEnv.fromDataStream(ds, "user, product, amount");
 Table result = tableEnv.sqlQuery(
   "SELECT SUM(amount) FROM " + table + " WHERE product LIKE '%Rubber%'");
 
@@ -80,7 +80,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 val ds: DataStream[(Long, String, Integer)] = env.addSource(...)
 
 // SQL query with an inlined (unregistered) table
-val table = ds.toTable(tableEnv, 'user, 'product, 'amount)
+val table = tableEnv.fromDataStream(ds, 'user, 'product, 'amount)
 val result = tableEnv.sqlQuery(
   s"SELECT SUM(amount) FROM $table WHERE product LIKE '%Rubber%'")
 

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -80,7 +80,7 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 val ds: DataStream[(Long, String, Integer)] = env.addSource(...)
 
 // SQL query with an inlined (unregistered) table
-val table = tableEnv.fromDataStream(ds, 'user, 'product, 'amount)
+val table = ds.toTable(tableEnv, 'user, 'product, 'amount)
 val result = tableEnv.sqlQuery(
   s"SELECT SUM(amount) FROM $table WHERE product LIKE '%Rubber%'")
 

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
@@ -1,0 +1,85 @@
+package org.apache.flink.table.examples.java;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+
+import java.util.Arrays;
+
+/**
+ * Simple example for demonstrating the use of SQL on a Stream Table in Java.
+ *
+ * <p>This example shows how to:
+ *  - Convert DataStreams to Tables
+ *  - Register a Table under a name
+ *  - Run a StreamSQL query on the registered Table
+ *
+ */
+public class StreamSQLExample {
+
+	// *************************************************************************
+	//     PROGRAM
+	// *************************************************************************
+
+	public static void main(String[] args) throws Exception {
+
+		// set up execution environment
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+
+		DataStream<Order> orderA = env.fromCollection(Arrays.asList(
+			new Order(1L, "beer", 3),
+			new Order(1L, "diaper", 4),
+			new Order(3L, "rubber", 2)));
+
+		DataStream<Order> orderB = env.fromCollection(Arrays.asList(
+			new Order(2L, "pen", 3),
+			new Order(2L, "rubber", 3),
+			new Order(4L, "beer", 1)));
+
+		// register the DataSet as table "WordCount"
+		Table tableA = tEnv.fromDataStream(orderA, "user, product, amount");
+		tEnv.registerDataStream("OrderB", orderB, "user, product, amount");
+
+		// run a SQL query on the Table and retrieve the result as a new Table
+		Table result = tEnv.sqlQuery("SELECT * FROM " + tableA + " WHERE amount > 2 UNION ALL " +
+						"SELECT * FROM OrderB WHERE amount < 2");
+
+		tEnv.toAppendStream(result, Order.class).print();
+
+		env.execute();
+	}
+
+	// *************************************************************************
+	//     USER DATA TYPES
+	// *************************************************************************
+
+	/**
+	 * Simple POJO.
+	 */
+	public static class Order {
+		public Long user;
+		public String product;
+		public int amount;
+
+		public Order() {
+		}
+
+		public Order(Long user, String product, int amount) {
+			this.user = user;
+			this.product = product;
+			this.amount = amount;
+		}
+
+		@Override
+		public String toString() {
+			return "Order{" +
+				"user=" + user +
+				", product='" + product + '\'' +
+				", amount=" + amount +
+				'}';
+		}
+	}
+}

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
@@ -57,11 +57,12 @@ public class StreamSQLExample {
 			new Order(2L, "rubber", 3),
 			new Order(4L, "beer", 1)));
 
-		// register the DataSet as table "WordCount"
+		// convert DataStream to Table
 		Table tableA = tEnv.fromDataStream(orderA, "user, product, amount");
+		// register DataStream as Table
 		tEnv.registerDataStream("OrderB", orderB, "user, product, amount");
 
-		// run a SQL query on the Table and retrieve the result as a new Table
+		// union the two tables
 		Table result = tEnv.sqlQuery("SELECT * FROM " + tableA + " WHERE amount > 2 UNION ALL " +
 						"SELECT * FROM OrderB WHERE amount < 2");
 

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.examples.java;
 
 import org.apache.flink.streaming.api.datastream.DataStream;

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 
 /**
-  * Simple example for demonstrating the use of SQL on a Stream Table.
+  * Simple example for demonstrating the use of SQL on a Stream Table in Scala.
   *
   * This example shows how to:
   *  - Convert DataStreams to Tables
@@ -54,12 +54,12 @@ object StreamSQLExample {
       Order(4L, "beer", 1)))
 
     // register the DataStreams under the name "OrderA" and "OrderB"
-    tEnv.registerDataStream("OrderA", orderA, 'user, 'product, 'amount)
+    var tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
     tEnv.registerDataStream("OrderB", orderB, 'user, 'product, 'amount)
 
     // union the two tables
     val result = tEnv.sqlQuery(
-      "SELECT * FROM OrderA WHERE amount > 2 UNION ALL " +
+      s"SELECT * FROM $tableA WHERE amount > 2 UNION ALL " +
         "SELECT * FROM OrderB WHERE amount < 2")
 
     result.toAppendStream[Order].print()

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -53,8 +53,9 @@ object StreamSQLExample {
       Order(2L, "rubber", 3),
       Order(4L, "beer", 1)))
 
-    // register the DataStreams under the name "OrderA" and "OrderB"
+    // convert DataStream to Table
     var tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
+    // register DataStream as Table
     tEnv.registerDataStream("OrderB", orderB, 'user, 'product, 'amount)
 
     // union the two tables


### PR DESCRIPTION
## What is the purpose of the change

Fix invalid java example (which uses a non-existing API) in doc. 

Also provide a new SQL example in java API not only for users' convenience, but also for developers' convenience to verify examples in our doc are correct and up-to-date.

## Brief change log

  - Fix the invalid java example to use correct SQL API
  - Add a runnable Flink SQL example for Java as `org.apache.flink.table.examples.java.StreamSQLExample`. The example's logic is the same as the corresponding example in scala `org.apache.flink.table.examples.scala.StreamSQLExample`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

The example can be run manually to verify it.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

  - Does this pull request introduce a new feature? (no)

