### PR TITLE
[FLINK-10552][DataStream API]Add supports for RichAsyncFunction in Scala API

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -97,10 +97,10 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction im
 	 * context only supports basic operations which are thread safe. Consequently, state access,
 	 * accumulators, broadcast variables and the distributed cache are disabled.
 	 */
-	private static class RichAsyncFunctionRuntimeContext implements RuntimeContext {
+	public static class RichAsyncFunctionRuntimeContext implements RuntimeContext {
 		private final RuntimeContext runtimeContext;
 
-		RichAsyncFunctionRuntimeContext(RuntimeContext context) {
+		public RichAsyncFunctionRuntimeContext(RuntimeContext context) {
 			runtimeContext = Preconditions.checkNotNull(context);
 		}
 
@@ -239,11 +239,16 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction im
 		}
 	}
 
-	private static class RichAsyncFunctionIterationRuntimeContext extends RichAsyncFunctionRuntimeContext implements IterationRuntimeContext {
+	/**
+	 * A wrapper class for async function's {@link IterationRuntimeContext}. The async function runtime
+	 * context only supports basic operations which are thread safe. Consequently, state access,
+	 * accumulators, broadcast variables, the distributed cache and iteration aggregator are disabled.
+	 */
+	public static class RichAsyncFunctionIterationRuntimeContext extends RichAsyncFunctionRuntimeContext implements IterationRuntimeContext {
 
 		private final IterationRuntimeContext iterationRuntimeContext;
 
-		RichAsyncFunctionIterationRuntimeContext(IterationRuntimeContext iterationRuntimeContext) {
+		public RichAsyncFunctionIterationRuntimeContext(IterationRuntimeContext iterationRuntimeContext) {
 			super(iterationRuntimeContext);
 
 			this.iterationRuntimeContext = Preconditions.checkNotNull(iterationRuntimeContext);

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RichAsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RichAsyncFunction.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala.async
+
+import org.apache.flink.api.common.functions.{AbstractRichFunction, IterationRuntimeContext, RuntimeContext}
+import org.apache.flink.streaming.api.functions.async.RichAsyncFunction.{RichAsyncFunctionIterationRuntimeContext, RichAsyncFunctionRuntimeContext}
+import org.apache.flink.util.Preconditions
+
+/**
+  * Rich variant of the [[AsyncFunction]].
+  * As a [[org.apache.flink.api.common.functions.RichFunction]], it gives access to
+  * the [[RuntimeContext]] and provides setup and teardown methods.
+  *
+  * @tparam IN The type of the input element
+  * @tparam OUT The type of the output elements
+  */
+trait RichAsyncFunction[IN, OUT] extends AbstractRichFunction with AsyncFunction[IN, OUT]{
+  override def setRuntimeContext(runtimeContext: RuntimeContext): Unit = {
+    Preconditions.checkNotNull(runtimeContext)
+
+    if (runtimeContext.isInstanceOf[IterationRuntimeContext]) {
+      super.setRuntimeContext(new RichAsyncFunctionIterationRuntimeContext(
+        runtimeContext.asInstanceOf[IterationRuntimeContext]));
+    } else {
+      super.setRuntimeContext(new RichAsyncFunctionRuntimeContext(runtimeContext));
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Support RichAsyncFunction in Scala API

## Brief change log
  - Change Async related RuntimeContext to public
  - Add RichAsyncFunction of Scala version

## Verifying this change

The runtime context has been tested in RichAsyncFunctionTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
