### PR TITLE
[FLINK-8921][table] Split code generated call expression

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -150,6 +150,11 @@ abstract class CodeGenerator(
   protected var hasCodeSplits: Boolean = false
 
   /**
+    * Flag that indicates that the generated expr needed to be split into several methods.
+    */
+  protected var isExprSplits: Boolean = true
+
+  /**
     * @return code block of statements that need to be placed in the member area of the Function
     *         (e.g. member variables and their initialization)
     */
@@ -1116,7 +1121,8 @@ abstract class CodeGenerator(
     for (i <- 0 to oplen-1) {
       val operand = operands.get(i)
       if (operand.code.size > 0 && totalLen > config.getMaxGeneratedCodeLength
-          && !call.getOperator.isInstanceOf[TableSqlFunction]) {
+          && !call.getOperator.isInstanceOf[TableSqlFunction]
+          && isExprSplits) {
         reusableInputUnboxingExprs.foreach { case (_, expr) =>
           // declaration
           val resultTypeTerm = primitiveTypeTermForTypeInfo(expr.resultType)
@@ -2060,11 +2066,11 @@ abstract class CodeGenerator(
 
     fieldTerm
   }
- 
+
   def getReusableMemberStatements(): mutable.LinkedHashSet[String] = {
     reusableMemberStatements
   }
- 
+
   def getReusablePerRecordStatements(): mutable.LinkedHashSet[String] = {
     reusablePerRecordStatements
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
@@ -435,7 +435,9 @@ class MatchCodeGenerator(
   }
 
   def generateCondition(call: RexNode): GeneratedExpression = {
+    isExprSplits = false
     val exp = call.accept(this)
+    isExprSplits = true
     aggregatesPerVariable.values.foreach(_.generateAggFunction())
     if (hasCodeSplits) {
       makeReusableInSplits(reusableAggregationExpr.values)
@@ -839,9 +841,11 @@ class MatchCodeGenerator(
       }.mkString("\n")
       isWithinAggExprState = false
 
+      reusableMemberStatements.add(s"private $rowTypeTerm $inputAggRowTerm;")
       j"""
-         |private $rowTypeTerm $funcName($rowTypeTerm $inputAggRowTerm) {
+         |private $rowTypeTerm $funcName($rowTypeTerm $inputAggRowTerm) throws Exception {
          |  $rowTypeTerm $resultTerm = new $rowTypeTerm(${inputExprs.size});
+         |  this.$inputAggRowTerm = $inputAggRowTerm;
          |  $exprs
          |  return $resultTerm;
          |}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
@@ -155,6 +155,7 @@ trait CommonCorrelate {
       val filterCondition = filterGenerator.generateExpression(condition.get)
       s"""
          |${filterGenerator.reuseInputUnboxingCode()}
+         |${filterGenerator.reusePerRecordCode()}
          |${filterCondition.code}
          |if (${filterCondition.resultTerm}) {
          |  ${crossResultExpr.code}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -868,16 +868,6 @@ class SqlITCase extends StreamingWithStateTestBase {
 
   @Test
   def testSplitExpr(): Unit = {
-    val data = List(
-      (1000L, "1", "Hello"),
-      (2000L, "2", "Hello"),
-      (3000L, null.asInstanceOf[String], "Hello"),
-      (4000L, "4", "Hello"),
-      (5000L, null.asInstanceOf[String], "Hello"),
-      (6000L, "6", "Hello"),
-      (7000L, "7", "Hello World"),
-      (8000L, "8", "Hello World"),
-      (20000L, "20", "Hello World"))
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
@@ -911,6 +901,74 @@ class SqlITCase extends StreamingWithStateTestBase {
       "6000,12fbd8ab94f93accb50bccef7f8eb820,225fedc8695caca8be0d5b1944c4a45e89671cda",
       "7000,851b1a7abc66ea346ec5956b7254d5c0,c6e2f7014441d1c31583f1496977fd12cc3bf1f4",
       "8000,b1dd377beb81c3919a134ae984ee9233,ae855eead87d6116c45c3ab161a09cd2765b4fb8")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testSplitExpr2(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+    val sql =
+      """
+        |select a,
+        |case when (c in ('Hello', '58','59','60','61','62','63','gd1','bj1','sh1',
+        |'sc1','hn1','sd1','js1','hub1','hb1','zj1','xb1','db1','fj1','gd2','sh2',
+        |'xn1','db2','hb2','js2','zj2','gd3','db3','hub2','hn2','sc2','hen1','gx1',
+        |'jx1','ah1','ln1','sx1','shx1','gz1','bj2','sh3','sd2','heb1','cq1','hlj1',
+        |'js3','jl1','hen2','fj2','gd4','xb2','hub3','xn2','hn3','gd5','js4','hb3',
+        |'zj3','sc3','ah2','jx2','shx2','gx2','gd6','hn4','hub4','sc4','gd7','cq2',
+        |'hn5','hub5','gd8','sc5','hn6','gx3','gd9','xn3','hub6','gd10','gd11','sc6',
+        |'hub7','hn7','yn1','gui1','xj1','yg1','gd12','hub8','gx5','gd13','40','41',
+        |'42','ln2','hlj2','hen3','sd3','ln3','heb2','hen4','bj3','sd4','hen5','sd5',
+        |'js5','fj3','db4','zj4','hb4','js6','sh4','sx2','jx3','hen6','ah3','sd6',
+        |'js8','zj6','heb4','tj1','nm1','zj7','heb5','hen7'))
+        |then 'classA'
+        |when (b in ('20', '51','52','53','54','55','56','57','gd1','bj1','sh1','sc1',
+        |'hn1','sd1','js1','hub1','hb1','zj1','xb1','db1','fj1','gd2','sh2','xn1',
+        |'db2','hb2','js2','zj2','gd3','db3','hub2','hn2','sc2','hen1','gx1','jx1',
+        |'ah1','ln1','sx1','shx1','gz1','bj2','sh3','sd2','heb1','cq1','hlj1','js3',
+        |'jl1','hen2','fj2','gd4','xb2','hub3','xn2','hn3','gd5','js4','hb3','zj3',
+        |'sc3','ah2','jx2','shx2','gx2','gd6','hn4','hub4','sc4','gd7','cq2','hn5',
+        |'hub5','gd8','sc5','hn6','gx3','gd9','xn3','hub6','gd10','gd11','sc6','hub7',
+        |'hn7','yn1','gui1','xj1','yg1','gd12','hub8','gx5','gd13','36','37','38',
+        |'39','ln2','hlj2','hen3','sd3','ln3','heb2','hen4','bj3','sd4','hen5','sd5',
+        |'js5','fj3','db4','zj4','hb4','js6','sh4','sx2','jx3','hen6','ah3','sd6',
+        |'js8','zj6','heb4','tj1','nm1','zj7','heb5','hen7'))
+        |then 'classB'
+        |when (c in ('Hello World', '43','44','45','46','47','48','49','50','gd1','bj1',
+        |'sh1','sc1','hn1','sd1','js1','hub1','hb1','zj1','xb1','db1','fj1','gd2',
+        |'sh2','xn1','db2','hb2','js2','zj2','gd3','db3','hub2','hn2','sc2','hen1',
+        |'gx1','jx1','ah1','ln1','sx1','shx1','gz1','bj2','sh3','sd2','heb1','cq1',
+        |'hlj1','js3','jl1','hen2','fj2','gd4','xb2','hub3','xn2','hn3','gd5','js4',
+        |'hb3','zj3','sc3','ah2','jx2','shx2','gx2','gd6','hn4','hub4','sc4','gd7',
+        |'cq2','hn5','hub5','gd8','sc5','hn6','gx3','gd9','xn3','hub6','gd10','gd11',
+        |'sc6','hub7','hn7','yn1','gui1','xj1','yg1','gd12','hub8','gx5','gd13',
+        |'33','34','35','ln2','hlj2','hen3','sd3','ln3','heb2','hen4','bj3','sd4',
+        |'hen5','sd5','js5','fj3','db4','zj4','hb4','js6','sh4','sx2','jx3','hen6',
+        |'ah3','sd6','js8','zj6','heb4','tj1','nm1','zj7','heb5','hen7'))
+        |then 'classC'
+        |else 'other'
+        |end as classNum
+        |from MyTable
+      """.stripMargin
+
+    val t = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+    val result = tEnv.sqlQuery(sql).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = List(
+      "1000,classA",
+      "2000,classA",
+      "3000,classA",
+      "4000,classA",
+      "5000,classA",
+      "6000,classA",
+      "7000,classC",
+      "8000,classC",
+      "20000,classB")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR splits expressions in code generator's visitcall to avoid JVM max method size

## Brief change log

  - *CodeGenerator*

## Verifying this change
This change added tests and can be verified as follows:

  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified existed tests by setting maxGeneratedCodeLength = 1*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
