### PR TITLE
[FLINK-10553] [sql] Unified sink and source table name in SQL statement

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -747,7 +747,8 @@ abstract class TableEnvironment(val config: TableConfig) {
         val queryResult = new Table(this, LogicalRelNode(planner.rel(validatedQuery).rel))
 
         // get name of sink table
-        val targetTableName = insert.getTargetTable.asInstanceOf[SqlIdentifier].names.get(0)
+        val targetTableName =
+          insert.getTargetTable.asInstanceOf[SqlIdentifier].names.asScala.mkString(".")
 
         // insert query result into sink table
         insertInto(queryResult, targetTableName, config)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/ExternalCatalogInsertTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/ExternalCatalogInsertTest.scala
@@ -53,7 +53,7 @@ class ExternalCatalogInsertTest extends TableTestBase {
       "test",
       CommonTestData.getInMemoryTestCatalog(isStreaming = false))
 
-    val sqlInsert = "INSERT INTO `test.db3.tb3` SELECT d * 2, e, g FROM test.db2.tb2 WHERE d < 3 " +
+    val sqlInsert = "INSERT INTO test.db3.tb3 SELECT d * 2, e, g FROM test.db2.tb2 WHERE d < 3 " +
       "UNION ALL (SELECT a * 2, b, c FROM test.db1.tb1)"
 
     tableBatchEnv.sqlUpdate(sqlInsert)
@@ -84,7 +84,7 @@ class ExternalCatalogInsertTest extends TableTestBase {
       "test",
       CommonTestData.getInMemoryTestCatalog(isStreaming = true))
 
-    val sqlInsert = "INSERT INTO `test.db3.tb3` SELECT d * 2, e, g FROM test.db2.tb2 WHERE d < 3 " +
+    val sqlInsert = "INSERT INTO test.db3.tb3 SELECT d * 2, e, g FROM test.db2.tb2 WHERE d < 3 " +
       "UNION ALL (SELECT a * 2, b, c FROM test.db1.tb1)"
 
     tableEnv.sqlUpdate(sqlInsert)


### PR DESCRIPTION
## What is the purpose of the change
This pull request solves a bug in flink SQL statement, in which sink table name in INSERT INTO clause can only be enclosed in back-ticks. The sink table name should be consisted with source table name in FROM clause.

## Verifying this change

This change is already covered by existing tests, such as *ExternalCatalogInsertTest#testBatchSQL*, *ExternalCatalogInsertTest#testStreamSQL*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
