### PR TITLE
[FLINK-10213] Task managers cache a negative DNS lookup of the blob server indefinitely

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -92,7 +92,13 @@ public final class BlobClient implements Closeable {
 				socket = new Socket();
 			}
 
-			socket.connect(serverAddress, clientConfig.getInteger(BlobServerOptions.CONNECT_TIMEOUT));
+			// Establish the socket using the hostname and port. This avoids a potential issue where the
+			// InetSocketAddress can cache a failure in hostname resolution forever.
+			socket.connect(
+				new InetSocketAddress(
+					serverAddress.getHostName(),
+					serverAddress.getPort()),
+				clientConfig.getInteger(BlobServerOptions.CONNECT_TIMEOUT));
 			socket.setSoTimeout(clientConfig.getInteger(BlobServerOptions.SO_TIMEOUT));
 		}
 		catch (Exception e) {
@@ -183,6 +189,10 @@ public final class BlobClient implements Closeable {
 
 	public boolean isClosed() {
 		return this.socket.isClosed();
+	}
+
+	public boolean isConnected() {
+		return socket.isConnected();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -491,7 +492,6 @@ public class BlobClientTest extends TestLogger {
 		}
 	}
 
-
 	/**
 	 * Tests the socket operation timeout.
 	 */
@@ -516,6 +516,14 @@ public class BlobClientTest extends TestLogger {
 		} finally {
 			clientConfig.setInteger(BlobServerOptions.SO_TIMEOUT, oldSoTimeout);
 			getBlobServer().setBlockingMillis(0);
+		}
+	}
+
+	@Test
+	public void testUnresolvedInetSocketAddress() throws Exception {
+		try (BlobClient client = new BlobClient(
+			InetSocketAddress.createUnresolved("localhost", getBlobServer().getPort()), getBlobClientConfig())) {
+			assertTrue(client.isConnected());
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a bug where a negative DNS resolution for the blob server address could be cached forever.

## Brief change log

* Updated BlobClient to create the socket using the hostname and port rather than the InetSocketAddress.

## Verifying this change

This change added tests and can be verified as follows:

* Added a test case to BlobClientTest for unresolved InetSocketAddresses. The test fails without the implemented fix and passes with implemented fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)