### PR TITLE
[FLINK-10367][network] Introduce NotificationResult for BufferListener to solve recursive stack overflow

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
@@ -25,6 +25,41 @@ package org.apache.flink.runtime.io.network.buffer;
 public interface BufferListener {
 
 	/**
+	 * Status of the notification result from the buffer listener.
+	 */
+	enum NotificationResult {
+		NONE(false, false),
+		BUFFER_USED_FINISHED(true, false),
+		BUFFER_USED_NEED_MORE(true, true);
+
+		private final boolean bufferUsed;
+		private final boolean needsMoreBuffers;
+
+		NotificationResult(boolean bufferUsed, boolean needsMoreBuffers) {
+			this.bufferUsed = bufferUsed;
+			this.needsMoreBuffers = needsMoreBuffers;
+		}
+
+		/**
+		 * Whether the notified buffer is accepted to use by the listener.
+		 *
+		 * @return <tt>true</tt> if the notified buffer is accepted.
+		 */
+		boolean bufferUsed() {
+			return bufferUsed;
+		}
+
+		/**
+		 * Whether the listener still needs more buffers to be notified.
+		 *
+		 * @return <tt>true</tt> if the listener is still waiting for more buffers.
+		 */
+		boolean needsMoreBuffers() {
+			return needsMoreBuffers;
+		}
+	}
+
+	/**
 	 * Notification callback if a buffer is recycled and becomes available in buffer pool.
 	 *
 	 * <p>Note: responsibility on recycling the given buffer is transferred to this implementation,
@@ -37,9 +72,9 @@ public interface BufferListener {
 	 * stack!
 	 *
 	 * @param buffer buffer that becomes available in buffer pool.
-	 * @return true if the listener wants to be notified next time.
+	 * @return NotificationResult if the listener wants to be notified next time.
 	 */
-	boolean notifyBufferAvailable(Buffer buffer);
+	NotificationResult notifyBufferAvailable(Buffer buffer);
 
 	/**
 	 * Notification callback if the buffer provider is destroyed.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.buffer;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.BufferListener.NotificationResult;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
@@ -258,36 +259,38 @@ class LocalBufferPool implements BufferPool {
 	@Override
 	public void recycle(MemorySegment segment) {
 		BufferListener listener;
-		synchronized (availableMemorySegments) {
-			if (isDestroyed || numberOfRequestedMemorySegments > currentPoolSize) {
-				returnMemorySegment(segment);
-				return;
-			} else {
-				listener = registeredListeners.poll();
-
-				if (listener == null) {
-					availableMemorySegments.add(segment);
-					availableMemorySegments.notify();
+		NotificationResult notificationResult = NotificationResult.NONE;
+		while (!notificationResult.bufferUsed()) {
+			synchronized (availableMemorySegments) {
+				if (isDestroyed || numberOfRequestedMemorySegments > currentPoolSize) {
+					returnMemorySegment(segment);
 					return;
+				} else {
+					listener = registeredListeners.poll();
+
+					if (listener == null) {
+						availableMemorySegments.add(segment);
+						availableMemorySegments.notify();
+						return;
+					}
 				}
 			}
-		}
 
-		// We do not know which locks have been acquired before the recycle() or are needed in the
-		// notification and which other threads also access them.
-		// -> call notifyBufferAvailable() outside of the synchronized block to avoid a deadlock (FLINK-9676)
-		// Note that in case of any exceptions notifyBufferAvailable() should recycle the buffer
-		// (either directly or later during error handling) and therefore eventually end up in this
-		// method again.
-		boolean needMoreBuffers = listener.notifyBufferAvailable(new NetworkBuffer(segment, this));
+			// We do not know which locks have been acquired before the recycle() or are needed in the
+			// notification and which other threads also access them.
+			// -> call notifyBufferAvailable() outside of the synchronized block to avoid a deadlock (FLINK-9676)
+			// Note that in case of any exceptions notifyBufferAvailable() should recycle the buffer
+			// (either directly or later during error handling) and therefore eventually end up in this method again.
+			notificationResult = listener.notifyBufferAvailable(new NetworkBuffer(segment, this));
 
-		if (needMoreBuffers) {
-			synchronized (availableMemorySegments) {
-				if (isDestroyed) {
-					// cleanup tasks how they would have been done if we only had one synchronized block
-					listener.notifyBufferDestroyed();
-				} else {
-					registeredListeners.add(listener);
+			if (notificationResult.needsMoreBuffers()) {
+				synchronized (availableMemorySegments) {
+					if (isDestroyed) {
+						// cleanup tasks how they would have been done if we only had one synchronized block
+						listener.notifyBufferDestroyed();
+					} else {
+						registeredListeners.add(listener);
+					}
 				}
 			}
 		}
@@ -388,5 +391,4 @@ class LocalBufferPool implements BufferPool {
 			returnMemorySegment(segment);
 		}
 	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -414,10 +414,14 @@ public class LocalBufferPoolTest extends TestLogger {
 			AtomicInteger times = new AtomicInteger(0);
 
 			@Override
-			public boolean notifyBufferAvailable(Buffer buffer) {
+			public NotificationResult notifyBufferAvailable(Buffer buffer) {
 				int newCount = times.incrementAndGet();
 				buffer.recycleBuffer();
-				return newCount < notificationTimes;
+				if (newCount < notificationTimes) {
+					return NotificationResult.BUFFER_USED_NEED_MORE;
+				} else {
+					return NotificationResult.BUFFER_USED_FINISHED;
+				}
 			}
 
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferListener.NotificationResult;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
@@ -150,7 +151,10 @@ public class RemoteInputChannelTest {
 						for (int j = 0; j < 128; j++) {
 							// this is the same buffer over and over again which will be
 							// recycled by the RemoteInputChannel
-							function.apply(inputChannel, buffer.retainBuffer(), j);
+							Object obj = function.apply(inputChannel, buffer.retainBuffer(), j);
+							if (obj instanceof NotificationResult && obj == NotificationResult.NONE) {
+								buffer.recycleBuffer();
+							}
 						}
 
 						if (inputChannel.isReleased()) {


### PR DESCRIPTION
## What is the purpose of the change

*In the process of `LocalBufferPool#recycle`, the recycled buffer would be notified to a `BufferListener`. But this `BufferListener` may not need floating buffers any more currently, so this buffer is recycled again to the `LocalBufferPool`, then another `BufferListener` is selected to be notified of this available buffer.

The above process may be repeatedly triggered in recursive way that will cause stack overflow error in extreme case. We ever encountered this error triggered by release all resources during task failover in large scale job, especially it will also result in buffer leak after stack overflow.*

## Brief change log

  - *Introduce the `NotificationResult` for describing the notification result for `BufferListener`*
  - *Adjust the process of `LocalBufferPool#recycle` to avoid recursive call*
  - *Adjust the process of `RemoteInputChannel#notifyBufferAvailable` accordingly*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
