### PR TITLE
[FLINK-10602] Use metric's ActorSystem in MetricFetcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityContext;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaQueryServiceRetriever;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
@@ -219,6 +220,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 				heartbeatServices,
 				metricRegistry,
 				archivedExecutionGraphStore,
+				new AkkaQueryServiceRetriever(
+					metricQueryServiceActorSystem,
+					Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT))),
 				this);
 
 			clusterComponent.getShutDownFuture().whenComplete(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 
 /**
  * Factory for the {@link DispatcherResourceManagerComponent}.
@@ -41,5 +42,6 @@ public interface DispatcherResourceManagerComponentFactory<T extends Dispatcher>
 		HeartbeatServices heartbeatServices,
 		MetricRegistry metricRegistry,
 		ArchivedExecutionGraphStore archivedExecutionGraphStore,
+		MetricQueryServiceRetriever metricQueryServiceRetriever,
 		FatalErrorHandler fatalErrorHandler) throws Exception;
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/VoidMetricQueryServiceRetriever.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/VoidMetricQueryServiceRetriever.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.retriever.impl;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceGateway;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.FlinkException;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link MetricQueryServiceRetriever} implementation which always fails the retrieval of
+ * the metric query service.
+ */
+public enum VoidMetricQueryServiceRetriever implements MetricQueryServiceRetriever {
+	INSTANCE;
+
+	@Override
+	public CompletableFuture<MetricQueryServiceGateway> retrieveService(String queryServicePath) {
+		return FutureUtils.completedExceptionally(new FlinkException("Cannot retrieve metric query service for " + queryServicePath + '.'));
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -55,6 +55,7 @@ import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.retriever.impl.VoidMetricQueryServiceRetriever;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.CheckedSupplier;
@@ -151,6 +152,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 				new HeartbeatServices(100L, 1000L),
 				NoOpMetricRegistry.INSTANCE,
 				new MemoryArchivedExecutionGraphStore(),
+				VoidMetricQueryServiceRetriever.INSTANCE,
 				fatalErrorHandler);
 
 			final Map<String, String> keyValues = config.toMap();


### PR DESCRIPTION
## What is the purpose of the change

Use the metric system's ActorSystem in the MetricFetcher. This makes the fetching
of metrics run in a separate ActorSystem from the one used in the RpcService. This
should decouple Flink from the metric system further and allows to individually
configure both systems.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
