### PR TITLE
[FLINK-4052] using non-local unreachable ip:port to fix unstable Test testReturnLocalHostAddressUsingHeuristics

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/ConnectionUtilsTest.java
@@ -43,24 +43,22 @@ public class ConnectionUtilsTest {
 
 	@Test
 	public void testReturnLocalHostAddressUsingHeuristics() throws Exception {
-		try (ServerSocket blocker = new ServerSocket(0, 1, InetAddress.getLocalHost())) {
-			// the "blocker" server socket simply does not accept connections
-			// this address is consequently "unreachable"
-			InetSocketAddress unreachable = new InetSocketAddress("localhost", blocker.getLocalPort());
+		// instead of using a unstable localhost:port as "unreachable" to cause Test fails unstably
+		// using a Absolutely unreachable outside ip:port
+		InetSocketAddress unreachable = new InetSocketAddress("8.8.8.8", 0xFFFF);
 
-			final long start = System.nanoTime();
-			InetAddress add = ConnectionUtils.findConnectingAddress(unreachable, 2000, 400);
+		final long start = System.nanoTime();
+		InetAddress add = ConnectionUtils.findConnectingAddress(unreachable, 2000, 400);
 
-			// check that it did not take forever (max 30 seconds)
-			// this check can unfortunately not be too tight, or it will be flaky on some CI infrastructure
-			assertTrue(System.nanoTime() - start < 30_000_000_000L);
+		// check that it did not take forever (max 30 seconds)
+		// this check can unfortunately not be too tight, or it will be flaky on some CI infrastructure
+		assertTrue(System.nanoTime() - start < 30_000_000_000L);
 
-			// we should have found a heuristic address
-			assertNotNull(add);
+		// we should have found a heuristic address
+		assertNotNull(add);
 
-			// make sure that we returned the InetAddress.getLocalHost as a heuristic
-			assertEquals(InetAddress.getLocalHost(), add);
-		}
+		// make sure that we returned the InetAddress.getLocalHost as a heuristic
+		assertEquals(InetAddress.getLocalHost(), add);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

See. [FLINK-4052](https://issues.apache.org/jira/browse/FLINK-4052) and also [FLINK-3687](https://issues.apache.org/jira/browse/FLINK-3687).

Fix testReturnLocalHostAddressUsingHeuristics unstable failure.

## Diagnose

I was able to 100% reproduce the failure in local environment as below.

```
java.lang.AssertionError: 
Expected :linxuewei.local/30.5.17.21
Actual   :/127.0.0.1
 <Click to see difference>

  at org.junit.Assert.fail(Assert.java:88)
  at org.junit.Assert.failNotEquals(Assert.java:834)
  at org.junit.Assert.assertEquals(Assert.java:118)
  at org.junit.Assert.assertEquals(Assert.java:144)
  at org.apache.flink.runtime.net.ConnectionUtilsTest.testReturnLocalHostAddressUsingHeuristics(ConnectionUtilsTest.java:64)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
``` 

In general, in my local env, there are two ip the test case will try to use to connect to the target unreachable endpoint. **30.5.17.21** and **127.0.0.1**.

Reproduce Step:

* when case try with 30.5.17.21, do nothing.
* when case try with 127.0.0.1, create a local process that listened on target unreachable port, in this case, the unreachable endpoint is now reachable now.
* before the case return 127.0.0.1, there are still some code will trying to connect to the endpoint with 30.5.17.21 again which is return by **InetAddress.getLocalHost()**

```
# See. ConnectionUtils.java line: 276

case SLOW_CONNECT:
  LOG.debug("Trying to connect to {} from local address {} with timeout {}",
      targetAddress, interfaceAddress, strategy.getTimeout());

  if (tryToConnect(interfaceAddress, targetAddress, strategy.getTimeout(), logging)) {
    return tryLocalHostBeforeReturning(interfaceAddress, targetAddress, logging);
  }
  break;
```

* before the tryLocalHostBeforeReturning called, kill the local process that listened on the target unreachable port. In this case, the test case will return 127.0.0.1 as assert compare result. Hans. the test case will failed.

## Proposal

In genernal, in the build environment, local port used corrupt could happened time to time, So I suggest we change the local unreachable endpoint to a outside unreachable endpoint, for instance 8.8.8.8:65535 in my pull request. I think this way can prevent the test failure happen again.

## Brief change log

* using non-local unreachable ip:port to fix unstable Test testReturnLocalHostAddressUsingHeuristics

## Verifying this change

Test testReturnLocalHostAddressUsingHeuristics fixed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
