### PR TITLE
[FLINK-9592][flink-connector-filesystem] added ability to hook file state changing

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/FileStateChangedCallback.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/FileStateChangedCallback.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.fs.bucketing;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * The {@code FileStateChangedCallback} is used to perform any additional operations, when {@link BucketingSink}
+ * moves file from one state to another.
+ */
+public interface FileStateChangedCallback {
+
+	void onInProgressToPending(FileSystem fs, Path path) throws IOException;
+
+	void onPendingToFinal(FileSystem fs, Path path) throws IOException;
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -1183,6 +1183,8 @@ public class BucketingSinkTest extends TestLogger {
 
 	private static final class FileStateChangedCallbackImpl implements FileStateChangedCallback {
 
+		private static final long serialVersionUID = 4806217568474143413L;
+
 		private String basePath;
 
 		public FileStateChangedCallbackImpl(String basePath) {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTestUtils.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTestUtils.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 public class BucketingSinkTestUtils {
 
 	public static final String PART_PREFIX = "part";
+	public static final String PART_SUFFIX = ".my";
 	public static final String PENDING_SUFFIX = ".pending";
 	public static final String IN_PROGRESS_SUFFIX = ".in-progress";
 	public static final String VALID_LENGTH_SUFFIX = ".valid";


### PR DESCRIPTION
### What is the purpose of the change:
This pull-request adds ability to hook the moment of file state changing

### Brief change log:

- when file is moved from inProgress to pending state the list of pre-configured hooks will be called
- when file is moved from pending into final state the list of pre-configured hooks will be called

### Verifying this change:
The following tests verify that hooks are called in proper time:

- testThatOnInProgressToPendingCallbackIsFiredWhenFilesAreMovedToPendingStateByTimeout
- testThatOnInProgressToPendingCallbackIsFiredWhenFilesAreMovedToPendingStateBySize
- testThatOnInProgressToPendingCallbackIsFiredWhenFunctionIsClosed
- testThatOnPendingToFinalCallbackIsFiredWhenCheckpointingIsCompleted

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, - Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (yes)

### Documentation:

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? Usage information about this feature was added to the description of **org.apache.flink.streaming.connectors.fs.bucketing.BucketingSink** class