### PR TITLE
[FLINK-10582] Make REST executor's thread priority configurable

### DIFF
--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -62,5 +62,10 @@
             <td style="word-wrap: break-word;">4</td>
             <td>The number of threads for the asynchronous processing of requests.</td>
         </tr>
+        <tr>
+            <td><h5>rest.server.thread-priority</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Thread priority of the REST server's executor for processing asynchronous requests. Lowering the thread priority will give Flink's main components more CPU time whereas increasing will allocate more time for the REST server's processing.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -121,4 +122,12 @@ public class RestOptions {
 		key("rest.server.numThreads")
 			.defaultValue(4)
 			.withDescription("The number of threads for the asynchronous processing of requests.");
+
+	public static final ConfigOption<Integer> SERVER_THREAD_PRIORITY = key("rest.server.thread-priority")
+		.defaultValue(Thread.NORM_PRIORITY)
+		.withDescription(Description.builder()
+			.text("Thread priority of the REST server's executor for processing asynchronous requests. " +
+				"Lowering the thread priority will give Flink's main components more CPU time whereas " +
+				"increasing will allocate more time for the REST server's processing.")
+			.build());
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
@@ -141,6 +141,7 @@ public abstract class AbstractDispatcherResourceManagerComponentFactory<T extend
 				blobServer,
 				WebMonitorEndpoint.createExecutorService(
 					configuration.getInteger(RestOptions.SERVER_NUM_THREADS),
+					configuration.getInteger(RestOptions.SERVER_THREAD_PRIORITY),
 					"DispatcherRestEndpoint"),
 				new AkkaQueryServiceRetriever(actorSystem, timeout),
 				highAvailabilityServices.getWebMonitorLeaderElectionService(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -356,6 +356,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					blobServer.getTransientBlobService(),
 					WebMonitorEndpoint.createExecutorService(
 						configuration.getInteger(RestOptions.SERVER_NUM_THREADS, 1),
+						configuration.getInteger(RestOptions.SERVER_THREAD_PRIORITY),
 						"DispatcherRestEndpoint"),
 					new AkkaQueryServiceRetriever(
 						metricQueryServiceActorSystem,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -783,11 +783,20 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		return archivedJson;
 	}
 
-	public static ExecutorService createExecutorService(int numThreads, String componentName) {
+	public static ExecutorService createExecutorService(int numThreads, int threadPriority, String componentName) {
+		if (threadPriority < Thread.MIN_PRIORITY || threadPriority > Thread.MAX_PRIORITY) {
+			throw new IllegalArgumentException(
+				String.format(
+					"The thread priority must be within (%s, %s) but it was %s.",
+					Thread.MIN_PRIORITY,
+					Thread.MAX_PRIORITY,
+					threadPriority));
+		}
+
 		return Executors.newFixedThreadPool(
 			numThreads,
 			new ExecutorThreadFactory.Builder()
-				.setThreadPriority(Thread.MIN_PRIORITY)
+				.setThreadPriority(threadPriority)
 				.setPoolName("Flink-" + componentName)
 				.build());
 	}


### PR DESCRIPTION
## What is the purpose of the change

Introduce RestOptions#SERVER_THREAD_PRIORITY("rest.server.thread-priority") to configure the
thread priority of the REST executor's threads.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
