### PR TITLE
[hotfix] Add Review Progress section to PR description template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -70,3 +70,15 @@ This change added tests and can be verified as follows:
 
   - Does this pull request introduce a new feature? (yes / no)
   - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
+
+----
+
+# Review Progress <!-- NOTE: DO NOT REMOVE THIS SECTION! -->
+
+* [ ] 1. The contribution is well-described.
+* [ ] 2. There is consensus that the contribution should go into to Flink.
+* [ ] 3. [Does not need specific attention | Needs specific attention for X | Has attention for X by Y]
+* [ ] 4. The architectural approach is sound.
+* [ ] 5. Overall code quality is good.
+
+Please see the [Pull Request Review Guide](https://flink.apache.org/reviewing-prs.html) if you have questions about the review process.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -73,7 +73,9 @@ This change added tests and can be verified as follows:
 
 ----
 
-# Review Progress <!-- NOTE: DO NOT REMOVE THIS SECTION! -->
+# Review Progress
+
+**NOTE: THE REVIEW PROGRESS MUST ONLY BE UPDATED BY AN APACHE FLINK COMMITTER!**
 
 * [ ] 1. The contribution is well-described.
 * [ ] 2. There is consensus that the contribution should go into to Flink.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -73,9 +73,7 @@ This change added tests and can be verified as follows:
 
 ----
 
-# Review Progress
-
-**NOTE: THE REVIEW PROGRESS MUST ONLY BE UPDATED BY AN APACHE FLINK COMMITTER!**
+# Review Progress <!-- NOTE: DO NOT REMOVE THIS SECTION! -->
 
 * [ ] 1. The contribution is well-described.
 * [ ] 2. There is consensus that the contribution should go into to Flink.


### PR DESCRIPTION
## What is the purpose of the change

* Add the Review Progress section to the PR description template.
* This change was discussed on the [dev mailing list](https://lists.apache.org/thread.html/d7fd1fe45949f7c706142c62de85d246c7f6a1485a186fd3e9dced01@%3Cdev.flink.apache.org%3E)

## Brief change log

* Add the Review Progress section to the PR description template.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? yes, see [review process description](https://flink.apache.org/reviewing-prs.html)
