### PR TITLE
[FLINK-10530][tests] Harden ProcessFailureCancelingITCase and AbstractTaskManagerProcessFailureRecovery

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -64,10 +64,9 @@ public class TaskManagerProcessFailureBatchRecoveryITCase extends AbstractTaskMa
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public void testTaskManagerFailure(int jobManagerPort, final File coordinateDir) throws Exception {
+	public void testTaskManagerFailure(Configuration configuration, final File coordinateDir) throws Exception {
 
-		final Configuration configuration = new Configuration();
-		ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment("localhost", jobManagerPort, configuration);
+		ExecutionEnvironment env = ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, configuration);
 		env.setParallelism(PARALLELISM);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0L));
 		env.getConfig().setExecutionMode(executionMode);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
@@ -61,14 +61,13 @@ public class TaskManagerProcessFailureStreamingRecoveryITCase extends AbstractTa
 	private static final int DATA_COUNT = 10000;
 
 	@Override
-	public void testTaskManagerFailure(int jobManagerPort, final File coordinateDir) throws Exception {
+	public void testTaskManagerFailure(Configuration configuration, final File coordinateDir) throws Exception {
 
 		final File tempCheckpointDir = tempFolder.newFolder();
 
-		final Configuration configuration = new Configuration();
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(
 			"localhost",
-			jobManagerPort,
+			1337, // not needed since we use ZooKeeper
 			configuration);
 		env.setParallelism(PARALLELISM);
 		env.getConfig().disableSysoutLogging();


### PR DESCRIPTION
## What is the purpose of the change

The problem is that the Dispatcher actor is being started before it gains leadership. When using the
standalone high availability services, then we don't wait until the Dispatcher has confirmed its
leader session id. We only wait until the actor has become available. Due to that it can happen that
we try to send a RPC message to the Dispatcher before it has actually set its leader session id.

This commit changes the above mentioned tests to use HA mode based on ZooKeeper. With that, we will
wait until the leader session id has been confirmed.

## Verifying this change

- Covered by the hardened tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
