### PR TITLE
[FLINK-10075] Redirect non-ssl requests to https url if ssl is enabled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/RedirectingSslHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/RedirectingSslHandler.java
@@ -18,25 +18,24 @@
 
 package org.apache.flink.runtime.net;
 
+import org.apache.flink.runtime.rest.handler.util.HandlerRedirectUtils;
+import org.apache.flink.runtime.rest.handler.util.KeepAliveWrite;
+
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.ByteToMessageDecoder;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpResponse;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequestDecoder;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseEncoder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCodec;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
 
-import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -44,19 +43,23 @@ import java.util.concurrent.CompletableFuture;
 
 /** SSL handler which automatically redirects Non-SSL requests to SSL address. */
 public class RedirectingSslHandler extends ByteToMessageDecoder {
-	protected final Logger log = LoggerFactory.getLogger(getClass());
+	private static final Logger log = LoggerFactory.getLogger(RedirectingSslHandler.class);
+
+	private static final String SSL_HANDLER_NAME = "ssl";
+	private static final String HTTP_CODEC_HANDLER_NAME = "http-codec";
+	private static final String NON_SSL_HANDLER_NAME = "redirecting-non-ssl";
 
 	/** the length of the ssl record header (in bytes). */
 	private static final int SSL_RECORD_HEADER_LENGTH = 5;
 
-	private final String confRedirectBaseUrl;
-	private final CompletableFuture<String> redirectBaseUrl;
-	private final SSLEngineFactory sslEngineFactory;
+	@Nonnull private final String confRedirectBaseUrl;
+	@Nonnull private final CompletableFuture<String> redirectBaseUrl;
+	@Nonnull private final SSLEngineFactory sslEngineFactory;
 
 	public RedirectingSslHandler(
-		String confRedirectHost,
-		CompletableFuture<String> redirectBaseUrl,
-		SSLEngineFactory sslEngineFactory) {
+		@Nonnull String confRedirectHost,
+		@Nonnull CompletableFuture<String> redirectBaseUrl,
+		@Nonnull SSLEngineFactory sslEngineFactory) {
 		this.confRedirectBaseUrl = "https://" + confRedirectHost + ":";
 		this.redirectBaseUrl = redirectBaseUrl;
 		this.sslEngineFactory = sslEngineFactory;
@@ -64,52 +67,39 @@ public class RedirectingSslHandler extends ByteToMessageDecoder {
 
 	@Override
 	protected void decode(ChannelHandlerContext context, ByteBuf in, List<Object> out) {
-		if (in.readableBytes() < SSL_RECORD_HEADER_LENGTH) {
-			return;
-		}
-		if (SslHandler.isEncrypted(in)) {
+		if (in.readableBytes() >= SSL_RECORD_HEADER_LENGTH && SslHandler.isEncrypted(in)) {
 			handleSsl(context);
 		} else {
-			context.pipeline().replace(this, "http-decoder", new HttpRequestDecoder());
-			context.pipeline().addAfter("http-decoder", "redirecting-non-ssl", newNonSslHandler());
+			context.pipeline().replace(this, HTTP_CODEC_HANDLER_NAME, new HttpServerCodec());
+			context.pipeline().addAfter(HTTP_CODEC_HANDLER_NAME, NON_SSL_HANDLER_NAME, new NonSslHandler());
 		}
 	}
 
 	private void handleSsl(ChannelHandlerContext context) {
-		SslHandler sslHandler = null;
+		SslHandler sslHandler = new SslHandler(sslEngineFactory.createSSLEngine());
 		try {
-			sslHandler = new SslHandler(sslEngineFactory.createSSLEngine());
-			context.pipeline().replace(this, "ssl", sslHandler);
-			sslHandler = null;
-		} finally {
-			// Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not
-			// transferred to the SslHandler.
-			if (sslHandler != null) {
-				ReferenceCountUtil.safeRelease(sslHandler.engine());
-			}
+			context.pipeline().replace(this, SSL_HANDLER_NAME, sslHandler);
+		} catch (Throwable t){
+			ReferenceCountUtil.safeRelease(sslHandler.engine());
+			throw t;
 		}
 	}
 
-	private ChannelHandler newNonSslHandler() {
-		return new ChannelInboundHandlerAdapter() {
-			private HttpResponseEncoder encoder = new HttpResponseEncoder();
+	private class NonSslHandler extends ChannelInboundHandlerAdapter {
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+			HttpRequest request = msg instanceof HttpRequest ? (HttpRequest) msg : null;
+			String path = request == null ? "" : request.uri();
+			String redirectAddress = getRedirectAddress(ctx);
+			log.trace("Received non-SSL request, redirecting to {}{}", redirectAddress, path);
+			HttpResponse response = HandlerRedirectUtils.getRedirectResponse(
+				redirectAddress, path, HttpResponseStatus.MOVED_PERMANENTLY);
+			KeepAliveWrite.flush(ctx, request, response);
+		}
 
-			@Override
-			public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-				String path = msg instanceof HttpRequest ? ((HttpRequest) msg).uri() : "";
-				String redirectUrl = getRedirectAddress(ctx) + path;
-				log.debug("Received non-SSL request, returning redirect to {}", redirectUrl);
-				FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
-					HttpResponseStatus.MOVED_PERMANENTLY, Unpooled.EMPTY_BUFFER);
-				response.headers().set(HttpHeaders.Names.LOCATION, redirectUrl);
-				encoder.write(ctx, response, ctx.voidPromise());
-				ctx.flush();
-			}
-		};
-	}
-
-	private String getRedirectAddress(ChannelHandlerContext ctx) throws Exception {
-		return redirectBaseUrl.isDone() ? redirectBaseUrl.get() :
-			confRedirectBaseUrl + ((InetSocketAddress) (ctx.channel()).localAddress()).getPort();
+		private String getRedirectAddress(ChannelHandlerContext ctx) throws Exception {
+			return redirectBaseUrl.isDone() ? redirectBaseUrl.get() :
+				confRedirectBaseUrl + ((InetSocketAddress) (ctx.channel()).localAddress()).getPort();
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/RedirectingSslHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/RedirectingSslHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.ByteToMessageDecoder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequestDecoder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseEncoder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/** SSL handler which automatically redirects Non-SSL requests to SSL address. */
+public class RedirectingSslHandler extends ByteToMessageDecoder {
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+
+	/** the length of the ssl record header (in bytes). */
+	private static final int SSL_RECORD_HEADER_LENGTH = 5;
+
+	private final String confRedirectBaseUrl;
+	private final CompletableFuture<String> redirectBaseUrl;
+	private final SSLEngineFactory sslEngineFactory;
+
+	public RedirectingSslHandler(
+		String confRedirectHost,
+		CompletableFuture<String> redirectBaseUrl,
+		SSLEngineFactory sslEngineFactory) {
+		this.confRedirectBaseUrl = "https://" + confRedirectHost + ":";
+		this.redirectBaseUrl = redirectBaseUrl;
+		this.sslEngineFactory = sslEngineFactory;
+	}
+
+	@Override
+	protected void decode(ChannelHandlerContext context, ByteBuf in, List<Object> out) {
+		if (in.readableBytes() < SSL_RECORD_HEADER_LENGTH) {
+			return;
+		}
+		if (SslHandler.isEncrypted(in)) {
+			handleSsl(context);
+		} else {
+			context.pipeline().replace(this, "http-decoder", new HttpRequestDecoder());
+			context.pipeline().addAfter("http-decoder", "redirecting-non-ssl", newNonSslHandler());
+		}
+	}
+
+	private void handleSsl(ChannelHandlerContext context) {
+		SslHandler sslHandler = null;
+		try {
+			sslHandler = new SslHandler(sslEngineFactory.createSSLEngine());
+			context.pipeline().replace(this, "ssl", sslHandler);
+			sslHandler = null;
+		} finally {
+			// Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not
+			// transferred to the SslHandler.
+			if (sslHandler != null) {
+				ReferenceCountUtil.safeRelease(sslHandler.engine());
+			}
+		}
+	}
+
+	private ChannelHandler newNonSslHandler() {
+		return new ChannelInboundHandlerAdapter() {
+			private HttpResponseEncoder encoder = new HttpResponseEncoder();
+
+			@Override
+			public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+				String path = msg instanceof HttpRequest ? ((HttpRequest) msg).uri() : "";
+				String redirectUrl = getRedirectAddress(ctx) + path;
+				log.debug("Received non-SSL request, returning redirect to {}", redirectUrl);
+				FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+					HttpResponseStatus.MOVED_PERMANENTLY, Unpooled.EMPTY_BUFFER);
+				response.headers().set(HttpHeaders.Names.LOCATION, redirectUrl);
+				encoder.write(ctx, response, ctx.voidPromise());
+				ctx.flush();
+			}
+		};
+	}
+
+	private String getRedirectAddress(ChannelHandlerContext ctx) throws Exception {
+		return redirectBaseUrl.isDone() ? redirectBaseUrl.get() :
+			confRedirectBaseUrl + ((InetSocketAddress) (ctx.channel()).localAddress()).getPort();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.net.RedirectingSslHandler;
 import org.apache.flink.runtime.net.SSLEngineFactory;
 import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
@@ -43,7 +44,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCodec;
-import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
 
 import org.slf4j.Logger;
@@ -156,7 +156,8 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 					// SSL should be the first handler in the pipeline
 					if (sslEngineFactory != null) {
-						ch.pipeline().addLast("ssl", new SslHandler(sslEngineFactory.createSSLEngine()));
+						ch.pipeline().addLast("ssl",
+							new RedirectingSslHandler(restAddress, restAddressFuture, sslEngineFactory));
 					}
 
 					ch.pipeline()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerRedirectUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerRedirectUtils.java
@@ -68,13 +68,16 @@ public class HandlerRedirectUtils {
 	}
 
 	public static HttpResponse getRedirectResponse(String redirectAddress, String path) {
+		return getRedirectResponse(redirectAddress, path, HttpResponseStatus.TEMPORARY_REDIRECT);
+	}
+
+	public static HttpResponse getRedirectResponse(String redirectAddress, String path, HttpResponseStatus code) {
 		checkNotNull(redirectAddress, "Redirect address");
 		checkNotNull(path, "Path");
 
 		String newLocation = String.format("%s%s", redirectAddress, path);
 
-		HttpResponse redirectResponse = new DefaultFullHttpResponse(
-				HttpVersion.HTTP_1_1, HttpResponseStatus.TEMPORARY_REDIRECT);
+		HttpResponse redirectResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, code);
 		redirectResponse.headers().set(HttpHeaders.Names.LOCATION, newLocation);
 		redirectResponse.headers().set(HttpHeaders.Names.CONTENT_LENGTH, 0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -96,6 +96,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -539,7 +540,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		Request request = new Request.Builder().url(httpUrl).build();
 		try (final Response response = client.newCall(request).execute()) {
 			assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), response.code());
-			assertTrue(response.headers().names().contains("Location"));
+			assertThat(response.headers().names(), hasItems("Location"));
 			assertEquals(httpsUrl, response.header("Location"));
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -530,6 +530,20 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 	}
 
+	@Test
+	public void testNonSslRedirectForEnabledSsl() throws Exception {
+		Assume.assumeTrue(config.getBoolean(SecurityOptions.SSL_REST_ENABLED));
+		OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
+		String httpsUrl = serverEndpoint.getRestBaseUrl() + "/path";
+		String httpUrl = httpsUrl.replace("https://", "http://");
+		Request request = new Request.Builder().url(httpUrl).build();
+		try (final Response response = client.newCall(request).execute()) {
+			assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), response.code());
+			assertTrue(response.headers().names().contains("Location"));
+			assertEquals(httpsUrl, response.header("Location"));
+		}
+	}
+
 	private HttpURLConnection openHttpConnectionForUpload(final String boundary) throws IOException {
 		final HttpURLConnection connection =
 			(HttpURLConnection) new URL(serverEndpoint.getRestBaseUrl() + "/upload").openConnection();


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a wrapper around SSL handler in rest server endpoint. 
The wrapper checks whether the request is encrypted and processes normally only encrypted requests.
The non-encrypted requests are redirected to advertised host with https protocol.
The path is added to the redirect url if the request is http and the path is available.

## Brief change log

  - add RedirectingSslHandler wrapper for SslHandler with redirecting in newNonSslHandler()
  - replace SslHandler in RestServerEndpoint with RedirectingSslHandler
  - add unit test  checking the redirection RestServerEndpointITCase.testNonSslRedirectForEnabledSsl()

## Verifying this change

unit tests, try access Flink UI with http url and ssl enabled in flink.conf

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
