### PR TITLE
[FLINK-10657] TPCHQuery3 fail with IllegalAccessException

### DIFF
--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/relational/TPCHQuery3.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/relational/TPCHQuery3.java
@@ -238,7 +238,7 @@ public class TPCHQuery3 {
 		}
 	}
 
-	private static class ShippingPriorityItem extends Tuple4<Long, Double, String, Long> {
+	public static class ShippingPriorityItem extends Tuple4<Long, Double, String, Long> {
 
 		public ShippingPriorityItem() {}
 

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/relational/TPCHQuery3.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/relational/TPCHQuery3.java
@@ -238,6 +238,9 @@ public class TPCHQuery3 {
 		}
 	}
 
+	/**
+	 * ShippingPriorityItem.
+	 */
 	public static class ShippingPriorityItem extends Tuple4<Long, Double, String, Long> {
 
 		public ShippingPriorityItem() {}


### PR DESCRIPTION
This is a trivial fix.

Similar with [FLINK-7998](https://issues.apache.org/jira/browse/FLINK-7998), ShoppingPriorityItem in example TPCHQuery3.java are set to private. This causes an IllegalAccessException exception because of reflection check in dynamic class instantiation. Making them public resolves the problem 