### PR TITLE
[FLINK-8865][sql-client] Add CLI query code completion in SQL Client

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -102,7 +102,9 @@ public class CliClient {
 		// this option is disabled for now for correct backslash escaping
 		// a "SELECT '\'" query should return a string with a backslash
 		lineReader.option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
-		lineReader.setVariable("errors", 1);
+		// this variable indicates the distance between the words in typoMatcher
+		// when do complete
+		lineReader.setVariable(LineReader.ERRORS, 1);
 
 		// create prompt
 		prompt = new AttributedStringBuilder()

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -97,10 +97,12 @@ public class CliClient {
 			.terminal(terminal)
 			.appName(CliStrings.CLI_NAME)
 			.parser(new SqlMultiLineParser())
+			.completer(new SqlCompleter(context, executor))
 			.build();
 		// this option is disabled for now for correct backslash escaping
 		// a "SELECT '\'" query should return a string with a backslash
 		lineReader.option(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
+		lineReader.setVariable("errors", 1);
 
 		// create prompt
 		prompt = new AttributedStringBuilder()

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
@@ -1,0 +1,98 @@
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.table.calcite.FlinkRelBuilder;
+import org.apache.flink.table.calcite.FlinkTypeFactory;
+import org.apache.flink.table.calcite.FlinkTypeSystem;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.local.LocalExecutor;
+import org.apache.flink.table.plan.cost.DataSetCostFactory;
+import org.apache.flink.table.validate.FunctionCatalog;
+
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.advise.SqlAdvisor;
+import org.apache.calcite.sql.advise.SqlAdvisorValidator;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlMoniker;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+import org.jline.utils.AttributedString;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * SQL Completer.
+ */
+public class SqlCompleter implements Completer {
+	private SessionContext context;
+	private Executor executor;
+	private SqlParser.Config parserConfig = SqlParser
+			.configBuilder()
+			.setLex(Lex.JAVA)
+			.setCaseSensitive(false)
+			.build();
+	private SqlOperatorTable operatorTable =
+			FunctionCatalog.withBuiltIns().getSqlOperatorTable();
+	private SchemaPlus rootSchema = CalciteSchema.createRootSchema(true, false).plus();
+	private SqlAdvisor advisor;
+
+	public SqlCompleter(SessionContext context, Executor executor) {
+		this.context = context;
+		this.executor = executor;
+
+		if (executor instanceof LocalExecutor) {
+			LocalExecutor localexecutor = (LocalExecutor) executor;
+			for (String tableName: localexecutor.listTables(context)) {
+				org.apache.calcite.schema.Table table = localexecutor.getTable(context, tableName);
+				rootSchema.add(tableName, table);
+			}
+			FrameworkConfig frameworkConfig = Frameworks.newConfigBuilder()
+					.defaultSchema(rootSchema)
+					.parserConfig(parserConfig)
+					.costFactory(new DataSetCostFactory())
+					.typeSystem(new FlinkTypeSystem())
+					.operatorTable(operatorTable)
+					.build();
+			FlinkTypeFactory typeFactory = FlinkRelBuilder.create(frameworkConfig).getTypeFactory();
+
+			Properties prop = new Properties();
+			prop.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(),
+					String.valueOf(parserConfig.caseSensitive()));
+			CalciteCatalogReader catalogReader = new CalciteCatalogReader(
+					CalciteSchema.from(rootSchema),
+					CalciteSchema.from(rootSchema).path(null),
+					typeFactory,
+					new CalciteConnectionConfigImpl(prop)
+					);
+
+			SqlAdvisorValidator validator = new SqlAdvisorValidator(operatorTable, catalogReader, typeFactory, SqlConformance.DEFAULT);
+			advisor = new SqlAdvisor(validator);
+		}
+	}
+
+	public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+		if (executor instanceof LocalExecutor) {
+			try {
+				final String[] replaced = {null};
+				List<SqlMoniker> hints = advisor.getCompletionHints(line.line(), line.cursor(), replaced);
+				for (SqlMoniker m: hints) {
+					candidates.add(new Candidate(AttributedString.stripAnsi(m.toIdentifier().toString()), m.toIdentifier().toString() , null, null, null, null, true));
+				}
+			} catch (Exception e) {
+				//ignore completer exception;
+			}
+		}
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
@@ -18,29 +18,10 @@
 
 package org.apache.flink.table.client.cli;
 
-import org.apache.flink.table.calcite.FlinkRelBuilder;
-import org.apache.flink.table.calcite.FlinkTypeFactory;
-import org.apache.flink.table.calcite.FlinkTypeSystem;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.local.LocalExecutor;
-import org.apache.flink.table.plan.cost.DataSetCostFactory;
-import org.apache.flink.table.validate.FunctionCatalog;
 
-import org.apache.calcite.config.CalciteConnectionConfigImpl;
-import org.apache.calcite.config.CalciteConnectionProperty;
-import org.apache.calcite.config.Lex;
-import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.prepare.CalciteCatalogReader;
-import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.sql.SqlOperatorTable;
-import org.apache.calcite.sql.advise.SqlAdvisor;
-import org.apache.calcite.sql.advise.SqlAdvisorValidator;
-import org.apache.calcite.sql.parser.SqlParser;
-import org.apache.calcite.sql.validate.SqlConformance;
-import org.apache.calcite.sql.validate.SqlMoniker;
-import org.apache.calcite.tools.FrameworkConfig;
-import org.apache.calcite.tools.Frameworks;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
@@ -48,7 +29,6 @@ import org.jline.reader.ParsedLine;
 import org.jline.utils.AttributedString;
 
 import java.util.List;
-import java.util.Properties;
 
 /**
  * SQL Completer.
@@ -56,61 +36,23 @@ import java.util.Properties;
 public class SqlCompleter implements Completer {
 	private SessionContext context;
 	private Executor executor;
-	private SqlParser.Config parserConfig = SqlParser
-			.configBuilder()
-			.setLex(Lex.JAVA)
-			.setCaseSensitive(false)
-			.build();
-	private SqlOperatorTable operatorTable =
-			FunctionCatalog.withBuiltIns().getSqlOperatorTable();
-	private SchemaPlus rootSchema = CalciteSchema.createRootSchema(true, false).plus();
-	private SqlAdvisor advisor;
 
 	public SqlCompleter(SessionContext context, Executor executor) {
 		this.context = context;
 		this.executor = executor;
-
-		if (executor instanceof LocalExecutor) {
-			LocalExecutor localexecutor = (LocalExecutor) executor;
-			for (String tableName: localexecutor.listTables(context)) {
-				org.apache.calcite.schema.Table table = localexecutor.getTable(context, tableName);
-				rootSchema.add(tableName, table);
-			}
-			FrameworkConfig frameworkConfig = Frameworks.newConfigBuilder()
-					.defaultSchema(rootSchema)
-					.parserConfig(parserConfig)
-					.costFactory(new DataSetCostFactory())
-					.typeSystem(new FlinkTypeSystem())
-					.operatorTable(operatorTable)
-					.build();
-			FlinkTypeFactory typeFactory = FlinkRelBuilder.create(frameworkConfig).getTypeFactory();
-
-			Properties prop = new Properties();
-			prop.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(),
-					String.valueOf(parserConfig.caseSensitive()));
-			CalciteCatalogReader catalogReader = new CalciteCatalogReader(
-					CalciteSchema.from(rootSchema),
-					CalciteSchema.from(rootSchema).path(null),
-					typeFactory,
-					new CalciteConnectionConfigImpl(prop)
-					);
-
-			SqlAdvisorValidator validator = new SqlAdvisorValidator(operatorTable, catalogReader, typeFactory, SqlConformance.DEFAULT);
-			advisor = new SqlAdvisor(validator);
-		}
 	}
 
 	public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
 		if (executor instanceof LocalExecutor) {
 			try {
-				final String[] replaced = {null};
-				List<SqlMoniker> hints = advisor.getCompletionHints(line.line(), line.cursor(), replaced);
-				for (SqlMoniker m: hints) {
-					candidates.add(new Candidate(AttributedString.stripAnsi(m.toIdentifier().toString()), m.toIdentifier().toString() , null, null, null, null, true));
-				}
+				LocalExecutor localExecutor = (LocalExecutor) executor;
+				List<String> hints = localExecutor.getCompletionHints(context, line.line(), line.cursor());
+				hints.forEach(hint->
+					candidates.add(new Candidate(AttributedString.stripAnsi(hint), hint , null, null, null, null, true)));
 			} catch (Exception e) {
 				//ignore completer exception;
 			}
 		}
 	}
+
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCompleter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.table.calcite.FlinkRelBuilder;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
@@ -22,8 +22,6 @@ import org.jline.reader.EOFError;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.DefaultParser;
 
-//import java.util.Collections;
-
 /**
  * Multi-line parser for parsing an arbitrary number of SQL lines until a line ends with ';'.
  */

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
@@ -26,6 +26,7 @@ import org.jline.reader.impl.DefaultParser;
  * Multi-line parser for parsing an arbitrary number of SQL lines until a line ends with ';'.
  */
 public class SqlMultiLineParser extends DefaultParser {
+
 	private static final String EOF_CHARACTER = ";";
 	private static final String NEW_LINE_PROMPT = ""; // results in simple '>' output
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
@@ -20,33 +20,29 @@ package org.apache.flink.table.client.cli;
 
 import org.jline.reader.EOFError;
 import org.jline.reader.ParsedLine;
-import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
+//import org.jline.reader.Parser;
 
-import java.util.Collections;
+//import java.util.Collections;
 
 /**
  * Multi-line parser for parsing an arbitrary number of SQL lines until a line ends with ';'.
  */
-public class SqlMultiLineParser implements Parser {
-
+//public class SqlMultiLineParser implements Parser {
+public class SqlMultiLineParser extends DefaultParser {
 	private static final String EOF_CHARACTER = ";";
 	private static final String NEW_LINE_PROMPT = ""; // results in simple '>' output
 
 	@Override
 	public ParsedLine parse(String line, int cursor, ParseContext context) {
-		if (!line.trim().endsWith(EOF_CHARACTER)) {
+		if (!line.trim().endsWith(EOF_CHARACTER)
+			&& context != ParseContext.COMPLETE) {
 			throw new EOFError(
 				-1,
 				-1,
 				"New line without EOF character.",
 				NEW_LINE_PROMPT);
 		}
-		return new DefaultParser.ArgumentList(
-			line,
-			Collections.singletonList(line),
-			0,
-			0,
-			cursor);
+		return super.parse(line, cursor, context);
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.client.cli;
 import org.jline.reader.EOFError;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.DefaultParser;
-//import org.jline.reader.Parser;
 
 //import java.util.Collections;
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlMultiLineParser.java
@@ -25,7 +25,6 @@ import org.jline.reader.impl.DefaultParser;
 /**
  * Multi-line parser for parsing an arbitrary number of SQL lines until a line ends with ';'.
  */
-//public class SqlMultiLineParser implements Parser {
 public class SqlMultiLineParser extends DefaultParser {
 	private static final String EOF_CHARACTER = ";";
 	private static final String NEW_LINE_PROMPT = ""; // results in simple '>' output

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -35,6 +35,8 @@ import org.apache.flink.table.api.QueryConfig;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -64,6 +67,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import scala.Option;
 
 /**
  * Executor that performs the Flink communication locally. The calls are blocking depending on the
@@ -233,6 +238,36 @@ public class LocalExecutor implements Executor {
 			// catch everything such that the query does not crash the executor
 			throw new SqlExecutionException("Invalid SQL statement.", t);
 		}
+	}
+
+	public org.apache.calcite.schema.Table getTable(SessionContext session, String name) throws SqlExecutionException {
+		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+
+		Class<?> clazz = Object.class;
+		if (tableEnv instanceof StreamTableEnvironment) {
+			StreamTableEnvironment tmpTableEnv = (StreamTableEnvironment) tableEnv;
+			clazz = tmpTableEnv.getClass();
+		} else if (tableEnv instanceof BatchTableEnvironment) {
+			BatchTableEnvironment tmpTableEnv = (BatchTableEnvironment) tableEnv;
+			clazz = tmpTableEnv.getClass();
+		}
+
+		for (; clazz != Object.class; clazz = clazz.getSuperclass()) {
+			try {
+				Method[] methods = clazz.getDeclaredMethods();
+
+				Method mt = clazz.getDeclaredMethod("getTable", String.class);
+				mt.setAccessible(true);
+				Option<org.apache.calcite.schema.Table> option =
+						(Option<org.apache.calcite.schema.Table>) mt.invoke(tableEnv, name);
+				return option.get();
+			} catch (Exception e) {
+				//ignore reflect get methods exception
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -28,7 +28,6 @@ import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.plan.RelOptPlanner.CannotPlanException
 import org.apache.calcite.plan.hep.{HepMatchOrder, HepPlanner, HepProgramBuilder}
 import org.apache.calcite.plan.{Convention, RelOptPlanner, RelOptUtil, RelTraitSet}
-import org.apache.calcite.plan.{RelOptPlanner, RelOptUtil, RelTraitSet}
 import org.apache.calcite.prepare.CalciteCatalogReader
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.schema.SchemaPlus


### PR DESCRIPTION
## What is the purpose of the change
This PR adds cli query code completion in SQL Client based on Calcite SqlAdvisor

## Brief change log
This change added tests and can be verified as follows:
 - *Added sql completer test*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented, add afterward)
