### PR TITLE
[FLINK-10665] [tests] Remove legacy test YARNSessionFIFOITCase#testJavaAPI

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/NoDataSource.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/NoDataSource.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+
+/**
+ * Parallel data source that produces no data, i.e., finishes immediately.
+ */
+public class NoDataSource implements ParallelSourceFunction<Integer> {
+
+	private static final long serialVersionUID = 1642561062000662861L;
+
+	@Override
+	public void run(SourceContext<Integer> ctx) {}
+
+	@Override
+	public void cancel() {}
+}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -124,7 +124,7 @@ public class YARNITCase extends YarnTestBase {
 		}
 	}
 
-	private static class NoDataSource implements ParallelSourceFunction<Integer> {
+	public static class NoDataSource implements ParallelSourceFunction<Integer> {
 
 		private static final long serialVersionUID = 1642561062000662861L;
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.yarn.util.YarnTestUtils;
 
 import org.apache.hadoop.fs.Path;
@@ -122,16 +121,5 @@ public class YARNITCase extends YarnTestBase {
 				}
 			}
 		}
-	}
-
-	public static class NoDataSource implements ParallelSourceFunction<Integer> {
-
-		private static final long serialVersionUID = 1642561062000662861L;
-
-		@Override
-		public void run(SourceContext<Integer> ctx) {}
-
-		@Override
-		public void cancel() {}
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -30,12 +30,11 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.SecureTestEnvironment;
-import org.apache.flink.yarn.YARNITCase.NoDataSource;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
+import org.apache.flink.yarn.util.YarnTestUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.flink.yarn.util.YarnTestUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -129,7 +129,4 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
 
 	@Override
 	public void testfullAlloc() {}
-
-	@Override
-	public void testJavaAPI() {}
 }


### PR DESCRIPTION
## What is the purpose of the change

Remove legacy test `YARNSessionFIFOITCase#testJavaAPI`. Since the functions are covered by `DefaultCLITest`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)

cc @tillrohrmann 
