### PR TITLE
[BP-1.6][FLINK-10309][rest] Before shutting down cluster, wait for asynchronous operations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -677,7 +677,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 				try {
 					checkpointCoordinator.receiveAcknowledgeMessage(ackMessage);
 				} catch (Throwable t) {
-					log.warn("Error while processing checkpoint acknowledgement message");
+					log.warn("Error while processing checkpoint acknowledgement message", t);
 				}
 			});
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -16,14 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.handler;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.rest.handler.FileUploads;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.HandlerRequestException;
-import org.apache.flink.runtime.rest.handler.RedirectHandler;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rest.FileUploadHandler;
 import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
@@ -33,6 +30,7 @@ import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException;
@@ -64,13 +62,19 @@ import java.util.concurrent.CompletableFuture;
  * @param <R> type of the incoming request
  * @param <M> type of the message parameters
  */
-public abstract class AbstractHandler<T extends RestfulGateway, R extends RequestBody, M extends MessageParameters> extends RedirectHandler<T> {
+public abstract class AbstractHandler<T extends RestfulGateway, R extends RequestBody, M extends MessageParameters> extends RedirectHandler<T> implements AutoCloseableAsync {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	protected static final ObjectMapper MAPPER = RestMapperUtils.getStrictObjectMapper();
 
 	private final UntypedResponseMessageHeaders<R, M> untypedResponseMessageHeaders;
+
+	/**
+	 * Used to ensure that the handler is not closed while there are still in-flight requests
+	 * dispatched outside of Netty's {@link org.apache.flink.shaded.netty4.io.netty.util.concurrent.EventExecutor}.
+	 */
+	private final InFlightRequestTracker inFlightRequestTracker;
 
 	protected AbstractHandler(
 			@Nonnull CompletableFuture<String> localAddressFuture,
@@ -81,6 +85,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 		super(localAddressFuture, leaderRetriever, timeout, responseHeaders);
 
 		this.untypedResponseMessageHeaders = Preconditions.checkNotNull(untypedResponseMessageHeaders);
+		this.inFlightRequestTracker = new InFlightRequestTracker();
 	}
 
 	@Override
@@ -92,6 +97,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 		FileUploads uploadedFiles = null;
 		try {
+			inFlightRequestTracker.registerRequest();
 			if (!(httpRequest instanceof FullHttpRequest)) {
 				// The RestServerEndpoint defines a HttpObjectAggregator in the pipeline that always returns
 				// FullHttpRequests.
@@ -154,8 +160,12 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 			final FileUploads finalUploadedFiles = uploadedFiles;
 			requestProcessingFuture
-				.whenComplete((Void ignored, Throwable throwable) -> cleanupFileUploads(finalUploadedFiles));
+				.whenComplete((Void ignored, Throwable throwable) -> {
+					inFlightRequestTracker.deregisterRequest();
+					cleanupFileUploads(finalUploadedFiles);
+				});
 		} catch (RestHandlerException rhe) {
+			inFlightRequestTracker.deregisterRequest();
 			HandlerUtils.sendErrorResponse(
 				ctx,
 				httpRequest,
@@ -164,6 +174,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 				responseHeaders);
 			cleanupFileUploads(uploadedFiles);
 		} catch (Throwable e) {
+			inFlightRequestTracker.deregisterRequest();
 			log.error("Request processing failed.", e);
 			HandlerUtils.sendErrorResponse(
 				ctx,
@@ -173,6 +184,15 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 				responseHeaders);
 			cleanupFileUploads(uploadedFiles);
 		}
+	}
+
+	@Override
+	public final CompletableFuture<Void> closeAsync() {
+		return FutureUtils.composeAfterwards(closeHandlerAsync(), inFlightRequestTracker::awaitAsync);
+	}
+
+	protected CompletableFuture<Void> closeHandlerAsync() {
+		return CompletableFuture.completedFuture(null);
 	}
 
 	private void cleanupFileUploads(@Nullable FileUploads uploadedFiles) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.rest.handler;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.rest.AbstractHandler;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/InFlightRequestTracker.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Phaser;
+
+/**
+ * Tracks in-flight client requests.
+ *
+ * @see AbstractHandler
+ */
+@ThreadSafe
+class InFlightRequestTracker {
+
+	private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+
+	private final Phaser phaser = new Phaser(1) {
+		@Override
+		protected boolean onAdvance(final int phase, final int registeredParties) {
+			terminationFuture.complete(null);
+			return true;
+		}
+	};
+
+	/**
+	 * Registers an in-flight request.
+	 */
+	public void registerRequest() {
+		phaser.register();
+	}
+
+	/**
+	 * Deregisters an in-flight request.
+	 */
+	public void deregisterRequest() {
+		phaser.arriveAndDeregister();
+	}
+
+	/**
+	 * Returns a future that completes when the in-flight requests that were registered prior to
+	 * calling this method are deregistered.
+	 */
+	public CompletableFuture<Void> awaitAsync() {
+		phaser.arriveAndDeregister();
+		return terminationFuture;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.async;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.AutoCloseableAsync;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Ticker;
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Cache to manage ongoing operations.
+ *
+ * <p>The cache allows to register ongoing operations by calling
+ * {@link #registerOngoingOperation(K, CompletableFuture)}, where the
+ * {@code CompletableFuture} contains the operation result. Completed operations will be
+ * removed from the cache automatically after a fixed timeout.
+ */
+@ThreadSafe
+class CompletedOperationCache<K extends OperationKey, R> implements AutoCloseableAsync {
+
+	private static final long COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS = 300L;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CompletedOperationCache.class);
+
+	/**
+	 * In-progress asynchronous operations.
+	 */
+	private final Map<K, ResultAccessTracker<R>> registeredOperationTriggers = new ConcurrentHashMap<>();
+
+	/**
+	 * Caches the result of completed operations.
+	 */
+	private final Cache<K, ResultAccessTracker<R>> completedOperations;
+
+	CompletedOperationCache() {
+		this(Ticker.systemTicker());
+	}
+
+	@VisibleForTesting
+	CompletedOperationCache(final Ticker ticker) {
+		completedOperations = CacheBuilder.newBuilder()
+			.expireAfterWrite(COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS, TimeUnit.SECONDS)
+			.removalListener((RemovalListener<K, ResultAccessTracker<R>>) removalNotification -> {
+				if (removalNotification.wasEvicted()) {
+					Preconditions.checkState(removalNotification.getKey() != null);
+					Preconditions.checkState(removalNotification.getValue() != null);
+
+					// When shutting down the cache, we wait until all results are accessed.
+					// When a result gets evicted from the cache, it will not be possible to access
+					// it any longer, and we might be in the process of shutting down, so we mark
+					// the result as accessed to avoid waiting indefinitely.
+					removalNotification.getValue().markAccessed();
+
+					LOGGER.info("Evicted result with trigger id {} because its TTL of {}s has expired.",
+						removalNotification.getKey().getTriggerId(),
+						COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS);
+				}
+			})
+			.ticker(ticker)
+			.build();
+	}
+
+	/**
+	 * Registers an ongoing operation with the cache.
+	 *
+	 * @param operationResultFuture A future containing the operation result.
+	 */
+	public void registerOngoingOperation(
+			final K operationKey,
+			final CompletableFuture<R> operationResultFuture) {
+		final ResultAccessTracker<R> inProgress = ResultAccessTracker.inProgress();
+		registeredOperationTriggers.put(operationKey, inProgress);
+		operationResultFuture.whenComplete((result, error) -> {
+			if (error == null) {
+				completedOperations.put(operationKey, inProgress.finishOperation(Either.Right(result)));
+			} else {
+				completedOperations.put(operationKey, inProgress.finishOperation(Either.Left(error)));
+			}
+			registeredOperationTriggers.remove(operationKey);
+		});
+	}
+
+	/**
+	 * Returns the operation result or a {@code Throwable} if the {@code CompletableFuture}
+	 * finished, otherwise {@code null}.
+	 *
+	 * @throws UnknownOperationKeyException If the operation is not found, and there is no ongoing
+	 *                                      operation under the provided key.
+	 */
+	@Nullable
+	public Either<Throwable, R> get(
+			final K operationKey) throws UnknownOperationKeyException {
+		ResultAccessTracker<R> resultAccessTracker;
+		if ((resultAccessTracker = registeredOperationTriggers.get(operationKey)) == null
+			&& (resultAccessTracker = completedOperations.getIfPresent(operationKey)) == null) {
+			throw new UnknownOperationKeyException(operationKey);
+		}
+
+		return resultAccessTracker.accessOperationResultOrError();
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		return FutureUtils.orTimeout(
+			asyncWaitForResultsToBeAccessed(),
+			COMPLETED_OPERATION_RESULT_CACHE_DURATION_SECONDS,
+			TimeUnit.SECONDS);
+	}
+
+	private CompletableFuture<Void> asyncWaitForResultsToBeAccessed() {
+		return FutureUtils.waitForAll(
+			Stream.concat(registeredOperationTriggers.values().stream(), completedOperations.asMap().values().stream())
+				.map(ResultAccessTracker::getAccessedFuture)
+				.collect(Collectors.toList()));
+	}
+
+	@VisibleForTesting
+	void cleanUp() {
+		completedOperations.cleanUp();
+	}
+
+	/**
+	 * Stores the result of an asynchronous operation, and tracks accesses to it.
+	 */
+	private static class ResultAccessTracker<R> {
+
+		/** Result of an asynchronous operation. Null if operation is in progress. */
+		@Nullable
+		private final Either<Throwable, R> operationResultOrError;
+
+		/** Future that completes if a non-null {@link #operationResultOrError} is accessed. */
+		private final CompletableFuture<Void> accessed;
+
+		private static <R> ResultAccessTracker<R> inProgress() {
+			return new ResultAccessTracker<>();
+		}
+
+		private ResultAccessTracker() {
+			this.operationResultOrError = null;
+			this.accessed = new CompletableFuture<>();
+		}
+
+		private ResultAccessTracker(final Either<Throwable, R> operationResultOrError, final CompletableFuture<Void> accessed) {
+			this.operationResultOrError = checkNotNull(operationResultOrError);
+			this.accessed = checkNotNull(accessed);
+		}
+
+		/**
+		 * Creates a new instance of the tracker with the result of the asynchronous operation set.
+		 */
+		public ResultAccessTracker<R> finishOperation(final Either<Throwable, R> operationResultOrError) {
+			checkState(this.operationResultOrError == null);
+
+			return new ResultAccessTracker<>(checkNotNull(operationResultOrError), this.accessed);
+		}
+
+		/**
+		 * If present, returns the result of the asynchronous operation, and marks the result as
+		 * accessed. If the result is not present, this method returns null.
+		 */
+		@Nullable
+		public Either<Throwable, R> accessOperationResultOrError() {
+			if (operationResultOrError != null) {
+				markAccessed();
+			}
+			return operationResultOrError;
+		}
+
+		public CompletableFuture<Void> getAccessedFuture() {
+			return accessed;
+		}
+
+		private void markAccessed() {
+			accessed.complete(null);
+		}
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/UnknownOperationKeyException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/UnknownOperationKeyException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.async;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Exception that indicates that there is no ongoing or completed savepoint for a given
+ * {@link JobID} and {@link TriggerId} pair.
+ */
+class UnknownOperationKeyException extends FlinkException {
+	private static final long serialVersionUID = 1L;
+
+	UnknownOperationKeyException(final Object operationKey) {
+		super("No ongoing operation for " + operationKey);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AsynchronousJobOperationKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AsynchronousJobOperationKey.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * A pair of {@link JobID} and {@link TriggerId} used as a key to a hash based
  * collection.
  *
- * @see AbstractAsynchronousOperationHandlers.CompletedOperationCache
+ * @see AbstractAsynchronousOperationHandlers
  */
 @Immutable
 public class AsynchronousJobOperationKey extends OperationKey {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandler.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.blob.TransientBlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
-import org.apache.flink.runtime.rest.AbstractHandler;
+import org.apache.flink.runtime.rest.handler.AbstractHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.ManualTicker;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
@@ -279,20 +280,6 @@ public class FileArchivedExecutionGraphStoreTest extends TestLogger {
 			10000L,
 			TestingUtils.defaultScheduledExecutor(),
 			Ticker.systemTicker());
-	}
-
-	private static final class ManualTicker extends Ticker {
-
-		private long currentTime = 0;
-
-		@Override
-		public long read() {
-			return currentTime;
-		}
-
-		void advanceTime(long duration, TimeUnit timeUnit) {
-			currentTime += timeUnit.toNanos(duration);
-		}
 	}
 
 	private static final class PartialArchivedExecutionGraphMatcher extends BaseMatcher<ArchivedExecutionGraph> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -92,6 +92,7 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -123,6 +124,8 @@ public class RestServerEndpointITCase extends TestLogger {
 	private final Configuration config;
 	private SSLContext defaultSSLContext;
 	private SSLSocketFactory defaultSSLSocketFactory;
+
+	private TestHandler testHandler;
 
 	public RestServerEndpointITCase(final Configuration config) {
 		this.config = requireNonNull(config);
@@ -187,7 +190,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
 			CompletableFuture.completedFuture(mockRestfulGateway);
 
-		TestHandler testHandler = new TestHandler(
+		testHandler = new TestHandler(
 			CompletableFuture.completedFuture(restAddress),
 			mockGatewayRetriever,
 			RpcUtils.INF_TIMEOUT);
@@ -228,7 +231,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 
 		if (serverEndpoint != null) {
-			serverEndpoint.close();
+			serverEndpoint.closeAsync().get(timeout.getSize(), timeout.getUnit());
 			serverEndpoint = null;
 		}
 	}
@@ -424,6 +427,49 @@ public class RestServerEndpointITCase extends TestLogger {
 		assertEquals("foobar", fileContents.trim());
 	}
 
+	/**
+	 * Tests that after calling {@link RestServerEndpoint#closeAsync()}, the handlers are closed
+	 * first, and we wait for in-flight requests to finish. As long as not all handlers are closed,
+	 * HTTP requests should be served.
+	 */
+	@Test
+	public void testShouldWaitForHandlersWhenClosing() throws Exception {
+		final CompletableFuture<Void> closeHandlerFuture = new CompletableFuture<>();
+		testHandler.closeFuture = closeHandlerFuture;
+
+		// Initiate closing RestServerEndpoint but the handler should block.
+		final CompletableFuture<Void> closeRestServerEndpointFuture = serverEndpoint.closeAsync();
+		assertThat(closeRestServerEndpointFuture.isDone(), is(false));
+
+		final TestParameters parameters = new TestParameters();
+		parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
+		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
+
+		final CompletableFuture<TestResponse> request;
+		synchronized (TestHandler.LOCK) {
+			request = restClient.sendRequest(
+				serverAddress.getHostName(),
+				serverAddress.getPort(),
+				new TestHeaders(),
+				parameters,
+				new TestRequest(1));
+			TestHandler.LOCK.wait();
+		}
+
+		// Allow handler to close but there is still one in-flight request which should prevent
+		// the RestServerEndpoint from closing.
+		closeHandlerFuture.complete(null);
+		assertThat(closeRestServerEndpointFuture.isDone(), is(false));
+
+		// Finish the in-flight request.
+		synchronized (TestHandler.LOCK) {
+			TestHandler.LOCK.notifyAll();
+		}
+
+		request.get(timeout.getSize(), timeout.getUnit());
+		closeRestServerEndpointFuture.get(timeout.getSize(), timeout.getUnit());
+	}
+
 	private HttpURLConnection openHttpConnectionForUpload(final String boundary) throws IOException {
 		final HttpURLConnection connection =
 			(HttpURLConnection) new URL(serverEndpoint.getRestBaseUrl() + "/upload").openConnection();
@@ -470,6 +516,8 @@ public class RestServerEndpointITCase extends TestLogger {
 
 		private static final int LARGE_RESPONSE_BODY_ID = 3;
 
+		private CompletableFuture<Void> closeFuture = CompletableFuture.completedFuture(null);
+
 		TestHandler(
 				CompletableFuture<String> localAddressFuture,
 				GatewayRetriever<RestfulGateway> leaderRetriever,
@@ -489,19 +537,30 @@ public class RestServerEndpointITCase extends TestLogger {
 
 			final int id = request.getRequestBody().id;
 			if (id == 1) {
-				synchronized (LOCK) {
-					try {
-						LOCK.notifyAll();
-						LOCK.wait();
-					} catch (InterruptedException ignored) {
+				// Intentionally schedule the work on a different thread. This is to simulate
+				// handlers where the CompletableFuture is finished by the RPC framework.
+				return CompletableFuture.supplyAsync(() -> {
+					synchronized (LOCK) {
+						try {
+							LOCK.notifyAll();
+							LOCK.wait();
+						} catch (InterruptedException ignored) {
+						}
 					}
-				}
+					return new TestResponse(id);
+				});
 			} else if (id == LARGE_RESPONSE_BODY_ID) {
 				return CompletableFuture.completedFuture(new TestResponse(
 					id,
 					createStringOfSize(TEST_REST_MAX_CONTENT_LENGTH)));
+			} else {
+				return CompletableFuture.completedFuture(new TestResponse(id));
 			}
-			return CompletableFuture.completedFuture(new TestResponse(id));
+		}
+
+		@Override
+		public CompletableFuture<Void> closeHandlerAsync() {
+			return closeFuture;
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.handler;
 
-import org.apache.flink.runtime.rest.handler.FileUploads;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.router.RouteResult;
 import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/InFlightRequestTrackerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link InFlightRequestTracker}.
+ */
+public class InFlightRequestTrackerTest {
+
+	private InFlightRequestTracker inFlightRequestTracker;
+
+	@Before
+	public void setUp() {
+		inFlightRequestTracker = new InFlightRequestTracker();
+	}
+
+	@Test
+	public void testShouldFinishAwaitAsyncImmediatelyIfNoRequests() {
+		assertTrue(inFlightRequestTracker.awaitAsync().isDone());
+	}
+
+	@Test
+	public void testShouldFinishAwaitAsyncIffAllRequestsDeregistered() {
+		inFlightRequestTracker.registerRequest();
+
+		final CompletableFuture<Void> awaitFuture = inFlightRequestTracker.awaitAsync();
+		assertFalse(awaitFuture.isDone());
+
+		inFlightRequestTracker.deregisterRequest();
+		assertTrue(awaitFuture.isDone());
+	}
+
+	@Test
+	public void testAwaitAsyncIsIdempotent() {
+		final CompletableFuture<Void> awaitFuture = inFlightRequestTracker.awaitAsync();
+		assertTrue(awaitFuture.isDone());
+
+		assertSame(
+			"The reference to the future must not change",
+			awaitFuture,
+			inFlightRequestTracker.awaitAsync());
+	}
+
+	@Test
+	public void testShouldTolerateRegisterAfterAwaitAsync() {
+		final CompletableFuture<Void> awaitFuture = inFlightRequestTracker.awaitAsync();
+		assertTrue(awaitFuture.isDone());
+
+		inFlightRequestTracker.registerRequest();
+
+		assertSame(
+			"The reference to the future must not change",
+			awaitFuture,
+			inFlightRequestTracker.awaitAsync());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCacheTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.async;
+
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.util.ManualTicker;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link CompletedOperationCache}.
+ */
+public class CompletedOperationCacheTest extends TestLogger {
+
+	private static final OperationKey TEST_OPERATION_KEY = new OperationKey(new TriggerId());
+
+	private static final CompletableFuture<String> TEST_OPERATION_RESULT = CompletableFuture.completedFuture("foo");
+
+	private ManualTicker manualTicker;
+
+	private CompletedOperationCache<OperationKey, String> completedOperationCache;
+
+	@Before
+	public void setUp() {
+		manualTicker = new ManualTicker();
+		completedOperationCache = new CompletedOperationCache<>(manualTicker);
+	}
+
+	@Test
+	public void testShouldFinishClosingCacheIfAllResultsAreEvicted() {
+		completedOperationCache.registerOngoingOperation(TEST_OPERATION_KEY, TEST_OPERATION_RESULT);
+		final CompletableFuture<Void> closeCacheFuture = completedOperationCache.closeAsync();
+		assertThat(closeCacheFuture.isDone(), is(false));
+
+		manualTicker.advanceTime(300, TimeUnit.SECONDS);
+		completedOperationCache.cleanUp();
+
+		assertThat(closeCacheFuture.isDone(), is(true));
+	}
+
+	@Test
+	public void testShouldFinishClosingCacheIfAllResultsAccessed() throws Exception {
+		completedOperationCache.registerOngoingOperation(TEST_OPERATION_KEY, TEST_OPERATION_RESULT);
+		final CompletableFuture<Void> closeCacheFuture = completedOperationCache.closeAsync();
+		assertThat(closeCacheFuture.isDone(), is(false));
+
+		final Either<Throwable, String> operationResultOrError = completedOperationCache.get(TEST_OPERATION_KEY);
+
+		assertThat(operationResultOrError, is(notNullValue()));
+		assertThat(operationResultOrError.right(), is(equalTo(TEST_OPERATION_RESULT.get())));
+		assertThat(closeCacheFuture.isDone(), is(true));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ManualTicker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ManualTicker.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Ticker;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Controllable {@link Ticker} implementation for tests.
+ */
+public final class ManualTicker extends Ticker {
+
+	private long currentTime;
+
+	@Override
+	public long read() {
+		return currentTime;
+	}
+
+	public void advanceTime(final long duration, final TimeUnit timeUnit) {
+		currentTime += timeUnit.toNanos(duration);
+	}
+}

--- a/flink-yarn-tests/src/test/resources/log4j-test.properties
+++ b/flink-yarn-tests/src/test/resources/log4j-test.properties
@@ -35,7 +35,7 @@ log4j.logger.org.apache.flink.runtime.leaderelection=INFO
 log4j.logger.org.apache.flink.runtime.leaderretrieval=INFO
 
 log4j.logger.org.apache.directory=OFF
-log4j.logger.org.mortbay.log=OFF, testlogger
+log4j.logger.org.mortbay.log=OFF
 log4j.logger.net.sf.ehcache=OFF
 log4j.logger.org.apache.hadoop.metrics2=OFF
 log4j.logger.org.apache.hadoop.conf.Configuration=OFF


### PR DESCRIPTION
## What is the purpose of the change

*Wait for the result of asynchronous operations to be served before shutting down the cluster.  This is necessary for the _"cancel with savepoint"_ operation. If we do not wait for the result to be accessed by the client, we may shutdown the cluster, and the client gets a `ConnectionException`.*

cc: @zentol 

## Brief change log

  - *Before shutting down cluster, wait for asynchronous operations.*
  - *Log stacktrace if checkpoint cannot be ack'ed.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test to `RestServerEndpointITCase` to verify that handlers are closed first.*
  - *Added unit tests for `CompletedOperationCache`.*
  - *Verified the changes by submitting and cancelling with savepoint of a job in a loop.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
