### PR TITLE
[FLINK-10454][tests] Start MiniCluster with rest port 0

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
@@ -41,6 +42,11 @@ import org.junit.Test;
 
 import java.util.BitSet;
 
+/**
+ * Tests that Flink can execute jobs with a higher parallelism than available number
+ * of slots. This effectively tests that Flink can execute jobs with blocking results
+ * in a staged fashion.
+ */
 public class SlotCountExceedingParallelismTest extends TestLogger {
 
 	// Test configuration
@@ -55,6 +61,7 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 	@BeforeClass
 	public static void setUp() throws Exception {
 		final Configuration config = new Configuration();
+		config.setInteger(RestOptions.PORT, 0);
 		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()


### PR DESCRIPTION
## What is the purpose of the change

Start the MiniCluster used by `ScheduleOrUpdateConsumersTest` and `SlotCountExceedingParallelismTest` with a rest port 0 in order to avoid port conflicts when these two tests are executed concurrently.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
