### PR TITLE
 [FLINK-10623][e2e] Extended sql-client e2e test with MATCH_RECOGNIZE 

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -306,6 +306,7 @@ function check_logs_for_errors {
       | grep -v "Async Kafka commit failed" \
       | grep -v "DisconnectException" \
       | grep -v "AskTimeoutException" \
+      | grep -v "Error while loading kafka-version.properties" \
       | grep -v "WARN  akka.remote.transport.netty.NettyTransport" \
       | grep -v  "WARN  org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" \
       | grep -v "jvm-exit-on-fatal-error" \

--- a/flink-libraries/flink-sql-client/pom.xml
+++ b/flink-libraries/flink-sql-client/pom.xml
@@ -64,6 +64,12 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-cep_2.11</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- logging utilities -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -156,6 +162,7 @@ under the License.
 										<include>org/apache/calcite/**</include>
 										<include>org/apache/flink/calcite/shaded/**</include>
 										<include>org/apache/flink/table/**</include>
+										<include>org/apache/flink/cep/**</include>
 										<include>org.codehaus.commons.compiler.properties</include>
 										<include>org/codehaus/janino/**</include>
 										<include>org/codehaus/commons/**</include>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamMatchRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamMatchRule.scala
@@ -42,11 +42,13 @@ class DataStreamMatchRule
       RelOptRule.convert(logicalMatch.getInput, FlinkConventions.DATASTREAM)
 
     try {
-      Class.forName("org.apache.flink.cep.pattern.Pattern")
+      Class
+        .forName("org.apache.flink.cep.pattern.Pattern",
+          false,
+          Thread.currentThread().getContextClassLoader)
     } catch {
       case ex: ClassNotFoundException => throw new TableException(
-        "MATCH RECOGNIZE clause requires flink-cep dependency to be present on the classpath.",
-        ex)
+        "MATCH RECOGNIZE clause requires flink-cep dependency to be present on the classpath.", ex)
     }
 
     new DataStreamMatch(


### PR DESCRIPTION
## What is the purpose of the change

This change:

- extends sql-client e2e test to use MATCH_RECOGNIZE clause
- fixes dependencies issues revealed by this test


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
