### PR TITLE
[FLINK-10656] Refactor org.apache.flink.runtime.io.network.api.reader…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractReader.java
@@ -33,7 +33,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * A basic reader implementation, which wraps an input gate and handles events.
  */
-public abstract class AbstractReader implements ReaderBase {
+public abstract class AbstractReader implements TaskEventSender, IterationReader {
 
 	/** The input gate to read from. */
 	protected final InputGate inputGate;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  *
  * @param <T> The type of the record that can be read with this record reader.
  */
-abstract class AbstractRecordReader<T extends IOReadableWritable> extends AbstractReader implements ReaderBase {
+abstract class AbstractRecordReader<T extends IOReadableWritable> extends AbstractReader {
 
 	private final RecordDeserializer<T>[] recordDeserializers;
 
@@ -72,7 +72,7 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 				DeserializationResult result = currentRecordDeserializer.getNextRecord(target);
 
 				if (result.isBufferConsumed()) {
-					final Buffer currentBuffer = currentRecordDeserializer.getCurrentBuffer();
+					final Buffer currentBuffer = currentRecordDeserializer.resetCurrentBuffer();
 
 					currentBuffer.recycleBuffer();
 					currentRecordDeserializer = null;
@@ -116,7 +116,7 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 
 	public void clearBuffers() {
 		for (RecordDeserializer<?> deserializer : recordDeserializers) {
-			Buffer buffer = deserializer.getCurrentBuffer();
+			Buffer buffer = deserializer.resetCurrentBuffer();
 			if (buffer != null && !buffer.isRecycled()) {
 				buffer.recycleBuffer();
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/IterationReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/IterationReader.java
@@ -18,17 +18,24 @@
 
 package org.apache.flink.runtime.io.network.api.reader;
 
-import org.apache.flink.core.io.IOReadableWritable;
-
-import java.io.IOException;
+import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.util.event.EventListener;
 
 /**
- * A record-oriented reader for mutable record types.
+ * Reader for iteration.
  */
-public interface MutableReader<T extends IOReadableWritable> extends TaskEventSender, IterationReader {
+public interface IterationReader {
 
-	boolean next(T target) throws IOException, InterruptedException;
+	void setIterativeReader();
 
-	void clearBuffers();
+	void startNextSuperstep();
 
+	boolean hasReachedEndOfSuperstep();
+
+	/**
+	 * Returns whether the reader has consumed the input.
+	 */
+	boolean isFinished();
+
+	void registerTaskEventListener(EventListener<TaskEvent> listener, Class<? extends TaskEvent> eventType);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/Reader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/Reader.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 /**
  * A record-oriented reader for immutable record types.
  */
-public interface Reader<T extends IOReadableWritable> extends ReaderBase {
+public interface Reader<T extends IOReadableWritable> extends TaskEventSender {
 
 	boolean hasNext() throws IOException, InterruptedException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/TaskEventSender.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/TaskEventSender.java
@@ -19,36 +19,13 @@
 package org.apache.flink.runtime.io.network.api.reader;
 
 import org.apache.flink.runtime.event.TaskEvent;
-import org.apache.flink.runtime.util.event.EventListener;
 
 import java.io.IOException;
 
 /**
  * The basic API for every reader.
  */
-public interface ReaderBase {
-
-	/**
-	 * Returns whether the reader has consumed the input.
-	 */
-	boolean isFinished();
-
-	// ------------------------------------------------------------------------
-	// Task events
-	// ------------------------------------------------------------------------
+public interface TaskEventSender {
 
 	void sendTaskEvent(TaskEvent event) throws IOException;
-
-	void registerTaskEventListener(EventListener<TaskEvent> listener, Class<? extends TaskEvent> eventType);
-
-	// ------------------------------------------------------------------------
-	// Iterations
-	// ------------------------------------------------------------------------
-
-	void setIterativeReader();
-
-	void startNextSuperstep();
-
-	boolean hasReachedEndOfSuperstep();
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordDeserializer.java
@@ -58,7 +58,11 @@ public interface RecordDeserializer<T extends IOReadableWritable> {
 
 	void setNextBuffer(Buffer buffer) throws IOException;
 
-	Buffer getCurrentBuffer();
+	/**
+	 * Reset currentBuffer to null.
+	 * @return current buffer
+	 */
+	Buffer resetCurrentBuffer();
 
 	void clear();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -82,7 +82,7 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 	}
 
 	@Override
-	public Buffer getCurrentBuffer () {
+	public Buffer resetCurrentBuffer() {
 		Buffer tmp = currentBuffer;
 		currentBuffer = null;
 		return tmp;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/IteratorWrappingTestSingleInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/IteratorWrappingTestSingleInputGate.java
@@ -81,7 +81,7 @@ public class IteratorWrappingTestSingleInputGate<T extends IOReadableWritable> e
 
 					hasData = inputIterator.next(reuse) != null;
 
-					// Call getCurrentBuffer to ensure size is set
+					// Call resetCurrentBuffer to ensure size is set
 					return Optional.of(new BufferAndAvailability(buildSingleBuffer(bufferBuilder), true, 0));
 				} else {
 					inputChannel.setReleased();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -172,7 +172,7 @@ public class StreamInputProcessor<IN> {
 				DeserializationResult result = currentRecordDeserializer.getNextRecord(deserializationDelegate);
 
 				if (result.isBufferConsumed()) {
-					currentRecordDeserializer.getCurrentBuffer().recycleBuffer();
+					currentRecordDeserializer.resetCurrentBuffer().recycleBuffer();
 					currentRecordDeserializer = null;
 				}
 
@@ -234,7 +234,7 @@ public class StreamInputProcessor<IN> {
 	public void cleanup() throws IOException {
 		// clear the buffers first. this part should not ever fail
 		for (RecordDeserializer<?> deserializer : recordDeserializers) {
-			Buffer buffer = deserializer.getCurrentBuffer();
+			Buffer buffer = deserializer.resetCurrentBuffer();
 			if (buffer != null && !buffer.isRecycled()) {
 				buffer.recycleBuffer();
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -209,7 +209,7 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 				}
 
 				if (result.isBufferConsumed()) {
-					currentRecordDeserializer.getCurrentBuffer().recycleBuffer();
+					currentRecordDeserializer.resetCurrentBuffer().recycleBuffer();
 					currentRecordDeserializer = null;
 				}
 
@@ -299,7 +299,7 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 	public void cleanup() throws IOException {
 		// clear the buffers first. this part should not ever fail
 		for (RecordDeserializer<?> deserializer : recordDeserializers) {
-			Buffer buffer = deserializer.getCurrentBuffer();
+			Buffer buffer = deserializer.resetCurrentBuffer();
 			if (buffer != null && !buffer.isRecycled()) {
 				buffer.recycleBuffer();
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -111,7 +111,7 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 					recordSerializer.copyToBufferBuilder(bufferBuilder);
 					bufferBuilder.finish();
 
-					// Call getCurrentBuffer to ensure size is set
+					// Call resetCurrentBuffer to ensure size is set
 					return Optional.of(new BufferAndAvailability(buildSingleBuffer(bufferBuilder), moreAvailable, 0));
 				} else if (input != null && input.isEvent()) {
 					AbstractEvent event = input.getEvent();


### PR DESCRIPTION

## What is the purpose of the change

The interface of ```org.apache.flink.runtime.io.network.api.reader.ReaderBase``` is not very clean, the API in it are called only by iteration and handle event. which is not related the name ```ReaderBase```. And the functionality is independent, so propose to change the name and split the interface to two isolated interface. 

## Brief change log

  - *Split interface ```ReaderBase``` to ```IterationReader``` and ```TaskEventSender```*
  - *rename ```getCurrentBuffer``` to ```resetCurrentBuffer```*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
