### PR TITLE
[FLINK-10436] Add ConfigOption#withFallbackKeys

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -117,7 +117,7 @@ public class ConfigOption<T> {
 	 */
 	public ConfigOption<T> withFallbackKeys(String... fallbackKeys) {
 		FallbackKey[] fallbackKeyArray = Arrays.stream(fallbackKeys)
-			.map(fallbackKey -> new FallbackKey(fallbackKey, false))
+			.map(FallbackKey::createFallbackKey)
 			.toArray(FallbackKey[]::new);
 		return new ConfigOption<>(key, description, defaultValue, fallbackKeyArray);
 	}
@@ -135,7 +135,7 @@ public class ConfigOption<T> {
 	 */
 	public ConfigOption<T> withDeprecatedKeys(String... deprecatedKeys) {
 		FallbackKey[] fallbackKeys = Arrays.stream(deprecatedKeys)
-			.map(deprecatedKey -> new FallbackKey(deprecatedKey, true))
+			.map(FallbackKey::createDeprecatedKey)
 			.toArray(FallbackKey[]::new);
 		return new ConfigOption<>(key, description, defaultValue, fallbackKeys);
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -705,10 +705,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 				// try the fallback keys
 				for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
 					if (this.confData.containsKey(fallbackKey.getKey())) {
-						if (fallbackKey.isDeprecated()) {
-							LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
-								fallbackKey.getKey(), configOption.key());
-						}
+						loggingFallback(fallbackKey, configOption);
 						return true;
 					}
 				}
@@ -746,10 +743,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 				for (FallbackKey fallbackKey : configOption.fallbackKeys()){
 					oldValue = this.confData.remove(fallbackKey.getKey());
 					if (oldValue != null){
-						if (fallbackKey.isDeprecated()) {
-							LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
-								fallbackKey.getKey(), configOption.key());
-						}
+						loggingFallback(fallbackKey, configOption);
 						return true;
 					}
 				}
@@ -798,10 +792,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 			for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
 				Object oo = getRawValue(fallbackKey.getKey());
 				if (oo != null) {
-					if (fallbackKey.isDeprecated()) {
-						LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
-							fallbackKey.getKey(), configOption.key());
-					}
+					loggingFallback(fallbackKey, configOption);
 					return oo;
 				}
 			}
@@ -813,6 +804,16 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	private Object getValueOrDefaultFromOption(ConfigOption<?> configOption) {
 		Object o = getRawValueFromOption(configOption);
 		return o != null ? o : configOption.defaultValue();
+	}
+
+	private void loggingFallback(FallbackKey fallbackKey, ConfigOption<?> configOption) {
+		if (fallbackKey.isDeprecated()) {
+			LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
+				fallbackKey.getKey(), configOption.key());
+		} else {
+			LOG.info("Config uses fallback configuration key '{}' instead of key '{}'",
+				fallbackKey.getKey(), configOption.key());
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -701,12 +701,14 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 			if (this.confData.containsKey(configOption.key())) {
 				return true;
 			}
-			else if (configOption.hasDeprecatedKeys()) {
-				// try the deprecated keys
-				for (String deprecatedKey : configOption.deprecatedKeys()) {
-					if (this.confData.containsKey(deprecatedKey)) {
-						LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
-							deprecatedKey, configOption.key());
+			else if (configOption.hasFallbackKeys()) {
+				// try the fallback keys
+				for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
+					if (this.confData.containsKey(fallbackKey.getKey())) {
+						if (fallbackKey.isDeprecated()) {
+							LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
+								fallbackKey.getKey(), configOption.key());
+						}
 						return true;
 					}
 				}
@@ -741,11 +743,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 			// try the current key
 			Object oldValue = this.confData.remove(configOption.key());
 			if (oldValue == null){
-				for (String deprecatedKey : configOption.deprecatedKeys()){
-					oldValue = this.confData.remove(deprecatedKey);
+				for (FallbackKey fallbackKey : configOption.fallbackKeys()){
+					oldValue = this.confData.remove(fallbackKey.getKey());
 					if (oldValue != null){
-						LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
-							deprecatedKey, configOption.key());
+						if (fallbackKey.isDeprecated()) {
+							LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
+								fallbackKey.getKey(), configOption.key());
+						}
 						return true;
 					}
 				}
@@ -789,13 +793,15 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 			// found a value for the current proper key
 			return o;
 		}
-		else if (configOption.hasDeprecatedKeys()) {
+		else if (configOption.hasFallbackKeys()) {
 			// try the deprecated keys
-			for (String deprecatedKey : configOption.deprecatedKeys()) {
-				Object oo = getRawValue(deprecatedKey);
+			for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
+				Object oo = getRawValue(fallbackKey.getKey());
 				if (oo != null) {
-					LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
-							deprecatedKey, configOption.key());
+					if (fallbackKey.isDeprecated()) {
+						LOG.warn("Config uses deprecated configuration key '{}' instead of proper key '{}'",
+							fallbackKey.getKey(), configOption.key());
+					}
 					return oo;
 				}
 			}

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -361,17 +361,17 @@ public final class DelegatingConfiguration extends Configuration {
 	private static <T> ConfigOption<T> prefixOption(ConfigOption<T> option, String prefix) {
 		String key = prefix + option.key();
 
-		List<String> deprecatedKeys;
-		if (option.hasDeprecatedKeys()) {
+		List<FallbackKey> deprecatedKeys;
+		if (option.hasFallbackKeys()) {
 			deprecatedKeys = new ArrayList<>();
-			for (String dk : option.deprecatedKeys()) {
-				deprecatedKeys.add(prefix + dk);
+			for (FallbackKey dk : option.fallbackKeys()) {
+				deprecatedKeys.add(new FallbackKey(prefix + dk.getKey(), true));
 			}
 		} else {
 			deprecatedKeys = Collections.emptyList();
 		}
 
-		String[] deprecated = deprecatedKeys.toArray(new String[deprecatedKeys.size()]);
+		FallbackKey[] deprecated = deprecatedKeys.toArray(new FallbackKey[0]);
 		return new ConfigOption<>(key,
 			option.description(),
 			option.defaultValue(),

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.flink.configuration.FallbackKey.createDeprecatedKey;
+
 /**
  * A configuration that manages a subset of keys with a common prefix from a given configuration.
  */
@@ -365,7 +367,7 @@ public final class DelegatingConfiguration extends Configuration {
 		if (option.hasFallbackKeys()) {
 			deprecatedKeys = new ArrayList<>();
 			for (FallbackKey dk : option.fallbackKeys()) {
-				deprecatedKeys.add(new FallbackKey(prefix + dk.getKey(), true));
+				deprecatedKeys.add(createDeprecatedKey(prefix + dk.getKey()));
 			}
 		} else {
 			deprecatedKeys = Collections.emptyList();

--- a/flink-core/src/main/java/org/apache/flink/configuration/FallbackKey.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/FallbackKey.java
@@ -19,7 +19,7 @@
 package org.apache.flink.configuration;
 
 /**
- * A class represents keys that fallback to another key.
+ * A key with FallbackKeys will fall back to the FallbackKeys if it itself is not configured.
  */
 public class FallbackKey {
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/FallbackKey.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/FallbackKey.java
@@ -23,6 +23,20 @@ package org.apache.flink.configuration;
  */
 public class FallbackKey {
 
+	// -------------------------
+	//  Factory methods
+	// -------------------------
+
+	static FallbackKey createFallbackKey(String key) {
+		return new FallbackKey(key, false);
+	}
+
+	static FallbackKey createDeprecatedKey(String key) {
+		return new FallbackKey(key, true);
+	}
+
+	// ------------------------------------------------------------------------
+
 	private final String key;
 
 	private final boolean isDeprecated;
@@ -35,7 +49,7 @@ public class FallbackKey {
 		return isDeprecated;
 	}
 
-	FallbackKey(String key, boolean isDeprecated) {
+	private FallbackKey(String key, boolean isDeprecated) {
 		this.key = key;
 		this.isDeprecated = isDeprecated;
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/FallbackKey.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/FallbackKey.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+/**
+ * A class represents keys that fallback to another key.
+ */
+public class FallbackKey {
+
+	private final String key;
+
+	private final boolean isDeprecated;
+
+	public String getKey() {
+		return key;
+	}
+
+	public boolean isDeprecated() {
+		return isDeprecated;
+	}
+
+	FallbackKey(String key, boolean isDeprecated) {
+		this.key = key;
+		this.isDeprecated = isDeprecated;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		} else if (o != null && o.getClass() == FallbackKey.class) {
+			FallbackKey that = (FallbackKey) o;
+			return this.key.equals(that.key) && (this.isDeprecated == that.isDeprecated);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * key.hashCode() + (isDeprecated ? 1 : 0);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("{key=%s, isDeprecated=%s}", key, isDeprecated);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -43,7 +43,7 @@ public class RestOptions {
 	public static final ConfigOption<String> ADDRESS =
 		key("rest.address")
 			.noDefaultValue()
-			.withDeprecatedKeys(JobManagerOptions.ADDRESS.key())
+			.withFallbackKeys(JobManagerOptions.ADDRESS.key())
 			.withDescription("The address that should be used by clients to connect to the server.");
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -306,6 +306,39 @@ public class ConfigurationTest extends TestLogger {
 	}
 
 	@Test
+	public void testFallbackKeys() {
+		Configuration cfg = new Configuration();
+		cfg.setInteger("the-key", 11);
+		cfg.setInteger("old-key", 12);
+		cfg.setInteger("older-key", 13);
+
+		ConfigOption<Integer> matchesFirst = ConfigOptions
+			.key("the-key")
+			.defaultValue(-1)
+			.withFallbackKeys("old-key", "older-key");
+
+		ConfigOption<Integer> matchesSecond = ConfigOptions
+			.key("does-not-exist")
+			.defaultValue(-1)
+			.withFallbackKeys("old-key", "older-key");
+
+		ConfigOption<Integer> matchesThird = ConfigOptions
+			.key("does-not-exist")
+			.defaultValue(-1)
+			.withFallbackKeys("foo", "older-key");
+
+		ConfigOption<Integer> notContained = ConfigOptions
+			.key("does-not-exist")
+			.defaultValue(-1)
+			.withFallbackKeys("not-there", "also-not-there");
+
+		assertEquals(11, cfg.getInteger(matchesFirst));
+		assertEquals(12, cfg.getInteger(matchesSecond));
+		assertEquals(13, cfg.getInteger(matchesThird));
+		assertEquals(-1, cfg.getInteger(notContained));
+	}
+
+	@Test
 	public void testRemove(){
 		Configuration cfg = new Configuration();
 		cfg.setInteger("a", 1);


### PR DESCRIPTION
## What is the purpose of the change

Add `ConfigOption#withFallbackKeys` to implement a similar function with `ConfigOption#withDeprecatedKeys`. That is, the `fallbackKey` falls back to current key if it has not been specified, but the use of current key would not print a deprecated message.

## Brief change log

- Introduce `FallbackKey` class to represent a key with `isDeprecated` message.
- Replace `deprecatedKeys` to `fallbackKeys` in `ConfigOption`


## Verifying this change

- Add a test `ConfigurationTest#testFallbackKeys` to check the fallback mechanism works.
- Manually check the issue report by the corresponding JIRA disappear.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann 