### PR TITLE
[FLINK-10693] [Scala API] Fix incorrect duplication in EitherSerializer

### DIFF
--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerConfigSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerConfigSnapshot.java
@@ -27,8 +27,8 @@ import scala.util.Either;
  * Configuration snapshot for serializers of Scala's {@link Either} type,
  * containing configuration snapshots of the Left and Right serializers.
  */
-public class ScalaEitherSerializerConfigSnapshot<E extends Either<L, R>, L, R>
-		extends CompositeTypeSerializerConfigSnapshot<E> {
+public class ScalaEitherSerializerConfigSnapshot<L, R>
+		extends CompositeTypeSerializerConfigSnapshot<Either<L, R>> {
 
 	private static final int VERSION = 1;
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
@@ -32,7 +32,16 @@ class EitherSerializer[A, B](
     val rightSerializer: TypeSerializer[B])
   extends TypeSerializer[Either[A, B]] {
 
-  override def duplicate: EitherSerializer[A,B] = this
+  override def duplicate: EitherSerializer[A,B] = {
+    val leftDup = leftSerializer.duplicate()
+    val rightDup = rightSerializer.duplicate()
+
+    if (leftDup.eq(leftSerializer) && rightDup.eq(rightSerializer)) {
+      this
+    } else {
+      new EitherSerializer[A, B](leftDup, rightDup)
+    }
+  }
 
   override def createInstance: Either[A, B] = {
     Left(null).asInstanceOf[Left[A, B]]

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
@@ -52,18 +52,18 @@ class EitherTypeInfo[A, B, T <: Either[A, B]](
 
   @PublicEvolving
   def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
-    val leftSerializer = if (leftTypeInfo != null) {
+    val leftSerializer: TypeSerializer[A] = if (leftTypeInfo != null) {
       leftTypeInfo.createSerializer(executionConfig)
     } else {
-      new NothingSerializer
+      (new NothingSerializer).asInstanceOf[TypeSerializer[A]]
     }
 
-    val rightSerializer = if (rightTypeInfo != null) {
+    val rightSerializer: TypeSerializer[B] = if (rightTypeInfo != null) {
       rightTypeInfo.createSerializer(executionConfig)
     } else {
-      new NothingSerializer
+      (new NothingSerializer).asInstanceOf[TypeSerializer[B]]
     }
-    new EitherSerializer(leftSerializer, rightSerializer)
+    new EitherSerializer[A, B](leftSerializer, rightSerializer).asInstanceOf[TypeSerializer[T]]
   }
 
   override def equals(obj: Any): Boolean = {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EitherSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EitherSerializerTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeutils.SerializerTestBase
+import org.apache.flink.api.common.typeutils.base.{IntSerializer, StringSerializer}
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
+
+import org.junit.Test
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+
+/**
+  * Test suite for the [[EitherSerializer]]
+  */
+class EitherSerializerTest extends SerializerTestBase[Either[String, Integer]] {
+
+  // --------------------------------------------------------------------------
+  //  test suite
+  // --------------------------------------------------------------------------
+
+  override protected def createSerializer() =
+    new EitherSerializer[String, Integer](
+      StringSerializer.INSTANCE,
+      IntSerializer.INSTANCE)
+
+  override protected def getLength: Int = -1
+
+  override protected def getTypeClass: Class[Either[String, Integer]] =
+    classOf[Either[String, Integer]]
+
+  override protected def getTestData: Array[Either[String, Integer]] =
+    Array[Either[String, Integer]](
+      Left("hello"),
+      Right(17),
+      Right(0),
+      Left("friend"),
+      Right(200),
+      Right(100),
+      Left("foo"),
+      Right(1060876234),
+      Left("bar")
+    )
+
+  // --------------------------------------------------------------------------
+  //  either serializer specific tests
+  // --------------------------------------------------------------------------
+
+  @Test
+  def testDuplication(): Unit = {
+    val serializerSS: EitherSerializer[String, String] =
+      new EitherSerializer[String, String](
+        StringSerializer.INSTANCE,
+        StringSerializer.INSTANCE
+      )
+
+    val serializerSO: EitherSerializer[String, Object] =
+      new EitherSerializer[String, Object](
+        StringSerializer.INSTANCE,
+        new KryoSerializer[Object](classOf[Object], new ExecutionConfig())
+      )
+
+    val serializerOS: EitherSerializer[Object, String] =
+      new EitherSerializer[Object, String](
+        new KryoSerializer[Object](classOf[Object], new ExecutionConfig()),
+        StringSerializer.INSTANCE
+      )
+
+    assertSame(serializerSS, serializerSS.duplicate())
+    assertNotSame(serializerSO, serializerSO.duplicate())
+    assertNotSame(serializerOS, serializerOS.duplicate())
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change / Brief change log

Fixes the duplication of the Scala `EitherSerialzer` that never deep copies, even though the nested serializers might require it.

## Verifying this change

  - Adds a self-contained unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
