### PR TITLE
[FLINK-10567]Fix TtlStateSerializer lost field during duplicate()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -224,7 +224,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 			TypeSerializer<?> ... originalSerializers) {
 			Preconditions.checkNotNull(originalSerializers);
 			Preconditions.checkArgument(originalSerializers.length == 2);
-			return new TtlSerializer<>(precomputed, (TypeSerializer<T>) originalSerializers[0], (TypeSerializer<T>) originalSerializers[1]);
+			return new TtlSerializer<>(precomputed, originalSerializers);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -224,7 +224,7 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 			TypeSerializer<?> ... originalSerializers) {
 			Preconditions.checkNotNull(originalSerializers);
 			Preconditions.checkArgument(originalSerializers.length == 2);
-			return new TtlSerializer<>(precomputed, (TypeSerializer<T>) originalSerializers[1]);
+			return new TtlSerializer<>(precomputed, (TypeSerializer<T>) originalSerializers[0], (TypeSerializer<T>) originalSerializers[1]);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is to fix the exception caused by the `TtlStateSerializer` lost the fieldSerializer during duplicate. Which can be reproduced by the testCase in this PR.


## Brief change log

- Add the filed in TtlStateSerializer

## Verifying this change

This change added tests and can be verified as follows:

`StateBackendTestBase#testValueStateWorkWithTtl`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)
