### PR TITLE
[FLINK-10511][Cluster Management] Reuse the port selection and RPC se…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -56,7 +56,6 @@ import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
-import org.apache.flink.util.NetUtils;
 
 import akka.actor.ActorSystem;
 import org.slf4j.Logger;
@@ -68,7 +67,6 @@ import java.net.BindException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -426,39 +424,14 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		}
 
 		final String portRangeDefinition = configuration.getString(TaskManagerOptions.RPC_PORT);
-
-		return bindWithPort(configuration, taskManagerHostname, portRangeDefinition);
-	}
-
-	private static RpcService bindWithPort(
-		Configuration configuration,
-		String taskManagerHostname,
-		String portRangeDefinition) throws Exception{
-
-		// parse port range definition and create port iterator
-		Iterator<Integer> portsIterator;
 		try {
-			portsIterator = NetUtils.getPortRangeFromString(portRangeDefinition);
+			return AkkaRpcServiceUtils.createRpcService(taskManagerHostname, portRangeDefinition, configuration);
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Invalid port range definition: " + portRangeDefinition);
-		}
-
-		while (portsIterator.hasNext()) {
-			try {
-				return AkkaRpcServiceUtils.createRpcService(taskManagerHostname, portsIterator.next(), configuration);
+			if (e instanceof BindException) {
+				throw new BindException("Could not start task manager on any port in port range "
+					+ portRangeDefinition);
 			}
-			catch (Exception e) {
-				// we can continue to try if this contains a netty channel exception
-				Throwable cause = e.getCause();
-				if (!(cause instanceof org.jboss.netty.channel.ChannelException ||
-					cause instanceof java.net.BindException)) {
-					throw e;
-				} // else fall through the loop and try the next port
-			}
+			throw e;
 		}
-
-		// if we come here, we have exhausted the port range
-		throw new BindException("Could not start task manager on any port in port range "
-			+ portRangeDefinition);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Reuse the port selection and RPC service creation logic in JM and TM

## Brief change log
  - Add support for creating RPC service for a port range in AkkaRpcServiceUtils
  - Get rid of port selection of TaskManager and use AkkaRpcServiceUtils instead
  - Move the creation of RpcService to AkkaRpcServiceUtils in ClusterEntrypoint

## Verifying this change

This change is already covered by existing tests, such as TaskManagerRunnerTest and all kinds of integration tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
