### PR TITLE
[FLINK-10668][e2e] Streaming File Sink E2E test fails because not all legitimate exceptions are excluded

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -144,6 +144,9 @@ cancel_job "${JOB_ID}"
 
 wait_job_terminal_state "${JOB_ID}" "CANCELED"
 
+# remove logs cause they contain a lot exceptions that shouldn't fail the test
+rm $FLINK_DIR/log/*
+
 # get all lines in part files and sort them numerically
 find "${OUTPUT_PATH}" -type f \( -iname "part-*" \) -exec cat {} + | sort -g > "${TEST_DATA_DIR}/complete_result"
 


### PR DESCRIPTION

## What is the purpose of the change

Streaming File Sink E2E test fails because not all legitimate exceptions are excluded. 
This pr removes logs in `test_streaming_file_sink.sh` when test finished cause `Streaming File Sink E2E test` contains exceptions that shouldn't fail the test. Furthermore, we have already checked the output results in this test.


## Brief change log

  - Removes logs in `test_streaming_file_sink.sh`


## Verifying this change

Run streaming file sink e2e test in local environment. Verify result is passed:
`[PASS] 'test-scripts/test_streaming_file_sink.sh' passed after 2 minutes and 40 seconds! Test exited with exit code 0.`
