### PR TITLE
[FLINK-10252] Handle oversized metric messges

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -77,6 +77,8 @@ public class MetricRegistryImpl implements MetricRegistry {
 
 	private final CompletableFuture<Void> terminationFuture;
 
+	private final long maximumFramesize;
+
 	@Nullable
 	private ActorRef queryService;
 
@@ -91,6 +93,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 	 * Creates a new MetricRegistry and starts the configured reporter.
 	 */
 	public MetricRegistryImpl(MetricRegistryConfiguration config) {
+		this.maximumFramesize = config.getQueryServiceMessageSizeLimit();
 		this.scopeFormats = config.getScopeFormats();
 		this.globalDelimiter = config.getDelimiter();
 		this.delimiters = new ArrayList<>(10);
@@ -184,7 +187,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 			Preconditions.checkState(!isShutdown(), "The metric registry has already been shut down.");
 
 			try {
-				queryService = MetricQueryService.startMetricQueryService(actorSystem, resourceID);
+				queryService = MetricQueryService.startMetricQueryService(actorSystem, resourceID, maximumFramesize);
 				metricQueryServicePath = AkkaUtils.getAkkaURL(actorSystem, queryService);
 			} catch (Exception e) {
 				LOG.warn("Could not start MetricDumpActor. No metrics will be submitted to the WebInterface.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
@@ -73,19 +73,38 @@ public class MetricDumpSerialization {
 
 		private static final long serialVersionUID = 6928770855951536906L;
 
-		public final byte[] serializedMetrics;
+		public final byte[] serializedCounters;
+		public final byte[] serializedGauges;
+		public final byte[] serializedMeters;
+		public final byte[] serializedHistograms;
+
 		public final int numCounters;
 		public final int numGauges;
 		public final int numMeters;
 		public final int numHistograms;
 
-		public MetricSerializationResult(byte[] serializedMetrics, int numCounters, int numGauges, int numMeters, int numHistograms) {
-			Preconditions.checkNotNull(serializedMetrics);
+		public MetricSerializationResult(
+			byte[] serializedCounters,
+			byte[] serializedGauges,
+			byte[] serializedMeters,
+			byte[] serializedHistograms,
+			int numCounters,
+			int numGauges,
+			int numMeters,
+			int numHistograms) {
+
+			Preconditions.checkNotNull(serializedCounters);
+			Preconditions.checkNotNull(serializedGauges);
+			Preconditions.checkNotNull(serializedMeters);
+			Preconditions.checkNotNull(serializedHistograms);
 			Preconditions.checkArgument(numCounters >= 0);
 			Preconditions.checkArgument(numGauges >= 0);
 			Preconditions.checkArgument(numMeters >= 0);
 			Preconditions.checkArgument(numHistograms >= 0);
-			this.serializedMetrics = serializedMetrics;
+			this.serializedCounters = serializedCounters;
+			this.serializedGauges = serializedGauges;
+			this.serializedMeters = serializedMeters;
+			this.serializedHistograms = serializedHistograms;
 			this.numCounters = numCounters;
 			this.numGauges = numGauges;
 			this.numMeters = numMeters;
@@ -102,7 +121,10 @@ public class MetricDumpSerialization {
 	 */
 	public static class MetricDumpSerializer {
 
-		private DataOutputSerializer buffer = new DataOutputSerializer(1024 * 32);
+		private DataOutputSerializer countersBuffer = new DataOutputSerializer(1024 * 8);
+		private DataOutputSerializer gaugesBuffer = new DataOutputSerializer(1024 * 8);
+		private DataOutputSerializer metersBuffer = new DataOutputSerializer(1024 * 8);
+		private DataOutputSerializer histogramsBuffer = new DataOutputSerializer(1024 * 8);
 
 		/**
 		 * Serializes the given metrics and returns the resulting byte array.
@@ -126,53 +148,66 @@ public class MetricDumpSerialization {
 			Map<Histogram, Tuple2<QueryScopeInfo, String>> histograms,
 			Map<Meter, Tuple2<QueryScopeInfo, String>> meters) {
 
-			buffer.clear();
-
+			countersBuffer.clear();
 			int numCounters = 0;
 			for (Map.Entry<Counter, Tuple2<QueryScopeInfo, String>> entry : counters.entrySet()) {
 				try {
-					serializeCounter(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					serializeCounter(countersBuffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
 					numCounters++;
 				} catch (Exception e) {
 					LOG.debug("Failed to serialize counter.", e);
 				}
 			}
 
+			gaugesBuffer.clear();
 			int numGauges = 0;
 			for (Map.Entry<Gauge<?>, Tuple2<QueryScopeInfo, String>> entry : gauges.entrySet()) {
 				try {
-					serializeGauge(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					serializeGauge(gaugesBuffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
 					numGauges++;
 				} catch (Exception e) {
 					LOG.debug("Failed to serialize gauge.", e);
 				}
 			}
 
+			histogramsBuffer.clear();
 			int numHistograms = 0;
 			for (Map.Entry<Histogram, Tuple2<QueryScopeInfo, String>> entry : histograms.entrySet()) {
 				try {
-					serializeHistogram(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					serializeHistogram(histogramsBuffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
 					numHistograms++;
 				} catch (Exception e) {
 					LOG.debug("Failed to serialize histogram.", e);
 				}
 			}
 
+			metersBuffer.clear();
 			int numMeters = 0;
 			for (Map.Entry<Meter, Tuple2<QueryScopeInfo, String>> entry : meters.entrySet()) {
 				try {
-					serializeMeter(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					serializeMeter(metersBuffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
 					numMeters++;
 				} catch (Exception e) {
 					LOG.debug("Failed to serialize meter.", e);
 				}
 			}
 
-			return new MetricSerializationResult(buffer.getCopyOfBuffer(), numCounters, numGauges, numMeters, numHistograms);
+			return new MetricSerializationResult(
+				countersBuffer.getCopyOfBuffer(),
+				gaugesBuffer.getCopyOfBuffer(),
+				metersBuffer.getCopyOfBuffer(),
+				histogramsBuffer.getCopyOfBuffer(),
+				numCounters,
+				numGauges,
+				numMeters,
+				numHistograms);
 		}
 
 		public void close() {
-			buffer = null;
+			countersBuffer = null;
+			gaugesBuffer = null;
+			metersBuffer = null;
+			histogramsBuffer = null;
 		}
 	}
 
@@ -280,13 +315,16 @@ public class MetricDumpSerialization {
 		 * @return A list containing the deserialized metrics.
 		 */
 		public List<MetricDump> deserialize(MetricDumpSerialization.MetricSerializationResult data) {
-			DataInputView in = new DataInputDeserializer(data.serializedMetrics, 0, data.serializedMetrics.length);
+			DataInputView countersInputView = new DataInputDeserializer(data.serializedCounters, 0, data.serializedCounters.length);
+			DataInputView gaugesInputView = new DataInputDeserializer(data.serializedGauges, 0, data.serializedGauges.length);
+			DataInputView metersInputView = new DataInputDeserializer(data.serializedMeters, 0, data.serializedMeters.length);
+			DataInputView histogramsInputView = new DataInputDeserializer(data.serializedHistograms, 0, data.serializedHistograms.length);
 
-			List<MetricDump> metrics = new ArrayList<>(data.numCounters + data.numGauges + data.numHistograms + data.numMeters);
+			List<MetricDump> metrics = new ArrayList<>(data.numCounters + data.numGauges + data.numMeters + data.numHistograms);
 
 			for (int x = 0; x < data.numCounters; x++) {
 				try {
-					metrics.add(deserializeCounter(in));
+					metrics.add(deserializeCounter(countersInputView));
 				} catch (Exception e) {
 					LOG.debug("Failed to deserialize counter.", e);
 				}
@@ -294,25 +332,25 @@ public class MetricDumpSerialization {
 
 			for (int x = 0; x < data.numGauges; x++) {
 				try {
-					metrics.add(deserializeGauge(in));
+					metrics.add(deserializeGauge(gaugesInputView));
 				} catch (Exception e) {
 					LOG.debug("Failed to deserialize gauge.", e);
 				}
 			}
 
-			for (int x = 0; x < data.numHistograms; x++) {
+			for (int x = 0; x < data.numMeters; x++) {
 				try {
-					metrics.add(deserializeHistogram(in));
+					metrics.add(deserializeMeter(metersInputView));
 				} catch (Exception e) {
-					LOG.debug("Failed to deserialize histogram.", e);
+					LOG.debug("Failed to deserialize meter.", e);
 				}
 			}
 
-			for (int x = 0; x < data.numMeters; x++) {
+			for (int x = 0; x < data.numHistograms; x++) {
 				try {
-					metrics.add(deserializeMeter(in));
+					metrics.add(deserializeHistogram(histogramsInputView));
 				} catch (Exception e) {
-					LOG.debug("Failed to deserialize meter.", e);
+					LOG.debug("Failed to deserialize histogram.", e);
 				}
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
@@ -70,6 +70,12 @@ public class MetricQueryService extends UntypedActor {
 	private final Map<Histogram, Tuple2<QueryScopeInfo, String>> histograms = new HashMap<>();
 	private final Map<Meter, Tuple2<QueryScopeInfo, String>> meters = new HashMap<>();
 
+	private final long messageSizeLimit;
+
+	public MetricQueryService(long messageSizeLimit) {
+		this.messageSizeLimit = messageSizeLimit;
+	}
+
 	@Override
 	public void postStop() {
 		serializer.close();
@@ -165,11 +171,16 @@ public class MetricQueryService extends UntypedActor {
 	 * @param resourceID resource ID to disambiguate the actor name
 	 * @return actor reference to the MetricQueryService
 	 */
-	public static ActorRef startMetricQueryService(ActorSystem actorSystem, ResourceID resourceID) {
+	public static ActorRef startMetricQueryService(
+		ActorSystem actorSystem,
+		ResourceID resourceID,
+		long maximumFramesize) {
+
 		String actorName = resourceID == null
 			? METRIC_QUERY_SERVICE_NAME
 			: METRIC_QUERY_SERVICE_NAME + "_" + resourceID.getResourceIdString();
-		return actorSystem.actorOf(Props.create(MetricQueryService.class), actorName);
+
+		return actorSystem.actorOf(Props.create(MetricQueryService.class, maximumFramesize), actorName);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerializerTest.java
@@ -70,7 +70,10 @@ public class MetricDumpSerializerTest {
 			Collections.<Meter, Tuple2<QueryScopeInfo, String>>emptyMap());
 
 		// no metrics should be serialized
-		Assert.assertEquals(0, output.serializedMetrics.length);
+		Assert.assertEquals(0, output.serializedCounters.length);
+		Assert.assertEquals(0, output.serializedGauges.length);
+		Assert.assertEquals(0, output.serializedHistograms.length);
+		Assert.assertEquals(0, output.serializedMeters.length);
 
 		List<MetricDump> deserialized = deserializer.deserialize(output);
 		Assert.assertEquals(0, deserialized.size());
@@ -141,7 +144,8 @@ public class MetricDumpSerializerTest {
 		gauges.put(g1, new Tuple2<QueryScopeInfo, String>(new QueryScopeInfo.TaskQueryScopeInfo("jid", "vid", 2, "D"), "g1"));
 		histograms.put(h1, new Tuple2<QueryScopeInfo, String>(new QueryScopeInfo.OperatorQueryScopeInfo("jid", "vid", 2, "opname", "E"), "h1"));
 
-		MetricDumpSerialization.MetricSerializationResult serialized = serializer.serialize(counters, gauges, histograms, meters);
+		MetricDumpSerialization.MetricSerializationResult serialized = serializer.serialize(
+			counters, gauges, histograms, meters);
 		List<MetricDump> deserialized = deserializer.deserialize(serialized);
 
 		// ===== Counters ==============================================================================================

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
@@ -49,7 +49,7 @@ public class MetricQueryServiceTest extends TestLogger {
 	public void testCreateDump() throws Exception {
 
 		ActorSystem s = AkkaUtils.createLocalActorSystem(new Configuration());
-		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null);
+		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, 50L);
 		TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
 		TestActor testActor = (TestActor) testActorRef.underlyingActor();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
@@ -53,173 +53,177 @@ public class MetricQueryServiceTest extends TestLogger {
 	@Test
 	public void testCreateDump() throws Exception {
 		ActorSystem s = AkkaUtils.createLocalActorSystem(new Configuration());
-		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, Long.MAX_VALUE);
-		TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
-		TestActor testActor = (TestActor) testActorRef.underlyingActor();
+		try {
+			ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, Long.MAX_VALUE);
+			TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
+			TestActor testActor = (TestActor) testActorRef.underlyingActor();
 
-		final Counter c = new SimpleCounter();
-		final Gauge<String> g = new Gauge<String>() {
-			@Override
-			public String getValue() {
-				return "Hello";
+			final Counter c = new SimpleCounter();
+			final Gauge<String> g = new Gauge<String>() {
+				@Override
+				public String getValue() {
+					return "Hello";
+				}
+			};
+			final Histogram h = new TestHistogram();
+			final Meter m = new Meter() {
+
+				@Override
+				public void markEvent() {
+				}
+
+				@Override
+				public void markEvent(long n) {
+				}
+
+				@Override
+				public double getRate() {
+					return 5;
+				}
+
+				@Override
+				public long getCount() {
+					return 10;
+				}
+			};
+
+			MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+			final TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+
+			MetricQueryService.notifyOfAddedMetric(serviceActor, c, "counter", tm);
+			MetricQueryService.notifyOfAddedMetric(serviceActor, g, "gauge", tm);
+			MetricQueryService.notifyOfAddedMetric(serviceActor, h, "histogram", tm);
+			MetricQueryService.notifyOfAddedMetric(serviceActor, m, "meter", tm);
+			serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
+			synchronized (testActor.lock) {
+				if (testActor.message == null) {
+					testActor.lock.wait();
+				}
 			}
-		};
-		final Histogram h = new TestHistogram();
-		final Meter m = new Meter() {
 
-			@Override
-			public void markEvent() {
+			MetricDumpSerialization.MetricSerializationResult dump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
+			testActor.message = null;
+			assertTrue(dump.serializedCounters.length > 0);
+			assertTrue(dump.serializedGauges.length > 0);
+			assertTrue(dump.serializedHistograms.length > 0);
+			assertTrue(dump.serializedMeters.length > 0);
+
+			MetricQueryService.notifyOfRemovedMetric(serviceActor, c);
+			MetricQueryService.notifyOfRemovedMetric(serviceActor, g);
+			MetricQueryService.notifyOfRemovedMetric(serviceActor, h);
+			MetricQueryService.notifyOfRemovedMetric(serviceActor, m);
+
+			serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
+			synchronized (testActor.lock) {
+				if (testActor.message == null) {
+					testActor.lock.wait();
+				}
 			}
 
-			@Override
-			public void markEvent(long n) {
-			}
-
-			@Override
-			public double getRate() {
-				return 5;
-			}
-
-			@Override
-			public long getCount() {
-				return 10;
-			}
-		};
-
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		final TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
-
-		MetricQueryService.notifyOfAddedMetric(serviceActor, c, "counter", tm);
-		MetricQueryService.notifyOfAddedMetric(serviceActor, g, "gauge", tm);
-		MetricQueryService.notifyOfAddedMetric(serviceActor, h, "histogram", tm);
-		MetricQueryService.notifyOfAddedMetric(serviceActor, m, "meter", tm);
-		serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
-		synchronized (testActor.lock) {
-			if (testActor.message == null) {
-				testActor.lock.wait();
-			}
+			MetricDumpSerialization.MetricSerializationResult emptyDump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
+			testActor.message = null;
+			assertEquals(0, emptyDump.serializedCounters.length);
+			assertEquals(0, emptyDump.serializedGauges.length);
+			assertEquals(0, emptyDump.serializedHistograms.length);
+			assertEquals(0, emptyDump.serializedMeters.length);
+		} finally {
+			s.terminate();
 		}
-
-		MetricDumpSerialization.MetricSerializationResult dump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
-		testActor.message = null;
-		assertTrue(dump.serializedCounters.length > 0);
-		assertTrue(dump.serializedGauges.length > 0);
-		assertTrue(dump.serializedHistograms.length > 0);
-		assertTrue(dump.serializedMeters.length > 0);
-
-		MetricQueryService.notifyOfRemovedMetric(serviceActor, c);
-		MetricQueryService.notifyOfRemovedMetric(serviceActor, g);
-		MetricQueryService.notifyOfRemovedMetric(serviceActor, h);
-		MetricQueryService.notifyOfRemovedMetric(serviceActor, m);
-
-		serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
-		synchronized (testActor.lock) {
-			if (testActor.message == null) {
-				testActor.lock.wait();
-			}
-		}
-
-		MetricDumpSerialization.MetricSerializationResult emptyDump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
-		testActor.message = null;
-		assertEquals(0, emptyDump.serializedCounters.length);
-		assertEquals(0, emptyDump.serializedGauges.length);
-		assertEquals(0, emptyDump.serializedHistograms.length);
-		assertEquals(0, emptyDump.serializedMeters.length);
-
-		s.terminate();
 	}
 
 	@Test
 	public void testHandleOversizedMetricMessage() throws Exception {
 		ActorSystem s = AkkaUtils.createLocalActorSystem(new Configuration());
-		final long sizeLimit = 200L;
-		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, sizeLimit);
-		TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
-		TestActor testActor = (TestActor) testActorRef.underlyingActor();
+		try {
+			final long sizeLimit = 200L;
+			ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, sizeLimit);
+			TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
+			TestActor testActor = (TestActor) testActorRef.underlyingActor();
 
-		final Counter c = new SimpleCounter();
-		final Histogram h = new TestHistogram();
-		final Meter m = new Meter() {
+			final Counter c = new SimpleCounter();
+			final Histogram h = new TestHistogram();
+			final Meter m = new Meter() {
 
-			@Override
-			public void markEvent() {
+				@Override
+				public void markEvent() {
+				}
+
+				@Override
+				public void markEvent(long n) {
+				}
+
+				@Override
+				public double getRate() {
+					return 5;
+				}
+
+				@Override
+				public long getCount() {
+					return 10;
+				}
+			};
+
+			MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+			final TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+
+			final String gaugeValue = "Hello";
+			final long requiredGaugesToExceedLimit = sizeLimit / gaugeValue.length() + 1;
+			List<Tuple2<String, Gauge<String>>> gauges = LongStream.range(0, requiredGaugesToExceedLimit)
+				.mapToObj(x -> Tuple2.of("gauge" + x, (Gauge<String>) () -> "Hello" + x))
+				.collect(Collectors.toList());
+			gauges.forEach(gauge -> MetricQueryService.notifyOfAddedMetric(serviceActor, gauge.f1, gauge.f0, tm));
+
+			MetricQueryService.notifyOfAddedMetric(serviceActor, c, "counter", tm);
+			MetricQueryService.notifyOfAddedMetric(serviceActor, h, "histogram", tm);
+			MetricQueryService.notifyOfAddedMetric(serviceActor, m, "meter", tm);
+
+			serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
+			synchronized (testActor.lock) {
+				if (testActor.message == null) {
+					testActor.lock.wait();
+				}
 			}
 
-			@Override
-			public void markEvent(long n) {
+			MetricDumpSerialization.MetricSerializationResult dump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
+			testActor.message = null;
+			assertTrue(dump.serializedCounters.length > 0);
+			assertEquals(1, dump.numCounters);
+			assertTrue(dump.serializedMeters.length > 0);
+			assertEquals(1, dump.numMeters);
+
+			// gauges exceeded the size limit and will be excluded
+			assertEquals(0, dump.serializedGauges.length);
+			assertEquals(0, dump.numGauges);
+
+			assertTrue(dump.serializedHistograms.length > 0);
+			assertEquals(1, dump.numHistograms);
+
+			// unregister all but one gauge to ensure gauges are reported again if the remaining fit
+			for (int x = 1; x < gauges.size(); x++) {
+				MetricQueryService.notifyOfRemovedMetric(serviceActor, gauges.get(x).f1);
 			}
 
-			@Override
-			public double getRate() {
-				return 5;
+			serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
+			synchronized (testActor.lock) {
+				if (testActor.message == null) {
+					testActor.lock.wait();
+				}
 			}
 
-			@Override
-			public long getCount() {
-				return 10;
-			}
-		};
+			MetricDumpSerialization.MetricSerializationResult recoveredDump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
+			testActor.message = null;
 
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		final TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
-
-		final String gaugeValue = "Hello";
-		final long requiredGaugesToExceedLimit = sizeLimit / gaugeValue.length() + 1;
-		List<Tuple2<String, Gauge<String>>> gauges = LongStream.range(0, requiredGaugesToExceedLimit)
-			.mapToObj(x -> Tuple2.of("gauge" + x, (Gauge<String>) () -> "Hello" + x))
-			.collect(Collectors.toList());
-		gauges.forEach(gauge -> MetricQueryService.notifyOfAddedMetric(serviceActor, gauge.f1, gauge.f0, tm));
-
-		MetricQueryService.notifyOfAddedMetric(serviceActor, c, "counter", tm);
-		MetricQueryService.notifyOfAddedMetric(serviceActor, h, "histogram", tm);
-		MetricQueryService.notifyOfAddedMetric(serviceActor, m, "meter", tm);
-
-		serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
-		synchronized (testActor.lock) {
-			if (testActor.message == null) {
-				testActor.lock.wait();
-			}
+			assertTrue(recoveredDump.serializedCounters.length > 0);
+			assertEquals(1, recoveredDump.numCounters);
+			assertTrue(recoveredDump.serializedMeters.length > 0);
+			assertEquals(1, recoveredDump.numMeters);
+			assertTrue(recoveredDump.serializedGauges.length > 0);
+			assertEquals(1, recoveredDump.numGauges);
+			assertTrue(recoveredDump.serializedHistograms.length > 0);
+			assertEquals(1, recoveredDump.numHistograms);
+		} finally {
+			s.terminate();
 		}
-
-		MetricDumpSerialization.MetricSerializationResult dump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
-		testActor.message = null;
-		assertTrue(dump.serializedCounters.length > 0);
-		assertEquals(1, dump.numCounters);
-		assertTrue(dump.serializedMeters.length > 0);
-		assertEquals(1, dump.numMeters);
-
-		// gauges exceeded the size limit and will be excluded
-		assertEquals(0, dump.serializedGauges.length);
-		assertEquals(0, dump.numGauges);
-
-		assertTrue(dump.serializedHistograms.length > 0);
-		assertEquals(1, dump.numHistograms);
-
-		// unregister all but one gauge to ensure gauges are reported again if the remaining fit
-		for (int x = 1; x < gauges.size(); x++) {
-			MetricQueryService.notifyOfRemovedMetric(serviceActor, gauges.get(x).f1);
-		}
-
-		serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
-		synchronized (testActor.lock) {
-			if (testActor.message == null) {
-				testActor.lock.wait();
-			}
-		}
-
-		MetricDumpSerialization.MetricSerializationResult recoveredDump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
-		testActor.message = null;
-
-		assertTrue(recoveredDump.serializedCounters.length > 0);
-		assertEquals(1, recoveredDump.numCounters);
-		assertTrue(recoveredDump.serializedMeters.length > 0);
-		assertEquals(1, recoveredDump.numMeters);
-		assertTrue(recoveredDump.serializedGauges.length > 0);
-		assertEquals(1, recoveredDump.numGauges);
-		assertTrue(recoveredDump.serializedHistograms.length > 0);
-		assertEquals(1, recoveredDump.numHistograms);
-
-		s.terminate();
 	}
 
 	private static class TestActor extends UntypedActor {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricQueryServiceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.metrics.dump;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -38,6 +39,10 @@ import akka.actor.UntypedActor;
 import akka.testkit.TestActorRef;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -47,9 +52,8 @@ import static org.junit.Assert.assertTrue;
 public class MetricQueryServiceTest extends TestLogger {
 	@Test
 	public void testCreateDump() throws Exception {
-
 		ActorSystem s = AkkaUtils.createLocalActorSystem(new Configuration());
-		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, 50L);
+		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, Long.MAX_VALUE);
 		TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
 		TestActor testActor = (TestActor) testActorRef.underlyingActor();
 
@@ -98,7 +102,10 @@ public class MetricQueryServiceTest extends TestLogger {
 
 		MetricDumpSerialization.MetricSerializationResult dump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
 		testActor.message = null;
-		assertTrue(dump.serializedMetrics.length > 0);
+		assertTrue(dump.serializedCounters.length > 0);
+		assertTrue(dump.serializedGauges.length > 0);
+		assertTrue(dump.serializedHistograms.length > 0);
+		assertTrue(dump.serializedMeters.length > 0);
 
 		MetricQueryService.notifyOfRemovedMetric(serviceActor, c);
 		MetricQueryService.notifyOfRemovedMetric(serviceActor, g);
@@ -114,7 +121,103 @@ public class MetricQueryServiceTest extends TestLogger {
 
 		MetricDumpSerialization.MetricSerializationResult emptyDump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
 		testActor.message = null;
-		assertEquals(0, emptyDump.serializedMetrics.length);
+		assertEquals(0, emptyDump.serializedCounters.length);
+		assertEquals(0, emptyDump.serializedGauges.length);
+		assertEquals(0, emptyDump.serializedHistograms.length);
+		assertEquals(0, emptyDump.serializedMeters.length);
+
+		s.terminate();
+	}
+
+	@Test
+	public void testHandleOversizedMetricMessage() throws Exception {
+		ActorSystem s = AkkaUtils.createLocalActorSystem(new Configuration());
+		final long sizeLimit = 200L;
+		ActorRef serviceActor = MetricQueryService.startMetricQueryService(s, null, sizeLimit);
+		TestActorRef testActorRef = TestActorRef.create(s, Props.create(TestActor.class));
+		TestActor testActor = (TestActor) testActorRef.underlyingActor();
+
+		final Counter c = new SimpleCounter();
+		final Histogram h = new TestHistogram();
+		final Meter m = new Meter() {
+
+			@Override
+			public void markEvent() {
+			}
+
+			@Override
+			public void markEvent(long n) {
+			}
+
+			@Override
+			public double getRate() {
+				return 5;
+			}
+
+			@Override
+			public long getCount() {
+				return 10;
+			}
+		};
+
+		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+		final TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+
+		final String gaugeValue = "Hello";
+		final long requiredGaugesToExceedLimit = sizeLimit / gaugeValue.length() + 1;
+		List<Tuple2<String, Gauge<String>>> gauges = LongStream.range(0, requiredGaugesToExceedLimit)
+			.mapToObj(x -> Tuple2.of("gauge" + x, (Gauge<String>) () -> "Hello" + x))
+			.collect(Collectors.toList());
+		gauges.forEach(gauge -> MetricQueryService.notifyOfAddedMetric(serviceActor, gauge.f1, gauge.f0, tm));
+
+		MetricQueryService.notifyOfAddedMetric(serviceActor, c, "counter", tm);
+		MetricQueryService.notifyOfAddedMetric(serviceActor, h, "histogram", tm);
+		MetricQueryService.notifyOfAddedMetric(serviceActor, m, "meter", tm);
+
+		serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
+		synchronized (testActor.lock) {
+			if (testActor.message == null) {
+				testActor.lock.wait();
+			}
+		}
+
+		MetricDumpSerialization.MetricSerializationResult dump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
+		testActor.message = null;
+		assertTrue(dump.serializedCounters.length > 0);
+		assertEquals(1, dump.numCounters);
+		assertTrue(dump.serializedMeters.length > 0);
+		assertEquals(1, dump.numMeters);
+
+		// gauges exceeded the size limit and will be excluded
+		assertEquals(0, dump.serializedGauges.length);
+		assertEquals(0, dump.numGauges);
+
+		assertTrue(dump.serializedHistograms.length > 0);
+		assertEquals(1, dump.numHistograms);
+
+		// unregister all but one gauge to ensure gauges are reported again if the remaining fit
+		for (int x = 1; x < gauges.size(); x++) {
+			MetricQueryService.notifyOfRemovedMetric(serviceActor, gauges.get(x).f1);
+		}
+
+		serviceActor.tell(MetricQueryService.getCreateDump(), testActorRef);
+		synchronized (testActor.lock) {
+			if (testActor.message == null) {
+				testActor.lock.wait();
+			}
+		}
+
+		MetricDumpSerialization.MetricSerializationResult recoveredDump = (MetricDumpSerialization.MetricSerializationResult) testActor.message;
+		testActor.message = null;
+
+		assertTrue(recoveredDump.serializedCounters.length > 0);
+		assertEquals(1, recoveredDump.numCounters);
+		assertTrue(recoveredDump.serializedMeters.length > 0);
+		assertEquals(1, recoveredDump.numMeters);
+		assertTrue(recoveredDump.serializedGauges.length > 0);
+		assertEquals(1, recoveredDump.numGauges);
+		assertTrue(recoveredDump.serializedHistograms.length > 0);
+		assertEquals(1, recoveredDump.numHistograms);
 
 		s.terminate();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherTest.java
@@ -99,7 +99,7 @@ public class MetricFetcherTest extends TestLogger {
 		MetricDumpSerialization.MetricSerializationResult requestMetricsAnswer = createRequestDumpAnswer(tmRID, jobID);
 
 		when(jmQueryService.queryMetrics(any(Time.class)))
-			.thenReturn(CompletableFuture.completedFuture(new MetricDumpSerialization.MetricSerializationResult(new byte[0], 0, 0, 0, 0)));
+			.thenReturn(CompletableFuture.completedFuture(new MetricDumpSerialization.MetricSerializationResult(new byte[0], new byte[0], new byte[0], new byte[0], 0, 0, 0, 0)));
 		when(tmQueryService.queryMetrics(any(Time.class)))
 			.thenReturn(CompletableFuture.completedFuture(requestMetricsAnswer));
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request handles oversized metric messges*


## Brief change log

  - *Handle oversized metric messges*

## Verifying this change

This change is already covered by existing tests, such as *MetricQueryServiceTest#testHandleOversizedMetricMessage*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
