### PR TITLE
[FLINK-10663][streaming] Fix NPE when StreamingFileSink is closed without initialization.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -375,6 +375,8 @@ public class StreamingFileSink<IN>
 
 	@Override
 	public void close() throws Exception {
-		buckets.close();
+		if (buckets != null) {
+			buckets.close();
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -60,7 +60,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 	}
 
 	@Test
-	public void testClosingWithoutOpenShouldNotFail() throws Exception {
+	public void testClosingWithoutInitializingStateShouldNotFail() throws Exception {
 		final File outDir = TEMP_FOLDER.newFolder();
 
 		try (OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -60,6 +60,17 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 	}
 
 	@Test
+	public void testClosingWithoutOpenShouldNotFail() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+
+		try (OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+				 TestUtils.createRescalingTestSink(outDir, 1, 0, 100L, 124L)
+		) {
+			testHarness.setup();
+		}
+	}
+
+	@Test
 	public void testTruncateAfterRecoveryAndOverwrite() throws Exception {
 		final File outDir = TEMP_FOLDER.newFolder();
 		OperatorSubtaskState snapshot;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -64,7 +64,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 		final File outDir = TEMP_FOLDER.newFolder();
 
 		try (OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
-				 TestUtils.createRescalingTestSink(outDir, 1, 0, 100L, 124L)
+					TestUtils.createRescalingTestSink(outDir, 1, 0, 100L, 124L)
 		) {
 			testHarness.setup();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -64,8 +64,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 		final File outDir = TEMP_FOLDER.newFolder();
 
 		try (OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
-					TestUtils.createRescalingTestSink(outDir, 1, 0, 100L, 124L)
-		) {
+					TestUtils.createRescalingTestSink(outDir, 1, 0, 100L, 124L)) {
 			testHarness.setup();
 		}
 	}


### PR DESCRIPTION

## What is the purpose of the change

*There is a potential NPE in the StreamingFileSink. If you don't want the NPE, this PR should be merged.*

cc: @kl0u 

## Brief change log

  - *Add null check to `StreamingFileSink#close()`.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test to `LocalStreamingFileSinkTest`.* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
