### PR TITLE
[FLINK-10572] [JobManager] Enable Per-Job level failover config

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -407,9 +407,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	/**
 	 * Sets the failover strategy. The failover strategy how the job computation recovers from task failures
-	 *
-	 * The default failover strategy mode is {@link FailoverStrategyType#FULL_RESTART_STRATEGY_NAME}.
-	 *
+	 * Set failover strategy here will overwrite cluster's default setting, which is {@link FailoverStrategyType#FULL_RESTART_STRATEGY_NAME}
 	 * @param strategy The strategy to use.
 	 */
 	@PublicEvolving

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -406,8 +406,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	/**
-	 * Sets the failover strategy. The failover strategy how the job computation recovers from task failures
-	 * Set failover strategy here will overwrite cluster's default setting, which is {@link FailoverStrategyType#FULL_RESTART_STRATEGY_NAME}
+	 * Sets the failover strategy. The failover strategy of how the job computation recovers from task failures
+	 * Set failover strategy here will overwrite cluster's default setting, which is {@link FailoverStrategyType#FULL_RESTART_STRATEGY}
 	 * @param strategy The strategy to use.
 	 */
 	@PublicEvolving

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -159,6 +159,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** Determines if a task fails or not if there is an error in writing its checkpoint data. Default: true */
 	private boolean failTaskOnCheckpointError = true;
 
+	/** Failover strategy, default value is 'none', that will use cluster's configuration */
+	private FailoverStrategyType failoverStrategy = FailoverStrategyType.None;
+
 	// ------------------------------- User code values --------------------------------------------
 
 	private GlobalJobParameters globalJobParameters;
@@ -400,6 +403,29 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	@PublicEvolving
 	public void setRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
 		this.restartStrategyConfiguration = Preconditions.checkNotNull(restartStrategyConfiguration);
+	}
+
+	/**
+	 * Sets the failover strategy. The failover strategy how the job computation recovers from task failures
+	 *
+	 * The default failover strategy mode is {@link FailoverStrategyType#FULL_RESTART_STRATEGY_NAME}.
+	 *
+	 * @param strategy The strategy to use.
+	 */
+	@PublicEvolving
+	public ExecutionConfig setFailoverStrategy(FailoverStrategyType strategy) {
+		this.failoverStrategy = strategy;
+		return this;
+	}
+
+	/**
+	 * Returns the failover strategy which has been set for the current job.
+	 *
+	 * @return The specified failover strategy
+	 */
+	@PublicEvolving
+	public FailoverStrategyType getFailoverStrategy() {
+		return this.failoverStrategy;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/FailoverStrategyType.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/FailoverStrategyType.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * This option specifies the failover strategy, i.e. how the job computation recovers from task failures.
+ */
+@PublicEvolving
+public enum FailoverStrategyType {
+
+	/**
+	 * Config name for the RestartAllStrategy.
+	 * Restarts all tasks when a failure occurred
+	 *
+	 * */
+	FULL_RESTART_STRATEGY_NAME("full"),
+
+	/**
+	 *  Config name for the RestartIndividualStrategy
+	 *  Restarts only the failed task. Should only be used if all tasks are independent components
+	 * */
+	INDIVIDUAL_RESTART_STRATEGY_NAME("individual"),
+
+	/**
+	 * Config name for the RestartPipelinedRegionStrategy
+	 * Restarts all tasks that could be affected by the task failure.
+	 * */
+	PIPELINED_REGION_RESTART_STRATEGY_NAME("region"),
+
+	/**
+	 * faiolver strategy not defined, will use the default strategy of cluster configuration
+	 * */
+	None("none");
+
+	private String value;
+
+	FailoverStrategyType(final String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return this.getValue();
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/FailoverStrategyType.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/FailoverStrategyType.java
@@ -31,22 +31,22 @@ public enum FailoverStrategyType {
 	 * Restarts all tasks when a failure occurred
 	 *
 	 * */
-	FULL_RESTART_STRATEGY_NAME("full"),
+	FULL_RESTART_STRATEGY("full"),
 
 	/**
 	 *  Config name for the RestartIndividualStrategy
 	 *  Restarts only the failed task. Should only be used if all tasks are independent components
 	 * */
-	INDIVIDUAL_RESTART_STRATEGY_NAME("individual"),
+	INDIVIDUAL_RESTART_STRATEGY("individual"),
 
 	/**
 	 * Config name for the RestartPipelinedRegionStrategy
 	 * Restarts all tasks that could be affected by the task failure.
 	 * */
-	PIPELINED_REGION_RESTART_STRATEGY_NAME("region"),
+	PIPELINED_REGION_RESTART_STRATEGY("region"),
 
 	/**
-	 * faiolver strategy not defined, will use the default strategy of cluster configuration
+	 * Faiolver strategy not defined, will use the default strategy of cluster configuration
 	 * */
 	None("none");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -19,11 +19,13 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.JobException;
@@ -91,6 +93,7 @@ public class ExecutionGraphBuilder {
 			CheckpointRecoveryFactory recoveryFactory,
 			Time rpcTimeout,
 			RestartStrategy restartStrategy,
+			FailoverStrategyType failoverStrategyType,
 			MetricGroup metrics,
 			BlobWriter blobWriter,
 			Time allocationTimeout,
@@ -108,6 +111,7 @@ public class ExecutionGraphBuilder {
 			recoveryFactory,
 			rpcTimeout,
 			restartStrategy,
+			failoverStrategyType,
 			metrics,
 			-1,
 			blobWriter,
@@ -132,6 +136,7 @@ public class ExecutionGraphBuilder {
 			CheckpointRecoveryFactory recoveryFactory,
 			Time rpcTimeout,
 			RestartStrategy restartStrategy,
+			FailoverStrategyType failoverStrategyType,
 			MetricGroup metrics,
 			int parallelismForAutoMax,
 			BlobWriter blobWriter,
@@ -144,8 +149,13 @@ public class ExecutionGraphBuilder {
 		final String jobName = jobGraph.getName();
 		final JobID jobId = jobGraph.getJobID();
 
+		final String strategyParam =
+			failoverStrategyType != FailoverStrategyType.None
+			? failoverStrategyType.toString()
+			: jobManagerConfig.getString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY);
+
 		final FailoverStrategy.Factory failoverStrategy =
-				FailoverStrategyLoader.loadFailoverStrategy(jobManagerConfig, log);
+				FailoverStrategyLoader.loadFailoverStrategy(strategyParam, log);
 
 		final JobInformation jobInformation = new JobInformation(
 			jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyLoader.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.runtime.executiongraph.failover;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.util.StringUtils;
-
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
@@ -46,8 +44,7 @@ public class FailoverStrategyLoader {
 	/**
 	 * Loads a FailoverStrategy Factory from the given configuration.
 	 */
-	public static FailoverStrategy.Factory loadFailoverStrategy(Configuration config, @Nullable Logger logger) {
-		final String strategyParam = config.getString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY);
+	public static FailoverStrategy.Factory loadFailoverStrategy(String strategyParam, @Nullable Logger logger) {
 
 		if (StringUtils.isNullOrWhitespaceOnly(strategyParam)) {
 			if (logger != null) {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1251,15 +1251,20 @@ class JobManager(
           throw new JobSubmissionException(jobId, "The given job is empty")
         }
 
-        val restartStrategyConfiguration = jobGraph
+        val executionConfig = jobGraph
           .getSerializedExecutionConfig
           .deserializeValue(userCodeLoader)
+
+        val restartStrategyConfiguration = executionConfig
           .getRestartStrategy
 
         val restartStrategy = RestartStrategyResolving
           .resolve(restartStrategyConfiguration,
             restartStrategyFactory,
             jobGraph.isCheckpointingEnabled)
+
+        val failoverStrategy = executionConfig
+          .getFailoverStrategy
 
         log.info(s"Using restart strategy $restartStrategy for $jobId.")
 
@@ -1291,6 +1296,7 @@ class JobManager(
           checkpointRecoveryFactory,
           Time.of(timeout.length, timeout.unit),
           restartStrategy,
+          failoverStrategy,
           jobMetrics,
           numSlots,
           blobServer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -107,6 +108,7 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			timeout,
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			10,
 			VoidBlobWriter.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.IntCounter;
@@ -709,6 +710,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			timeout,
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			1,
 			blobWriter,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.JobException;
@@ -74,6 +75,7 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
@@ -103,6 +105,7 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
@@ -132,6 +135,7 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
@@ -174,6 +178,7 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 				new StandaloneCheckpointRecoveryFactory(),
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy(),
+				FailoverStrategyType.None,
 				new UnregisteredMetricsGroup(),
 				VoidBlobWriter.getInstance(),
 				AkkaUtils.getDefaultTimeout(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
@@ -615,6 +616,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			timeout,
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			1,
 			VoidBlobWriter.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
@@ -454,6 +455,7 @@ public class ExecutionGraphTestUtils {
 			new StandaloneCheckpointRecoveryFactory(),
 			timeout,
 			restartStrategy,
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			1,
 			VoidBlobWriter.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
@@ -221,6 +222,7 @@ public class ExecutionVertexLocalityTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			timeout,
 			new FixedDelayRestartStrategy(10, 0L),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			1,
 			VoidBlobWriter.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/PipelinedFailoverRegionBuildingTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph.failover;
 
+import org.apache.flink.api.common.FailoverStrategyType;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -639,6 +640,7 @@ public class PipelinedFailoverRegionBuildingTest extends TestLogger {
 			new StandaloneCheckpointRecoveryFactory(),
 			timeout,
 			new NoRestartStrategy(),
+			FailoverStrategyType.None,
 			new UnregisteredMetricsGroup(),
 			1000,
 			VoidBlobWriter.getInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
@@ -113,7 +112,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SupplierWithException;
-
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -126,7 +124,6 @@ import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
## What is the purpose of the change

*Today we Failover strategy is a cluster level config, we cannot set it for individual job, this PR try to expose the config to ExecutionConfig and let it can be set in per-job level*


## Brief change log

  - *Add enum FailoverStrategyType*
  - *Add set FailoverStrategyType in ExecutionConfig*
  - *Extract FailoverStrategyType and pass it to ExecutionGraph*


## Verifying this change

This change added tests and can be verified as follows:
  - *A test in jobMaster to validate the config was passed correctly.*

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  yes

## Documentation
  - If yes, how is the feature documented? (not documented, will be handled in [FLINK-10574](https://issues.apache.org/jira/browse/FLINK-10574)
