### PR TITLE
[FLINK-10613][hbase][tests] Remove logger casts

### DIFF
--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseTestingClusterAutostarter.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseTestingClusterAutostarter.java
@@ -24,7 +24,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.logging.impl.Log4JLogger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -36,10 +35,6 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.ScannerCallable;
-import org.apache.hadoop.hbase.ipc.AbstractRpcClient;
-import org.apache.hadoop.hbase.ipc.RpcServer;
-import org.apache.log4j.Level;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -149,9 +144,6 @@ public class HBaseTestingClusterAutostarter extends TestLogger implements Serial
 	@BeforeClass
 	public static void setUp() throws Exception {
 		LOG.info("HBase minicluster: Starting");
-		((Log4JLogger) RpcServer.LOG).getLogger().setLevel(Level.ALL);
-		((Log4JLogger) AbstractRpcClient.LOG).getLogger().setLevel(Level.ALL);
-		((Log4JLogger) ScannerCallable.LOG).getLogger().setLevel(Level.ALL);
 
 		TEST_UTIL.startMiniCluster(1);
 


### PR DESCRIPTION
This PR removes some logger casts in the HBase IT case. The casting is only used to increase the log-level, but this can be done more safely via the `log4j-test.properties` file.

I do not modify the log4j properties in this PR since it seems unnecessary in the first place. Chances are that someone trying to debug the code will just get lost in a sea of trace messages from hbase.