### PR TITLE
[FLINK-9808] [state-backends] Migrate state when necessary in state backends

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/BackwardsCompatibleSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/BackwardsCompatibleSerializerSnapshot.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+
 import java.io.IOException;
 
 /**
@@ -48,13 +49,13 @@ public class BackwardsCompatibleSerializerSnapshot<T> implements TypeSerializerS
 	}
 
 	@Override
-	public void write(DataOutputView out) throws IOException {
+	public void writeSnapshot(DataOutputView out) throws IOException {
 		throw new UnsupportedOperationException(
 			"This is a dummy config snapshot used only for backwards compatibility.");
 	}
 
 	@Override
-	public void read(int version, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+	public void readSnapshot(int version, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
 		throw new UnsupportedOperationException(
 			"This is a dummy config snapshot used only for backwards compatibility.");
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.common.typeutils;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -29,11 +28,37 @@ import java.io.Serializable;
 /**
  * This interface describes the methods that are required for a data type to be handled by the Flink
  * runtime. Specifically, this interface contains the serialization and copying methods.
- * <p>
- * The methods in this class are assumed to be stateless, such that it is effectively thread safe. Stateful
+ *
+ * <p>The methods in this class are assumed to be stateless, such that it is effectively thread safe. Stateful
  * implementations of the methods may lead to unpredictable side effects and will compromise both stability and
  * correctness of the program.
- * 
+ *
+ * <p><b>Upgrading TypeSerializers to the new TypeSerializerSnapshot model</b>
+ *
+ * <p>This section is relevant if you implemented a TypeSerializer in Flink versions up to 1.6 and want
+ * to adapt that implementation to the new interfaces that support proper state schema evolution. Please
+ * follow these steps:
+ *
+ * <ul>
+ *     <li>Change the type serializer's config snapshot to implement {@link TypeSerializerSnapshot}, rather
+ *     than extending {@code TypeSerializerConfigSnapshot} (as previously).
+ *     <li>Move the compatibility check from the {@link TypeSerializer#ensureCompatibility(TypeSerializerConfigSnapshot)}
+ *     method to the {@link TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)} method.
+ * </ul>
+ *
+ * <p><b>Maintaining Backwards Compatibility</b>
+ *
+ * <p>If you want your serializer to be able to restore checkpoints from Flink 1.6 and before, add the steps
+ * below in addition to the steps above.
+ *
+ * <ul>
+ *     <li>Retain the old serializer snapshot class (extending {@code TypeSerializerConfigSnapshot}) under
+ *     the same name and give the updated serializer snapshot class (the one extending {@code TypeSerializerSnapshot})
+ *     a new name.
+ *     <li>Keep the {@link TypeSerializer#ensureCompatibility(TypeSerializerConfigSnapshot)} on the TypeSerializer
+ *     as well.
+ * </ul>
+ *
  * @param <T> The data type that the serializer serializes.
  */
 @PublicEvolving
@@ -163,85 +188,55 @@ public abstract class TypeSerializer<T> implements Serializable {
 	public abstract int hashCode();
 
 	// --------------------------------------------------------------------------------------------
-	// Serializer configuration snapshotting & compatibility
+	// Serializer configuration snapshot for checkpoints/savepoints
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Create a snapshot of the serializer's current configuration to be stored along with the managed state it is
-	 * registered to (if any - this method is only relevant if this serializer is registered for serialization of
-	 * managed state).
+	 * Snapshots the configuration of this TypeSerializer. This method is only relevant if the serializer is
+	 * used to state stored in checkpoints/savepoints.
 	 *
-	 * <p>The configuration snapshot should contain information about the serializer's parameter settings and its
-	 * serialization format. When a new serializer is registered to serialize the same managed state that this
-	 * serializer was registered to, the returned configuration snapshot can be used to ensure compatibility
-	 * of the new serializer and determine if state migration is required.
+	 * <p>The snapshot of the TypeSerializer is supposed to contain all information that affects the serialization
+	 * format of the serializer. The snapshot serves two purposes: First, to reproduce the serializer when the
+	 * checkpoint/savepoint is restored, and second, to check whether the serialization format is compatible
+	 * with the serializer used in the restored program.
 	 *
-	 * @see TypeSerializerSnapshot
+	 * <p><b>IMPORTANT:</b> TypeSerializerSnapshots changed after Flink 1.6. Serializers implemented against
+	 * Flink versions up to 1.6 should still work, but adjust to new model to enable state evolution and be
+	 * future-proof.
+	 * See the class-level comments, section "Upgrading TypeSerializers to the new TypeSerializerSnapshot model"
+	 * for details.
+	 *
+	 * @see TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)
 	 *
 	 * @return snapshot of the serializer's current configuration (cannot be {@code null}).
 	 */
 	public abstract TypeSerializerSnapshot<T> snapshotConfiguration();
 
+	// --------------------------------------------------------------------------------------------
+	//  Deprecated methods for backwards compatibility
+	// --------------------------------------------------------------------------------------------
+
 	/**
-	 * Ensure compatibility of this serializer with a preceding serializer that was registered for serialization of
-	 * the same managed state (if any - this method is only relevant if this serializer is registered for
-	 * serialization of managed state).
+	 * This method is deprecated. It used to resolved compatibility of the serializer with serializer
+	 * config snapshots in checkpoints. The responsibility for this has moved to
+	 * {@link TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)}.
 	 *
-	 * <p>The compatibility check in this method should be performed by inspecting the preceding serializer's configuration
-	 * snapshot. The method may reconfigure the serializer (if required and possible) so that it may be compatible,
-	 * or provide a signaling result that informs Flink that state migration is necessary before continuing to use
-	 * this serializer.
+	 * <p>New serializers should not override this method any more! Serializers implemented against Flink
+	 * versions up to 1.6 should still work, but should adjust to new model to enable state evolution and
+	 * be future-proof. See the class-level comments, section <i>"Upgrading TypeSerializers to the new
+	 * TypeSerializerSnapshot model"</i> for details.
 	 *
-	 * <p>The result can be one of the following:
-	 * <ul>
-	 *     <li>{@link CompatibilityResult#compatible()}: this signals Flink that this serializer is compatible, or
-	 *     has been reconfigured to be compatible, to continue reading previous data, and that the
-	 *     serialization schema remains the same. No migration needs to be performed.</li>
-	 *
-	 *     <li>{@link CompatibilityResult#requiresMigration(TypeDeserializer)}: this signals Flink that
-	 *     migration needs to be performed, because this serializer is not compatible, or cannot be reconfigured to be
-	 *     compatible, for previous data. Furthermore, in the case that the preceding serializer cannot be found or
-	 *     restored to read the previous data to perform the migration, the provided convert deserializer can be
-	 *     used as a fallback resort.</li>
-	 *
-	 *     <li>{@link CompatibilityResult#requiresMigration()}: this signals Flink that migration needs to be
-	 *     performed, because this serializer is not compatible, or cannot be reconfigured to be compatible, for
-	 *     previous data. If the preceding serializer cannot be found (either its implementation changed or it was
-	 *     removed from the classpath) then the migration will fail due to incapability to read previous data.</li>
-	 * </ul>
-	 *
-	 * @see CompatibilityResult
-	 *
-	 * @param configSnapshot configuration snapshot of a preceding serializer for the same managed state
-	 *
-	 * @return the determined compatibility result (cannot be {@code null}).
+	 * @deprecated Replaced by {@link TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)}.
 	 */
 	@Deprecated
 	public CompatibilityResult<T> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
-		throw new IllegalStateException(
-			"Seems like that you are still using TypeSerializerConfigSnapshot; if so, this method must be implemented. " +
-				"Once you change to directly use TypeSerializerSnapshot, then you can safely remove the implementation " +
-				"of this method.");
-	}
-
-	@Internal
-	public final CompatibilityResult<T> ensureCompatibility(TypeSerializerSnapshot<?> configSnapshot) {
-		if (configSnapshot instanceof TypeSerializerConfigSnapshot) {
-			return ensureCompatibility((TypeSerializerConfigSnapshot<?>) configSnapshot);
-		} else {
-			@SuppressWarnings("unchecked")
-			TypeSerializerSnapshot<T> casted = (TypeSerializerSnapshot<T>) configSnapshot;
-
-			TypeSerializerSchemaCompatibility<T, ? extends TypeSerializer<T>> compat = casted.resolveSchemaCompatibility(this);
-			if (compat.isCompatibleAsIs()) {
-				return CompatibilityResult.compatible();
-			} else if (compat.isCompatibleAfterMigration()) {
-				return CompatibilityResult.requiresMigration();
-			} else if (compat.isIncompatible()) {
-				throw new IllegalStateException("The new serializer is incompatible.");
-			} else {
-				throw new IllegalStateException("Unidentifiable schema compatibility type. This is a bug, please file a JIRA.");
-			}
-		}
+		throw new UnsupportedOperationException(
+				"This method is not supported any more - please evolve your TypeSerializer the following way:\n\n" +
+				"  - If you have a serializer whose 'ensureCompatibility()' method delegates to another\n" +
+				"    serializer's 'ensureCompatibility()', please use" +
+						"'CompatibilityUtil.resolveCompatibilityResult(snapshot, this)' instead.\n\n" +
+				"  - If you updated your serializer (removed overriding the 'ensureCompatibility()' method),\n" +
+				"    please also update the corresponding config snapshot to not extend 'TypeSerializerConfigSnapshot'" +
+						"any more.\n\n");
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerConfigSnapshot.java
@@ -22,12 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.VersionedIOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 
 /**
- * A {@code TypeSerializerConfigSnapshot} is a point-in-time view of a {@link TypeSerializer's} configuration.
+ * A {@code TypeSerializerConfigSnapshot} is a point-in-time view of a {@link TypeSerializer}'s configuration.
  * The configuration snapshot of a serializer is persisted within checkpoints
  * as a single source of meta information about the schema of serialized data in the checkpoint.
  * This serves three purposes:
@@ -42,7 +43,7 @@ import java.io.IOException;
  *   This is performed by providing the new serializer to the corresponding serializer configuration
  *   snapshots in checkpoints.</li>
  *
- *   <li><strong>Factory for a read serializer when schema conversion is required:<strong> in the case that new
+ *   <li><strong>Factory for a read serializer when schema conversion is required:</strong> in the case that new
  *   serializers are not compatible to read previous data, a schema conversion process executed across all data
  *   is required before the new serializer can be continued to be used. This conversion process requires a compatible
  *   read serializer to restore serialized bytes as objects, and then written back again using the new serializer.
@@ -149,7 +150,12 @@ public abstract class TypeSerializerConfigSnapshot<T> extends VersionedIOReadabl
 	}
 
 	@Override
-	public final void read(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+	public final void writeSnapshot(DataOutputView out) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -118,7 +118,7 @@ public class TypeSerializerSerializationUtil {
 		} catch (UnloadableTypeSerializerException e) {
 			if (useDummyPlaceholder) {
 				LOG.warn("Could not read a requested serializer. Replaced with a UnloadableDummyTypeSerializer.", e.getCause());
-				return new UnloadableDummyTypeSerializer<>(e.getSerializerBytes());
+				return new UnloadableDummyTypeSerializer<>(e.getSerializerBytes(), e);
 			} else {
 				throw e;
 			}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -118,7 +118,7 @@ public class TypeSerializerSerializationUtil {
 		} catch (UnloadableTypeSerializerException e) {
 			if (useDummyPlaceholder) {
 				LOG.warn("Could not read a requested serializer. Replaced with a UnloadableDummyTypeSerializer.", e.getCause());
-				return new UnloadableDummyTypeSerializer<>(e.getSerializerBytes(), e);
+				return new UnloadableDummyTypeSerializer<>(e.getSerializerBytes(), e.getCause());
 			} else {
 				throw e;
 			}
@@ -231,8 +231,6 @@ public class TypeSerializerSerializationUtil {
 	 * Utility serialization proxy for a {@link TypeSerializer}.
 	 */
 	public static final class TypeSerializerSerializationProxy<T> extends VersionedIOReadableWritable {
-
-		private static final Logger LOG = LoggerFactory.getLogger(TypeSerializerSerializationProxy.class);
 
 		private static final int VERSION = 1;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 /**
- * A {@code TypeSerializerSnapshot} is a point-in-time view of a {@link TypeSerializer's} configuration.
+ * A {@code TypeSerializerSnapshot} is a point-in-time view of a {@link TypeSerializer}'s configuration.
  * The configuration snapshot of a serializer is persisted within checkpoints
  * as a single source of meta information about the schema of serialized data in the checkpoint.
  * This serves three purposes:
@@ -40,7 +40,7 @@ import java.io.IOException;
  *   This is performed by providing the new serializer to the correspondibng serializer configuration
  *   snapshots in checkpoints.</li>
  *
- *   <li><strong>Factory for a read serializer when schema conversion is required:<strong> in the case that new
+ *   <li><strong>Factory for a read serializer when schema conversion is required:</strong> in the case that new
  *   serializers are not compatible to read previous data, a schema conversion process executed across all data
  *   is required before the new serializer can be continued to be used. This conversion process requires a compatible
  *   read serializer to restore serialized bytes as objects, and then written back again using the new serializer.
@@ -86,9 +86,9 @@ public interface TypeSerializerSnapshot<T> {
 	 *
 	 * @param out the {@link DataOutputView} to write the snapshot to.
 	 *
-	 * @throws IOException
+	 * @throws IOException Thrown if the snapshot data could not be written.
 	 */
-	void write(DataOutputView out) throws IOException;
+	void writeSnapshot(DataOutputView out) throws IOException;
 
 	/**
 	 * Reads the serializer snapshot from the provided {@link DataInputView}.
@@ -100,9 +100,9 @@ public interface TypeSerializerSnapshot<T> {
 	 * @param in the {@link DataInputView} to read the snapshot from.
 	 * @param userCodeClassLoader the user code classloader
 	 *
-	 * @throws IOException
+	 * * @throws IOException Thrown if the snapshot data could be read or parsed.
 	 */
-	void read(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException;
+	void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException;
 
 	/**
 	 * Recreates a serializer instance from this snapshot. The returned

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -114,8 +114,16 @@ public interface TypeSerializerSnapshot<T> {
 	TypeSerializer<T> restoreSerializer();
 
 	/**
-	 * Checks a new serializer's compatibility to read data written by the prior
-	 * serializer.
+	 * Checks a new serializer's compatibility to read data written by the prior serializer.
+	 *
+	 * <p>When a checkpoint/savepoint is restored, this method checks whether the serialization
+	 * format of the data in the checkpoint/savepoint is compatible for the format of the serializer used by the
+	 * program that restores the checkpoint/savepoint. The outcome can be that the serialization format is
+	 * compatible, that the program's serializer needs to reconfigure itself (meaning to incorporate some
+	 * information from the TypeSerializerSnapshot to be compatible), that the format is outright incompatible,
+	 * or that a migration needed. In the latter case, the TypeSerializerSnapshot produces a serializer to
+	 * deserialize the data, and the restoring program's serializer re-serializes the data, thus converting
+	 * the format during the restore operation.
 	 *
 	 * @param newSerializer the new serializer to check.
 	 * @param <NS> the type of the new serializer

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotSerializationUtil.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -136,7 +137,7 @@ public class TypeSerializerSnapshotSerializationUtil {
 				out.writeBoolean(false);
 
 				out.writeInt(serializerSnapshot.getCurrentVersion());
-				serializerSnapshot.write(out);
+				serializerSnapshot.writeSnapshot(out);
 			}
 		}
 
@@ -179,7 +180,7 @@ public class TypeSerializerSnapshotSerializationUtil {
 					}
 				} else {
 					int readVersion = in.readInt();
-					serializerSnapshot.read(readVersion, in, userCodeClassLoader);
+					serializerSnapshot.readSnapshot(readVersion, in, userCodeClassLoader);
 				}
 			} else {
 				// Flink version before 1.7.x, and after 1.3.x
@@ -190,7 +191,7 @@ public class TypeSerializerSnapshotSerializationUtil {
 					((TypeSerializerConfigSnapshot<T>) serializerSnapshot).read(in);
 				} else {
 					int readVersion = in.readInt();
-					serializerSnapshot.read(readVersion, in, userCodeClassLoader);
+					serializerSnapshot.readSnapshot(readVersion, in, userCodeClassLoader);
 				}
 			}
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/UnloadableDummyTypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/UnloadableDummyTypeSerializer.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.util.Arrays;
@@ -33,14 +34,28 @@ import java.util.Arrays;
 public class UnloadableDummyTypeSerializer<T> extends TypeSerializer<T> {
 
 	private static final long serialVersionUID = 2526330533671642711L;
+
 	private final byte[] actualBytes;
 
+	@Nullable
+	private final Throwable originalError;
+
 	public UnloadableDummyTypeSerializer(byte[] actualBytes) {
+		this(actualBytes, null);
+	}
+
+	public UnloadableDummyTypeSerializer(byte[] actualBytes, @Nullable Throwable originalError) {
 		this.actualBytes = Preconditions.checkNotNull(actualBytes);
+		this.originalError = originalError;
 	}
 
 	public byte[] getActualBytes() {
 		return actualBytes;
+	}
+
+	@Nullable
+	public Throwable getOriginalError() {
+		return originalError;
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.common.typeutils;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -121,12 +120,13 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), getSerializer());
 		}
 
-		CompatibilityResult strategy = getSerializer().ensureCompatibility(restoredConfig);
-		assertFalse(strategy.isRequiresMigration());
+		TypeSerializerSchemaCompatibility<T, ? extends TypeSerializer<T>> strategy = restoredConfig.resolveSchemaCompatibility(getSerializer());
+		assertTrue(strategy.isCompatibleAsIs());
 
 		// also verify that the serializer's reconfigure implementation detects incompatibility
-		strategy = getSerializer().ensureCompatibility(new TestIncompatibleSerializerConfigSnapshot<>());
-		assertTrue(strategy.isRequiresMigration());
+		TypeSerializerSnapshot<T> incompatibleSnapshot = new TestIncompatibleSerializerConfigSnapshot<>();
+		strategy = incompatibleSnapshot.resolveSchemaCompatibility(getSerializer());
+		assertTrue(strategy.isIncompatible());
 	}
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -122,11 +122,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 
 		TypeSerializerSchemaCompatibility<T, ? extends TypeSerializer<T>> strategy = restoredConfig.resolveSchemaCompatibility(getSerializer());
 		assertTrue(strategy.isCompatibleAsIs());
-
-		// also verify that the serializer's reconfigure implementation detects incompatibility
-		TypeSerializerSnapshot<T> incompatibleSnapshot = new TestIncompatibleSerializerConfigSnapshot<>();
-		strategy = incompatibleSnapshot.resolveSchemaCompatibility(getSerializer());
-		assertTrue(strategy.isIncompatible());
 	}
 
 	@Test
@@ -540,23 +535,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 				int skipped = skipBytes(numBytes);
 				numBytes -= skipped;
 			}
-		}
-	}
-
-	public static final class TestIncompatibleSerializerConfigSnapshot<T> extends TypeSerializerConfigSnapshot<T> {
-		@Override
-		public int getVersion() {
-			return 0;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj instanceof TestIncompatibleSerializerConfigSnapshot;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshotSerializationUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -106,8 +107,8 @@ public class EnumSerializerTest extends TestLogger {
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), serializer);
 		}
 
-		CompatibilityResult<PublicEnum> compatResult = serializer.ensureCompatibility(restoredConfig);
-		assertFalse(compatResult.isRequiresMigration());
+		TypeSerializerSchemaCompatibility<PublicEnum, ?> compatResult = restoredConfig.resolveSchemaCompatibility(serializer);
+		assertTrue(compatResult.isCompatibleAsIs());
 
 		assertEquals(PublicEnum.FOO.ordinal(), serializer.getValueToOrdinal().get(PublicEnum.FOO).intValue());
 		assertEquals(PublicEnum.BAR.ordinal(), serializer.getValueToOrdinal().get(PublicEnum.BAR).intValue());

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshotSerializationUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -56,7 +56,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 	 */
 	@Test
 	public void checkIndenticalEnums() throws Exception {
-		Assert.assertFalse(checkCompatibility(ENUM_A, ENUM_A).isRequiresMigration());
+		Assert.assertTrue(checkCompatibility(ENUM_A, ENUM_A).isCompatibleAsIs());
 	}
 
 	/**
@@ -64,7 +64,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 	 */
 	@Test
 	public void checkAppendedField() throws Exception {
-		Assert.assertFalse(checkCompatibility(ENUM_A, ENUM_B).isRequiresMigration());
+		Assert.assertTrue(checkCompatibility(ENUM_A, ENUM_B).isCompatibleAsIs());
 	}
 
 	/**
@@ -72,7 +72,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 	 */
 	@Test
 	public void checkRemovedField() throws Exception {
-		Assert.assertTrue(checkCompatibility(ENUM_A, ENUM_C).isRequiresMigration());
+		Assert.assertTrue(checkCompatibility(ENUM_A, ENUM_C).isIncompatible());
 	}
 
 	/**
@@ -80,11 +80,11 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 	 */
 	@Test
 	public void checkDifferentFieldOrder() throws Exception {
-		Assert.assertFalse(checkCompatibility(ENUM_A, ENUM_D).isRequiresMigration());
+		Assert.assertTrue(checkCompatibility(ENUM_A, ENUM_D).isCompatibleAsIs());
 	}
 
 	@SuppressWarnings("unchecked")
-	private static CompatibilityResult checkCompatibility(String enumSourceA, String enumSourceB)
+	private static TypeSerializerSchemaCompatibility checkCompatibility(String enumSourceA, String enumSourceB)
 		throws IOException, ClassNotFoundException {
 
 		ClassLoader classLoader = compileAndLoadEnum(
@@ -116,7 +116,7 @@ public class EnumSerializerUpgradeTest extends TestLogger {
 		}
 
 		EnumSerializer enumSerializer2 = new EnumSerializer(classLoader2.loadClass(ENUM_NAME));
-		return enumSerializer2.ensureCompatibility(restoredSnapshot);
+		return restoredSnapshot.resolveSchemaCompatibility(enumSerializer2);
 	}
 
 	private static ClassLoader compileAndLoadEnum(File root, String filename, String source) throws IOException {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -34,13 +34,13 @@ import java.util.Set;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.CompositeType.FlatFieldDescriptor;
 import org.apache.flink.api.common.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.common.operators.Keys.IncompatibleKeysException;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshotSerializationUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
@@ -63,7 +63,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -311,8 +310,10 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), pojoSerializer2);
 		}
 
-		CompatibilityResult<SubTestUserClassA> compatResult = pojoSerializer2.ensureCompatibility(pojoSerializerConfigSnapshot);
-		assertTrue(compatResult.isRequiresMigration());
+		@SuppressWarnings("unchecked")
+		TypeSerializerSchemaCompatibility<SubTestUserClassA, ?> compatResult =
+			pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer2);
+		assertTrue(compatResult.isIncompatible());
 	}
 
 	/**
@@ -352,8 +353,10 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), pojoSerializer);
 		}
 
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(pojoSerializerConfigSnapshot);
-		assertTrue(!compatResult.isRequiresMigration());
+		@SuppressWarnings("unchecked")
+		TypeSerializerSchemaCompatibility<TestUserClass, ?> compatResult =
+			pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+		assertTrue(compatResult.isCompatibleAsIs());
 
 		// reconfigure - check reconfiguration result and that registration ids remains the same
 		//assertEquals(ReconfigureResult.COMPATIBLE, pojoSerializer.reconfigure(pojoSerializerConfigSnapshot));
@@ -397,8 +400,10 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		}
 
 		// reconfigure - check reconfiguration result and that subclass serializer cache is repopulated
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(pojoSerializerConfigSnapshot);
-		assertFalse(compatResult.isRequiresMigration());
+		@SuppressWarnings("unchecked")
+		TypeSerializerSchemaCompatibility<TestUserClass, ?> compatResult =
+			pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+		assertTrue(compatResult.isCompatibleAsIs());
 		assertEquals(2, pojoSerializer.getSubclassSerializerCache().size());
 		assertTrue(pojoSerializer.getSubclassSerializerCache().containsKey(SubTestUserClassA.class));
 		assertTrue(pojoSerializer.getSubclassSerializerCache().containsKey(SubTestUserClassB.class));
@@ -460,8 +465,10 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		// reconfigure - check reconfiguration result and that
 		// 1) subclass serializer cache is repopulated
 		// 2) registrations also contain the now registered subclasses
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(pojoSerializerConfigSnapshot);
-		assertFalse(compatResult.isRequiresMigration());
+		@SuppressWarnings("unchecked")
+		TypeSerializerSchemaCompatibility<TestUserClass, ?> compatResult =
+			pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+		assertTrue(compatResult.isCompatibleAsIs());
 		assertEquals(2, pojoSerializer.getSubclassSerializerCache().size());
 		assertTrue(pojoSerializer.getSubclassSerializerCache().containsKey(SubTestUserClassA.class));
 		assertTrue(pojoSerializer.getSubclassSerializerCache().containsKey(SubTestUserClassB.class));
@@ -537,8 +544,9 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 				new HashMap<>()); // empty; irrelevant for this test
 
 		// reconfigure - check reconfiguration result and that fields are reordered to the previous order
-		CompatibilityResult<TestUserClass> compatResult = pojoSerializer.ensureCompatibility(mockPreviousConfigSnapshot);
-		assertFalse(compatResult.isRequiresMigration());
+		TypeSerializerSchemaCompatibility<TestUserClass, ?> compatResult =
+			mockPreviousConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+		assertTrue(compatResult.isCompatibleAsIs());
 		int i = 0;
 		for (Field field : mockOriginalFieldOrder) {
 			assertEquals(field, pojoSerializer.getFields()[i]);
@@ -580,7 +588,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 					pojoSerializer);
 		}
 
-		Assert.assertFalse(pojoSerializer.ensureCompatibility(deserializedConfig).isRequiresMigration());
+		Assert.assertTrue(deserializedConfig.resolveSchemaCompatibility(pojoSerializer).isCompatibleAsIs());
 		verifyPojoSerializerConfigSnapshotWithSerializerSerializationFailure(config, deserializedConfig);
 	}
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/LegacyAvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/LegacyAvroExternalJarProgramITCase.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.avro.testjar.AvroExternalJarProgram;
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
+import org.apache.flink.test.util.TestEnvironment;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+
+/**
+ * IT case for the {@link AvroExternalJarProgram}.
+ */
+public class LegacyAvroExternalJarProgramITCase extends TestLogger {
+
+	private static final String JAR_FILE = "maven-test-jar.jar";
+
+	private static final String TEST_DATA_FILE = "/testdata.avro";
+
+	@Test
+	public void testExternalProgram() {
+
+		LocalFlinkMiniCluster testMiniCluster = null;
+
+		try {
+			int parallelism = 4;
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, parallelism);
+			testMiniCluster = new LocalFlinkMiniCluster(config, false);
+			testMiniCluster.start();
+
+			String jarFile = JAR_FILE;
+			String testData = getClass().getResource(TEST_DATA_FILE).toString();
+
+			PackagedProgram program = new PackagedProgram(new File(jarFile), new String[] { testData });
+
+			TestEnvironment.setAsContext(
+				testMiniCluster,
+				parallelism,
+				Collections.singleton(new Path(jarFile)),
+				Collections.<URL>emptyList());
+
+			config.setString(JobManagerOptions.ADDRESS, "localhost");
+			config.setInteger(JobManagerOptions.PORT, testMiniCluster.getLeaderRPCPort());
+
+			program.invokeInteractiveModeForExecution();
+		}
+		catch (Throwable t) {
+			System.err.println(t.getMessage());
+			t.printStackTrace();
+			Assert.fail("Error during the packaged program execution: " + t.getMessage());
+		}
+		finally {
+			TestEnvironment.unsetAsContext();
+
+			if (testMiniCluster != null) {
+				try {
+					testMiniCluster.stop();
+				} catch (Throwable t) {
+					// ignore
+				}
+			}
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializerTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializerTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -105,10 +104,10 @@ public class BackwardsCompatibleAvroSerializerTest {
 		validateDeserialization(serializer);
 
 		// sanity check for the test: check that a PoJoSerializer and the original serializer work together
-		assertFalse(serializer.ensureCompatibility(configSnapshot).isRequiresMigration());
+		assertTrue(configSnapshot.resolveSchemaCompatibility(serializer).isCompatibleAsIs());
 
 		final TypeSerializer<SimpleUser> newSerializer = new AvroTypeInfo<>(SimpleUser.class, true).createSerializer(new ExecutionConfig());
-		assertFalse(newSerializer.ensureCompatibility(configSnapshot).isRequiresMigration());
+		assertTrue(configSnapshot.resolveSchemaCompatibility(newSerializer).isCompatibleAsIs());
 
 		// deserialize the data and make sure this still works
 		validateDeserialization(newSerializer);
@@ -116,7 +115,7 @@ public class BackwardsCompatibleAvroSerializerTest {
 		TypeSerializerSnapshot<SimpleUser> nextSnapshot = newSerializer.snapshotConfiguration();
 		final TypeSerializer<SimpleUser> nextSerializer = new AvroTypeInfo<>(SimpleUser.class, true).createSerializer(new ExecutionConfig());
 
-		assertFalse(nextSerializer.ensureCompatibility(nextSnapshot).isRequiresMigration());
+		assertTrue(nextSnapshot.resolveSchemaCompatibility(nextSerializer).isCompatibleAsIs());
 
 		// deserialize the data and make sure this still works
 		validateDeserialization(nextSerializer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -24,9 +24,9 @@ import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -228,42 +228,32 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 			final StateMetaInfoSnapshot metaInfoSnapshot = restoredBroadcastStateMetaInfos.get(name);
 
-			@SuppressWarnings("unchecked")
-			RegisteredBroadcastStateBackendMetaInfo<K, V> restoredMetaInfo = new RegisteredBroadcastStateBackendMetaInfo<K, V>(metaInfoSnapshot);
+			// check whether new serializers are incompatible
+			TypeSerializerSnapshot<K> keySerializerSnapshot = Preconditions.checkNotNull(
+				(TypeSerializerSnapshot<K>) metaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER));
 
-			// check compatibility to determine if state migration is required
-			CompatibilityResult<K> keyCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					restoredMetaInfo.getKeySerializer(),
-					UnloadableDummyTypeSerializer.class,
-					//TODO this keys should not be exposed and should be adapted after FLINK-9377 was merged
-					metaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER),
-					broadcastStateKeySerializer);
-
-			CompatibilityResult<V> valueCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					restoredMetaInfo.getValueSerializer(),
-					UnloadableDummyTypeSerializer.class,
-					//TODO this keys should not be exposed and should be adapted after FLINK-9377 was merged
-					metaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER),
-					broadcastStateValueSerializer);
-
-			if (!keyCompatibility.isRequiresMigration() && !valueCompatibility.isRequiresMigration()) {
-				// new serializer is compatible; use it to replace the old serializer
-				broadcastState.setStateMetaInfo(
-						new RegisteredBroadcastStateBackendMetaInfo<>(
-								name,
-								OperatorStateHandle.Mode.BROADCAST,
-								broadcastStateKeySerializer,
-								broadcastStateValueSerializer));
-			} else {
-				// TODO state migration currently isn't possible.
-
-				// NOTE: for heap backends, it is actually fine to proceed here without failing the restore,
-				// since the state has already been deserialized to objects and we can just continue with
-				// the new serializer; we're deliberately failing here for now to have equal functionality with
-				// the RocksDB backend to avoid confusion for users.
-
-				throw StateMigrationException.notSupported();
+			TypeSerializerSchemaCompatibility<K, ?> keyCompatibility =
+				keySerializerSnapshot.resolveSchemaCompatibility(broadcastStateKeySerializer);
+			if (keyCompatibility.isIncompatible()) {
+				throw new StateMigrationException("The new key serializer for broadcast state must not be incompatible.");
 			}
+
+			TypeSerializerSnapshot<V> valueSerializerSnapshot = Preconditions.checkNotNull(
+				(TypeSerializerSnapshot<V>) metaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
+
+			TypeSerializerSchemaCompatibility<V, ?> valueCompatibility =
+				valueSerializerSnapshot.resolveSchemaCompatibility(broadcastStateValueSerializer);
+			if (valueCompatibility.isIncompatible()) {
+				throw new StateMigrationException("The new value serializer for broadcast state must not be incompatible.");
+			}
+
+			// new serializer is compatible; use it to replace the old serializer
+			broadcastState.setStateMetaInfo(
+					new RegisteredBroadcastStateBackendMetaInfo<>(
+							name,
+							OperatorStateHandle.Mode.BROADCAST,
+							broadcastStateKeySerializer,
+							broadcastStateValueSerializer));
 		}
 
 		accessedBroadcastStatesByName.put(name, broadcastState);
@@ -606,27 +596,19 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 			// check compatibility to determine if state migration is required
 			TypeSerializer<S> newPartitionStateSerializer = partitionStateSerializer.duplicate();
-			CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					metaInfo.getPartitionStateSerializer(),
-					UnloadableDummyTypeSerializer.class,
-					//TODO this keys should not be exposed and should be adapted after FLINK-9377 was merged
-					restoredSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER),
-					newPartitionStateSerializer);
 
-			if (!stateCompatibility.isRequiresMigration()) {
-				// new serializer is compatible; use it to replace the old serializer
-				partitionableListState.setStateMetaInfo(
-					new RegisteredOperatorStateBackendMetaInfo<>(name, newPartitionStateSerializer, mode));
-			} else {
-				// TODO state migration currently isn't possible.
+			@SuppressWarnings("unchecked")
+			TypeSerializerSnapshot<S> stateSerializerSnapshot = Preconditions.checkNotNull(
+				(TypeSerializerSnapshot<S>) restoredSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
 
-				// NOTE: for heap backends, it is actually fine to proceed here without failing the restore,
-				// since the state has already been deserialized to objects and we can just continue with
-				// the new serializer; we're deliberately failing here for now to have equal functionality with
-				// the RocksDB backend to avoid confusion for users.
-
-				throw StateMigrationException.notSupported();
+			TypeSerializerSchemaCompatibility<S, ?> stateCompatibility =
+				stateSerializerSnapshot.resolveSchemaCompatibility(newPartitionStateSerializer);
+			if (stateCompatibility.isIncompatible()) {
+				throw new StateMigrationException("The new state serializer for operator state must not be incompatible.");
 			}
+
+			partitionableListState.setStateMetaInfo(
+				new RegisteredOperatorStateBackendMetaInfo<>(name, newPartitionStateSerializer, mode));
 		}
 
 		accessedStatesByName.put(name, partitionableListState);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -19,11 +19,9 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.StateDescriptor;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
@@ -191,23 +189,25 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		}
 
 		// check compatibility results to determine if state migration is required
-		CompatibilityResult<N> namespaceCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-			restoredStateMetaInfoSnapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER),
-			null,
-			restoredStateMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
-				StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER),
-			newNamespaceSerializer);
+		@SuppressWarnings("unchecked")
+		TypeSerializerSnapshot<N> namespaceSerializerSnapshot = Preconditions.checkNotNull(
+			(TypeSerializerSnapshot<N>) restoredStateMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
+				StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER));
+
+		TypeSerializerSchemaCompatibility<N, ?> namespaceCompatibility =
+			namespaceSerializerSnapshot.resolveSchemaCompatibility(newNamespaceSerializer);
 
 		TypeSerializer<S> newStateSerializer = newStateDescriptor.getSerializer();
-		CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-			restoredStateMetaInfoSnapshot.restoreTypeSerializer(
-				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER),
-			UnloadableDummyTypeSerializer.class,
-			restoredStateMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
-				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER),
-			newStateSerializer);
 
-		if (namespaceCompatibility.isRequiresMigration() || stateCompatibility.isRequiresMigration()) {
+		@SuppressWarnings("unchecked")
+		TypeSerializerSnapshot<S> stateSerializerSnapshot = Preconditions.checkNotNull(
+			(TypeSerializerSnapshot<S>) restoredStateMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
+				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
+
+		TypeSerializerSchemaCompatibility<S, ?> stateCompatibility =
+			stateSerializerSnapshot.resolveSchemaCompatibility(newStateSerializer);
+
+		if (!namespaceCompatibility.isCompatibleAsIs() || !stateCompatibility.isCompatibleAsIs()) {
 			// TODO state migration currently isn't possible.
 			throw StateMigrationException.notSupported();
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -20,11 +20,9 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.StateMigrationException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -149,81 +147,42 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		return result;
 	}
 
-	/**
-	 * Checks compatibility of a restored k/v state, with the new {@link StateDescriptor} provided to it.
-	 * This checks that the descriptor specifies identical names and state types, as well as
-	 * serializers that are compatible for the restored k/v state bytes.
-	 */
-	@Nonnull
-	public static <N, S> RegisteredKeyValueStateBackendMetaInfo<N, S> resolveKvStateCompatibility(
-		StateMetaInfoSnapshot restoredStateMetaInfoSnapshot,
-		TypeSerializer<N> newNamespaceSerializer,
-		StateDescriptor<?, S> newStateDescriptor,
-		@Nullable StateSnapshotTransformer<S> snapshotTransformer) throws StateMigrationException {
-
-		Preconditions.checkState(restoredStateMetaInfoSnapshot.getBackendStateType()
-				== StateMetaInfoSnapshot.BackendStateType.KEY_VALUE,
-			"Incompatible state types. " +
-				"Was [" + restoredStateMetaInfoSnapshot.getBackendStateType() + "], " +
-				"registered as [" + StateMetaInfoSnapshot.BackendStateType.KEY_VALUE + "].");
-
-		Preconditions.checkState(
-			Objects.equals(newStateDescriptor.getName(), restoredStateMetaInfoSnapshot.getName()),
-			"Incompatible state names. " +
-				"Was [" + restoredStateMetaInfoSnapshot.getName() + "], " +
-				"registered with [" + newStateDescriptor.getName() + "].");
-
-		final StateDescriptor.Type restoredType =
-			StateDescriptor.Type.valueOf(
-				restoredStateMetaInfoSnapshot.getOption(
-					StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE));
-
-		if (!Objects.equals(newStateDescriptor.getType(), StateDescriptor.Type.UNKNOWN)
-			&& !Objects.equals(restoredType, StateDescriptor.Type.UNKNOWN)) {
-
-			Preconditions.checkState(
-				newStateDescriptor.getType() == restoredType,
-				"Incompatible key/value state types. " +
-					"Was [" + restoredType + "], " +
-					"registered with [" + newStateDescriptor.getType() + "].");
-		}
-
-		// check compatibility results to determine if state migration is required
-		@SuppressWarnings("unchecked")
-		TypeSerializerSnapshot<N> namespaceSerializerSnapshot = Preconditions.checkNotNull(
-			(TypeSerializerSnapshot<N>) restoredStateMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
-				StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER));
-
-		TypeSerializerSchemaCompatibility<N, ?> namespaceCompatibility =
-			namespaceSerializerSnapshot.resolveSchemaCompatibility(newNamespaceSerializer);
-
-		TypeSerializer<S> newStateSerializer = newStateDescriptor.getSerializer();
-
-		@SuppressWarnings("unchecked")
-		TypeSerializerSnapshot<S> stateSerializerSnapshot = Preconditions.checkNotNull(
-			(TypeSerializerSnapshot<S>) restoredStateMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
-				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
-
-		TypeSerializerSchemaCompatibility<S, ?> stateCompatibility =
-			stateSerializerSnapshot.resolveSchemaCompatibility(newStateSerializer);
-
-		if (!namespaceCompatibility.isCompatibleAsIs() || !stateCompatibility.isCompatibleAsIs()) {
-			// TODO state migration currently isn't possible.
-			throw StateMigrationException.notSupported();
-		} else {
-			return new RegisteredKeyValueStateBackendMetaInfo<>(
-				newStateDescriptor.getType(),
-				newStateDescriptor.getName(),
-				newNamespaceSerializer,
-				newStateSerializer,
-				snapshotTransformer);
-		}
-	}
-
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
 		return computeSnapshot();
+	}
+
+	public static void checkStateMetaInfo(StateMetaInfoSnapshot stateMetaInfoSnapshot, StateDescriptor<?, ?> stateDesc) {
+		Preconditions.checkState(
+			stateMetaInfoSnapshot != null,
+			"Requested to check compatibility of a restored RegisteredKeyedBackendStateMetaInfo," +
+				" but its corresponding restored snapshot cannot be found.");
+
+		Preconditions.checkState(stateMetaInfoSnapshot.getBackendStateType()
+				== StateMetaInfoSnapshot.BackendStateType.KEY_VALUE,
+			"Incompatible state types. " +
+				"Was [" + stateMetaInfoSnapshot.getBackendStateType() + "], " +
+				"registered as [" + StateMetaInfoSnapshot.BackendStateType.KEY_VALUE + "].");
+
+		Preconditions.checkState(
+			Objects.equals(stateDesc.getName(), stateMetaInfoSnapshot.getName()),
+			"Incompatible state names. " +
+				"Was [" + stateMetaInfoSnapshot.getName() + "], " +
+				"registered with [" + stateDesc.getName() + "].");
+
+		final StateDescriptor.Type restoredType =
+			StateDescriptor.Type.valueOf(
+				stateMetaInfoSnapshot.getOption(
+					StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE));
+
+		if (stateDesc.getType() != StateDescriptor.Type.UNKNOWN && restoredType != StateDescriptor.Type.UNKNOWN) {
+			Preconditions.checkState(
+				stateDesc.getType() == restoredType,
+				"Incompatible key/value state types. " +
+					"Was [" + restoredType + "], " +
+					"registered with [" + stateDesc.getType() + "].");
+		}
 	}
 
 	@Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
@@ -42,21 +42,4 @@ public abstract class RegisteredStateMetaInfoBase {
 
 	@Nonnull
 	public abstract StateMetaInfoSnapshot snapshot();
-
-	public static RegisteredStateMetaInfoBase fromMetaInfoSnapshot(@Nonnull StateMetaInfoSnapshot snapshot) {
-
-		final StateMetaInfoSnapshot.BackendStateType backendStateType = snapshot.getBackendStateType();
-		switch (backendStateType) {
-			case KEY_VALUE:
-				return new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
-			case OPERATOR:
-				return new RegisteredOperatorStateBackendMetaInfo<>(snapshot);
-			case BROADCAST:
-				return new RegisteredBroadcastStateBackendMetaInfo<>(snapshot);
-			case PRIORITY_QUEUE:
-				return new RegisteredPriorityQueueStateBackendMetaInfo<>(snapshot);
-			default:
-				throw new IllegalArgumentException("Unknown backend state type: " + backendStateType);
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -405,10 +405,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			try {
 				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(fsDataInputStream);
 
-				// isSerializerPresenceRequired flag is set to true, since for the heap state backend,
-				// deserialization of state happens eagerly at restore time
 				KeyedBackendSerializationProxy<K> serializationProxy =
-						new KeyedBackendSerializationProxy<>(userCodeClassLoader, true);
+						new KeyedBackendSerializationProxy<>(userCodeClassLoader);
 
 				serializationProxy.read(inView);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendMigrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendMigrationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import java.io.File;
+
+/**
+ * Tests for the keyed state backend and operator state backend, as created by the
+ * {@link FsStateBackend}.
+ */
+public class FileStateBackendMigrationTest extends StateBackendMigrationTestBase<FsStateBackend> {
+
+	@Override
+	protected FsStateBackend getStateBackend() throws Exception {
+		File checkpointPath = tempFolder.newFolder();
+		return new FsStateBackend(checkpointPath.toURI(), false);
+	}
+
+	@Override
+	protected BackendSerializationTimeliness getStateBackendSerializationTimeliness() {
+		return BackendSerializationTimeliness.ON_CHECKPOINTS;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendMigrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendMigrationTest.java
@@ -31,9 +31,4 @@ public class FileStateBackendMigrationTest extends StateBackendMigrationTestBase
 		File checkpointPath = tempFolder.newFolder();
 		return new FsStateBackend(checkpointPath.toURI(), false);
 	}
-
-	@Override
-	protected BackendSerializationTimeliness getStateBackendSerializationTimeliness() {
-		return BackendSerializationTimeliness.ON_CHECKPOINTS;
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -32,13 +32,13 @@ import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.testutils.ArtificialCNFExceptionThrowingClassLoader;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FutureUtil;
 
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.concurrent.RunnableFuture;
@@ -141,8 +141,8 @@ public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBack
 			operatorStateBackend.restore(StateObjectCollection.singleton(stateHandle));
 
 			fail("The operator state restore should have failed if the previous state serializer could not be loaded.");
-		} catch (IOException expected) {
-			Assert.assertTrue(expected.getMessage().contains("Unable to restore operator state"));
+		} catch (Exception expected) {
+			Assert.assertTrue(ExceptionUtils.findThrowable(expected, ClassNotFoundException.class).isPresent());
 		} finally {
 			stateHandle.discardState();
 		}
@@ -194,8 +194,8 @@ public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBack
 						Collections.singleton(StringSerializer.class.getName()))));
 
 			fail("The keyed state restore should have failed if the previous state serializer could not be loaded.");
-		} catch (IOException expected) {
-			Assert.assertTrue(expected.getMessage().contains("Unable to restore keyed state"));
+		} catch (Exception expected) {
+			Assert.assertTrue(ExceptionUtils.findThrowable(expected, ClassNotFoundException.class).isPresent());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.runtime.util.BlockingCheckpointOutputStream;
 import org.apache.flink.testutils.ArtificialCNFExceptionThrowingClassLoader;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FutureUtil;
 import org.apache.flink.util.Preconditions;
 
@@ -889,8 +890,8 @@ public class OperatorStateBackendTest {
 			operatorStateBackend.restore(StateObjectCollection.singleton(stateHandle));
 
 			fail("The operator state restore should have failed if the previous state serializer could not be loaded.");
-		} catch (IOException expected) {
-			Assert.assertTrue(expected.getMessage().contains("Unable to restore operator state"));
+		} catch (Exception expected) {
+			Assert.assertTrue(ExceptionUtils.findThrowable(expected, ClassNotFoundException.class).isPresent());
 		} finally {
 			stateHandle.discardState();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -72,14 +72,13 @@ public class SerializationProxiesTest {
 		}
 
 		serializationProxy =
-				new KeyedBackendSerializationProxy<>(Thread.currentThread().getContextClassLoader(), true);
+				new KeyedBackendSerializationProxy<>(Thread.currentThread().getContextClassLoader());
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
 			serializationProxy.read(new DataInputViewStreamWrapper(in));
 		}
 
 		Assert.assertTrue(serializationProxy.isUsingKeyGroupCompression());
-		Assert.assertEquals(keySerializer, serializationProxy.restoreKeySerializer());
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 		assertEqualStateMetaInfoSnapshotsLists(stateMetaInfoList, serializationProxy.getStateMetaInfoSnapshots());
 	}
@@ -120,15 +119,13 @@ public class SerializationProxiesTest {
 			new KeyedBackendSerializationProxy<>(
 				new ArtificialCNFExceptionThrowingClassLoader(
 					Thread.currentThread().getContextClassLoader(),
-					cnfThrowingSerializerClasses),
-				false);
+					cnfThrowingSerializerClasses));
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
 			serializationProxy.read(new DataInputViewStreamWrapper(in));
 		}
 
 		Assert.assertEquals(true, serializationProxy.isUsingKeyGroupCompression());
-		Assert.assertTrue(serializationProxy.restoreKeySerializer() instanceof UnloadableDummyTypeSerializer);
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 
 		for (StateMetaInfoSnapshot snapshot : serializationProxy.getStateMetaInfoSnapshots()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1,0 +1,793 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.types.StringValue;
+import org.apache.flink.util.TestLogger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.RunnableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for the {@link KeyedStateBackend} and {@link OperatorStateBackend} as produced
+ * by various {@link StateBackend}s.
+ *
+ * <p>The tests in this test base focuses on the verification of state serializers usage when they are
+ * either compatible or requiring state migration after restoring the state backends.
+ */
+@SuppressWarnings("serial")
+public abstract class StateBackendMigrationTestBase<B extends AbstractStateBackend> extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+	// lazily initialized stream storage
+	private CheckpointStorageLocation checkpointStorageLocation;
+
+	/**
+	 * Different "personalities" of {@link CustomStringSerializer}. Instead of creating
+	 * different classes we parameterize the serializer with this and
+	 * {@link CustomStringSerializerSnapshot} will instantiate serializers with the correct
+	 * personality.
+	 */
+	public enum SerializerVersion {
+		INITIAL,
+		RESTORE,
+		NEW
+	}
+
+	/**
+	 * The compatibility behaviour of {@link CustomStringSerializer}. This controls what
+	 * type of serializer {@link CustomStringSerializerSnapshot} will create for
+	 * the different methods that return/create serializers.
+	 */
+	public enum SerializerCompatibilityType {
+		COMPATIBLE_AS_IS,
+		REQUIRES_MIGRATION
+	}
+
+	/**
+	 * The serialization timeliness behaviour of the state backend under test.
+	 * This is used by the test base to decide what serialization behaviour should be verified for.
+	 */
+	public enum BackendSerializationTimeliness {
+		/** This corresponds to off-heap backends which requires de-/serialization on each state access, e.g. RocksDB. */
+		ON_ACCESS,
+
+		/** This corresponds to heap-based backends which only performs state serialization on checkpointing. */
+		ON_CHECKPOINTS
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testValueStateWithSerializerRequiringMigration() throws Exception {
+		CustomStringSerializer.resetCountingMaps();
+
+		CheckpointStreamFactory streamFactory = createStreamFactory();
+		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		try {
+			ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>(
+				"id",
+				new CustomStringSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS, SerializerVersion.INITIAL));
+			ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
+
+			// ============ Modifications to the state ============
+			//  For eager serialization backends:
+			//    This should result in serializer personality INITIAL having 2 serialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should not result in any serialize / deserialize calls
+
+			backend.setCurrentKey(1);
+			state.update("1");
+			backend.setCurrentKey(2);
+			state.update("2");
+			backend.setCurrentKey(1);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			} else {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Snapshot #1 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality INITIAL having 2 serialize calls
+			KeyedStateHandle snapshot1 = runSnapshot(
+				backend.snapshot(1L, 2L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
+			backend.dispose();
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			} else {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Restore from snapshot #1 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality RESTORE having 2 deserialize calls
+			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot1);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			} else {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals((Integer) 2, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			ValueStateDescriptor<String> newKvId = new ValueStateDescriptor<>("id",
+				new CustomStringSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION, SerializerVersion.NEW));
+
+			// ============ State registration that triggers state migration ============
+			//  For eager serialization backends:
+			//    This should result in serializer personality RESTORE having 2 deserialize calls, and NEW having 2 serialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			ValueState<String> restored1 = backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, newKvId);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals((Integer) 2, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			} else {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ More modifications to the state ============
+			//  For eager serialization backends:
+			//    This should result in serializer personality NEW having 2 serialize calls and 3 deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			backend.setCurrentKey(1);
+			assertEquals("1", restored1.value());
+			restored1.update("1"); // s, NEW
+			backend.setCurrentKey(2);
+			assertEquals("2", restored1.value());
+			restored1.update("3"); // s, NEW
+			assertEquals("3", restored1.value());
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals((Integer) 3, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			} else {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Snapshot #2 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality NEW having 2 serialize calls
+			KeyedStateHandle snapshot2 = runSnapshot(
+				backend.snapshot(2L, 3L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
+			backend.dispose();
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			} else {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// and restore once with NEW from NEW so that we see a read using the NEW serializer
+			// on the file backend
+			ValueStateDescriptor<String> newKvId2 = new ValueStateDescriptor<>(
+				"id",
+				new CustomStringSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS, SerializerVersion.NEW));
+
+			// ============ Restore from snapshot #2 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality RESTORE having 2 deserialize calls
+			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot2);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals(null, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+			} else {
+				assertEquals(null, CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals((Integer) 2, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, newKvId2);
+			snapshot2.discardState();
+			snapshot1.discardState();
+		} finally {
+			backend.dispose();
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testValueStateWithNewSerializer() throws Exception {
+		CustomStringSerializer.resetCountingMaps();
+
+		CheckpointStreamFactory streamFactory = createStreamFactory();
+		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+		try {
+			ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>(
+				"id",
+				new CustomStringSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS, SerializerVersion.INITIAL));
+			ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
+
+			// ============ Modifications to the state ============
+			//  For eager serialization backends:
+			//    This should result in serializer personality INITIAL having 2 serialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should not result in any serialize / deserialize calls
+
+			backend.setCurrentKey(1);
+			state.update("1");
+			backend.setCurrentKey(2);
+			state.update("2");
+			backend.setCurrentKey(1);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			} else {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Snapshot #1 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality INITIAL having 2 serialize calls
+			KeyedStateHandle snapshot1 = runSnapshot(
+				backend.snapshot(1L, 2L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
+			backend.dispose();
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			} else {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Restore from snapshot #1 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality RESTORE having 2 deserialize calls
+			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot1);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.INITIAL));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.INITIAL));
+			} else {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals((Integer) 2, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			ValueStateDescriptor<String> newKvId = new ValueStateDescriptor<>("id",
+				new CustomStringSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS, SerializerVersion.NEW));
+			ValueState<String> restored1 = backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, newKvId);
+
+			// ============ More modifications to the state ============
+			//  For eager serialization backends:
+			//    This should result in serializer personality NEW having 2 serialize calls and 3 deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should not result in any serialize / deserialize calls
+
+			backend.setCurrentKey(1);
+			assertEquals("1", restored1.value());
+			restored1.update("1");
+			backend.setCurrentKey(2);
+			assertEquals("2", restored1.value());
+			restored1.update("3");
+			assertEquals("3", restored1.value());
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertEquals((Integer) 3, CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			} else {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Snapshot #2 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality NEW having 2 serialize calls
+			KeyedStateHandle snapshot2 = runSnapshot(
+				backend.snapshot(2L, 3L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry);
+			snapshot1.discardState();
+			backend.dispose();
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			} else {
+				assertEquals((Integer) 2, CustomStringSerializer.serializeCalled.get(SerializerVersion.NEW));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.NEW));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			// ============ Restore from snapshot #2 ============
+			//  For eager serialization backends:
+			//    This should not result in any serialize / deserialize calls
+			//
+			//  For lazy serialization backends:
+			//    This should result in serializer personality RESTORE having 2 deserialize calls
+			ValueStateDescriptor<String> newKvId2 = new ValueStateDescriptor<>("id",
+				new CustomStringSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS, SerializerVersion.NEW));
+			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot2);
+
+			if (getStateBackendSerializationTimeliness() == BackendSerializationTimeliness.ON_ACCESS) {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertNull(CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+			} else {
+				assertNull(CustomStringSerializer.serializeCalled.get(SerializerVersion.RESTORE));
+				assertEquals((Integer) 2, CustomStringSerializer.deserializeCalled.get(SerializerVersion.RESTORE));
+			}
+			CustomStringSerializer.resetCountingMaps();
+
+			backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, newKvId2);
+			snapshot2.discardState();
+		} finally {
+			backend.dispose();
+		}
+	}
+
+	public static class CustomStringSerializer extends TypeSerializer<String> {
+
+		private static final long serialVersionUID = 1L;
+
+		private static final String EMPTY = "";
+
+		private SerializerCompatibilityType compatibilityType;
+		private SerializerVersion serializerVersion;
+
+		private static final String CONFIG_PAYLOAD = "configPayload";
+
+		// for counting how often the methods were called from serializers of the different personalities
+		public static Map<SerializerVersion, Integer> serializeCalled = new HashMap<>();
+		public static Map<SerializerVersion, Integer> deserializeCalled = new HashMap<>();
+
+		static void resetCountingMaps() {
+			serializeCalled = new HashMap<>();
+			deserializeCalled = new HashMap<>();
+		}
+
+		CustomStringSerializer(
+			SerializerCompatibilityType compatibilityType,
+			SerializerVersion serializerVersion) {
+			this.compatibilityType = compatibilityType;
+			this.serializerVersion = serializerVersion;
+		}
+
+		@Override
+		public boolean isImmutableType() {
+			return true;
+		}
+
+		@Override
+		public String createInstance() {
+			return EMPTY;
+		}
+
+		@Override
+		public String copy(String from) {
+			return from;
+		}
+
+		@Override
+		public String copy(String from, String reuse) {
+			return from;
+		}
+
+		@Override
+		public int getLength() {
+			return -1;
+		}
+
+		@Override
+		public void serialize(String record, DataOutputView target) throws IOException {
+			serializeCalled.compute(serializerVersion, (k, v) -> v == null ? 1 : v + 1);
+			StringValue.writeString(record, target);
+		}
+
+		@Override
+		public String deserialize(DataInputView source) throws IOException {
+			deserializeCalled.compute(serializerVersion, (k, v) -> v == null ? 1 : v + 1);
+			return StringValue.readString(source);
+		}
+
+		@Override
+		public String deserialize(String record, DataInputView source) throws IOException {
+			deserializeCalled.compute(serializerVersion, (k, v) -> v == null ? 1 : v + 1);
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			StringValue.copyString(source, target);
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return obj instanceof CustomStringSerializer;
+		}
+
+		@Override
+		public TypeSerializer<String> duplicate() {
+			return this;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof CustomStringSerializer;
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		@Override
+		public TypeSerializerSnapshot<String> snapshotConfiguration() {
+			return new CustomStringSerializerSnapshot(CONFIG_PAYLOAD);
+		}
+
+		SerializerCompatibilityType getCompatibilityType() {
+			return compatibilityType;
+		}
+	}
+
+	public static class CustomStringSerializerSnapshot implements TypeSerializerSnapshot<String> {
+
+		private String configPayload;
+
+		public CustomStringSerializerSnapshot() {}
+
+		public CustomStringSerializerSnapshot(String configPayload) {
+			this.configPayload = configPayload;
+		}
+
+		@Override
+		public void writeSnapshot(DataOutputView out) throws IOException {
+			out.writeUTF(configPayload);
+		}
+
+		@Override
+		public void readSnapshot(int readVersion, DataInputView in, ClassLoader classLoader) throws IOException {
+			configPayload = in.readUTF();
+		}
+
+		@Override
+		public TypeSerializer<String> restoreSerializer() {
+			return new CustomStringSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS, SerializerVersion.RESTORE);
+
+		}
+
+		@Override
+		public <NS extends TypeSerializer<String>> TypeSerializerSchemaCompatibility<String, NS> resolveSchemaCompatibility(NS newSerializer) {
+			if (newSerializer instanceof CustomStringSerializer) {
+				SerializerCompatibilityType compatibilityType = ((CustomStringSerializer) newSerializer).getCompatibilityType();
+
+				if (compatibilityType == SerializerCompatibilityType.COMPATIBLE_AS_IS) {
+					return TypeSerializerSchemaCompatibility.compatibleAsIs();
+				} else {
+					return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+				}
+			} else {
+				return TypeSerializerSchemaCompatibility.incompatible();
+			}
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof CustomStringSerializerSnapshot;
+		}
+
+		@Override
+		public int hashCode() {
+			return 0;
+		}
+
+		@Override
+		public int getCurrentVersion() {
+			return 0;
+		}
+	}
+
+	public static class CustomVoidNamespaceSerializer extends TypeSerializer<VoidNamespace> {
+
+		private static final long serialVersionUID = 1L;
+
+		public static final CustomVoidNamespaceSerializer INSTANCE = new CustomVoidNamespaceSerializer();
+
+		@Override
+		public boolean isImmutableType() {
+			return true;
+		}
+
+		@Override
+		public VoidNamespace createInstance() {
+			return VoidNamespace.get();
+		}
+
+		@Override
+		public VoidNamespace copy(VoidNamespace from) {
+			return VoidNamespace.get();
+		}
+
+		@Override
+		public VoidNamespace copy(VoidNamespace from, VoidNamespace reuse) {
+			return VoidNamespace.get();
+		}
+
+		@Override
+		public int getLength() {
+			return 0;
+		}
+
+		@Override
+		public void serialize(VoidNamespace record, DataOutputView target) throws IOException {
+			// Make progress in the stream, write one byte.
+			//
+			// We could just skip writing anything here, because of the way this is
+			// used with the state backends, but if it is ever used somewhere else
+			// (even though it is unlikely to happen), it would be a problem.
+			target.write(0);
+		}
+
+		@Override
+		public VoidNamespace deserialize(DataInputView source) throws IOException {
+			source.readByte();
+			return VoidNamespace.get();
+		}
+
+		@Override
+		public VoidNamespace deserialize(VoidNamespace reuse, DataInputView source) throws IOException {
+			source.readByte();
+			return VoidNamespace.get();
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			target.write(source.readByte());
+		}
+
+		@Override
+		public TypeSerializer<VoidNamespace> duplicate() {
+			return this;
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return obj instanceof CustomVoidNamespaceSerializer;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof CustomVoidNamespaceSerializer;
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		@Override
+		public TypeSerializerSnapshot<VoidNamespace> snapshotConfiguration() {
+			return new CustomVoidNamespaceSerializerSnapshot();
+		}
+	}
+
+	public static class CustomVoidNamespaceSerializerSnapshot implements TypeSerializerSnapshot<VoidNamespace> {
+
+		@Override
+		public TypeSerializer<VoidNamespace> restoreSerializer() {
+			return new CustomVoidNamespaceSerializer();
+		}
+
+		@Override
+		public <NS extends TypeSerializer<VoidNamespace>> TypeSerializerSchemaCompatibility<VoidNamespace, NS> resolveSchemaCompatibility(NS newSerializer) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		}
+
+		@Override
+		public void writeSnapshot(DataOutputView out) throws IOException {}
+
+		@Override
+		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof CustomVoidNamespaceSerializerSnapshot;
+		}
+
+		@Override
+		public int hashCode() {
+			return 0;
+		}
+
+		@Override
+		public int getCurrentVersion() {
+			return 0;
+		}
+	}
+
+	protected abstract B getStateBackend() throws Exception;
+
+	protected abstract BackendSerializationTimeliness getStateBackendSerializationTimeliness();
+
+	private CheckpointStreamFactory createStreamFactory() throws Exception {
+		if (checkpointStorageLocation == null) {
+			checkpointStorageLocation = getStateBackend()
+				.createCheckpointStorage(new JobID())
+				.initializeLocationForCheckpoint(1L);
+		}
+		return checkpointStorageLocation;
+	}
+
+	private <K> AbstractKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer) throws Exception {
+		return createKeyedBackend(keySerializer, new DummyEnvironment());
+	}
+
+	private  <K> AbstractKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer, Environment env) throws Exception {
+		return createKeyedBackend(
+			keySerializer,
+			10,
+			new KeyGroupRange(0, 9),
+			env);
+	}
+
+	private  <K> AbstractKeyedStateBackend<K> createKeyedBackend(
+		TypeSerializer<K> keySerializer,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		Environment env) throws Exception {
+		AbstractKeyedStateBackend<K> backend = getStateBackend().createKeyedStateBackend(
+			env,
+			new JobID(),
+			"test_op",
+			keySerializer,
+			numberOfKeyGroups,
+			keyGroupRange,
+			env.getTaskKvStateRegistry());
+		backend.restore(null);
+		return backend;
+	}
+
+	private  <K> AbstractKeyedStateBackend<K> restoreKeyedBackend(TypeSerializer<K> keySerializer, KeyedStateHandle state) throws Exception {
+		return restoreKeyedBackend(keySerializer, state, new DummyEnvironment());
+	}
+
+	private  <K> AbstractKeyedStateBackend<K> restoreKeyedBackend(
+		TypeSerializer<K> keySerializer,
+		KeyedStateHandle state,
+		Environment env) throws Exception {
+		return restoreKeyedBackend(
+			keySerializer,
+			10,
+			new KeyGroupRange(0, 9),
+			Collections.singletonList(state),
+			env);
+	}
+
+	private  <K> AbstractKeyedStateBackend<K> restoreKeyedBackend(
+		TypeSerializer<K> keySerializer,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		List<KeyedStateHandle> state,
+		Environment env) throws Exception {
+		AbstractKeyedStateBackend<K> backend = getStateBackend().createKeyedStateBackend(
+			env,
+			new JobID(),
+			"test_op",
+			keySerializer,
+			numberOfKeyGroups,
+			keyGroupRange,
+			env.getTaskKvStateRegistry());
+		backend.restore(new StateObjectCollection<>(state));
+		return backend;
+	}
+
+	private KeyedStateHandle runSnapshot(
+		RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshotRunnableFuture,
+		SharedStateRegistry sharedStateRegistry) throws Exception {
+
+		if (!snapshotRunnableFuture.isDone()) {
+			snapshotRunnableFuture.run();
+		}
+
+		SnapshotResult<KeyedStateHandle> snapshotResult = snapshotRunnableFuture.get();
+		KeyedStateHandle jobManagerOwnedSnapshot = snapshotResult.getJobManagerOwnedSnapshot();
+		if (jobManagerOwnedSnapshot != null) {
+			jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry);
+		}
+		return jobManagerOwnedSnapshot;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -133,7 +133,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -133,6 +133,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -148,6 +149,14 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 	@Rule
 	public final ExpectedException expectedException = ExpectedException.none();
+
+	/**
+	 * The serialization timeliness behaviour of the state backend under test.
+	 */
+	public enum BackendSerializationTimeliness {
+		ON_ACCESS,
+		ON_CHECKPOINTS
+	}
 
 	// lazily initialized stream storage
 	private CheckpointStorageLocation checkpointStorageLocation;
@@ -971,6 +980,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 	@Test
 	public void testStateSerializerReconfiguration() throws Exception {
+
 		CheckpointStreamFactory streamFactory = createStreamFactory();
 		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 		Environment env = new DummyEnvironment();

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerCompatibilityTest.scala
@@ -21,13 +21,13 @@ package org.apache.flink.api.scala.runtime
 import java.io.InputStream
 
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSerializationUtil, TypeSerializerSnapshot}
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializerConfigSnapshot
 import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.api.scala.runtime.TupleSerializerCompatibilityTestGenerator._
 import org.apache.flink.api.scala.typeutils.CaseClassSerializer
 import org.apache.flink.core.memory.DataInputViewStreamWrapper
-import org.junit.Assert.{assertEquals, assertFalse, assertNotNull, assertTrue}
+import org.junit.Assert.{assertEquals, assertNotNull, assertTrue}
 import org.junit.Test
 
 /**
@@ -48,8 +48,11 @@ class TupleSerializerCompatibilityTest {
 
       assertEquals(1, deserialized.size)
 
-      val oldSerializer = deserialized.get(0).f0
-      val oldConfigSnapshot = deserialized.get(0).f1
+      val oldSerializer: TypeSerializer[TestCaseClass] =
+        deserialized.get(0).f0.asInstanceOf[TypeSerializer[TestCaseClass]]
+
+      val oldConfigSnapshot: TypeSerializerSnapshot[TestCaseClass] =
+        deserialized.get(0).f1.asInstanceOf[TypeSerializerSnapshot[TestCaseClass]]
 
       // test serializer and config snapshot
       assertNotNull(oldSerializer)
@@ -61,9 +64,9 @@ class TupleSerializerCompatibilityTest {
 
       val currentSerializer = createTypeInformation[TestCaseClass]
         .createSerializer(new ExecutionConfig())
-      assertFalse(currentSerializer
-        .ensureCompatibility(oldConfigSnapshot)
-        .isRequiresMigration)
+      assertTrue(oldConfigSnapshot
+        .resolveSchemaCompatibility(currentSerializer)
+        .isCompatibleAsIs)
 
       // test old data serialization
       is.close()

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.api.scala.typeutils
 import java.io._
 import java.net.{URL, URLClassLoader}
 
-import org.apache.flink.api.common.typeutils.{CompatibilityResult, TypeSerializerSnapshotSerializationUtil}
+import org.apache.flink.api.common.typeutils.{TypeSerializerSchemaCompatibility, TypeSerializerSnapshotSerializationUtil}
 import org.apache.flink.core.memory.{DataInputViewStreamWrapper, DataOutputViewStreamWrapper}
 import org.apache.flink.util.TestLogger
 import org.junit.rules.TemporaryFolder
@@ -84,7 +84,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
     */
   @Test
   def checkIdenticalEnums(): Unit = {
-    assertFalse(checkCompatibility(enumA, enumA).isRequiresMigration)
+    assertTrue(checkCompatibility(enumA, enumA).isCompatibleAsIs)
   }
 
   /**
@@ -92,7 +92,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
     */
   @Test
   def checkAppendedField(): Unit = {
-    assertFalse(checkCompatibility(enumA, enumB).isRequiresMigration)
+    assertTrue(checkCompatibility(enumA, enumB).isCompatibleAsIs)
   }
 
   /**
@@ -100,7 +100,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
     */
   @Test
   def checkRemovedField(): Unit = {
-    assertTrue(checkCompatibility(enumA, enumC).isRequiresMigration)
+    assertTrue(checkCompatibility(enumA, enumC).isIncompatible)
   }
 
   /**
@@ -108,7 +108,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
     */
   @Test
   def checkDifferentFieldOrder(): Unit = {
-    assertTrue(checkCompatibility(enumA, enumD).isRequiresMigration)
+    assertTrue(checkCompatibility(enumA, enumD).isIncompatible)
   }
 
   /**
@@ -117,12 +117,12 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
   @Test
   def checkDifferentIds(): Unit = {
     assertTrue(
-      "Different ids should cause a migration.",
-      checkCompatibility(enumA, enumE).isRequiresMigration)
+      "Different ids should be incompatible.",
+      checkCompatibility(enumA, enumE).isIncompatible)
   }
 
   def checkCompatibility(enumSourceA: String, enumSourceB: String)
-    : CompatibilityResult[Enumeration#Value] = {
+    : TypeSerializerSchemaCompatibility[Enumeration#Value, _] = {
     import EnumValueSerializerUpgradeTest._
 
     val classLoader = compileAndLoadEnum(tempFolder.newFolder(), s"$enumName.scala", enumSourceA)
@@ -152,7 +152,7 @@ class EnumValueSerializerUpgradeTest extends TestLogger with JUnitSuiteLike {
     val enum2 = instantiateEnum[Enumeration](classLoader2, enumName)
 
     val enumValueSerializer2 = new EnumValueSerializer(enum2)
-    enumValueSerializer2.ensureCompatibility(snapshot2)
+    snapshot2.resolveSchemaCompatibility(enumValueSerializer2)
   }
 }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -95,6 +95,7 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.Snapshot;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1359,48 +1360,159 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	 * already have a registered entry for that and return it (after some necessary state compatibility checks)
 	 * or create a new one if it does not exist.
 	 */
-	private <N, S> Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, S>> tryRegisterKvStateInformation(
-			StateDescriptor<?, S> stateDesc,
+	private <N, S extends State, SV> Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> tryRegisterKvStateInformation(
+			StateDescriptor<S, SV> stateDesc,
 			TypeSerializer<N> namespaceSerializer,
-			@Nullable StateSnapshotTransformer<S> snapshotTransformer) throws StateMigrationException {
+			@Nullable StateSnapshotTransformer<SV> snapshotTransformer) throws Exception {
 
 		Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> stateInfo =
 			kvStateInformation.get(stateDesc.getName());
 
-		RegisteredKeyValueStateBackendMetaInfo<N, S> newMetaInfo;
+		TypeSerializer<SV> stateSerializer = stateDesc.getSerializer();
+		RegisteredKeyValueStateBackendMetaInfo<N, SV> newMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(
+			stateDesc.getType(),
+			stateDesc.getName(),
+			namespaceSerializer,
+			stateSerializer,
+			snapshotTransformer);
+
 		if (stateInfo != null) {
-
-			StateMetaInfoSnapshot restoredMetaInfoSnapshot = restoredKvStateMetaInfos.get(stateDesc.getName());
-
-			Preconditions.checkState(
-				restoredMetaInfoSnapshot != null,
-				"Requested to check compatibility of a restored RegisteredKeyedBackendStateMetaInfo," +
-					" but its corresponding restored snapshot cannot be found.");
-
-			newMetaInfo = RegisteredKeyValueStateBackendMetaInfo.resolveKvStateCompatibility(
-				restoredMetaInfoSnapshot,
-				namespaceSerializer,
+			newMetaInfo = migrateStateIfNecessary(
+				newMetaInfo,
 				stateDesc,
-				snapshotTransformer);
+				namespaceSerializer,
+				stateSerializer,
+				stateInfo);
 
 			stateInfo.f1 = newMetaInfo;
 		} else {
-			String stateName = stateDesc.getName();
-
-			newMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(
-				stateDesc.getType(),
-				stateName,
-				namespaceSerializer,
-				stateDesc.getSerializer(),
-				snapshotTransformer);
-
-			ColumnFamilyHandle columnFamily = createColumnFamily(stateName);
+			ColumnFamilyHandle columnFamily = createColumnFamily(stateDesc.getName());
 
 			stateInfo = Tuple2.of(columnFamily, newMetaInfo);
 			registerKvStateInformation(stateDesc.getName(), stateInfo);
 		}
 
 		return Tuple2.of(stateInfo.f0, newMetaInfo);
+	}
+
+	private <N, S extends State, SV> RegisteredKeyValueStateBackendMetaInfo<N, SV> migrateStateIfNecessary(
+			RegisteredKeyValueStateBackendMetaInfo<N, SV> newMetaInfo,
+			StateDescriptor<S, SV> stateDesc,
+			TypeSerializer<N> namespaceSerializer,
+			TypeSerializer<SV> stateSerializer,
+			Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> stateInfo) throws Exception {
+
+		StateMetaInfoSnapshot restoredMetaInfoSnapshot = restoredKvStateMetaInfos.get(stateDesc.getName());
+
+		Preconditions.checkState(
+			restoredMetaInfoSnapshot != null,
+			"Requested to check compatibility of a restored RegisteredKeyedBackendStateMetaInfo," +
+				" but its corresponding restored snapshot cannot be found.");
+
+		@SuppressWarnings("unchecked")
+		TypeSerializerSnapshot<N> namespaceSerializerSnapshot = Preconditions.checkNotNull(
+			(TypeSerializerSnapshot<N>) restoredMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
+				StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER.toString()));
+
+		TypeSerializerSchemaCompatibility<N, ?> namespaceCompatibility =
+			namespaceSerializerSnapshot.resolveSchemaCompatibility(namespaceSerializer);
+		if (!namespaceCompatibility.isCompatibleAsIs()) {
+			throw new StateMigrationException("The new namespace serializer must be compatible.");
+		}
+
+		@SuppressWarnings("unchecked")
+		TypeSerializerSnapshot<SV> stateSerializerSnapshot = Preconditions.checkNotNull(
+			(TypeSerializerSnapshot<SV>) restoredMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
+				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString()));
+
+		RegisteredKeyValueStateBackendMetaInfo.checkStateMetaInfo(restoredMetaInfoSnapshot, stateDesc);
+
+		TypeSerializerSchemaCompatibility<SV, ?> stateCompatibility =
+			stateSerializerSnapshot.resolveSchemaCompatibility(stateSerializer);
+
+		if (stateCompatibility.isCompatibleAfterMigration()) {
+			migrateStateValues(stateDesc, stateInfo, restoredMetaInfoSnapshot, newMetaInfo, stateSerializer);
+		} else if (stateCompatibility.isIncompatible()) {
+			throw new StateMigrationException("The new state serializer cannot be incompatible.");
+		}
+
+		return newMetaInfo;
+	}
+
+	/**
+	 * Migrate only the state value, that is the "value" that is stored in RocksDB. We don't migrate
+	 * the key here, which is made up of key group, key, namespace and map key
+	 * (in case of MapState).
+	 */
+	private <N, S extends State, SV> void migrateStateValues(
+		StateDescriptor<S, SV> stateDesc,
+		Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> stateInfo,
+		StateMetaInfoSnapshot restoredMetaInfoSnapshot,
+		RegisteredKeyValueStateBackendMetaInfo<N, SV> newMetaInfo,
+		TypeSerializer<SV> newStateSerializer) throws Exception {
+
+		if (stateDesc.getType() == StateDescriptor.Type.MAP) {
+			throw new StateMigrationException("The new serializer for a MapState requires state migration in order for the job to proceed." +
+				" However, migration for MapState currently isn't supported.");
+		}
+
+		LOG.info(
+			"Performing state migration for state {} because the state serializer's schema, i.e. serialization format, has changed.",
+			stateDesc);
+
+		// we need to get an actual state instance because migration is different
+		// for different state types. For example, ListState needs to deal with
+		// individual elements
+		StateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
+		if (stateFactory == null) {
+			String message = String.format("State %s is not supported by %s",
+				stateDesc.getClass(), this.getClass());
+			throw new FlinkRuntimeException(message);
+		}
+		State state = stateFactory.createState(
+			stateDesc,
+			Tuple2.of(stateInfo.f0, newMetaInfo),
+			RocksDBKeyedStateBackend.this);
+		if (!(state instanceof AbstractRocksDBState)) {
+			throw new FlinkRuntimeException(
+				"State should be an AbstractRocksDBState but is " + state);
+		}
+
+		@SuppressWarnings("unchecked")
+		AbstractRocksDBState<?, ?, SV, S> rocksDBState = (AbstractRocksDBState<?, ?, SV, S>) state;
+
+		Snapshot rocksDBSnapshot = db.getSnapshot();
+		try (
+			RocksIteratorWrapper iterator = getRocksIterator(db, stateInfo.f0);
+			RocksDBWriteBatchWrapper batchWriter = new RocksDBWriteBatchWrapper(db, getWriteOptions())
+		) {
+			iterator.seekToFirst();
+
+			@SuppressWarnings("unchecked")
+			TypeSerializerSnapshot<SV> priorValueSerializerSnapshot = (TypeSerializerSnapshot<SV>)
+				Preconditions.checkNotNull(restoredMetaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
+			TypeSerializer<SV> priorValueSerializer = priorValueSerializerSnapshot.restoreSerializer();
+
+			DataInputDeserializer serializedValueInput = new DataInputDeserializer();
+			DataOutputSerializer migratedSerializedValueOutput = new DataOutputSerializer(512);
+			while (iterator.isValid()) {
+				serializedValueInput.setBuffer(iterator.value());
+
+				rocksDBState.migrateSerializedValue(
+					serializedValueInput,
+					migratedSerializedValueOutput,
+					priorValueSerializer,
+					newStateSerializer);
+
+				batchWriter.put(stateInfo.f0, iterator.key(), migratedSerializedValueOutput.getCopyOfBuffer());
+
+				migratedSerializedValueOutput.clear();
+				iterator.next();
+			}
+		} finally {
+			db.releaseSnapshot(rocksDBSnapshot);
+			rocksDBSnapshot.close();
+		}
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1718,9 +1718,12 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				TypeSerializerSchemaCompatibility<T, ?> compatibilityResult =
 					serializerSnapshot.resolveSchemaCompatibility(byteOrderedElementSerializer);
 
-				// TODO implement proper migration for priority queue state
+				// Since priority queue elements are written into RocksDB
+				// as keys prefixed with the key group and namespace, we do not support
+				// migrating them. Therefore, here we only check for incompatibility.
 				if (compatibilityResult.isIncompatible()) {
-					throw new FlinkRuntimeException(StateMigrationException.notSupported());
+					throw new FlinkRuntimeException(
+						new StateMigrationException("The new priority queue serializer must not be incompatible."));
 				}
 
 				// update meta info with new serializer

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1606,7 +1606,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				TypeSerializerSchemaCompatibility<T, ?> compatibilityResult =
 					serializerSnapshot.resolveSchemaCompatibility(byteOrderedElementSerializer);
 
-				if (compatibilityResult.isCompatibleAfterMigration()) {
+				// TODO implement proper migration for priority queue state
+				if (compatibilityResult.isIncompatible()) {
 					throw new FlinkRuntimeException(StateMigrationException.notSupported());
 				}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.StateBackendMigrationTestBase;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 
@@ -50,12 +51,13 @@ public class RocksDBStateBackendMigrationTest extends StateBackendMigrationTestB
 		dbPath = tempFolder.newFolder().getAbsolutePath();
 		String checkpointPath = tempFolder.newFolder().toURI().toString();
 		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath), enableIncrementalCheckpointing);
+
+		Configuration configuration = new Configuration();
+		configuration.setString(
+			RocksDBOptions.TIMER_SERVICE_FACTORY,
+			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
+		backend = backend.configure(configuration);
 		backend.setDbStoragePath(dbPath);
 		return backend;
-	}
-
-	@Override
-	protected BackendSerializationTimeliness getStateBackendSerializationTimeliness() {
-		return BackendSerializationTimeliness.ON_ACCESS;
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.runtime.state.StateBackendMigrationTestBase;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Tests for the partitioned state part of {@link RocksDBStateBackend}.
+ */
+@RunWith(Parameterized.class)
+public class RocksDBStateBackendMigrationTest extends StateBackendMigrationTestBase<RocksDBStateBackend> {
+
+	@Parameterized.Parameters(name = "Incremental checkpointing: {0}")
+	public static Collection<Boolean> parameters() {
+		return Arrays.asList(false, true);
+	}
+
+	@Parameterized.Parameter
+	public boolean enableIncrementalCheckpointing;
+
+	// Store it because we need it for the cleanup test.
+	private String dbPath;
+
+	@Override
+	protected RocksDBStateBackend getStateBackend() throws IOException {
+		dbPath = tempFolder.newFolder().getAbsolutePath();
+		String checkpointPath = tempFolder.newFolder().toURI().toString();
+		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath), enableIncrementalCheckpointing);
+		backend.setDbStoragePath(dbPath);
+		return backend;
+	}
+
+	@Override
+	protected BackendSerializationTimeliness getStateBackendSerializationTimeliness() {
+		return BackendSerializationTimeliness.ON_ACCESS;
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
@@ -290,12 +290,12 @@ public class TypeSerializerSnapshotMigrationITCase extends SavepointMigrationTes
 		}
 
 		@Override
-		public void write(DataOutputView out) throws IOException {
+		public void writeSnapshot(DataOutputView out) throws IOException {
 			out.writeUTF(configPayload);
 		}
 
 		@Override
-		public void read(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
 			if (readVersion != 1) {
 				throw new IllegalStateException("Can not recognize read version: " + readVersion);
 			}


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #6930. Only the last commit is relevant.

This PR adds the procedure of migrating state (i.e., reading state bytes with the restored prior serializer, and then re-writing the deserialized object with the new serializer).

- This should only ever occur in the RocksDB state backend, since the restore / snapshotting of heap-based backends are already a migration process by nature. This is identified by a result of `TypeSerializerSchemaCompatibility.compatibleAfterMigration()` on the state serializer's compatibility check.
- For heap-based backends, we only need to check that the new state serializer isn't incompatible. This is identified by a result of `TypeSerializerSchemaCompatibility.incompatible()` on the state serializer's compatibility check.

## Brief change log

- Add `migrateSerializedValue` to `AbstractRocksDBStateValue`
- Use the new method to iterate through RocksDB bytes when state migration is necessary
- Adapt heap-based backends to check fail when new serializers are incompatible.
- Add a `StateMigrationTestBase` that verifies serializers are being used as expected for a restore procedure

## Verifying this change

The main new test coverage that covers this is in the `StateMigrationTestBase` class.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
