### PR TITLE
[FLINK-10680][streaming] Fix IllegalArgumentException caused by negative offset in TumblingWindows

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -51,8 +51,8 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	private final long offset;
 
 	protected TumblingEventTimeWindows(long size, long offset) {
-		if (offset < 0 || offset >= size) {
-			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy 0 <= offset < size");
+		if (size <= 0 || Math.abs(offset) >= size) {
+			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy 0 <= abs(offset) < size");
 		}
 
 		this.size = size;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -49,8 +49,8 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	private final long offset;
 
 	private TumblingProcessingTimeWindows(long size, long offset) {
-		if (offset < 0 || offset >= size) {
-			throw new IllegalArgumentException("TumblingProcessingTimeWindows parameters must satisfy  0 <= offset < size");
+		if (size <= 0 || Math.abs(offset) >= size) {
+			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy 0 <= abs(offset) < size");
 		}
 
 		this.size = size;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -50,7 +50,7 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 
 	private TumblingProcessingTimeWindows(long size, long offset) {
 		if (size <= 0 || Math.abs(offset) >= size) {
-			throw new IllegalArgumentException("TumblingEventTimeWindows parameters must satisfy 0 <= abs(offset) < size");
+			throw new IllegalArgumentException("TumblingProcessingTimeWindows parameters must satisfy 0 <= abs(offset) < size");
 		}
 
 		this.size = size;


### PR DESCRIPTION
## What is the purpose of the change

By design, the offset could be either positive or negative to fit in different time zones, but there's a check that ensures the offset is greater than zero. 

This PR fixes the IllegalArguementException caused by negative offsets in TumblingEventTimeWindows and TumblingProcessingTimeWindows.

## Brief change log

- Change the condition of the parameter checks in TumblingEventTimeWindows and TumblingProcessingTimeWindows from `0 <= offset < size` to `0 <= abs(offset) < size`.

## Verifying this change

This change added tests and can be verified as follows:

- Updated the tests for invalid parameters for time window assigners.
- Added tests for negative offsets of time windows.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
