### PR TITLE
[FLINK-10227] Remove javax.xml.bind.DatatypeConverter

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/JobID.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobID.java
@@ -20,8 +20,7 @@ package org.apache.flink.api.common;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+import org.apache.flink.util.StringUtils;
 
 import java.nio.ByteBuffer;
 
@@ -107,7 +106,7 @@ public final class JobID extends AbstractID {
 	 */
 	public static JobID fromHexString(String hexString) {
 		try {
-			return new JobID(DatatypeConverter.parseHexBinary(hexString));
+			return new JobID(StringUtils.hexStringToByte(hexString));
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Cannot parse JobID from \"" + hexString + "\".", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
@@ -19,8 +19,7 @@
 package org.apache.flink.runtime.jobgraph;
 
 import org.apache.flink.util.AbstractID;
-
-import javax.xml.bind.DatatypeConverter;
+import org.apache.flink.util.StringUtils;
 
 /**
  * A class for statistically unique job vertex IDs.
@@ -41,6 +40,6 @@ public class JobVertexID extends AbstractID {
 	}
 
 	public static JobVertexID fromHexString(String hexString) {
-		return new JobVertexID(DatatypeConverter.parseHexBinary(hexString));
+		return new JobVertexID(StringUtils.hexStringToByte(hexString));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TriggerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TriggerId.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.StringUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
@@ -28,8 +29,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotatio
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
-
-import javax.xml.bind.DatatypeConverter;
 
 import java.io.IOException;
 
@@ -50,7 +49,7 @@ public final class TriggerId extends AbstractID {
 	}
 
 	public static TriggerId fromHexString(String hexString) {
-		return new TriggerId(DatatypeConverter.parseHexBinary(hexString));
+		return new TriggerId(StringUtils.hexStringToByte(hexString));
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*Remove usage of javax.xml.bind.DatatypeConverter for java 9 compatibility*


## Brief change log

*Remove usage of javax.xml.bind.DatatypeConverter*


## Verifying this change

This change is a trivial rework

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
