### PR TITLE
[FLINK-10570] Fixed clearing shared buffer nodes when using After match skip strategy

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -389,6 +389,7 @@ public class NFA<T> {
 					sharedBufferAccessor);
 
 				result.add(sharedBufferAccessor.materializeMatch(matchedResult.get(0)));
+				sharedBufferAccessor.releaseNode(earliestMatch.getPreviousBufferEntry());
 				earliestMatch = nfaState.getCompletedMatches().peek();
 			}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes releasing nodes for matches when after match skip strategy is applied.

## Verifying this change

This change added tests and can be verified as follows:
* `org.apache.flink.cep.nfa.AfterMatchSkipITCase#testSharedBufferIsProperlyCleared`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
