### PR TITLE
[FLINK-10514][docs] change tachyon to alluxio in doc

### DIFF
--- a/flink-fs-tests/src/test/resources/log4j-test.properties
+++ b/flink-fs-tests/src/test/resources/log4j-test.properties
@@ -16,8 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-# Tachyon's test-jar dependency adds a log4j.properties file to classpath.
-# Until the issue is resolved (see https://github.com/amplab/tachyon/pull/571)
+# Alluxio's test-jar dependency adds a log4j.properties file to classpath.
+# Until the issue is resolved (see https://github.com/Alluxio/alluxio/pull/571)
 # we provide a log4j.properties file ourselves.
 
 log4j.rootLogger=OFF, testlogger

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -447,7 +447,7 @@ public abstract class StreamExecutionEnvironment {
 	 *
 	 * <p>In contrast, the {@link org.apache.flink.runtime.state.filesystem.FsStateBackend}
 	 * stores checkpoints of the state (also maintained as heap objects) in files. When using a replicated
-	 * file system (like HDFS, S3, MapR FS, Tachyon, etc) this will guarantee that state is not lost upon
+	 * file system (like HDFS, S3, MapR FS, Alluxio, etc) this will guarantee that state is not lost upon
 	 * failures of individual nodes and that streaming program can be executed highly available and strongly
 	 * consistent (assuming that Flink is run in high-availability mode).
 	 *

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -241,7 +241,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    *
    * In contrast, the [[org.apache.flink.runtime.state.filesystem.FsStateBackend]]
    * stores checkpoints of the state (also maintained as heap objects) in files.
-   * When using a replicated file system (like HDFS, S3, MapR FS, Tachyon, etc) this will guarantee
+   * When using a replicated file system (like HDFS, S3, MapR FS, Alluxio, etc) this will guarantee
    * that state is not lost upon failures of individual nodes and that streaming program can be
    * executed highly available and strongly consistent.
    */


### PR DESCRIPTION
## What is the purpose of the change
*Since Tachyon was renamed to Alluxio, replace the remaining Tachyon to Alluxio in docs.*
