### PR TITLE
[FLINK-10601] [YARN] Make user home dir consistent with Flink default filesystem

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -46,11 +46,11 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
@@ -723,6 +724,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// initialize file system
 		// Copy the application master jar to the filesystem
 		// Create a local resource to point to the destination jar path
+		yarnConfiguration.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
+				org.apache.flink.core.fs.FileSystem.getDefaultFsUri().toString());
 		final FileSystem fs = FileSystem.get(yarnConfiguration);
 		final Path homeDir = fs.getHomeDirectory();
 


### PR DESCRIPTION
## What is the purpose of the change
Currently, Flink client uses the raw default Hadoop filesystem to upload local files, and this could be problematic when using a non-default filesystem for HA or checkpointing in delegation tokens scenarios. The jobmanager only has the delegation tokens for the default FS, so it gets authentication errors when trying to connect a non-default filesystem.

So I propose to make the default FS with the Flink filesystem property `fs.default-scheme` on the client side (AbstractYarnClusterDescriptor), to avoid this problem and also make the client behavior more configurable.

## Brief change log

- Replace the `fs.defaultFS` property in the yarn configuration with the initiated Flink filesystem's default scheme.

## Verifying this change

This change added tests and can be verified as follows:

- Set the default fs in core.xml to a non-exist fs, and set the `fs.default-scheme` property to a valid one in flink-conf.yaml, then run the WordCount example to see if it works well. There would be errors while the client tries to upload the files to the remote system if things go wrong. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not documented
