### PR TITLE
[FLINK-10676][table] Add 'as' method for OverWindowWithOrderBy

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1579,7 +1579,7 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
 
         <p><a href="tableApi.html#unbounded-over-windows">Unbounded over windows</a> are specified using a constant, i.e., <code>UNBOUNDED_RANGE</code> for a time interval or <code>UNBOUNDED_ROW</code> for a row-count interval. Unbounded over windows start with the first row of a partition.</p>
         
-        <p>If the <code>preceding</code> and <code>following</code> clause both are omitted, RANGE UNBOUNDED PRECEDING AND CURRENT ROW is used as default for window.</p>
+        <p>If the <code>preceding</code> clause is omitted, <code>UNBOUNDED_RANGE</code> and <code>CURRENT_RANGE</code> are used as the default <code>preceding</code> and <code>following</code> for the window.</p>
       </td>
     </tr>
     <tr>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1571,13 +1571,15 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
     </tr>
     <tr>
       <td><code>preceding</code></td>
-      <td>Required</td>
+      <td>Optional</td>
       <td>
         <p>Defines the interval of rows that are included in the window and precede the current row. The interval can either be specified as time or row-count interval.</p>
 
         <p><a href="tableApi.html#bounded-over-windows">Bounded over windows</a> are specified with the size of the interval, e.g., <code>10.minutes</code> for a time interval or <code>10.rows</code> for a row-count interval.</p>
 
         <p><a href="tableApi.html#unbounded-over-windows">Unbounded over windows</a> are specified using a constant, i.e., <code>UNBOUNDED_RANGE</code> for a time interval or <code>UNBOUNDED_ROW</code> for a row-count interval. Unbounded over windows start with the first row of a partition.</p>
+        
+        <p>If the <code>preceding</code> and <code>following</code> clause both are omitted, RANGE UNBOUNDED PRECEDING AND CURRENT ROW is used as default for window.</p>
       </td>
     </tr>
     <tr>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/windows.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/windows.scala
@@ -18,7 +18,8 @@
 
 package org.apache.flink.table.api.java
 
-import org.apache.flink.table.api.{TumbleWithSize, OverWindowWithPreceding, SlideWithSize, SessionWithGap}
+import org.apache.flink.table.api.scala.{CURRENT_RANGE, UNBOUNDED_RANGE}
+import org.apache.flink.table.api._
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 
 /**
@@ -144,4 +145,21 @@ class OverWindowWithOrderBy(
     new OverWindowWithPreceding(partitionByExpr, orderByExpr, precedingExpr)
   }
 
+  /**
+    * Assigns an alias for this window that the following `select()` clause can refer to.
+    *
+    * @param alias alias for this over window
+    * @return over window
+    */
+  def as(alias: String): OverWindow = as(ExpressionParser.parseExpression(alias))
+
+  /**
+    * Assigns an alias for this window that the following `select()` clause can refer to.
+    *
+    * @param alias alias for this over window
+    * @return over window
+    */
+  def as(alias: Expression): OverWindow = {
+    OverWindow(alias, partitionByExpr, orderByExpr, UNBOUNDED_RANGE, CURRENT_RANGE)
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/windows.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/windows.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.api.java
 
 import org.apache.flink.table.api.scala.{CURRENT_RANGE, UNBOUNDED_RANGE}
-import org.apache.flink.table.api._
+import org.apache.flink.table.api.{OverWindow, TumbleWithSize, OverWindowWithPreceding, SlideWithSize, SessionWithGap}
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/windows.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/windows.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.api.scala
 
-import org.apache.flink.table.api._
+import org.apache.flink.table.api.{OverWindow, TumbleWithSize, OverWindowWithPreceding, SlideWithSize, SessionWithGap}
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/windows.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/windows.scala
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.api.scala
 
-import org.apache.flink.table.api.{TumbleWithSize, OverWindowWithPreceding, SlideWithSize, SessionWithGap}
-import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.api._
+import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 
 /**
   * Helper object for creating a tumbling window. Tumbling windows are consecutive, non-overlapping
@@ -127,7 +127,6 @@ case class PartitionedOver(partitionBy: Array[Expression]) {
 
 case class OverWindowWithOrderBy(partitionBy: Seq[Expression], orderBy: Expression) {
 
-
   /**
     * Set the preceding offset (based on time or row-count intervals) for over window.
     *
@@ -138,4 +137,21 @@ case class OverWindowWithOrderBy(partitionBy: Seq[Expression], orderBy: Expressi
     new OverWindowWithPreceding(partitionBy, orderBy, preceding)
   }
 
+  /**
+    * Assigns an alias for this window that the following `select()` clause can refer to.
+    *
+    * @param alias alias for this over window
+    * @return over window
+    */
+  def as(alias: String): OverWindow = as(ExpressionParser.parseExpression(alias))
+
+  /**
+    * Assigns an alias for this window that the following `select()` clause can refer to.
+    *
+    * @param alias alias for this over window
+    * @return over window
+    */
+  def as(alias: Expression): OverWindow = {
+    OverWindow(alias, partitionBy, orderBy, UNBOUNDED_RANGE, CURRENT_RANGE)
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
@@ -287,7 +287,15 @@ class OverWindowTest extends TableTestBase {
       "sum(a) OVER (PARTITION BY c ORDER BY proctime RANGE UNBOUNDED preceding) as cnt2 " +
       "FROM MyTable " +
       "WINDOW w AS (PARTITION BY c ORDER BY proctime RANGE UNBOUNDED preceding)"
+
+    val sql3 = "SELECT " +
+      "c, " +
+      "count(a) OVER (PARTITION BY c ORDER BY proctime) as cnt1, " +
+      "sum(a) OVER (PARTITION BY c ORDER BY proctime) as cnt2 " +
+      "from MyTable"
+
     streamUtil.verifySqlPlansIdentical(sql, sql2)
+    streamUtil.verifySqlPlansIdentical(sql, sql3)
 
     val expected =
       unaryNode(
@@ -522,6 +530,13 @@ class OverWindowTest extends TableTestBase {
       "count(a) OVER (PARTITION BY c ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt1, " +
       "sum(a) OVER (PARTITION BY c ORDER BY rowtime RANGE UNBOUNDED preceding) as cnt2 " +
       "from MyTable"
+
+    val sql1 = "SELECT " +
+      "c, " +
+      "count(a) OVER (PARTITION BY c ORDER BY rowtime) as cnt1, " +
+      "sum(a) OVER (PARTITION BY c ORDER BY rowtime) as cnt2 " +
+      "from MyTable"
+    streamUtil.verifySqlPlansIdentical(sql, sql1)
 
     val expected =
       unaryNode(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
@@ -194,9 +194,14 @@ class OverWindowTest extends TableTestBase {
     val weightedAvg = new WeightedAvgWithRetract
 
     val result = table
-      .window(Over partitionBy 'c orderBy 'proctime preceding UNBOUNDED_RANGE following
-         CURRENT_RANGE as 'w)
+      .window(Over partitionBy 'c orderBy 'proctime preceding UNBOUNDED_RANGE as 'w)
       .select('a, 'c, 'a.count over 'w, weightedAvg('c, 'a) over 'w)
+
+    val result2 = table
+      .window(Over partitionBy 'c orderBy 'proctime as 'w)
+      .select('a, 'c, 'a.count over 'w, weightedAvg('c, 'a) over 'w)
+
+    streamUtil.verify2Tables(result, result2)
 
     val expected =
       unaryNode(
@@ -458,6 +463,12 @@ class OverWindowTest extends TableTestBase {
       .window(Over partitionBy 'c orderBy 'rowtime preceding UNBOUNDED_RANGE following
          CURRENT_RANGE as 'w)
       .select('a, 'c, 'a.count over 'w, weightedAvg('c, 'a) over 'w as 'wAvg)
+
+    val result2 = table
+      .window(Over partitionBy 'c orderBy 'rowtime as 'w)
+      .select('a, 'c, 'a.count over 'w, weightedAvg('c, 'a) over 'w as 'wAvg)
+
+    streamUtil.verify2Tables(result, result2)
 
     val expected =
       unaryNode(


### PR DESCRIPTION

## What is the purpose of the change

The preceding clause of OVER Window in the traditional database is optional. The default is UNBOUNDED. So we can add the `as` method to `OverWindowWithOrderBy`. This way OVER Window is written more easily. e.g.:
`.window(Over partitionBy 'c orderBy 'proctime preceding UNBOUNDED_ROW as 'w)`
Can be simplified as follows:
`.window(Over partitionBy 'c orderBy 'proctime as 'w)`

SQL has already supported such feature.

## Brief change log

  - Add `as` function for `OverWindowWithOrderBy` both for scala and java.
  - Add tests to check result plan.


## Verifying this change

This change added tests and can be verified as follows:

  - Added tests that validate result plan, such as tests in `OverWindowTest` and `OverWindowStringExpressionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
