### PR TITLE
[hotfix][docs] fix rest_api.md mistakes at Cancel Job section

### DIFF
--- a/docs/monitoring/rest_api.md
+++ b/docs/monitoring/rest_api.md
@@ -590,7 +590,7 @@ Sample Result:
 
 ##### Cancel Job
 
-`DELETE` request to **`/jobs/:jobid/cancel`**.
+`GET` request to **`/jobs/:jobid/yarn-cancel`**.
 
 Triggers job cancellation, result on success is `{}`.
 


### PR DESCRIPTION
`DELETE` request to **`/jobs/:jobid/cancel`** always return {"errors": ["Not found."]}, since the correct API should be `GET` request to `/jobs/:jobid/yarn-cancel`