### PR TITLE
[hotfix] [docs] Update cluster setup docs to reflect the new syntax of jobmanager.sh script.

### DIFF
--- a/docs/ops/deployment/cluster_setup.md
+++ b/docs/ops/deployment/cluster_setup.md
@@ -137,7 +137,7 @@ You can add both JobManager and TaskManager instances to your running cluster wi
 #### Adding a JobManager
 
 {% highlight bash %}
-bin/jobmanager.sh ((start|start-foreground) cluster)|stop|stop-all
+bin/jobmanager.sh ((start|start-foreground) [host] [webui-port])|stop|stop-all
 {% endhighlight %}
 
 #### Adding a TaskManager


### PR DESCRIPTION
[docs] Update cluster setup docs to reflect the new syntax of jobmanager.sh script.

jobmanager.sh script syntax changed in Flink 1.5 as documented here: https://ci.apache.org/projects/flink/flink-docs-stable/release-notes/flink-1.5.html#changed-syntax-of-jobmanagersh-script
