### PR TITLE
[FLINK-10692] Harden Confluent schema registry E2E test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -135,16 +135,29 @@ function start_confluent_schema_registry {
 
   # wait until the schema registry REST endpoint is up
   for i in {1..30}; do
-    QUERY_RESULT=$(curl "${SCHEMA_REGISTRY_URL}/subjects" 2> /dev/null || true)
-
-    if [[ ${QUERY_RESULT} =~ \[.*\] ]]; then
+    if get_and_verify_schema_subjects_exist; then
         echo "Schema registry is up."
-        break
+        return 0
     fi
 
     echo "Waiting for schema registry..."
     sleep 1
   done
+
+  if ! get_and_verify_schema_subjects_exist; then
+      echo "Could not start confluent schema registry"
+      exit 1
+  fi
+}
+
+function get_schema_subjects {
+    curl "${SCHEMA_REGISTRY_URL}/subjects" 2> /dev/null || true
+}
+
+function get_and_verify_schema_subjects_exist {
+    QUERY_RESULT=$(get_schema_subjects)
+
+    [[ ${QUERY_RESULT} =~ \[.*\] ]]
 }
 
 function stop_confluent_schema_registry {


### PR DESCRIPTION
## What is the purpose of the change

This commit fails the Confluent schema registry E2E test test_confluent_schema_registry.sh
if it cannot start the Confluent schema registry. Before the test would simply deadlock in
such a situation.

## Verifying this change

- Tested manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
