### PR TITLE
[FLINK-8482][DataStream] Allow users to choose from different timestamp strategies for interval join

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -43,9 +43,10 @@ import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.util.Collector;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
@@ -103,6 +104,8 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 	private final long lowerBound;
 	private final long upperBound;
 
+	private final IntervalJoinOperator.TimestampStrategy timestampStrategy;
+
 	private final TypeSerializer<T1> leftTypeSerializer;
 	private final TypeSerializer<T2> rightTypeSerializer;
 
@@ -131,19 +134,25 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 			long upperBound,
 			boolean lowerBoundInclusive,
 			boolean upperBoundInclusive,
+			TimestampStrategy timestampStrategy,
 			TypeSerializer<T1> leftTypeSerializer,
 			TypeSerializer<T2> rightTypeSerializer,
-			ProcessJoinFunction<T1, T2, OUT> udf) {
+			ProcessJoinFunction<T1, T2, OUT> udf
+	) {
 
 		super(Preconditions.checkNotNull(udf));
 
 		Preconditions.checkArgument(lowerBound <= upperBound,
 			"lowerBound <= upperBound must be fulfilled");
 
+		Preconditions.checkNotNull(timestampStrategy);
+
 		// Move buffer by +1 / -1 depending on inclusiveness in order not needing
 		// to check for inclusiveness later on
 		this.lowerBound = (lowerBoundInclusive) ? lowerBound : lowerBound + 1L;
 		this.upperBound = (upperBoundInclusive) ? upperBound : upperBound - 1L;
+
+		this.timestampStrategy = timestampStrategy;
 
 		this.leftTypeSerializer = Preconditions.checkNotNull(leftTypeSerializer);
 		this.rightTypeSerializer = Preconditions.checkNotNull(rightTypeSerializer);
@@ -252,18 +261,48 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 		}
 	}
 
+	private long calculateNecessaryWatermarkDelay() {
+		switch (this.timestampStrategy) {
+			case MIN:
+				return Math.max(upperBound, -lowerBound);
+			case MAX:
+				return 0;
+			case LEFT:
+				return (upperBound < 0) ? 0 : upperBound;
+			case RIGHT:
+				return (lowerBound > 0) ? 0 : -lowerBound;
+			default:
+				throw new FlinkRuntimeException("Unsupported timestamp strategy: " + this.timestampStrategy);
+		}
+	}
+
 	private boolean isLate(long timestamp) {
 		long currentWatermark = internalTimerService.currentWatermark();
 		return currentWatermark != Long.MIN_VALUE && timestamp < currentWatermark;
 	}
 
 	private void collect(T1 left, T2 right, long leftTimestamp, long rightTimestamp) throws Exception {
-		final long resultTimestamp = Math.max(leftTimestamp, rightTimestamp);
+		final long resultTimestamp = calculateResultTimestamp(leftTimestamp, rightTimestamp);
 
 		collector.setAbsoluteTimestamp(resultTimestamp);
 		context.updateTimestamps(leftTimestamp, rightTimestamp, resultTimestamp);
 
 		userFunction.processElement(left, right, context, collector);
+	}
+
+	private long calculateResultTimestamp(long leftTs, long rightTs) {
+		switch (this.timestampStrategy) {
+			case MIN:
+				return Math.min(leftTs, rightTs);
+			case MAX:
+				return Math.max(leftTs, rightTs);
+			case LEFT:
+				return leftTs;
+			case RIGHT:
+				return rightTs;
+			default:
+				throw new FlinkRuntimeException("Unsupported timestamp strategy: " + timestampStrategy);
+		}
 	}
 
 	private static <T> void addToBuffer(
@@ -307,6 +346,25 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 	@Override
 	public void onProcessingTime(InternalTimer<K, String> timer) throws Exception {
 		// do nothing.
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		if (timeServiceManager != null) {
+			// Advance the timerService according to the "original" watermark.
+			// This means that all timers that this operator registers as well as timers
+			// registered via the UDF are with respect to the watermark as it comes in,
+			// as opposed to the possibly delayed watermark emitted by the operator
+			timeServiceManager.advanceWatermark(mark);
+		}
+
+		// Delay the watermark so that even in scenarios where the results of a join
+		// are from elements that were buffered and watermark has progressed in the meantime,
+		// we will never produce late data
+		long delayedTimestamp = mark.getTimestamp() - calculateNecessaryWatermarkDelay();
+		Watermark delayedWatermark = new Watermark(delayedTimestamp);
+
+		output.emitWatermark(delayedWatermark);
 	}
 
 	/**
@@ -354,6 +412,37 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 			Preconditions.checkArgument(outputTag != null, "OutputTag must not be null");
 			output.collect(outputTag, new StreamRecord<>(value, getTimestamp()));
 		}
+	}
+
+	/**
+	 * TimestampStrategy defines which timestamp of the two joined elements to
+	 * assign to the joined pair.
+	 */
+	public enum TimestampStrategy {
+
+		/**
+		 * When two elements are joined, assign the minimum timestamp of those two
+		 * elements as the timestamp of the joined pair.
+		 */
+		MIN,
+
+		/**
+		 * When two elements are joined, assign the maximum timestamp of those two
+		 * elements as the timestamp of the joined pair.
+		 */
+		MAX,
+
+		/**
+		 * When two elements are joined, assign the timestamp of the left element
+		 * as the the timestamp of the joined pair.
+		 */
+		LEFT,
+
+		/**
+		 * When two elements are joined, assign the timestamp of the right element
+		 * as the the timestamp of the joined pair.
+		 */
+		RIGHT
 	}
 
 	/**
@@ -523,4 +612,5 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 	MapState<Long, List<BufferEntry<T2>>> getRightBuffer() {
 		return rightBuffer;
 	}
+
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
 import org.apache.flink.streaming.api.functions.query.{QueryableAppendingStateOperator, QueryableValueStateOperator}
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
 import org.apache.flink.streaming.api.operators.StreamGroupedReduce
+import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.TimestampStrategy
 import org.apache.flink.streaming.api.scala.function.StatefulFunction
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
@@ -174,6 +175,8 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     private var lowerBoundInclusive = true
     private var upperBoundInclusive = true
 
+    private var timestampStrategy = TimestampStrategy.MAX
+
     /**
       * Set the lower bound to be exclusive
       */
@@ -189,6 +192,30 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     @PublicEvolving
     def upperBoundExclusive(): IntervalJoined[IN1, IN2, KEY] = {
       this.upperBoundInclusive = false
+      this
+    }
+
+    @Public
+    def assignMaxTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.MAX
+      this
+    }
+
+    @Public
+    def assignMinTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.MIN
+      this
+    }
+
+    @Public
+    def assignLeftTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.LEFT
+      this
+    }
+
+    @Public
+    def assignRightTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.RIGHT
       this
     }
 
@@ -208,7 +235,8 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
         lowerBound,
         upperBound,
         lowerBoundInclusive,
-        upperBoundInclusive)
+        upperBoundInclusive,
+        timestampStrategy)
       asScalaStream(javaJoined.process(processJoinFunction))
     }
   }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -96,6 +96,144 @@ class IntervalJoinITCase extends AbstractTestBase {
       "(key,1):(key,2)"
     )
   }
+
+  @Test
+  @throws[Exception]
+  def testUseLeftTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val streamTwo = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(0L), Time.milliseconds(2L))
+      .assignLeftTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          Assert.assertEquals(ctx.getTimestamp, ctx.getLeftTimestamp)
+
+        }
+      })
+
+    env.execute()
+  }
+
+  @Test
+  @throws[Exception]
+  def testUseRightTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 1L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val streamTwo = env.fromElements(("key", 2L), ("key", 3L), ("key", 4L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(-2L), Time.milliseconds(0L))
+      .assignRightTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          Assert.assertEquals(ctx.getTimestamp, ctx.getRightTimestamp)
+
+        }
+      })
+
+    env.execute()
+  }
+
+  @Test
+  @throws[Exception]
+  def testUseMaxTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 1L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val streamTwo = env.fromElements(("key", 2L), ("key", 3L), ("key", 4L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(-2L), Time.milliseconds(0L))
+      .assignMaxTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          val expected = Math.max(ctx.getRightTimestamp, ctx.getLeftTimestamp)
+          Assert.assertEquals(ctx.getTimestamp, expected)
+
+        }
+      })
+
+    env.execute()
+  }
+
+  @Test
+  @throws[Exception]
+  def testUseMinTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+    val streamTwo = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(-2L), Time.milliseconds(0L))
+      .assignRightTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          val expected = Math.min(ctx.getRightTimestamp, ctx.getLeftTimestamp)
+          Assert.assertEquals(ctx.getTimestamp, expected)
+
+        }
+      })
+
+    env.execute()
+  }
 }
 
 object Companion {


### PR DESCRIPTION
## What is the purpose of the change

This change will allow users to choose from different timestamp strategies when using the IntervalJoin in the DataStream API. A timestamp strategy defines which timestamp gets assigned to two elements that are joined together. The default is `.assignMaxTimestamp()` in order to not break existing semantics. 

The usage in the API looks as follows

```
leftKeyedStream.intervalJoin(rightKeyedStream)
        .between(<Time>, <Time>)
        .assignLeftTimestamp() // this is optional
        .process(<ProcessJoinFunction>)
``` 

The possible options to pick from are
- `assignLeftTimestamp()`:
- `assignRightTimestamp()`
- `assignMinTimestamp()`
- `assignMaxTimestamp()`

In certain scenarios the watermark emitted by the IntervalJoinOperator needs to be delayed, in order to not produce any late data. This is only necessary when choosing `assignMinTimestamp()` or for certain combinations of upper / lower bound and `assignRightTimestamp()` / `assignLeftTimestamp()`. It is never necessary when using `assignMaxTimestamp()`.

Delaying watermarks is implemented by subtracting the necessary delay from each incoming watermarks timestamp before emitting it. Note that this only takes effect with respect to downstream operators. The internal timerservice will still be advanced by the original watermark, so that timers (including those defined by the user) will still be fired with respect to the original watermark.

## Brief change log
  - Implement timestamp strategies in IntervalJoinOperator
  - Add to Scala DataStream API
  - Add to Java DataStream API
  - Add test cases to IntervalJoinITCase (both java & scala)

## Verifying this change
  - Extends integration tests in IntervalJoinITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
