### PR TITLE
[FLINK-10537][network] Fix network small performance degradation after merging [FLINK-9913]

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
@@ -108,6 +108,7 @@ public class DataOutputSerializer implements DataOutputView {
 	}
 
 	public void pruneBuffer() {
+		clear();
 		if (this.buffer.length > PRUNE_BUFFER_THRESHOLD) {
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Releasing serialization buffer of " + this.buffer.length + " bytes.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
@@ -82,9 +82,9 @@ public interface RecordSerializer<T extends IOReadableWritable> {
 	SerializationResult copyToBufferBuilder(BufferBuilder bufferBuilder);
 
 	/**
-	 * Checks to decrease the size of intermediate data serialization buffer after finishing the
-	 * whole serialization process including {@link #serializeRecord(IOReadableWritable)} and
-	 * {@link #copyToBufferBuilder(BufferBuilder)}.
+	 * Clears the buffer and checks to decrease the size of intermediate data serialization buffer
+	 * after finishing the whole serialization process including
+	 * {@link #serializeRecord(IOReadableWritable)} and {@link #copyToBufferBuilder(BufferBuilder)}.
 	 */
 	void prune();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -92,20 +92,9 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	 */
 	@Override
 	public SerializationResult copyToBufferBuilder(BufferBuilder targetBuffer) {
-		boolean mustCommit = false;
-		if (lengthBuffer.hasRemaining()) {
-			targetBuffer.append(lengthBuffer);
-			mustCommit = true;
-		}
-
-		if (dataBuffer.hasRemaining()) {
-			targetBuffer.append(dataBuffer);
-			mustCommit = true;
-		}
-
-		if (mustCommit) {
-			targetBuffer.commit();
-		}
+		targetBuffer.append(lengthBuffer);
+		targetBuffer.append(dataBuffer);
+		targetBuffer.commit();
 
 		return getSerializationResult(targetBuffer);
 	}


### PR DESCRIPTION
This PR tries to address small performance regression first [spotted here](https://github.com/apache/flink/pull/6417#pullrequestreview-154263375) and [visible here](http://codespeed.dak8s.net:8000/timeline/#/?exe=1&ben=networkThroughput.1,100ms&env=2&revs=200&equid=off&quarts=on&extr=on).

Checks removed by this commit were performed once per every record, while before [FLINK-9913] those checks were executed only once per "continue writing with new buffer". Apparently those checks have some overhead once per record while are helping to avoid the need to commit the data very rarely.

This change is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
