### PR TITLE
[FLINK-10516] [yarn] fix YarnApplicationMasterRunner fail to initialize FileSystem with correct Flink Configuration during setup

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -67,6 +68,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -159,6 +161,13 @@ public class YarnApplicationMasterRunner {
 			LOG.debug("YARN dynamic properties: {}", dynamicProperties);
 
 			final Configuration flinkConfig = createConfiguration(currDir, dynamicProperties);
+
+			// configure the filesystems
+			try {
+				FileSystem.initialize(flinkConfig);
+			} catch (IOException e) {
+				throw new IOException("Error while configuring the filesystems.", e);
+			}
 
 			File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
 			if (remoteKeytabPrincipal != null && f.exists()) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
@@ -19,9 +19,12 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.util.OperatingSystem;
 
+import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.Assume;
@@ -29,9 +32,14 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +56,7 @@ import static org.apache.flink.yarn.YarnConfigKeys.ENV_HADOOP_USER_NAME;
 import static org.apache.flink.yarn.YarnConfigKeys.FLINK_JAR_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -56,6 +65,8 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the {@link YarnApplicationMasterRunner}.
  */
+@PrepareForTest(FileSystem.class)
+@RunWith(PowerMockRunner.class)
 public class YarnApplicationMasterRunnerTest {
 	private static final Logger LOG = LoggerFactory.getLogger(YarnApplicationMasterRunnerTest.class);
 
@@ -108,5 +119,38 @@ public class YarnApplicationMasterRunnerTest {
 		ContainerLaunchContext ctx = Utils.createTaskExecutorContext(flinkConf, yarnConf, env, tmParams,
 			taskManagerConf, workingDirectory, taskManagerMainClass, LOG);
 		assertEquals("file", ctx.getLocalResources().get("flink.jar").getResource().getScheme());
+	}
+
+	@Test
+	public void testRunAndInitializeFileSystem() throws Exception {
+		// Mock necessary system variables
+		Map<String, String> map = new HashMap<String, String>(System.getenv());
+		map.put(YarnConfigKeys.ENV_HADOOP_USER_NAME, "foo");
+		// Create dynamic properties to be used in the Flink configuration
+		map.put(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES, "myKey=myValue");
+		CommonTestUtils.setEnv(map);
+
+		// Create a temporary flink-conf.yaml and to be deleted on JVM exits
+		File currDir = new File(System.getenv().get(ApplicationConstants.Environment.PWD.key()));
+		String path = String.format("%s/%s.%s", currDir, "flink-conf", "yaml");
+		File f = new File(path);
+		f.createNewFile();
+		f.deleteOnExit();
+
+		// Mock FileSystem.initialize()
+		PowerMockito.mockStatic(FileSystem.class);
+		PowerMockito.doNothing().when(FileSystem.class);
+		FileSystem.initialize(any(Configuration.class));
+
+		String[] args = new String[5];
+		YarnApplicationMasterRunner yarnApplicationMasterRunner = new YarnApplicationMasterRunner();
+		yarnApplicationMasterRunner.run(args);
+
+		// Verify FileSystem.initialize() is invoked with the correct Flink config
+		ArgumentCaptor<Configuration> propertiesCaptor =
+			ArgumentCaptor.forClass(Configuration.class);
+		PowerMockito.verifyStatic();
+		FileSystem.initialize(propertiesCaptor.capture());
+		assertEquals("myValue", propertiesCaptor.getValue().getString("myKey", ""));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes YarnApplicationMasterRunner explicitly initialize FileSystem with Flink Configuration, so that the HadoopFileSystem can take in the custom HDFS configuration (e.g. core-site.xml under fs.hdfs.hadoopconf) for Flink 1.4

## Verifying this change
This change added tests and can be verified as follows:
  - Added a unit tests to verify the FileSystem.initialize() is called with correct Flink Config when YarnApplicationMasterRunner.run() is called


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable