### PR TITLE
[FLINK-10524] Retry MemoryManager#release if NoSuchElementException

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -454,7 +455,7 @@ public class MemoryManager {
 					// the only way to exit the loop
 					successfullyReleased = true;
 				}
-				catch (ConcurrentModificationException e) {
+				catch (ConcurrentModificationException | NoSuchElementException e) {
 					// this may happen in the case where an asynchronous
 					// call releases the memory. fall through the loop and try again
 				}


### PR DESCRIPTION
## What is the purpose of the change

The MemoryManager#release method retries in case of ConcurrentModificationExceptions because
memory can be released concurrently. In case of concurrent releases we can also see a
NoSuchElementException if we are in the ArrayList.Itr#next call past the concurrent modification
check and try to access, for example, an index which is exceeding the ArrayList's size. Thus,
we should also retry on seeing a NoSuchElementException because it indicates a concurrent
modification.

## Verifying this change

- Covered by `MemoryManagerConcurrentModReleaseTest.testConcurrentModificationWhileReleasing`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
