### PR TITLE
[FLINK-10642][table] fix CodeGen split fields errors in special config

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1057,13 +1057,13 @@ abstract class CodeGenerator(
 
         // declaration
         val resultTypeTerm = primitiveTypeTermForTypeInfo(expr.resultType)
-        if (nullCheck) {
+        if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
           reusableMemberStatements.add(s"private boolean ${expr.nullTerm};")
         }
         reusableMemberStatements.add(s"private $resultTypeTerm ${expr.resultTerm};")
 
         // assignment
-        if (nullCheck) {
+        if (nullCheck && !expr.nullTerm.equals(NEVER_NULL) && !expr.nullTerm.equals(ALWAYS_NULL)) {
           reusablePerRecordStatements.add(s"this.${expr.nullTerm} = ${expr.nullTerm};")
         }
         reusablePerRecordStatements.add(s"this.${expr.resultTerm} = ${expr.resultTerm};")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
@@ -578,6 +578,22 @@ class CalcITCase(
     val expected = List("a,a,d,d,e,e", "x,x,z,z,z,z").mkString("\n")
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
+
+  @Test
+  def testSplitFeildsOnCustomType(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setMaxGeneratedCodeLength(1)  // splits fields
+
+    val ds = CollectionDataSets.getCustomTypeDataSet(env)
+    val filterDs = ds.toTable(tEnv, 'myInt as 'i, 'myLong as 'l, 'myString as 's)
+      .filter( 's.like("%a%") && 's.charLength > 12)
+      .select('i, 'l, 's.charLength)
+
+    val expected = "3,3,25\n" + "3,5,14\n"
+    val results = filterDs.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
 }
 
 object CalcITCase {


### PR DESCRIPTION
## What is the purpose of the change
This PR tries to fix several tests errors when setting maxGeneratedCodeLength  1 to force split fields. e.g.
`
  CalcITCase.testFilterOnCustomType:260 ? InvalidProgram Table program cannot be...
  JavaTableEnvironmentITCase.testAsFromAndToPojo:394 ? InvalidProgram Table prog...
  JavaTableEnvironmentITCase.testAsFromAndToPrivateFieldPojo:421 ? InvalidProgram
  JavaTableEnvironmentITCase.testAsFromPojo:288 ? InvalidProgram Table program c...
  JavaTableEnvironmentITCase.testAsFromPrivateFieldsPojo:366 ? InvalidProgram Ta...
  JavaTableEnvironmentITCase.testAsWithPojoAndGenericTypes:453 ? InvalidProgram ...
  TimeAttributesITCase.testPojoSupport:566 ? JobExecution Job execution failed.
`
## Brief change log
  - *CodeGenerator*

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
