### PR TITLE
[FLINK-10361] [test] Harden instable elastic search end-to-end test case

### DIFF
--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -41,22 +41,22 @@ function setup_elasticsearch {
     $elasticsearchDir/bin/elasticsearch &
 }
 
-function verify_elasticsearch_process_exist {
-    for ((i=1;i<=10;i++)); do
-        local elasticsearchProcess=$(jps | grep Elasticsearch | awk '{print $2}')
+function wait_elasticsearch_working {
+    echo "Waiting for Elasticsearch node to work..."
 
-        echo "Waiting for Elasticsearch node to start ..."
+    for ((i=1;i<=60;i++)); do
+        curl -XGET 'http://localhost:9200'
 
-        # make sure the elasticsearch node is actually running
-        if [ "$elasticsearchProcess" != "Elasticsearch" ]; then
+        # make sure the elasticsearch node is actually working
+        if [ $? -ne 0 ]; then
             sleep 1
         else
-            echo "Elasticsearch node is running."
+            echo "Elasticsearch node is working."
             return
         fi
     done
 
-    echo "Elasticsearch node did not start properly"
+    echo "Elasticsearch node is not working"
     exit 1
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -95,7 +95,7 @@ else
 fi
 
 setup_elasticsearch "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
-verify_elasticsearch_process_exist
+wait_elasticsearch_working
 
 function shutdownAndCleanup {
     # don't call ourselves again for another signal interruption

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -109,7 +109,7 @@ ELASTICSEARCH_VERSION=6
 DOWNLOAD_URL='https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.1.tar.gz'
 
 setup_elasticsearch $DOWNLOAD_URL
-verify_elasticsearch_process_exist
+wait_elasticsearch_working
 
 ################################################################################
 # Run a SQL statement

--- a/flink-end-to-end-tests/test-scripts/test_streaming_elasticsearch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_elasticsearch.sh
@@ -26,7 +26,7 @@ DOWNLOAD_URL=$2
 mkdir -p $TEST_DATA_DIR
 
 setup_elasticsearch $DOWNLOAD_URL
-verify_elasticsearch_process_exist
+wait_elasticsearch_working
 
 start_cluster
 


### PR DESCRIPTION
## What is the purpose of the change

- Try to harden the instable test case `test_streaming_elasticsearch.sh` in flink-end-to-end-test module

## Brief change log

- Waiting the Elasticsearch ready by checking the port 9200 is listened or not
- Waiting for 60s due to it sometimes costs more than 30s to be ready in my poor computer

## Verifying this change

- Tested this case manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
