### PR TITLE
[FLINK-9788] Fix ExecutionGraph inconsistency for global failures when restarting

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1151,18 +1151,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				current == JobStatus.SUSPENDED ||
 				current.isGloballyTerminalState()) {
 				return;
-			}
-			else if (current == JobStatus.RESTARTING) {
-				// we handle 'failGlobal()' while in 'RESTARTING' as a safety net in case something
-				// has gone wrong in 'RESTARTING' and we need to re-attempt the restarts
-				initFailureCause(t);
-
-				final long globalVersionForRestart = incrementGlobalModVersion();
-				if (tryRestartOrFail(globalVersionForRestart)) {
-					return;
-				}
-			}
-			else if (transitionState(current, JobStatus.FAILING, t)) {
+			} else if (transitionState(current, JobStatus.FAILING, t)) {
 				initFailureCause(t);
 
 				// make sure no concurrent local or global actions interfere with the failover
@@ -1240,7 +1229,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 						colGroups.add(cgroup);
 					}
 
-					jv.resetForNewExecution(resetTimestamp, globalModVersion);
+					jv.resetForNewExecution(resetTimestamp, expectedGlobalVersion);
 				}
 
 				for (int i = 0; i < stateTimestamps.length; i++) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -90,7 +90,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.spy;
 
 /**
  * Tests the restart behaviour of the {@link ExecutionGraph}.
@@ -851,14 +850,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	}
 
 	private static Tuple2<ExecutionGraph, Instance> createExecutionGraph(RestartStrategy restartStrategy) throws Exception {
-		return createExecutionGraph(restartStrategy, false);
-	}
-
-	private static Tuple2<ExecutionGraph, Instance> createSpyExecutionGraph(RestartStrategy restartStrategy) throws Exception {
-		return createExecutionGraph(restartStrategy, true);
-	}
-
-	private static Tuple2<ExecutionGraph, Instance> createExecutionGraph(RestartStrategy restartStrategy, boolean isSpy) throws Exception {
 		Instance instance = ExecutionGraphTestUtils.getInstance(
 			new ActorTaskManagerGateway(
 				new SimpleActorGateway(TestingUtils.directExecutionContext())),
@@ -872,9 +863,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Pointwise job", sender);
 
 		ExecutionGraph eg = newExecutionGraph(restartStrategy, scheduler);
-		if (isSpy) {
-			eg = spy(eg);
-		}
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
 		assertEquals(JobStatus.CREATED, eg.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -57,11 +58,14 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Test;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -86,8 +90,11 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishAllVertices;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.switchToRunning;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilJobStatus;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -217,23 +224,21 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		// Kill the instance and wait for the job to restart
 		instance.markDead();
 
-		Deadline deadline = TestingUtils.TESTING_DURATION().fromNow();
-
-		while (deadline.hasTimeLeft() &&
-			executionGraph.getState() != JobStatus.RESTARTING) {
-
-			Thread.sleep(100);
-		}
+		waitUntilJobStatus(executionGraph, JobStatus.RESTARTING, TestingUtils.TESTING_DURATION().toMillis());
 
 		assertEquals(JobStatus.RESTARTING, executionGraph.getState());
 
-		// The restarting should not fail with an ordinary exception
-		executionGraph.failGlobal(new Exception("Test exception"));
+		// If we fail when being in RESTARTING, then we should try to restart again
+		final long globalModVersion = executionGraph.getGlobalModVersion();
+		final Exception testException = new Exception("Test exception");
+		executionGraph.failGlobal(testException);
 
+		assertNotEquals(globalModVersion, executionGraph.getGlobalModVersion());
 		assertEquals(JobStatus.RESTARTING, executionGraph.getState());
+		assertEquals(testException, executionGraph.getFailureCause()); // we should have updated the failure cause
 
 		// but it should fail when sending a SuppressRestartsException
-		executionGraph.failGlobal(new SuppressRestartsException(new Exception("Test exception")));
+		executionGraph.failGlobal(new SuppressRestartsException(new Exception("Suppress restart exception")));
 
 		assertEquals(JobStatus.FAILED, executionGraph.getState());
 
@@ -770,6 +775,68 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the {@link ExecutionGraph} can handle concurrent failures while
+	 * being in the RESTARTING state.
+	 */
+	@Test
+	public void testConcurrentFailureWhileRestarting() throws Exception {
+		final long timeout = 5000L;
+
+		final CountDownLatch countDownLatch = new CountDownLatch(2);
+		final CountDownLatchRestartStrategy restartStrategy = new CountDownLatchRestartStrategy(countDownLatch);
+		final ExecutionGraph executionGraph = createSimpleExecutionGraph(restartStrategy, new TestingSlotProvider(ignored -> new CompletableFuture<>()));
+
+		executionGraph.setQueuedSchedulingAllowed(true);
+		executionGraph.scheduleForExecution();
+
+		assertThat(executionGraph.getState(), is(JobStatus.RUNNING));
+
+		executionGraph.failGlobal(new FlinkException("Test exception"));
+
+		executor.execute(() -> {
+			countDownLatch.countDown();
+			try {
+				countDownLatch.await();
+			} catch (InterruptedException e) {
+				ExceptionUtils.rethrow(e);
+			}
+
+			executionGraph.failGlobal(new FlinkException("Concurrent exception"));
+		});
+
+		waitUntilJobStatus(executionGraph, JobStatus.RUNNING, timeout);
+	}
+
+	private static final class CountDownLatchRestartStrategy implements RestartStrategy {
+
+		private final CountDownLatch countDownLatch;
+
+		private CountDownLatchRestartStrategy(CountDownLatch countDownLatch) {
+			this.countDownLatch = countDownLatch;
+		}
+
+		@Override
+		public boolean canRestart() {
+			return true;
+		}
+
+		@Override
+		public void restart(RestartCallback restarter, ScheduledExecutor executor) {
+			executor.execute(() -> {
+				countDownLatch.countDown();
+
+				try {
+					countDownLatch.await();
+				} catch (InterruptedException e) {
+					ExceptionUtils.rethrow(e);
+				}
+
+				restarter.triggerFullRecovery();
+			});
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -858,12 +925,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 		scheduler.newInstanceAvailable(instance);
 
-		JobVertex sender = ExecutionGraphTestUtils.createJobVertex("Task", NUM_TASKS, NoOpInvokable.class);
-
-		JobGraph jobGraph = new JobGraph("Pointwise job", sender);
-
-		ExecutionGraph eg = newExecutionGraph(restartStrategy, scheduler);
-		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
+		ExecutionGraph eg = createSimpleExecutionGraph(restartStrategy, scheduler);
 
 		assertEquals(JobStatus.CREATED, eg.getState());
 
@@ -872,7 +934,23 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		return new Tuple2<>(eg, instance);
 	}
 
-	private static ExecutionGraph newExecutionGraph(RestartStrategy restartStrategy, Scheduler scheduler) throws IOException {
+	private static ExecutionGraph createSimpleExecutionGraph(RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException, JobException {
+		JobGraph jobGraph = createJobGraph(NUM_TASKS);
+
+		ExecutionGraph eg = newExecutionGraph(restartStrategy, slotProvider);
+		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
+
+		return eg;
+	}
+
+	@Nonnull
+	private static JobGraph createJobGraph(int parallelism) {
+		JobVertex sender = ExecutionGraphTestUtils.createJobVertex("Task", parallelism, NoOpInvokable.class);
+
+		return new JobGraph("Pointwise job", sender);
+	}
+
+	private static ExecutionGraph newExecutionGraph(RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException {
 		return new ExecutionGraph(
 			TestingUtils.defaultExecutor(),
 			TestingUtils.defaultExecutor(),
@@ -882,7 +960,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			restartStrategy,
-			scheduler);
+			slotProvider);
 	}
 
 	private static void restartAfterFailure(ExecutionGraph eg, FiniteDuration timeout, boolean haltAfterRestart) throws InterruptedException, TimeoutException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -130,7 +130,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	@Test
 	public void testRestartAutomatically() throws Exception {
-		RestartStrategy restartStrategy = new FixedDelayRestartStrategy(1, 1000);
+		RestartStrategy restartStrategy = new FixedDelayRestartStrategy(1, 0L);
 		Tuple2<ExecutionGraph, Instance> executionGraphInstanceTuple = createExecutionGraph(restartStrategy);
 		ExecutionGraph eg = executionGraphInstanceTuple.f0;
 
@@ -333,7 +333,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobVertex sender = ExecutionGraphTestUtils.createJobVertex("Task1", 1, NoOpInvokable.class);
 		JobVertex receiver = ExecutionGraphTestUtils.createJobVertex("Task2", 1, NoOpInvokable.class);
 		JobGraph jobGraph = new JobGraph("Pointwise job", sender, receiver);
-		ExecutionGraph eg = newExecutionGraph(new FixedDelayRestartStrategy(1, 1000), scheduler);
+		ExecutionGraph eg = newExecutionGraph(new FixedDelayRestartStrategy(1, 0L), scheduler);
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
 		assertEquals(JobStatus.CREATED, eg.getState());
@@ -925,8 +925,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	private static void waitForAsyncRestart(ExecutionGraph eg, FiniteDuration timeout) throws InterruptedException {
 		Deadline deadline = timeout.fromNow();
+		long waitingTime = 10L;
 		while (deadline.hasTimeLeft() && eg.getState() != JobStatus.RUNNING) {
-			Thread.sleep(100);
+			Thread.sleep(waitingTime);
+			waitingTime = Math.min(waitingTime << 1, 100L);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -92,9 +92,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 
+/**
+ * Tests the restart behaviour of the {@link ExecutionGraph}.
+ */
 public class ExecutionGraphRestartTest extends TestLogger {
 
-	private final static int NUM_TASKS = 31;
+	private static final int NUM_TASKS = 31;
 
 	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(4);
 


### PR DESCRIPTION
## What is the purpose of the change

The problem was that a concurrent global failure could start a concurrent
restart operation without terminating the previous operation. Terminating
the previous restart operation means to cancel all current Executions and
wait for cancellation completion. Due to the missing wait, it could happen
that previously reset Executions are being tried to reset again. This violates
a sanity check and would lead to a restart loop.

The problem is fixed by not distinguishing between a fail which happens in
state JobStatus.RESTARTING and in any other state. Due to this, we will always
cancel all existing Executions and only trigger the restart after all Executions
have reached a terminal state.

## Brief change log

- Remove `RESTARTING` branch from `ExecutionGraph#failGlobal`
- Use `expectedGlobalVersion` when resetting `Executions` in `ExecutionGraph#restart`

## Verifying this change

- Added `ExecutionGraphRestartTest#testConcurrentFailureWhileRestarting`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes**)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
