### PR TITLE
[FLINK-10156][table] Deprecate Table.writeToSink()

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -536,6 +536,9 @@ result.insertInto("CsvSinkTable");
 // get a TableEnvironment
 val tableEnv = TableEnvironment.getTableEnvironment(env)
 
+// create a TableSink
+val sink: TableSink = new CsvTableSink("/path/to/file", fieldDelim = "|")
+
 // register the TableSink with a specific schema
 val fieldNames: Array[String] = Array("a", "b", "c")
 val fieldTypes: Array[TypeInformation] = Array(Types.INT, Types.STRING, Types.LONG)
@@ -544,8 +547,6 @@ tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink)
 // compute a result Table using Table API operators and/or SQL queries
 val result: Table = ...
 
-// create a TableSink
-val sink: TableSink = new CsvTableSink("/path/to/file", fieldDelim = "|")
 // emit the result Table to the registered TableSink
 result.insertInto("CsvSinkTable")
 

--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -46,6 +46,8 @@ StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 tableEnv.registerTable("table1", ...)            // or
 tableEnv.registerTableSource("table2", ...);     // or
 tableEnv.registerExternalCatalog("extCat", ...);
+// register an output Table
+tableEnv.registerTableSink("outputTable", ...);
 
 // create a Table from a Table API query
 Table tapiResult = tableEnv.scan("table1").select(...);
@@ -53,7 +55,7 @@ Table tapiResult = tableEnv.scan("table1").select(...);
 Table sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ... ");
 
 // emit a Table API result Table to a TableSink, same for SQL result
-tapiResult.writeToSink(...);
+tapiResult.insertInto("outputTable");
 
 // execute
 env.execute();
@@ -72,7 +74,9 @@ val tableEnv = TableEnvironment.getTableEnvironment(env)
 // register a Table
 tableEnv.registerTable("table1", ...)           // or
 tableEnv.registerTableSource("table2", ...)     // or
-tableEnv.registerExternalCatalog("extCat", ...) 
+tableEnv.registerExternalCatalog("extCat", ...)
+// register an output Table
+tableEnv.registerTableSink("outputTable", ...);
 
 // create a Table from a Table API query
 val tapiResult = tableEnv.scan("table1").select(...)
@@ -80,7 +84,7 @@ val tapiResult = tableEnv.scan("table1").select(...)
 val sqlResult  = tableEnv.sqlQuery("SELECT ... FROM table2 ...")
 
 // emit a Table API result Table to a TableSink, same for SQL result
-tapiResult.writeToSink(...)
+tapiResult.insertInto("outputTable")
 
 // execute
 env.execute()
@@ -500,10 +504,7 @@ A batch `Table` can only be written to a `BatchTableSink`, while a streaming `Ta
 
 Please see the documentation about [Table Sources & Sinks]({{ site.baseurl }}/dev/table/sourceSinks.html) for details about available sinks and instructions for how to implement a custom `TableSink`.
 
-There are two ways to emit a table:
-
-1. The `Table.writeToSink(TableSink sink)` method emits the table using the provided `TableSink` and automatically configures the sink with the schema of the table to emit.
-2. The `Table.insertInto(String sinkTable)` method looks up a `TableSink` that was registered with a specific schema under the provided name in the `TableEnvironment`'s catalog. The schema of the table to emit is validated against the schema of the registered `TableSink`.
+The `Table.insertInto(String tableName)` method emits the `Table` to a registered `TableSink`. The method looks up the `TableSink` from the catalog by the name and validates that the schema of the `Table` is identical to the schema of the `TableSink`. 
 
 The following examples shows how to emit a `Table`:
 
@@ -513,22 +514,17 @@ The following examples shows how to emit a `Table`:
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
 StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
 
-// compute a result Table using Table API operators and/or SQL queries
-Table result = ...
-
 // create a TableSink
 TableSink sink = new CsvTableSink("/path/to/file", fieldDelim = "|");
 
-// METHOD 1:
-//   Emit the result Table to the TableSink via the writeToSink() method
-result.writeToSink(sink);
-
-// METHOD 2:
-//   Register the TableSink with a specific schema
+// register the TableSink with a specific schema
 String[] fieldNames = {"a", "b", "c"};
 TypeInformation[] fieldTypes = {Types.INT, Types.STRING, Types.LONG};
 tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink);
-//   Emit the result Table to the registered TableSink via the insertInto() method
+
+// compute a result Table using Table API operators and/or SQL queries
+Table result = ...
+// emit the result Table to the registered TableSink
 result.insertInto("CsvSinkTable");
 
 // execute the program
@@ -540,22 +536,17 @@ result.insertInto("CsvSinkTable");
 // get a TableEnvironment
 val tableEnv = TableEnvironment.getTableEnvironment(env)
 
+// register the TableSink with a specific schema
+val fieldNames: Array[String] = Array("a", "b", "c")
+val fieldTypes: Array[TypeInformation] = Array(Types.INT, Types.STRING, Types.LONG)
+tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink)
+
 // compute a result Table using Table API operators and/or SQL queries
 val result: Table = ...
 
 // create a TableSink
 val sink: TableSink = new CsvTableSink("/path/to/file", fieldDelim = "|")
-
-// METHOD 1:
-//   Emit the result Table to the TableSink via the writeToSink() method
-result.writeToSink(sink)
-
-// METHOD 2:
-//   Register the TableSink with a specific schema
-val fieldNames: Array[String] = Array("a", "b", "c")
-val fieldTypes: Array[TypeInformation] = Array(Types.INT, Types.STRING, Types.LONG)
-tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, sink)
-//   Emit the result Table to the registered TableSink via the insertInto() method
+// emit the result Table to the registered TableSink
 result.insertInto("CsvSinkTable")
 
 // execute the program
@@ -576,7 +567,7 @@ Table API and SQL queries are translated into [DataStream]({{ site.baseurl }}/de
 
 A Table API or SQL query is translated when:
 
-* a `Table` is emitted to a `TableSink`, i.e., when `Table.writeToSink()` or `Table.insertInto()` is called.
+* a `Table` is emitted to a `TableSink`, i.e., when `Table.insertInto()` is called.
 * a SQL update query is specified, i.e., when `TableEnvironment.sqlUpdate()` is called.
 * a `Table` is converted into a `DataStream` or `DataSet` (see [Integration with DataStream and DataSet API](#integration-with-dataStream-and-dataSet-api)).
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1072,7 +1072,7 @@ val sink: CsvTableSink = new CsvTableSink(
     path,                             // output path 
     fieldDelim = "|",                 // optional: delimit files by '|'
     numFiles = 1,                     // optional: write to a single file
-    writeMode = WriteMode.OVERWRITE), // optional: override existing files
+    writeMode = WriteMode.OVERWRITE)  // optional: override existing files
 
 tableEnv.registerTableSink(
   "csvOutputTable",
@@ -1135,7 +1135,7 @@ tableEnv.registerTableSink(
   Array[TypeInformation[_]](Types.INT))
 
 val table: Table = ???
-table.insertInto("jdbcTableSink")
+table.insertInto("jdbcOutputTable")
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1047,30 +1047,42 @@ The sink only supports append-only streaming tables. It cannot be used to emit a
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-Table table = ...
-
-table.writeToSink(
-  new CsvTableSink(
+CsvTableSink sink = new CsvTableSink(
     path,                  // output path 
     "|",                   // optional: delimit files by '|'
     1,                     // optional: write to a single file
-    WriteMode.OVERWRITE)); // optional: override existing files
+    WriteMode.OVERWRITE);  // optional: override existing files
 
+tableEnv.registerTableSink(
+  "csvOutputTable",
+  sink,
+  // specify table schema
+  new String[]{"f0", "f1"},
+  new TypeInformation[]{Types.STRING, Types.INT});
+
+Table table = ...
+table.insertInto("csvOutputTable");
 {% endhighlight %}
 </div>
 
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-val table: Table = ???
-
-table.writeToSink(
-  new CsvTableSink(
+val sink: CsvTableSink = new CsvTableSink(
     path,                             // output path 
     fieldDelim = "|",                 // optional: delimit files by '|'
     numFiles = 1,                     // optional: write to a single file
-    writeMode = WriteMode.OVERWRITE)) // optional: override existing files
+    writeMode = WriteMode.OVERWRITE), // optional: override existing files
 
+tableEnv.registerTableSink(
+  "csvOutputTable",
+  sink,
+  // specify table schema
+  Array[String]("f0", "f1"),
+  Array[TypeInformation[_]](Types.STRING, Types.INT))
+
+val table: Table = ???
+table.insertInto("csvOutputTable")
 {% endhighlight %}
 </div>
 </div>
@@ -1094,8 +1106,15 @@ JDBCAppendTableSink sink = JDBCAppendTableSink.builder()
   .setParameterTypes(INT_TYPE_INFO)
   .build();
 
+tableEnv.registerTableSink(
+  "jdbcOutputTable",
+  sink,
+  // specify table schema
+  new String[]{"id"},
+  new TypeInformation[]{Types.INT});
+
 Table table = ...
-table.writeToSink(sink);
+table.insertInto("jdbcOutputTable");
 {% endhighlight %}
 </div>
 
@@ -1108,8 +1127,15 @@ val sink: JDBCAppendTableSink = JDBCAppendTableSink.builder()
   .setParameterTypes(INT_TYPE_INFO)
   .build()
 
+tableEnv.registerTableSink(
+  "jdbcOutputTable",
+  sink,
+  // specify table schema
+  Array[String]("id"),
+  Array[TypeInformation[_]](Types.INT))
+
 val table: Table = ???
-table.writeToSink(sink)
+table.insertInto("jdbcTableSink")
 {% endhighlight %}
 </div>
 </div>
@@ -1137,8 +1163,15 @@ CassandraAppendTableSink sink = new CassandraAppendTableSink(
   // the query must match the schema of the table
   INSERT INTO flink.myTable (id, name, value) VALUES (?, ?, ?));
 
+tableEnv.registerTableSink(
+  "cassandraOutputTable",
+  sink,
+  // specify table schema
+  new String[]{"id", "name", "value"},
+  new TypeInformation[]{Types.INT, Types.STRING, Types.DOUBLE});
+
 Table table = ...
-table.writeToSink(sink);
+table.insertInto(cassandraOutputTable);
 {% endhighlight %}
 </div>
 
@@ -1151,8 +1184,15 @@ val sink: CassandraAppendTableSink = new CassandraAppendTableSink(
   // the query must match the schema of the table
   INSERT INTO flink.myTable (id, name, value) VALUES (?, ?, ?))
 
+tableEnv.registerTableSink(
+  "cassandraOutputTable",
+  sink,
+  // specify table schema
+  Array[String]("id", "name", "value"),
+  Array[TypeInformation[_]](Types.INT, Types.STRING, Types.DOUBLE))
+
 val table: Table = ???
-table.writeToSink(sink)
+table.insertInto(cassandraOutputTable)
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -516,7 +516,7 @@ Table result = ...
 TableSink<Row> sink = ...
 
 // emit result Table via a TableSink
-result.writeToSink(sink, qConfig);
+result.insertInto("outputTable", qConfig);
 
 // convert result Table into a DataStream<Row>
 DataStream<Row> stream = tableEnv.toAppendStream(result, Row.class, qConfig);
@@ -540,7 +540,7 @@ val result: Table = ???
 val sink: TableSink[Row] = ???
 
 // emit result Table via a TableSink
-result.writeToSink(sink, qConfig)
+result.insertInto("outputTable", qConfig)
 
 // convert result Table into a DataStream[Row]
 val stream: DataStream[Row] = result.toAppendStream[Row](qConfig)

--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -515,6 +515,13 @@ Table result = ...
 // create TableSink
 TableSink<Row> sink = ...
 
+// register TableSink
+tableEnv.registerTableSink(
+  "outputTable",               // table name
+  new String[]{...},           // field names
+  new TypeInformation[]{...},  // field types
+  sink);                       // table sink
+
 // emit result Table via a TableSink
 result.insertInto("outputTable", qConfig);
 
@@ -538,6 +545,13 @@ val result: Table = ???
 
 // create TableSink
 val sink: TableSink[Row] = ???
+
+// register TableSink
+tableEnv.registerTableSink(
+  "outputTable",                  // table name
+  Array[String](...),             // field names
+  Array[TypeInformation[_]](...), // field types
+  sink)                           // table sink
 
 // emit result Table via a TableSink
 result.insertInto("outputTable", qConfig)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/table.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/table.scala
@@ -893,7 +893,7 @@ class Table(
     * @tparam T The data type that the [[TableSink]] expects.
     *
     * @deprecated Will be removed in a future release. Please register the TableSink and use
-    *             [[insertInto()]].
+    *             Table.insertInto().
     */
   @deprecated("This method will be removed. Please register the TableSink and use " +
     "Table.insertInto().", "1.7.0")
@@ -920,7 +920,7 @@ class Table(
     * @tparam T The data type that the [[TableSink]] expects.
     *
     * @deprecated Will be removed in a future release. Please register the TableSink and use
-    *             [[insertInto()]].
+    *             Table.insertInto().
     */
   @deprecated("This method will be removed. Please register the TableSink and use " +
     "Table.insertInto().", "1.7.0")
@@ -979,7 +979,7 @@ class Table(
   def insertInto(tableName: String, conf: QueryConfig): Unit = {
     this.logicalPlan match {
       case _: LogicalTableFunctionCall =>
-        throw new ValidationException("TableFunction can only be used in join and leftOuterJoin.")
+        throw ValidationException("TableFunction can only be used in join and leftOuterJoin.")
       case _ =>
         tableEnv.insertInto(this, tableName, conf)
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/table.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/table.scala
@@ -891,7 +891,13 @@ class Table(
     *
     * @param sink The [[TableSink]] to which the [[Table]] is written.
     * @tparam T The data type that the [[TableSink]] expects.
+    *
+    * @deprecated Will be removed in a future release. Please register the TableSink and use
+    *             [[insertInto()]].
     */
+  @deprecated("This method will be removed. Please register the TableSink and use " +
+    "Table.insertInto().", "1.7.0")
+  @Deprecated
   def writeToSink[T](sink: TableSink[T]): Unit = {
     val queryConfig = Option(this.tableEnv) match {
       case None => null
@@ -912,7 +918,13 @@ class Table(
     * @param sink The [[TableSink]] to which the [[Table]] is written.
     * @param conf The configuration for the query that writes to the sink.
     * @tparam T The data type that the [[TableSink]] expects.
+    *
+    * @deprecated Will be removed in a future release. Please register the TableSink and use
+    *             [[insertInto()]].
     */
+  @deprecated("This method will be removed. Please register the TableSink and use " +
+    "Table.insertInto().", "1.7.0")
+  @Deprecated
   def writeToSink[T](sink: TableSink[T], conf: QueryConfig): Unit = {
     // get schema information of table
     val rowType = getRelNode.getRowType
@@ -944,7 +956,12 @@ class Table(
     * @param tableName Name of the registered [[TableSink]] to which the [[Table]] is written.
     */
   def insertInto(tableName: String): Unit = {
-    tableEnv.insertInto(this, tableName, this.tableEnv.queryConfig)
+    this.logicalPlan match {
+      case _: LogicalTableFunctionCall =>
+        throw new ValidationException("TableFunction can only be used in join and leftOuterJoin.")
+      case _ =>
+        tableEnv.insertInto(this, tableName, this.tableEnv.queryConfig)
+    }
   }
 
   /**
@@ -960,7 +977,12 @@ class Table(
     * @param conf The [[QueryConfig]] to use.
     */
   def insertInto(tableName: String, conf: QueryConfig): Unit = {
-    tableEnv.insertInto(this, tableName, conf)
+    this.logicalPlan match {
+      case _: LogicalTableFunctionCall =>
+        throw new ValidationException("TableFunction can only be used in join and leftOuterJoin.")
+      case _ =>
+        tableEnv.insertInto(this, tableName, conf)
+    }
   }
 
   /**

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
@@ -35,7 +35,7 @@ class TableSinkValidationTest extends TableTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'id, 'num, 'text)
-    tEnv.registerTableSink("testSink",new TestAppendSink)
+    tEnv.registerTableSink("testSink", new TestAppendSink)
 
     t.groupBy('text)
     .select('text, 'id.count, 'num.sum)
@@ -72,7 +72,7 @@ class TableSinkValidationTest extends TableTestBase {
 
     val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
-    tEnv.registerTableSink("testSink",new TestAppendSink)
+    tEnv.registerTableSink("testSink", new TestAppendSink)
 
     ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 'h)
       .select('c, 'g)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
@@ -35,10 +35,11 @@ class TableSinkValidationTest extends TableTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'id, 'num, 'text)
+    tEnv.registerTableSink("testSink",new TestAppendSink)
 
     t.groupBy('text)
     .select('text, 'id.count, 'num.sum)
-    .writeToSink(new TestAppendSink)
+    .insertInto("testSink")
 
     // must fail because table is not append-only
     env.execute()
@@ -53,11 +54,12 @@ class TableSinkValidationTest extends TableTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text)
+    tEnv.registerTableSink("testSink", new TestUpsertSink(Array("len", "cTrue"), false))
 
     t.select('id, 'num, 'text.charLength() as 'len, ('id > 0) as 'cTrue)
     .groupBy('len, 'cTrue)
     .select('len, 'id.count, 'num.sum)
-    .writeToSink(new TestUpsertSink(Array("len", "cTrue"), false))
+    .insertInto("testSink")
 
     // must fail because table is updating table without full key
     env.execute()
@@ -70,10 +72,11 @@ class TableSinkValidationTest extends TableTestBase {
 
     val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.registerTableSink("testSink",new TestAppendSink)
 
     ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 'h)
       .select('c, 'g)
-      .writeToSink(new TestAppendSink)
+      .insertInto("testSink")
 
     // must fail because table is not append-only
     env.execute()

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSinksValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSinksValidationTest.scala
@@ -34,11 +34,12 @@ class TableSinksValidationTest extends TableTestBase {
     val util = streamTestUtil()
 
     val t = util.addTable[(Int, Long, String)]("MyTable", 'id, 'num, 'text)
+    util.tableEnv.registerTableSink("testSink",new TestAppendSink)
 
     t.groupBy('text)
     .select('text, 'id.count, 'num.sum)
     // must fail because table is not append-only
-    .writeToSink(new TestAppendSink)
+    .insertInto("testSink")
   }
 
   @Test(expected = classOf[TableException])

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSinksValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSinksValidationTest.scala
@@ -34,7 +34,7 @@ class TableSinksValidationTest extends TableTestBase {
     val util = streamTestUtil()
 
     val t = util.addTable[(Int, Long, String)]("MyTable", 'id, 'num, 'text)
-    util.tableEnv.registerTableSink("testSink",new TestAppendSink)
+    util.tableEnv.registerTableSink("testSink", new TestAppendSink)
 
     t.groupBy('text)
     .select('text, 'id.count, 'num.sum)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -315,7 +315,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
 
     val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
             .groupBy('c)
-            .select('c, 'b.max as 'bMax)
+            .select('c, 'b.max)
 
     t.insertInto("testSink")
     env.execute()

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment, TableException, Types}
+import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
 import org.junit.Assert._

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, Strea
 import org.junit.Assert._
 import org.junit.Test
 import org.apache.flink.api.common.time.Time
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.expressions.{Literal, Null}
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, WeightedAvg}
@@ -77,6 +78,12 @@ class JoinITCase extends StreamingWithStateTestBase {
     val leftTable = env.fromCollection(data1).toTable(tEnv, 'a, 'b)
     val rightTable = env.fromCollection(data2).toTable(tEnv, 'bb, 'c)
 
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(Array("a,b"), false).configure(
+        Array[String]("a", "b", "c"),
+        Array[TypeInformation[_]](Types.INT, Types.LONG, Types.LONG)))
+
     val leftTableWithPk = leftTable
       .groupBy('a)
       .select('a, 'b.count as 'b)
@@ -88,7 +95,7 @@ class JoinITCase extends StreamingWithStateTestBase {
     leftTableWithPk
       .join(rightTableWithPk, 'b === 'bb)
       .select('a, 'b, 'c)
-      .writeToSink(new TestUpsertSink(Array("a,b"), false), queryConfig)
+      .insertInto("upsertSink", queryConfig)
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -135,6 +142,12 @@ class JoinITCase extends StreamingWithStateTestBase {
     val leftTable = env.fromCollection(data1).toTable(tEnv, 'a, 'b)
     val rightTable = env.fromCollection(data2).toTable(tEnv, 'bb, 'c, 'd)
 
+    tEnv.registerTableSink(
+      "retractSink",
+      new TestRetractSink().configure(
+        Array[String]("a", "b", "c", "d"),
+        Array[TypeInformation[_]](Types.INT, Types.INT, Types.INT, Types.INT)))
+
     val leftTableWithPk = leftTable
       .groupBy('a)
       .select('a, 'b.max as 'b)
@@ -142,7 +155,7 @@ class JoinITCase extends StreamingWithStateTestBase {
     leftTableWithPk
       .join(rightTable, 'a === 'bb && ('a < 4 || 'a > 4))
       .select('a, 'b, 'c, 'd)
-      .writeToSink(new TestRetractSink, queryConfig)
+      .insertInto("retractSink", queryConfig)
 
     env.execute()
     val results = RowCollector.getAndClearValues

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -54,7 +54,7 @@ class TableSinkITCase extends AbstractTestBase {
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
     val tEnv = TableEnvironment.getTableEnvironment(env)
-    MemoryTableSourceSinkUtil.clear
+    MemoryTableSourceSinkUtil.clear()
 
     val input = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(r => r._2)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -92,6 +92,12 @@ class TableSinkITCase extends AbstractTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     env.setParallelism(4)
 
+    tEnv.registerTableSink(
+      "csvSink",
+      new CsvTableSink(path).configure(
+        Array[String]("c", "b"),
+        Array[TypeInformation[_]](Types.STRING, Types.SQL_TIMESTAMP)))
+
     val input = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._2)
       .map(x => x).setParallelism(4) // increase DOP to 4
@@ -99,7 +105,7 @@ class TableSinkITCase extends AbstractTestBase {
     input.toTable(tEnv, 'a, 'b.rowtime, 'c)
       .where('a < 5 || 'a > 17)
       .select('c, 'b)
-      .writeToSink(new CsvTableSink(path))
+      .insertInto("csvSink")
 
     env.execute()
 
@@ -127,10 +133,16 @@ class TableSinkITCase extends AbstractTestBase {
         .assignAscendingTimestamps(_._1.toLong)
         .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
+    tEnv.registerTableSink(
+      "appendSink",
+      new TestAppendSink().configure(
+        Array[String]("t", "icnt", "nsum"),
+        Array[TypeInformation[_]](Types.SQL_TIMESTAMP, Types.LONG, Types.LONG)))
+
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w)
-      .select('w.end, 'id.count, 'num.sum)
-      .writeToSink(new TestAppendSink)
+      .select('w.end as 't, 'id.count as 'icnt, 'num.sum as 'nsum)
+      .insertInto("appendSink")
 
     env.execute()
 
@@ -155,9 +167,15 @@ class TableSinkITCase extends AbstractTestBase {
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
+    tEnv.registerTableSink(
+      "appendSink",
+      new TestAppendSink().configure(
+        Array[String]("c", "g"),
+        Array[TypeInformation[_]](Types.STRING, Types.STRING)))
+
     ds1.join(ds2).where('b === 'e)
       .select('c, 'g)
-      .writeToSink(new TestAppendSink)
+      .insertInto("appendSink")
 
     env.execute()
 
@@ -177,10 +195,16 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text)
 
+    tEnv.registerTableSink(
+      "retractSink",
+      new TestRetractSink().configure(
+        Array[String]("len", "icnt", "nsum"),
+        Array[TypeInformation[_]](Types.INT, Types.LONG, Types.LONG)))
+
     t.select('id, 'num, 'text.charLength() as 'len)
       .groupBy('len)
-      .select('len, 'id.count, 'num.sum)
-      .writeToSink(new TestRetractSink)
+      .select('len, 'id.count as 'icnt, 'num.sum as 'nsum)
+      .insertInto("retractSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -209,10 +233,16 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
+    tEnv.registerTableSink(
+      "retractSink",
+      new TestRetractSink().configure(
+        Array[String]("t", "icnt", "nsum"),
+        Array[TypeInformation[_]](Types.SQL_TIMESTAMP, Types.LONG, Types.LONG)))
+
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w)
-      .select('w.end, 'id.count, 'num.sum)
-      .writeToSink(new TestRetractSink)
+      .select('w.end as 't, 'id.count as 'icnt, 'num.sum as 'nsum)
+      .insertInto("retractSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -244,12 +274,18 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text)
 
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(Array("cnt", "cTrue"), false).configure(
+        Array[String]("cnt", "lencnt", "cTrue"),
+        Array[TypeInformation[_]](Types.LONG, Types.LONG, Types.BOOLEAN)))
+
     t.select('id, 'num, 'text.charLength() as 'len, ('id > 0) as 'cTrue)
       .groupBy('len, 'cTrue)
       .select('len, 'id.count as 'cnt, 'cTrue)
       .groupBy('cnt, 'cTrue)
-      .select('cnt, 'len.count, 'cTrue)
-      .writeToSink(new TestUpsertSink(Array("cnt", "cTrue"), false))
+      .select('cnt, 'len.count as 'lencnt, 'cTrue)
+      .insertInto("upsertSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -279,10 +315,16 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(Array("wend", "num"), true).configure(
+        Array[String]("num", "wend", "icnt"),
+        Array[TypeInformation[_]](Types.LONG, Types.SQL_TIMESTAMP, Types.LONG)))
+
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w, 'num)
-      .select('num, 'w.end as 'wend, 'id.count)
-      .writeToSink(new TestUpsertSink(Array("wend", "num"), true))
+      .select('num, 'w.end as 'wend, 'id.count as 'icnt)
+      .insertInto("upsertSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -317,10 +359,17 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(Array("wstart", "wend", "num"), true).configure(
+        Array[String]("wstart", "wend", "num", "icnt"),
+        Array[TypeInformation[_]]
+          (Types.SQL_TIMESTAMP, Types.SQL_TIMESTAMP, Types.LONG, Types.LONG)))
+
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w, 'num)
-      .select('w.start as 'wstart, 'w.end as 'wend, 'num, 'id.count)
-      .writeToSink(new TestUpsertSink(Array("wstart", "wend", "num"), true))
+      .select('w.start as 'wstart, 'w.end as 'wend, 'num, 'id.count as 'icnt)
+      .insertInto("upsertSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -355,10 +404,16 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(null, true).configure(
+        Array[String]("wend", "cnt"),
+        Array[TypeInformation[_]](Types.SQL_TIMESTAMP, Types.LONG)))
+
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w, 'num)
       .select('w.end as 'wend, 'id.count as 'cnt)
-      .writeToSink(new TestUpsertSink(null, true))
+      .insertInto("upsertSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues
@@ -393,10 +448,16 @@ class TableSinkITCase extends AbstractTestBase {
       .assignAscendingTimestamps(_._1.toLong)
       .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
 
+    tEnv.registerTableSink(
+      "upsertSink",
+      new TestUpsertSink(null, true).configure(
+        Array[String]("num", "cnt"),
+        Array[TypeInformation[_]](Types.LONG, Types.LONG)))
+
     t.window(Tumble over 5.millis on 'rowtime as 'w)
       .groupBy('w, 'num)
       .select('num, 'id.count as 'cnt)
-      .writeToSink(new TestUpsertSink(null, true))
+      .insertInto("upsertSink")
 
     env.execute()
     val results = RowCollector.getAndClearValues


### PR DESCRIPTION
## What is the purpose of the change

* Deprecate `Table.writeToSink()` as discussed in FLINK-10156

## Brief change log

* Deprecate `Table.writeToSink()`
* Port usage of `writeToSink()` to `insertInto()`

## Verifying this change

* run existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? Docs have been adjusted.