### PR TITLE
[Flink-6036][table]Let catalog support partition.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.api
 
+import  _root_.java.util.{LinkedHashMap => JLinkedHashMap}
+import com.google.common.base.Joiner
+
 import org.apache.flink.table.descriptors.DescriptorProperties
 import org.apache.flink.table.factories.TableFactory
 
@@ -79,6 +82,50 @@ object ValidationException {
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)
+
+/**
+  * Exception for operation on a nonexistent partition
+  *
+  * @param catalog       catalog name
+  * @param table         table name
+  * @param partitionSpec partition spec
+  * @param cause         the cause
+  */
+case class PartitionNotExistException(
+  catalog: String,
+  table: String,
+  partitionSpec: JLinkedHashMap[String, String],
+  cause: Throwable)
+  extends RuntimeException(
+    s"Partition [${Joiner.on(",").withKeyValueSeparator("=").join(partitionSpec)}] " +
+      s"does not exist in table $catalog.$table!", cause) {
+
+  def this(catalog: String, table: String, partitionSpec: JLinkedHashMap[String, String]) =
+    this(catalog, table, partitionSpec, null)
+
+}
+
+/**
+  * Exception for adding an already existed partition
+  *
+  * @param catalog       catalog name
+  * @param table         table name
+  * @param partitionSpec partition spec
+  * @param cause         the cause
+  */
+case class PartitionAlreadyExistException(
+  catalog: String,
+  table: String,
+  partitionSpec: JLinkedHashMap[String, String],
+  cause: Throwable)
+  extends RuntimeException(
+    s"Partition [${Joiner.on(",").withKeyValueSeparator("=").join(partitionSpec)}] " +
+      s"already exists in table $catalog.$table!", cause) {
+
+  def this(catalog: String, table: String, partitionSpec: JLinkedHashMap[String, String]) =
+    this(catalog, table, partitionSpec, null)
+
+}
 
 /**
   * Exception for an operation on a nonexistent table

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -162,6 +162,25 @@ case class TableAlreadyExistException(
 }
 
 /**
+  * Exception for do operation about partition on a non-partitioned table.
+  *
+  * @param catalog    catalog name
+  * @param table      table name
+  * @param cause      the cause
+  */
+case class TableNotPartitionedException(
+    catalog: String,
+    table: String,
+    cause: Throwable)
+  extends UnsupportedOperationException(
+    s"Cannot do any operation about partition on the non-partitioned table $catalog.$table!",
+    cause) {
+
+  def this(catalog: String, table: String) = this(catalog, table, null)
+
+}
+
+/**
   * Exception for operation on a nonexistent catalog
   *
   * @param catalog catalog name

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.catalog
 
+import java.util.{LinkedHashMap => JLinkedHashMap}
+
 import org.apache.flink.table.api._
 
 /**
@@ -102,5 +104,59 @@ trait CrudExternalCatalog extends ExternalCatalog {
     */
   @throws[CatalogNotExistException]
   def alterSubCatalog(name: String, catalog: ExternalCatalog, ignoreIfNotExists: Boolean): Unit
+
+
+  /**
+    * Adds partition into an external Catalog table
+    *
+    * @param tableName      table name
+    * @param partition      partition description of partition which to create
+    * @param ignoreIfExists if partition already exists in the catalog, not throw exception and
+    *                       leave the existed partition if ignoreIfExists is true;
+    *                       else throw PartitionAlreadyExistException
+    * @throws TableNotExistException         if table does not exist in the catalog yet
+    * @throws PartitionAlreadyExistException if partition exists in the catalog and
+    *                                        ignoreIfExists is false
+    */
+  @throws[TableNotExistException]
+  @throws[PartitionAlreadyExistException]
+  def createPartition(
+    tableName: String,
+    partition: ExternalCatalogPartition,
+    ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes partition of an external Catalog table
+    *
+    * @param tableName         table name
+    * @param partSpec          partition specification
+    * @param ignoreIfNotExists if partition not exist yet, not throw exception if ignoreIfNotExists
+    *                          is true; else throw PartitionNotExistException
+    * @throws TableNotExistException     if table does not exist in the catalog yet
+    * @throws PartitionNotExistException if partition does not exist in the catalog yet
+    */
+  @throws[TableNotExistException]
+  @throws[PartitionNotExistException]
+  def dropPartition(
+    tableName: String,
+    partSpec: JLinkedHashMap[String, String],
+    ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters an existed external Catalog table partition
+    *
+    * @param tableName         table name
+    * @param partition         description of partition which to alter
+    * @param ignoreIfNotExists if the partition not exist yet, not throw exception if
+    *                          ignoreIfNotExists is true; else throw PartitionNotExistException
+    * @throws TableNotExistException     if table does not exist in the catalog yet
+    * @throws PartitionNotExistException if partition does not exist in the catalog yet
+    */
+  @throws[TableNotExistException]
+  @throws[PartitionNotExistException]
+  def alterPartition(
+    tableName: String,
+    partition: ExternalCatalogPartition,
+    ignoreIfNotExists: Boolean): Unit
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
@@ -114,10 +114,12 @@ trait CrudExternalCatalog extends ExternalCatalog {
     * @param ignoreIfExists if partition already exists in the catalog, not throw exception and
     *                       leave the existed partition if ignoreIfExists is true;
     *                       else throw PartitionAlreadyExistException
+    * @throws TableNotPartitionedException   if add partition on a non-partitioned table.
     * @throws TableNotExistException         if table does not exist in the catalog yet
     * @throws PartitionAlreadyExistException if partition exists in the catalog and
     *                                        ignoreIfExists is false
     */
+  @throws[TableNotPartitionedException]
   @throws[TableNotExistException]
   @throws[PartitionAlreadyExistException]
   def createPartition(
@@ -132,9 +134,11 @@ trait CrudExternalCatalog extends ExternalCatalog {
     * @param partSpec          partition specification
     * @param ignoreIfNotExists if partition not exist yet, not throw exception if ignoreIfNotExists
     *                          is true; else throw PartitionNotExistException
+    * @throws TableNotPartitionedException   if drop partition on a non-partitioned table.
     * @throws TableNotExistException     if table does not exist in the catalog yet
     * @throws PartitionNotExistException if partition does not exist in the catalog yet
     */
+  @throws[TableNotPartitionedException]
   @throws[TableNotExistException]
   @throws[PartitionNotExistException]
   def dropPartition(
@@ -149,9 +153,11 @@ trait CrudExternalCatalog extends ExternalCatalog {
     * @param partition         description of partition which to alter
     * @param ignoreIfNotExists if the partition not exist yet, not throw exception if
     *                          ignoreIfNotExists is true; else throw PartitionNotExistException
+    * @throws TableNotPartitionedException   if alter partition on a non-partitioned table.
     * @throws TableNotExistException     if table does not exist in the catalog yet
     * @throws PartitionNotExistException if partition does not exist in the catalog yet
     */
+  @throws[TableNotPartitionedException]
   @throws[TableNotExistException]
   @throws[PartitionNotExistException]
   def alterPartition(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -36,10 +36,12 @@ trait ExternalCatalog {
     *
     * @param tableName table name
     * @param partSpec  partition specification
+    * @throws TableNotPartitionedException   if get partition on a non-partitioned table.
     * @throws TableNotExistException     if table does not exist in the catalog yet
     * @throws PartitionNotExistException if partition does not exist in the catalog yet
     * @return found partition
     */
+  @throws[TableNotPartitionedException]
   @throws[TableNotExistException]
   @throws[PartitionNotExistException]
   def getPartition(
@@ -50,10 +52,11 @@ trait ExternalCatalog {
     * Gets the partition specification list of a table from external catalog
     *
     * @param tableName table name
-    * @throws CatalogNotExistException  if database does not exist in the catalog yet
+    * @throws TableNotPartitionedException   if alter partition on a non-partitioned table.
     * @throws TableNotExistException    if table does not exist in the catalog yet
     * @return list of partition spec
     */
+  @throws[TableNotPartitionedException]
   @throws[TableNotExistException]
   def listPartitions(tableName: String): JList[JLinkedHashMap[String, String]]
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -18,9 +18,9 @@
 
 package org.apache.flink.table.catalog
 
-import java.util.{List => JList}
+import java.util.{LinkedHashMap => JLinkedHashMap, List => JList}
 
-import org.apache.flink.table.api._
+import org.apache.flink.table.api.{PartitionNotExistException, _}
 
 /**
   * An [[ExternalCatalog]] is the connector between an external database catalog and Flink's
@@ -30,6 +30,32 @@ import org.apache.flink.table.api._
   * and access information.
   */
 trait ExternalCatalog {
+
+  /**
+    * Gets the partition from external Catalog
+    *
+    * @param tableName table name
+    * @param partSpec  partition specification
+    * @throws TableNotExistException     if table does not exist in the catalog yet
+    * @throws PartitionNotExistException if partition does not exist in the catalog yet
+    * @return found partition
+    */
+  @throws[TableNotExistException]
+  @throws[PartitionNotExistException]
+  def getPartition(
+    tableName: String,
+    partSpec: JLinkedHashMap[String, String]): ExternalCatalogPartition
+
+  /**
+    * Gets the partition specification list of a table from external catalog
+    *
+    * @param tableName table name
+    * @throws CatalogNotExistException  if database does not exist in the catalog yet
+    * @throws TableNotExistException    if table does not exist in the catalog yet
+    * @return list of partition spec
+    */
+  @throws[TableNotExistException]
+  def listPartitions(tableName: String): JList[JLinkedHashMap[String, String]]
 
   /**
     * Get a table from this catalog.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogPartition.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogPartition.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.descriptors.DescriptorProperties._
+import org.apache.flink.table.descriptors.StatisticsValidator._
+import org.apache.flink.table.descriptors._
+import org.apache.flink.table.plan.stats.PartitionStats
+
+import scala.collection.JavaConverters._
+
+/**
+  * Partition definition of an external Catalog table
+  *
+  * @param partitionSpec partition specification
+  * @param properties    partition properties
+  */
+class ExternalCatalogPartition(
+    val partitionSpec: java.util.LinkedHashMap[String, String],
+    private val properties: java.util.Map[String, String])
+  extends Descriptor {
+
+  // ----------------------------------------------------------------------------------------------
+  // Legacy code
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+    * Reads table statistics from the descriptors properties.
+    *
+    * @deprecated This method exists for backwards-compatibility only.
+    */
+  @Deprecated
+  @deprecated
+  def getStats: Option[PartitionStats] = {
+    val normalizedProps = new DescriptorProperties()
+    addProperties(normalizedProps)
+    val rowCount = toScala(normalizedProps.getOptionalLong(STATISTICS_ROW_COUNT))
+    rowCount match {
+      case Some(cnt) =>
+        val columnStats = readColumnStats(normalizedProps, STATISTICS_COLUMNS)
+        Some(PartitionStats(cnt, columnStats.asJava))
+      case None =>
+        None
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+    * Internal method for properties conversion.
+    */
+  override private[flink] def addProperties(descriptorProperties: DescriptorProperties): Unit = {
+    descriptorProperties.putProperties(properties)
+  }
+}
+
+object ExternalCatalogPartition {
+
+  /**
+    * Creates a builder for creating an [[ExternalCatalogPartition]].
+    *
+    * @param connectorDescriptor Connector descriptor describing the external system
+    * @return External catalog partition builder
+    */
+  def builder(connectorDescriptor: ConnectorDescriptor): ExternalCatalogPartitionBuilder = {
+    new ExternalCatalogPartitionBuilder(connectorDescriptor)
+  }
+
+}
+
+/**
+  * Builder for an [[ExternalCatalogPartition]].
+  *
+  * @param connectorDescriptor Connector descriptor describing the external system
+  */
+class ExternalCatalogPartitionBuilder(private val connectorDescriptor: ConnectorDescriptor)
+  extends TableDescriptor {
+
+  private var statisticsDescriptor: Option[Statistics] = None
+  private var metadataDescriptor: Option[Metadata] = None
+  private var partitionSpec: java.util.LinkedHashMap[String, String] = _
+
+  /**
+    * Specifies the statistics for this external partition.
+    */
+  def withStatistics(statistics: Statistics): ExternalCatalogPartitionBuilder = {
+    statisticsDescriptor = Some(statistics)
+    this
+  }
+
+  /**
+    * Specifies the metadata for this external partition.
+    */
+  def withMetadata(metadata: Metadata): ExternalCatalogPartitionBuilder = {
+    metadataDescriptor = Some(metadata)
+    this
+  }
+
+  def withPartitionSpec(
+    partitionSpec: java.util.LinkedHashMap[String, String]): ExternalCatalogPartitionBuilder = {
+    require(partitionSpec != null && !partitionSpec.isEmpty)
+    this.partitionSpec = partitionSpec
+    this
+  }
+
+  /**
+    * build the configured [[ExternalCatalogPartition]].
+    *
+    * @return External catalog table
+    */
+  def build(): ExternalCatalogPartition = {
+    require(partitionSpec != null)
+    new ExternalCatalogPartition(
+      partitionSpec,
+      DescriptorProperties.toJavaMap(this))
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+    * Internal method for properties conversion.
+    */
+  override private[flink] def addProperties(properties: DescriptorProperties): Unit = {
+    connectorDescriptor.addProperties(properties)
+    statisticsDescriptor.foreach(_.addProperties(properties))
+    metadataDescriptor.foreach(_.addProperties(properties))
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -312,24 +312,7 @@ class ExternalCatalogTableBuilder(private val connectorDescriptor: ConnectorDesc
     *
     * @return External catalog table
     */
-  def asTableSource(): ExternalCatalogTable = this.partitionColumnNames match {
-      case Some(pc) =>
-        new ExternalCatalogPartitionedTable(
-          isBatch,
-          isStreaming,
-          isSource = true,
-          isSink = false,
-          pc,
-          DescriptorProperties.toJavaMap(this)
-        )
-      case None =>
-        new ExternalCatalogTable(
-          isBatch,
-          isStreaming,
-          isSource = true,
-          isSink = false,
-          DescriptorProperties.toJavaMap(this))
-   }
+  def asTableSource(): ExternalCatalogTable = build(true, false)
 
   /**
     * Declares this external table as a table sink and returns the
@@ -337,23 +320,7 @@ class ExternalCatalogTableBuilder(private val connectorDescriptor: ConnectorDesc
     *
     * @return External catalog table
     */
-  def asTableSink(): ExternalCatalogTable = this.partitionColumnNames match {
-    case Some(pc) =>
-      new ExternalCatalogPartitionedTable(
-        isBatch,
-        isStreaming,
-        isSource = false,
-        isSink = true,
-        pc,
-        DescriptorProperties.toJavaMap(this))
-    case None =>
-      new ExternalCatalogTable(
-        isBatch,
-        isStreaming,
-        isSource = false,
-        isSink = true,
-        DescriptorProperties.toJavaMap(this))
-  }
+  def asTableSink(): ExternalCatalogTable = build(false, true)
 
   /**
     * Declares this external table as both a table source and sink. It returns the
@@ -361,23 +328,33 @@ class ExternalCatalogTableBuilder(private val connectorDescriptor: ConnectorDesc
     *
     * @return External catalog table
     */
-  def asTableSourceAndSink(): ExternalCatalogTable = this.partitionColumnNames match {
-    case Some(pc) =>
-      new ExternalCatalogPartitionedTable(
-        isBatch,
-        isStreaming,
-        isSource = true,
-        isSink = true,
-        pc,
-        DescriptorProperties.toJavaMap(this))
-    case None =>
-      new ExternalCatalogTable(
-        isBatch,
-        isStreaming,
-        isSource = true,
-        isSink = true,
-        DescriptorProperties.toJavaMap(this))
-  }
+  def asTableSourceAndSink(): ExternalCatalogTable = build(true, true)
+
+  /**
+    * Build an ExternalCatalogTable.
+    * @param isSource Flag to create an external table whether could be declared as table source.
+    * @param isSink   Flag to create an external table whether could be declared as table sink.
+    *
+    * @return External catalog table
+    */
+  private def build(isSource: Boolean, isSink: Boolean): ExternalCatalogTable =
+    this.partitionColumnNames match {
+      case Some(pc) =>
+        new ExternalCatalogPartitionedTable(
+          isBatch,
+          isStreaming,
+          isSource,
+          isSink,
+          pc,
+          DescriptorProperties.toJavaMap(this))
+      case None =>
+        new ExternalCatalogTable(
+          isBatch,
+          isStreaming,
+          isSource,
+          isSink,
+          DescriptorProperties.toJavaMap(this))
+    }
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/PartitionStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/PartitionStats.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import java.util.{HashMap, Map}
+
+/**
+  * Partition statistics
+  *
+  * @param rowCount cardinality of table
+  * @param colStats statistics of table columns
+  */
+case class PartitionStats(rowCount: Long, colStats: Map[String, ColumnStats] = new HashMap())
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
@@ -153,7 +153,7 @@ class InMemoryExternalCatalogTest {
     assertEquals(partitionSpecs.get(0), newPartitionSpec)
   }
 
-  @Test(expected = classOf[UnsupportedOperationException])
+  @Test(expected = classOf[TableNotPartitionedException])
   def testCreatePartitionOnUnPartitionedTable(): Unit = {
     val tableName = "t1"
     catalog.createTable(
@@ -165,6 +165,20 @@ class InMemoryExternalCatalogTest {
     newPartitionSpec.put("ds", "2016-02-01")
     val newPartition = createPartition(newPartitionSpec)
     catalog.createPartition(tableName, newPartition, ignoreIfExists = false)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testCreateInvalidPartitionSpec(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      tableName,
+      createPartitionedTableInstance,
+      ignoreIfExists = false)
+    val newPartitionSpec = new LinkedHashMap[String, String]
+    newPartitionSpec.put("h", "12")
+    newPartitionSpec.put("ds", "2016-02-01")
+    val newPartition = createPartition(newPartitionSpec)
+    catalog.createPartition(tableName, newPartition, false)
   }
 
   @Test(expected = classOf[PartitionAlreadyExistException])


### PR DESCRIPTION
## What is the purpose of the change
This pull request supports partition in external catalog.

## Brief change log

  - * Introduces ExternalCatalogPartition to describe partition in ExternalCatalog*
  - * Adds getPartition and listPartitions methods in ExternalCatalog *
  - * Adds createPartition, dropPartition, alterPartition in CrudExternalCatalog *
  - * Implements new added method in InMemoryExternalCatalog *

## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - *Added test that validates that crud operation on partition in ExternalCatalog*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
