### PR TITLE
[FLINK-8483][DataStream] Implement and expose outer joins

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/ProcessJoinFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/ProcessJoinFunction.java
@@ -65,17 +65,17 @@ public abstract class ProcessJoinFunction<IN1, IN2, OUT> extends AbstractRichFun
 		/**
 		 * @return The timestamp of the left element of a joined pair
 		 */
-		public abstract long getLeftTimestamp();
+		public abstract Long getLeftTimestamp();
 
 		/**
 		 * @return The timestamp of the right element of a joined pair
 		 */
-		public abstract long getRightTimestamp();
+		public abstract Long getRightTimestamp();
 
 		/**
 		 * @return The timestamp of the joined pair.
 		 */
-		public abstract long getTimestamp();
+		public abstract Long getTimestamp();
 
 		/**
 		 * Emits a record to the side output identified by the {@link OutputTag}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -43,9 +43,10 @@ import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.util.Collector;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
@@ -103,6 +104,8 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 	private final long lowerBound;
 	private final long upperBound;
 
+	private final IntervalJoinOperator.TimestampStrategy timestampStrategy;
+
 	private final TypeSerializer<T1> leftTypeSerializer;
 	private final TypeSerializer<T2> rightTypeSerializer;
 
@@ -131,19 +134,25 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 			long upperBound,
 			boolean lowerBoundInclusive,
 			boolean upperBoundInclusive,
+			TimestampStrategy timestampStrategy,
 			TypeSerializer<T1> leftTypeSerializer,
 			TypeSerializer<T2> rightTypeSerializer,
-			ProcessJoinFunction<T1, T2, OUT> udf) {
+			ProcessJoinFunction<T1, T2, OUT> udf
+	) {
 
 		super(Preconditions.checkNotNull(udf));
 
 		Preconditions.checkArgument(lowerBound <= upperBound,
 			"lowerBound <= upperBound must be fulfilled");
 
+		Preconditions.checkNotNull(timestampStrategy);
+
 		// Move buffer by +1 / -1 depending on inclusiveness in order not needing
 		// to check for inclusiveness later on
 		this.lowerBound = (lowerBoundInclusive) ? lowerBound : lowerBound + 1L;
 		this.upperBound = (upperBoundInclusive) ? upperBound : upperBound - 1L;
+
+		this.timestampStrategy = timestampStrategy;
 
 		this.leftTypeSerializer = Preconditions.checkNotNull(leftTypeSerializer);
 		this.rightTypeSerializer = Preconditions.checkNotNull(rightTypeSerializer);
@@ -252,18 +261,48 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 		}
 	}
 
+	private long calculateNecessaryWatermarkDelay() {
+		switch (this.timestampStrategy) {
+			case MIN:
+				return Math.max(upperBound, -lowerBound);
+			case MAX:
+				return 0;
+			case LEFT:
+				return (upperBound < 0) ? 0 : upperBound;
+			case RIGHT:
+				return (lowerBound > 0) ? 0 : -lowerBound;
+			default:
+				throw new FlinkRuntimeException("Unsupported timestamp strategy: " + this.timestampStrategy);
+		}
+	}
+
 	private boolean isLate(long timestamp) {
 		long currentWatermark = internalTimerService.currentWatermark();
 		return currentWatermark != Long.MIN_VALUE && timestamp < currentWatermark;
 	}
 
 	private void collect(T1 left, T2 right, long leftTimestamp, long rightTimestamp) throws Exception {
-		final long resultTimestamp = Math.max(leftTimestamp, rightTimestamp);
+		final long resultTimestamp = calculateResultTimestamp(leftTimestamp, rightTimestamp);
 
 		collector.setAbsoluteTimestamp(resultTimestamp);
 		context.updateTimestamps(leftTimestamp, rightTimestamp, resultTimestamp);
 
 		userFunction.processElement(left, right, context, collector);
+	}
+
+	private long calculateResultTimestamp(long leftTs, long rightTs) {
+		switch (this.timestampStrategy) {
+			case MIN:
+				return Math.min(leftTs, rightTs);
+			case MAX:
+				return Math.max(leftTs, rightTs);
+			case LEFT:
+				return leftTs;
+			case RIGHT:
+				return rightTs;
+			default:
+				throw new FlinkRuntimeException("Unsupported timestamp strategy: " + timestampStrategy);
+		}
 	}
 
 	private static <T> void addToBuffer(
@@ -307,6 +346,25 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 	@Override
 	public void onProcessingTime(InternalTimer<K, String> timer) throws Exception {
 		// do nothing.
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		if (timeServiceManager != null) {
+			// Advance the timerService according to the "original" watermark.
+			// This means that all timers that this operator registers as well as timers
+			// registered via the UDF are with respect to the watermark as it comes in,
+			// as opposed to the possibly delayed watermark emitted by the operator
+			timeServiceManager.advanceWatermark(mark);
+		}
+
+		// Delay the watermark so that even in scenarios where the results of a join
+		// are from elements that were buffered and watermark has progressed in the meantime,
+		// we will never produce late data
+		long delayedTimestamp = mark.getTimestamp() - calculateNecessaryWatermarkDelay();
+		Watermark delayedWatermark = new Watermark(delayedTimestamp);
+
+		output.emitWatermark(delayedWatermark);
 	}
 
 	/**
@@ -354,6 +412,37 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 			Preconditions.checkArgument(outputTag != null, "OutputTag must not be null");
 			output.collect(outputTag, new StreamRecord<>(value, getTimestamp()));
 		}
+	}
+
+	/**
+	 * TimestampStrategy defines which timestamp of the two joined elements to
+	 * assign to the joined pair.
+	 */
+	public enum TimestampStrategy {
+
+		/**
+		 * When two elements are joined, assign the minimum timestamp of those two
+		 * elements as the timestamp of the joined pair.
+		 */
+		MIN,
+
+		/**
+		 * When two elements are joined, assign the maximum timestamp of those two
+		 * elements as the timestamp of the joined pair.
+		 */
+		MAX,
+
+		/**
+		 * When two elements are joined, assign the timestamp of the left element
+		 * as the the timestamp of the joined pair.
+		 */
+		LEFT,
+
+		/**
+		 * When two elements are joined, assign the timestamp of the right element
+		 * as the the timestamp of the joined pair.
+		 */
+		RIGHT
 	}
 
 	/**
@@ -523,4 +612,5 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 	MapState<Long, List<BufferEntry<T2>>> getRightBuffer() {
 		return rightBuffer;
 	}
+
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.operators.join.JoinType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
@@ -47,9 +47,13 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.api.java.operators.join.JoinType.LEFT_OUTER;
+import static org.apache.flink.api.java.operators.join.JoinType.RIGHT_OUTER;
 import static org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.TimestampStrategy.LEFT;
 import static org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.TimestampStrategy.MAX;
 import static org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.TimestampStrategy.MIN;
@@ -97,22 +101,22 @@ public class IntervalJoinOperatorTest {
 		setupHarness(lowerBound, lowerBoundInclusive, upperBound, upperBoundInclusive)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(1, 2, timestampStrategy),
-				streamRecordOf(1, 3, timestampStrategy),
-				streamRecordOf(2, 3, timestampStrategy),
-				streamRecordOf(2, 4, timestampStrategy),
-				streamRecordOf(3, 4, timestampStrategy))
+				streamRecordOf(1L, 2L),
+				streamRecordOf(1L, 3L),
+				streamRecordOf(2L, 3L),
+				streamRecordOf(2L, 4L),
+				streamRecordOf(3L, 4L))
 			.noLateRecords()
 			.close();
 
 		setupHarness(-1 * upperBound, upperBoundInclusive, -1 * lowerBound, lowerBoundInclusive)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(2, 1, timestampStrategy),
-				streamRecordOf(3, 1, timestampStrategy),
-				streamRecordOf(3, 2, timestampStrategy),
-				streamRecordOf(4, 2, timestampStrategy),
-				streamRecordOf(4, 3, timestampStrategy))
+				streamRecordOf(2L, 1L),
+				streamRecordOf(3L, 1L),
+				streamRecordOf(3L, 2L),
+				streamRecordOf(4L, 2L),
+				streamRecordOf(4L, 3L))
 			.noLateRecords()
 			.close();
 	}
@@ -123,11 +127,11 @@ public class IntervalJoinOperatorTest {
 		setupHarness(-2, true, -1, true)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(2, 1, timestampStrategy),
-				streamRecordOf(3, 1, timestampStrategy),
-				streamRecordOf(3, 2, timestampStrategy),
-				streamRecordOf(4, 2, timestampStrategy),
-				streamRecordOf(4, 3, timestampStrategy)
+				streamRecordOf(2L, 1L),
+				streamRecordOf(3L, 1L),
+				streamRecordOf(3L, 2L),
+				streamRecordOf(4L, 2L),
+				streamRecordOf(4L, 3L)
 			)
 			.noLateRecords()
 			.close();
@@ -139,16 +143,16 @@ public class IntervalJoinOperatorTest {
 		setupHarness(-1, true, 1, true)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(1, 1, timestampStrategy),
-				streamRecordOf(1, 2, timestampStrategy),
-				streamRecordOf(2, 1, timestampStrategy),
-				streamRecordOf(2, 2, timestampStrategy),
-				streamRecordOf(2, 3, timestampStrategy),
-				streamRecordOf(3, 2, timestampStrategy),
-				streamRecordOf(3, 3, timestampStrategy),
-				streamRecordOf(3, 4, timestampStrategy),
-				streamRecordOf(4, 3, timestampStrategy),
-				streamRecordOf(4, 4, timestampStrategy)
+				streamRecordOf(1L, 1L),
+				streamRecordOf(1L, 2L),
+				streamRecordOf(2L, 1L),
+				streamRecordOf(2L, 2L),
+				streamRecordOf(2L, 3L),
+				streamRecordOf(3L, 2L),
+				streamRecordOf(3L, 3L),
+				streamRecordOf(3L, 4L),
+				streamRecordOf(4L, 3L),
+				streamRecordOf(4L, 4L)
 			)
 			.noLateRecords()
 			.close();
@@ -160,11 +164,11 @@ public class IntervalJoinOperatorTest {
 		setupHarness(1, true, 2, true)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(1, 2, timestampStrategy),
-				streamRecordOf(1, 3, timestampStrategy),
-				streamRecordOf(2, 3, timestampStrategy),
-				streamRecordOf(2, 4, timestampStrategy),
-				streamRecordOf(3, 4, timestampStrategy)
+				streamRecordOf(1L, 2L),
+				streamRecordOf(1L, 3L),
+				streamRecordOf(2L, 3L),
+				streamRecordOf(2L, 4L),
+				streamRecordOf(3L, 4L)
 			)
 			.noLateRecords()
 			.close();
@@ -176,8 +180,8 @@ public class IntervalJoinOperatorTest {
 		setupHarness(-3, false, -1, false)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(3, 1, timestampStrategy),
-				streamRecordOf(4, 2, timestampStrategy)
+				streamRecordOf(3L, 1L),
+				streamRecordOf(4L, 2L)
 			)
 			.noLateRecords()
 			.close();
@@ -189,10 +193,10 @@ public class IntervalJoinOperatorTest {
 		setupHarness(-1, false, 1, false)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(1, 1, timestampStrategy),
-				streamRecordOf(2, 2, timestampStrategy),
-				streamRecordOf(3, 3, timestampStrategy),
-				streamRecordOf(4, 4, timestampStrategy)
+				streamRecordOf(1L, 1L),
+				streamRecordOf(2L, 2L),
+				streamRecordOf(3L, 3L),
+				streamRecordOf(4L, 4L)
 			)
 			.noLateRecords()
 			.close();
@@ -204,8 +208,8 @@ public class IntervalJoinOperatorTest {
 		setupHarness(1, false, 3, false)
 			.processElementsAndWatermarks(1, 4)
 			.andExpect(
-				streamRecordOf(1, 3, timestampStrategy),
-				streamRecordOf(2, 4, timestampStrategy)
+				streamRecordOf(1L, 3L),
+				streamRecordOf(2L, 4L)
 			)
 			.noLateRecords()
 			.close();
@@ -233,6 +237,8 @@ public class IntervalJoinOperatorTest {
 
 	@Test
 	public void testNoLateDateRightAndMin() throws Exception {
+		// This testcase would fail if we wouldn't delay the watermark
+		// for the TimestampStrategies MIN and RIGHT
 		setupHarness(-1, true, 1, true)
 			.processElement2(1)
 			.processWatermark2(1)
@@ -395,6 +401,94 @@ public class IntervalJoinOperatorTest {
 	}
 
 	@Test
+	public void testLeftOuterJoinWithNoPreviousCompleteJoin() throws Exception {
+		setupHarness(0, true, 0, true, LEFT_OUTER, IntervalJoinOperator.TimestampStrategy.LEFT)
+			.processElement1(1)
+			.processWatermark1(2)
+			.processWatermark2(2)
+			.andExpect(
+				streamRecordOf(1L, null, 1L)
+			)
+			.noLateRecords();
+	}
+
+	@Test
+	public void testLeftOuterJoinWithPreviousCompleteJoinLeftFirst() throws Exception {
+		setupHarness(0, true, 0, true, LEFT_OUTER, IntervalJoinOperator.TimestampStrategy.LEFT)
+			.processElement1(1)
+			.processElement1(2)
+			.processElement2(1)
+			.processWatermark1(2)
+			.processWatermark2(2)
+			.andExpect(
+				streamRecordOf(1L, 1L, 1L),
+				streamRecordOf(2L, null, 2L)
+
+			)
+			.noLateRecords();
+	}
+
+	@Test
+	public void testLeftOuterJoinWithPreviousCompleteJoinRightFirst() throws Exception {
+		setupHarness(0, true, 0, true, LEFT_OUTER, IntervalJoinOperator.TimestampStrategy.LEFT)
+			.processElement2(1)
+			.processElement1(1)
+			.processElement1(2)
+			.processWatermark1(2)
+			.processWatermark2(2)
+			.andExpect(
+				streamRecordOf(1L, 1L, 1L),
+				streamRecordOf(2L, null, 2L)
+
+			)
+			.noLateRecords();
+	}
+
+	@Test
+	public void testRightOuterJoinWithNoPreviousCompleteJoin() throws Exception {
+		setupHarness(0, true, 0, true, RIGHT_OUTER, IntervalJoinOperator.TimestampStrategy.RIGHT)
+			.processElement2(1)
+			.processWatermark1(2)
+			.processWatermark2(2)
+			.andExpect(
+				streamRecordOf(null, 1L, 1L)
+			)
+			.noLateRecords();
+	}
+
+	@Test
+	public void testRightOuterJoinWithPreviousCompleteJoinLeftFirst() throws Exception {
+		setupHarness(0, true, 0, true, RIGHT_OUTER, IntervalJoinOperator.TimestampStrategy.RIGHT)
+			.processElement1(1)
+			.processElement2(1)
+			.processElement2(2)
+			.processWatermark1(2)
+			.processWatermark2(2)
+			.andExpect(
+				streamRecordOf(1L, 1L, 1L),
+				streamRecordOf(null, 2L, 2L)
+
+			)
+			.noLateRecords();
+	}
+
+	@Test
+	public void testRightOuterJoinWithPreviousCompleteJoinRightFirst() throws Exception {
+		setupHarness(0, true, 0, true, RIGHT_OUTER, IntervalJoinOperator.TimestampStrategy.RIGHT)
+			.processElement2(1)
+			.processElement2(2)
+			.processElement1(1)
+			.processWatermark1(2)
+			.processWatermark2(2)
+			.andExpect(
+				streamRecordOf(1L, 1L, 1L),
+				streamRecordOf(null, 2L, 2L)
+
+			)
+			.noLateRecords();
+	}
+
+	@Test
 	public void testRestoreFromSnapshot() throws Exception {
 
 		// config
@@ -405,7 +499,7 @@ public class IntervalJoinOperatorTest {
 
 		// create first test harness
 		OperatorSubtaskState handles;
-		List<StreamRecord<Tuple2<TestElem, TestElem>>> expectedOutput;
+		List<StreamRecord<JoinResult>> expectedOutput;
 
 		try (TestHarness testHarness = createTestHarness(
 			lowerBound,
@@ -441,13 +535,13 @@ public class IntervalJoinOperatorTest {
 			testHarness.close();
 
 			expectedOutput = Lists.newArrayList(
-				streamRecordOf(1, 1, timestampStrategy),
-				streamRecordOf(1, 2, timestampStrategy),
-				streamRecordOf(2, 1, timestampStrategy),
-				streamRecordOf(2, 2, timestampStrategy),
-				streamRecordOf(2, 3, timestampStrategy),
-				streamRecordOf(3, 2, timestampStrategy),
-				streamRecordOf(3, 3, timestampStrategy)
+				streamRecordOf(1L, 1L),
+				streamRecordOf(1L, 2L),
+				streamRecordOf(2L, 1L),
+				streamRecordOf(2L, 2L),
+				streamRecordOf(2L, 3L),
+				streamRecordOf(3L, 2L),
+				streamRecordOf(3L, 3L)
 			);
 
 			TestHarnessUtil.assertNoLateRecords(testHarness.getOutput());
@@ -467,17 +561,17 @@ public class IntervalJoinOperatorTest {
 			newTestHarness.open();
 
 			// process elements
-			newTestHarness.processElement1(createStreamRecord(4, "lhs"));
+			newTestHarness.processElement1(createStreamRecord(4L, "lhs"));
 			newTestHarness.processWatermark1(new Watermark(4));
 
-			newTestHarness.processElement2(createStreamRecord(4, "rhs"));
+			newTestHarness.processElement2(createStreamRecord(4L, "rhs"));
 			newTestHarness.processWatermark2(new Watermark(4));
 
 			// assert expected output
 			expectedOutput = Lists.newArrayList(
-				streamRecordOf(3, 4, timestampStrategy),
-				streamRecordOf(4, 3, timestampStrategy),
-				streamRecordOf(4, 4, timestampStrategy)
+				streamRecordOf(3L, 4L),
+				streamRecordOf(4L, 3L),
+				streamRecordOf(4L, 4L)
 			);
 
 			TestHarnessUtil.assertNoLateRecords(newTestHarness.getOutput());
@@ -488,23 +582,24 @@ public class IntervalJoinOperatorTest {
 	@Test
 	public void testContextCorrectLeftTimestamp() throws Exception {
 
-		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+		IntervalJoinOperator<String, TestElem, TestElem, JoinResult> op =
 			new IntervalJoinOperator<>(
 				-1,
 				1,
 				true,
 				true,
 				this.timestampStrategy,
+				JoinType.INNER,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new ProcessJoinFunction<TestElem, TestElem, JoinResult>() {
 					@Override
 					public void processElement(
 						TestElem left,
 						TestElem right,
 						Context ctx,
-						Collector<Tuple2<TestElem, TestElem>> out) throws Exception {
-						Assert.assertEquals(left.ts, ctx.getLeftTimestamp());
+						Collector<JoinResult> out) throws Exception {
+						Assert.assertEquals((Long) left.ts, ctx.getLeftTimestamp());
 					}
 				}
 			);
@@ -525,16 +620,17 @@ public class IntervalJoinOperatorTest {
 
 	@Test
 	public void testReturnsCorrectTimestamp() throws Exception {
-		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+		IntervalJoinOperator<String, TestElem, TestElem, JoinResult> op =
 			new IntervalJoinOperator<>(
 				-1,
 				1,
 				true,
 				true,
 				this.timestampStrategy,
+				JoinType.INNER,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new ProcessJoinFunction<TestElem, TestElem, JoinResult>() {
 
 					private static final long serialVersionUID = 1L;
 
@@ -543,7 +639,7 @@ public class IntervalJoinOperatorTest {
 						TestElem left,
 						TestElem right,
 						Context ctx,
-						Collector<Tuple2<TestElem, TestElem>> out) throws Exception {
+						Collector<JoinResult> out) throws Exception {
 
 						long expected;
 						switch (timestampStrategy) {
@@ -563,7 +659,7 @@ public class IntervalJoinOperatorTest {
 								throw new RuntimeException("Unsupported timestamp strategy: " + timestampStrategy);
 						}
 
-						Assert.assertEquals(expected, ctx.getTimestamp());
+						Assert.assertEquals((Long) expected, ctx.getTimestamp());
 					}
 				}
 			);
@@ -585,23 +681,24 @@ public class IntervalJoinOperatorTest {
 	@Test
 	public void testContextCorrectRightTimestamp() throws Exception {
 
-		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+		IntervalJoinOperator<String, TestElem, TestElem, JoinResult> op =
 			new IntervalJoinOperator<>(
 				-1,
 				1,
 				true,
 				true,
 				this.timestampStrategy,
+				JoinType.INNER,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new ProcessJoinFunction<TestElem, TestElem, JoinResult>() {
 					@Override
 					public void processElement(
 						TestElem left,
 						TestElem right,
 						Context ctx,
-						Collector<Tuple2<TestElem, TestElem>> out) throws Exception {
-						Assert.assertEquals(right.ts, ctx.getRightTimestamp());
+						Collector<JoinResult> out) throws Exception {
+						Assert.assertEquals((Long) right.ts, ctx.getRightTimestamp());
 					}
 				}
 			);
@@ -660,23 +757,23 @@ public class IntervalJoinOperatorTest {
 			.processElement1(5)
 			.processElement2(5)
 			.andExpect(
-				streamRecordOf(1, 1, timestampStrategy),
-				streamRecordOf(1, 2, timestampStrategy),
+				streamRecordOf(1L, 1L),
+				streamRecordOf(1L, 2L),
 
-				streamRecordOf(2, 1, timestampStrategy),
-				streamRecordOf(2, 2, timestampStrategy),
-				streamRecordOf(2, 3, timestampStrategy),
+				streamRecordOf(2L, 1L),
+				streamRecordOf(2L, 2L),
+				streamRecordOf(2L, 3L),
 
-				streamRecordOf(3, 2, timestampStrategy),
-				streamRecordOf(3, 3, timestampStrategy),
-				streamRecordOf(3, 4, timestampStrategy),
+				streamRecordOf(3L, 2L),
+				streamRecordOf(3L, 3L),
+				streamRecordOf(3L, 4L),
 
-				streamRecordOf(4, 3, timestampStrategy),
-				streamRecordOf(4, 4, timestampStrategy),
-				streamRecordOf(4, 5, timestampStrategy),
+				streamRecordOf(4L, 3L),
+				streamRecordOf(4L, 4L),
+				streamRecordOf(4L, 5L),
 
-				streamRecordOf(5, 4, timestampStrategy),
-				streamRecordOf(5, 5, timestampStrategy)
+				streamRecordOf(5L, 4L),
+				streamRecordOf(5L, 5L)
 			)
 			.noLateRecords()
 			.close();
@@ -698,7 +795,7 @@ public class IntervalJoinOperatorTest {
 	}
 
 	private void assertOutput(
-		Iterable<StreamRecord<Tuple2<TestElem, TestElem>>> expectedOutput,
+		Iterable<StreamRecord<JoinResult>> expectedOutput,
 		Queue<Object> actualOutput) {
 
 		int actualSize = actualOutput.stream()
@@ -714,7 +811,7 @@ public class IntervalJoinOperatorTest {
 			actualSize
 		);
 
-		for (StreamRecord<Tuple2<TestElem, TestElem>> record : expectedOutput) {
+		for (StreamRecord<JoinResult> record : expectedOutput) {
 			Assert.assertTrue(actualOutput.contains(record));
 		}
 	}
@@ -724,13 +821,14 @@ public class IntervalJoinOperatorTest {
 		long upperBound,
 		boolean upperBoundInclusive) throws Exception {
 
-		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
+		IntervalJoinOperator<String, TestElem, TestElem, JoinResult> operator =
 			new IntervalJoinOperator<>(
 				lowerBound,
 				upperBound,
 				lowerBoundInclusive,
 				upperBoundInclusive,
 				timestampStrategy,
+				JoinType.INNER,
 				TestElem.serializer(),
 				TestElem.serializer(),
 				new PassthroughFunction()
@@ -744,18 +842,23 @@ public class IntervalJoinOperatorTest {
 		);
 	}
 
-	private JoinTestBuilder setupHarness(long lowerBound,
+	private JoinTestBuilder setupHarness(
+		long lowerBound,
 		boolean lowerBoundInclusive,
 		long upperBound,
-		boolean upperBoundInclusive) throws Exception {
+		boolean upperBoundInclusive,
+		JoinType joinType,
+		IntervalJoinOperator.TimestampStrategy timestampStrategy
+	) throws Exception {
 
-		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
+		IntervalJoinOperator<String, TestElem, TestElem, JoinResult> operator =
 			new IntervalJoinOperator<>(
 				lowerBound,
 				upperBound,
 				lowerBoundInclusive,
 				upperBoundInclusive,
 				timestampStrategy,
+				joinType,
 				TestElem.serializer(),
 				TestElem.serializer(),
 				new PassthroughFunction()
@@ -771,14 +874,24 @@ public class IntervalJoinOperatorTest {
 		return new JoinTestBuilder(t, operator);
 	}
 
+	private JoinTestBuilder setupHarness(
+		long lowerBound,
+		boolean lowerBoundInclusive,
+		long upperBound,
+		boolean upperBoundInclusive
+	) throws Exception {
+
+		return setupHarness(lowerBound, lowerBoundInclusive, upperBound, upperBoundInclusive, JoinType.INNER, timestampStrategy);
+	}
+
 	private class JoinTestBuilder {
 
-		private IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator;
+		private IntervalJoinOperator<String, TestElem, TestElem, JoinResult> operator;
 		private TestHarness testHarness;
 
 		public JoinTestBuilder(
 			TestHarness t,
-			IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator
+			IntervalJoinOperator<String, TestElem, TestElem, JoinResult> operator
 		) throws Exception {
 
 			this.testHarness = t;
@@ -842,7 +955,7 @@ public class IntervalJoinOperatorTest {
 		}
 
 		@SafeVarargs
-		public final JoinTestBuilder andExpect(StreamRecord<Tuple2<TestElem, TestElem>>... elems) {
+		public final JoinTestBuilder andExpect(StreamRecord<JoinResult>... elems) {
 			assertOutput(Lists.newArrayList(elems), testHarness.getOutput());
 			return this;
 		}
@@ -895,25 +1008,45 @@ public class IntervalJoinOperatorTest {
 		}
 	}
 
-	private static class PassthroughFunction extends ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>> {
+	private static class PassthroughFunction extends ProcessJoinFunction<TestElem, TestElem, JoinResult> {
 
 		@Override
 		public void processElement(
 			TestElem left,
 			TestElem right,
 			Context ctx,
-			Collector<Tuple2<TestElem, TestElem>> out) throws Exception {
-			out.collect(Tuple2.of(left, right));
+			Collector<JoinResult> out) throws Exception {
+			out.collect(JoinResult.of(left, right));
 		}
 	}
 
-	private StreamRecord<Tuple2<TestElem, TestElem>> streamRecordOf(
-		long lhsTs,
-		long rhsTs,
-		IntervalJoinOperator.TimestampStrategy strategy
+	private StreamRecord<JoinResult> streamRecordOf(
+		Long leftTimestamp,
+		Long rightTimestamp,
+		Long resultTimestamp
 	) {
-		TestElem lhs = new TestElem(lhsTs, "lhs");
-		TestElem rhs = new TestElem(rhsTs, "rhs");
+		TestElem left = leftTimestamp != null
+			? new TestElem(leftTimestamp, "lhs")
+			: null;
+
+		TestElem right = rightTimestamp != null
+			? new TestElem(rightTimestamp, "rhs")
+			: null;
+
+		return new StreamRecord<>(JoinResult.of(left, right), resultTimestamp);
+	}
+
+	private StreamRecord<JoinResult> streamRecordOf(Long lhsTs, Long rhsTs) {
+
+		TestElem lhs = null;
+		if (lhsTs != null) {
+			lhs = new TestElem(lhsTs, "lhs");
+		}
+
+		TestElem rhs = null;
+		if (rhsTs != null) {
+			rhs = new TestElem(rhsTs, "rhs");
+		}
 
 		long ts;
 		switch (timestampStrategy) {
@@ -933,7 +1066,39 @@ public class IntervalJoinOperatorTest {
 				throw new RuntimeException("Unsupported timestamp strategy: " + timestampStrategy);
 		}
 
-		return new StreamRecord<>(Tuple2.of(lhs, rhs), ts);
+		return new StreamRecord<>(JoinResult.of(lhs, rhs), ts);
+	}
+
+	private static class JoinResult {
+		private Optional<TestElem> lhs;
+		private Optional<TestElem> rhs;
+
+		public JoinResult(TestElem lhs, TestElem rhs) {
+			this.lhs = Optional.ofNullable(lhs);
+			this.rhs = Optional.ofNullable(rhs);
+		}
+
+		static JoinResult of(TestElem lhs, TestElem rhs) {
+			return new JoinResult(lhs, rhs);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			JoinResult that = (JoinResult) o;
+			return Objects.equals(lhs, that.lhs) &&
+				Objects.equals(rhs, that.rhs);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(lhs, rhs);
+		}
 	}
 
 	private static class TestElem {
@@ -1025,10 +1190,10 @@ public class IntervalJoinOperatorTest {
 	/**
 	 * Custom test harness to avoid endless generics in all of the test code.
 	 */
-	private static class TestHarness extends KeyedTwoInputStreamOperatorTestHarness<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> {
+	private static class TestHarness extends KeyedTwoInputStreamOperatorTestHarness<String, TestElem, TestElem, JoinResult> {
 
 		TestHarness(
-			TwoInputStreamOperator<TestElem, TestElem, Tuple2<TestElem, TestElem>> operator,
+			TwoInputStreamOperator<TestElem, TestElem, JoinResult> operator,
 			KeySelector<TestElem, String> keySelector1,
 			KeySelector<TestElem, String> keySelector2,
 			TypeInformation<String> keyType) throws Exception {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.functions._
 import org.apache.flink.api.common.state.{FoldingStateDescriptor, ReducingStateDescriptor, ValueStateDescriptor}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.streaming.api.datastream.{QueryableStateStream, DataStream => JavaStream, KeyedStream => KeyedJavaStream, WindowedStream => WindowedJavaStream}
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction.AggregationType
 import org.apache.flink.streaming.api.functions.aggregation.{ComparableAggregator, SumAggregator}
@@ -176,6 +177,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     private var upperBoundInclusive = true
 
     private var timestampStrategy = TimestampStrategy.MAX
+    private var joinType = JoinType.INNER
 
     /**
       * Set the lower bound to be exclusive
@@ -219,6 +221,24 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
       this
     }
 
+    @Public
+    def leftOuter(): IntervalJoined[IN1, IN2, KEY] = {
+      this.joinType = JoinType.LEFT_OUTER
+      this
+    }
+
+    @Public
+    def rightOuter(): IntervalJoined[IN1, IN2, KEY] = {
+      this.joinType = JoinType.RIGHT_OUTER
+      this
+    }
+
+    @Public
+    def fullOuter(): IntervalJoined[IN1, IN2, KEY] = {
+      this.joinType = JoinType.FULL_OUTER
+      this
+    }
+
     /**
       * Completes the join operation with the user function that is executed for each joined pair
       * of elements.
@@ -236,6 +256,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
         upperBound,
         lowerBoundInclusive,
         upperBoundInclusive,
+        joinType,
         timestampStrategy)
       asScalaStream(javaJoined.process(processJoinFunction))
     }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
 import org.apache.flink.streaming.api.functions.query.{QueryableAppendingStateOperator, QueryableValueStateOperator}
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
 import org.apache.flink.streaming.api.operators.StreamGroupedReduce
+import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.TimestampStrategy
 import org.apache.flink.streaming.api.scala.function.StatefulFunction
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
@@ -174,6 +175,8 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     private var lowerBoundInclusive = true
     private var upperBoundInclusive = true
 
+    private var timestampStrategy = TimestampStrategy.MAX
+
     /**
       * Set the lower bound to be exclusive
       */
@@ -189,6 +192,30 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     @PublicEvolving
     def upperBoundExclusive(): IntervalJoined[IN1, IN2, KEY] = {
       this.upperBoundInclusive = false
+      this
+    }
+
+    @Public
+    def assignMaxTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.MAX
+      this
+    }
+
+    @Public
+    def assignMinTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.MIN
+      this
+    }
+
+    @Public
+    def assignLeftTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.LEFT
+      this
+    }
+
+    @Public
+    def assignRightTimestamp(): IntervalJoined[IN1, IN2, KEY] = {
+      this.timestampStrategy = TimestampStrategy.RIGHT
       this
     }
 
@@ -208,7 +235,8 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
         lowerBound,
         upperBound,
         lowerBoundInclusive,
-        upperBoundInclusive)
+        upperBoundInclusive,
+        timestampStrategy)
       asScalaStream(javaJoined.process(processJoinFunction))
     }
   }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -96,6 +96,144 @@ class IntervalJoinITCase extends AbstractTestBase {
       "(key,1):(key,2)"
     )
   }
+
+  @Test
+  @throws[Exception]
+  def testUseLeftTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val streamTwo = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(0L), Time.milliseconds(2L))
+      .assignLeftTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          Assert.assertEquals(ctx.getTimestamp, ctx.getLeftTimestamp)
+
+        }
+      })
+
+    env.execute()
+  }
+
+  @Test
+  @throws[Exception]
+  def testUseRightTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 1L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val streamTwo = env.fromElements(("key", 2L), ("key", 3L), ("key", 4L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(-2L), Time.milliseconds(0L))
+      .assignRightTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          Assert.assertEquals(ctx.getTimestamp, ctx.getRightTimestamp)
+
+        }
+      })
+
+    env.execute()
+  }
+
+  @Test
+  @throws[Exception]
+  def testUseMaxTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 1L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val streamTwo = env.fromElements(("key", 2L), ("key", 3L), ("key", 4L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(-2L), Time.milliseconds(0L))
+      .assignMaxTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          val expected = Math.max(ctx.getRightTimestamp, ctx.getLeftTimestamp)
+          Assert.assertEquals(ctx.getTimestamp, expected)
+
+        }
+      })
+
+    env.execute()
+  }
+
+  @Test
+  @throws[Exception]
+  def testUseMinTimestamp(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val streamOne = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+    val streamTwo = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    streamOne.intervalJoin(streamTwo)
+      .between(Time.milliseconds(-2L), Time.milliseconds(0L))
+      .assignRightTimestamp()
+      .process(new ProcessJoinFunction[(String, Long), (String, Long), String]() {
+        @throws[Exception]
+        override def processElement(
+            left: (String, Long),
+            right: (String, Long),
+            ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
+            out: Collector[String]): Unit = {
+
+          val expected = Math.min(ctx.getRightTimestamp, ctx.getLeftTimestamp)
+          Assert.assertEquals(ctx.getTimestamp, expected)
+
+        }
+      })
+
+    env.execute()
+  }
 }
 
 object Companion {

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -202,6 +202,103 @@ class IntervalJoinITCase extends AbstractTestBase {
   }
 
   @Test
+  def testRightOuterJoin(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val leftKeyedStream = env.fromElements(("key", 0L), ("key", 1L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val rightKeyedStream = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val sink = new ResultSink()
+
+    leftKeyedStream.intervalJoin(rightKeyedStream)
+      .between(Time.milliseconds(0), Time.milliseconds(0))
+      .rightOuter()
+      .process(new CombineToStringJoinFunction())
+      .addSink(sink)
+
+    env.execute()
+
+    sink.expectInAnyOrder(
+      "(key,0):(key,0)",
+      "(key,1):(key,1)",
+      "null:(key,2)",
+      "(key,3):(key,3)"
+    )
+  }
+
+  @Test
+  def testLeftOuterJoin(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val leftKeyedStream = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val rightKeyedStream = env.fromElements(("key", 0L), ("key", 1L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val sink = new ResultSink()
+
+    leftKeyedStream.intervalJoin(rightKeyedStream)
+      .between(Time.milliseconds(0), Time.milliseconds(0))
+      .leftOuter()
+      .process(new CombineToStringJoinFunction())
+      .addSink(sink)
+
+    env.execute()
+
+    sink.expectInAnyOrder(
+      "(key,0):(key,0)",
+      "(key,1):(key,1)",
+      "(key,2):null",
+      "(key,3):(key,3)"
+    )
+  }
+
+  @Test
+  def testFullOuterJoin(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val leftKeyedStream = env.fromElements(("key", 0L), ("key", 1L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val rightKeyedStream = env.fromElements(("key", 0L), ("key", 2L), ("key", 3L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val sink = new ResultSink()
+
+    leftKeyedStream.intervalJoin(rightKeyedStream)
+      .between(Time.milliseconds(0), Time.milliseconds(0))
+      .fullOuter()
+      .process(new CombineToStringJoinFunction())
+      .addSink(sink)
+
+    env.execute()
+
+    sink.expectInAnyOrder(
+      "(key,0):(key,0)",
+      "(key,1):null",
+      "null:(key,2)",
+      "(key,3):(key,3)"
+    )
+  }
+
+  @Test
   @throws[Exception]
   def testUseMinTimestamp(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
@@ -242,12 +339,22 @@ object Companion {
 
 class ResultSink extends SinkFunction[String] {
 
+  Companion.results.clear()
+
   override def invoke(value: String, context: SinkFunction.Context[_]): Unit = {
     Companion.results.append(value)
   }
 
   def expectInAnyOrder(expected: String*): Unit = {
-    Assert.assertTrue(expected.toSet.equals(Companion.results.toSet))
+    val expectedSet = expected.toSet
+    val actualSet = Companion.results.toSet
+
+    if (!expectedSet.equals(actualSet)) {
+      println(expectedSet)
+      println(actualSet)
+    }
+
+    Assert.assertTrue(expectedSet.equals(actualSet))
   }
 }
 
@@ -263,6 +370,12 @@ class CombineToStringJoinFunction
                         right: (String, Long),
                         ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context,
                         out: Collector[String]): Unit = {
-    out.collect(left + ":" + right)
+    if (left == null) {
+      out.collect("null:" + right)
+    } else if (right == null) {
+      out.collect(left + ":null")
+    } else {
+      out.collect(left + ":" + right)
+    }
   }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExt
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
@@ -52,6 +53,216 @@ public class IntervalJoinITCase {
 	@Before
 	public void setup() {
 		testResults = new ArrayList<>();
+	}
+
+	@Test
+	public void testLeftOuterJoin() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2),
+			Tuple2.of("key", 3)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 3)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.leftOuter()
+			.process(new CombineToStringJoinFunction())
+			.addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,0)",
+			"(key,1):(key,1)",
+			"(key,2):null",
+			"(key,3):(key,3)"
+		);
+	}
+
+	@Test(expected = FlinkRuntimeException.class)
+	public void testLeftOuterJoinCantUseTimestampStrategyRight() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0))
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.leftOuter()
+			.assignRightTimestamp()
+			.process(new CombineToStringJoinFunction()).addSink(new ResultSink());
+	}
+
+	@Test
+	public void testRightOuterJoin() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 3)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2),
+			Tuple2.of("key", 3)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.rightOuter()
+			.process(new CombineToStringJoinFunction()).addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,0)",
+			"(key,1):(key,1)",
+			"null:(key,2)",
+			"(key,3):(key,3)"
+		);
+	}
+
+	@Test(expected = FlinkRuntimeException.class)
+	public void testRightOuterJoinCantUseTimestampStrategyLeft() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0))
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.rightOuter()
+			.assignLeftTimestamp()
+			.process(new CombineToStringJoinFunction()).addSink(new ResultSink());
+	}
+
+	@Test
+	public void testFullOuterJoin() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 3)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 2),
+			Tuple2.of("key", 3)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.fullOuter()
+			.process(new CombineToStringJoinFunction()).addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,0)",
+			"(key,1):null",
+			"null:(key,2)",
+			"(key,3):(key,3)"
+		);
+	}
+
+	@Test(expected = FlinkRuntimeException.class)
+	public void testFullOuterJoinCantUseTimestampStrategyLeft() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0))
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.fullOuter()
+			.assignLeftTimestamp()
+			.process(new CombineToStringJoinFunction()).addSink(new ResultSink());
+	}
+
+	@Test(expected = FlinkRuntimeException.class)
+	public void testFullOuterJoinCantUseTimestampStrategyRight() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> leftStream = env.fromElements(
+			Tuple2.of("key", 0))
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> rightStream = env.fromElements(
+			Tuple2.of("key", 0)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		leftStream.intervalJoin(rightStream)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.fullOuter()
+			.assignRightTimestamp()
+			.process(new CombineToStringJoinFunction()).addSink(new ResultSink());
 	}
 
 	@Test
@@ -443,7 +654,8 @@ public class IntervalJoinITCase {
 			.process(new ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
 				@Override
 				public void processElement(Tuple2<String, Integer> left, Tuple2<String, Integer> right, Context ctx, Collector<String> out) throws Exception {
-					Assert.assertEquals(ctx.getTimestamp(), Math.max(ctx.getRightTimestamp(), ctx.getLeftTimestamp()));
+					Long expected = Math.max(ctx.getRightTimestamp(), ctx.getLeftTimestamp());
+					Assert.assertEquals(ctx.getTimestamp(), expected);
 				}
 			})
 			.addSink(new ResultSink());
@@ -476,7 +688,8 @@ public class IntervalJoinITCase {
 			.process(new ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
 				@Override
 				public void processElement(Tuple2<String, Integer> left, Tuple2<String, Integer> right, Context ctx, Collector<String> out) throws Exception {
-					Assert.assertEquals(ctx.getTimestamp(), Math.min(ctx.getRightTimestamp(), ctx.getLeftTimestamp()));
+					Long expected = Math.min(ctx.getRightTimestamp(), ctx.getLeftTimestamp());
+					Assert.assertEquals(ctx.getTimestamp(), expected);
 				}
 			})
 			.addSink(new ResultSink());
@@ -496,14 +709,7 @@ public class IntervalJoinITCase {
 		streamOne.keyBy(new Tuple2KeyExtractor())
 			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
 			.between(Time.milliseconds(0), Time.milliseconds(0))
-			.process(new ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
-				@Override
-				public void processElement(Tuple2<String, Integer> left,
-					Tuple2<String, Integer> right, Context ctx,
-					Collector<String> out) throws Exception {
-					out.collect(left + ":" + right);
-				}
-			});
+			.process(new CombineToStringJoinFunction());
 	}
 
 	private static void expectInAnyOrder(String... expected) {
@@ -529,9 +735,18 @@ public class IntervalJoinITCase {
 
 	private static class CombineToStringJoinFunction extends ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String> {
 		@Override
-		public void processElement(Tuple2<String, Integer> left,
-			Tuple2<String, Integer> right, Context ctx, Collector<String> out) {
-			out.collect(left + ":" + right);
+		public void processElement(
+			Tuple2<String, Integer> left,
+			Tuple2<String, Integer> right, Context ctx,
+			Collector<String> out
+		) throws Exception {
+			if (left == null) {
+				out.collect("null:" + right);
+			} else if (right == null) {
+				out.collect(left + ":null");
+			} else {
+				out.collect(left + ":" + right);
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
*This depends on FLINK-8482*
 
This PR adds leftOuter, rightOuter and fullOuter joins to the IntervalJoin in the DataStream API.

The usage is as follows:

```java 
leftKeyedStream.intervalJoin(rightKeyedStream)
    .between(<Time>,<Time>)
    .process(new ProcessJoinFunction() { ... })
```

Note that some combinations of outer joins and timestamp strategies are not valid. An example of this would be using TimestampStrategy.RIGHT with JoinType.LEFT_OUTER.

Internally the outer joins are implemented by

1. For each incoming element, a timer is registered with the timestamp at which the element can safely be removed from the buffer, because it will never be joined anymore (as calculated by the watermark and join boundaries). This timer is bound to the namespace with represents the side to which the element and its buffer belong to.

2. Each element that is added to the buffer has a flag that indicates whether this element has been joined yet. Whenever elements are joined, this flag will be set.  

3. When a timer fires, elements from the respective buffer (as indicated by the timers namespace) will be removed from the buffer and emitted, if they have not been joined yet.

This approach means that the number of timers is roughly the same as the number of elements (a little less if many elements have the same timestamp). This is a tradeoff for only needing to access on bucket in the buffer for each side on cleanup, versus needing to iterate over all entries each time.

## Brief change log

This feature is implemented and tested by
- adding the implementation of outer joins to the IntervalJoin Operator
- adding the implementation of outer joins to the DataStream Java API
- adding the implementation of outer joins to the DataStream Scala API
- adding unit tests in the IntervalJoinOperatorTest
- adding IT tests in the IntervalJoinITTest


## Verifying this change

This change added tests and can be verified as follows:
- adding unit tests in the IntervalJoinOperatorTest
- adding IT tests in the IntervalJoinITTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs