### PR TITLE
[FLINK-10463][table] Null literal cannot be properly parsed in Java Table API function call

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -4186,7 +4186,7 @@ CAST(value AS type)
       </td>
       <td>
         <p>Returns a new <i>value</i> being cast to type <i>type</i>. See the supported types <a href="sql.html#data-types">here</a>.</p>
-        <p>E.g., <code>CAST('42' AS INT)</code> returns 42.</p>
+        <p>E.g., <code>CAST('42' AS INT)</code> returns 42; <code>CAST(NULL AS VARCHAR)</code> returns NULL of type VARCHAR.</p>
       </td>
     </tr>
   </tbody>
@@ -4211,7 +4211,7 @@ ANY.cast(TYPE)
       </td>
       <td>
         <p>Returns a new <i>ANY</i> being cast to type <i>TYPE</i>. See the supported types <a href="tableApi.html#data-types">here</a>.</p>
-        <p>E.g., <code>'42'.cast(INT)</code> returns 42.</p>
+        <p>E.g., <code>'42'.cast(INT)</code> returns 42; <code>Null(STRING)</code> returns NULL of type STRING.</p>
       </td>
     </tr>
     </tbody>
@@ -4236,7 +4236,7 @@ ANY.cast(TYPE)
       </td>
       <td>
         <p>Returns a new <i>ANY</i> being cast to type <i>TYPE</i>. See the supported types <a href="tableApi.html#data-types">here</a>.</p>
-        <p>E.g., <code>"42".cast(Types.INT)</code> returns 42.</p>
+        <p>E.g., <code>"42".cast(Types.INT)</code> returns 42; <code>Null(Types.STRING)</code> returns NULL of type STRING.</p>
       </td>
     </tr>
   </tbody>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -455,7 +455,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
   // suffix/prefix composite
 
-  lazy val composite: PackratParser[Expression] = over | nullLiteral | suffixed | prefixed | atom |
+  lazy val composite: PackratParser[Expression] = over | suffixed | nullLiteral | prefixed | atom |
     failure("Composite expression expected.")
 
   // unary ops

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -645,6 +645,12 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "'foobar'.regexpReplace('oo|ar', f33)",
       "REGEXP_REPLACE('foobar', 'oo|ar', f33)",
       "null")
+
+    testAllApis(
+      Null(Types.STRING).regexpReplace("oo|ar", 'f33),
+      "Null(STRING).regexpReplace('oo|ar', f33)",
+      "REGEXP_REPLACE(CAST(NULL AS VARCHAR), 'oo|ar', f33)",
+      "null")
   }
 
   @Test


### PR DESCRIPTION

## What is the purpose of the change

This is a hotfix to solve Null literal parse problem in Java Table API function call. For example, the expression `Null(STRING).regexpReplace('oo|ar', '')` throws parse exception.

## Brief change log

  - Fix parse problem for Null literal.
  - Add documents about cast null to types.
  - Add a test to verify result.

## Verifying this change

This change added tests and can be verified as follows:

  - Added a test for the parse

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
