### PR TITLE
[FLINK-9635] Fix scheduling for local recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotProfile.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 
 /**
  * A slot profile describes the profile of a slot into which a task wants to be scheduled. The profile contains
@@ -47,16 +48,30 @@ public class SlotProfile {
 
 	/** This contains desired allocation ids of the slot. */
 	@Nonnull
-	private final Collection<AllocationID> priorAllocations;
+	private final Collection<AllocationID> preferredAllocations;
+
+	/** This contains all prior allocation ids from the whole execution graph. */
+	@Nonnull
+	private final Set<AllocationID> previousExecutionGraphAllocations;
 
 	public SlotProfile(
 		@Nonnull ResourceProfile resourceProfile,
 		@Nonnull Collection<TaskManagerLocation> preferredLocations,
-		@Nonnull Collection<AllocationID> priorAllocations) {
+		@Nonnull Collection<AllocationID> preferredAllocations) {
+
+		this(resourceProfile, preferredLocations, preferredAllocations, Collections.emptySet());
+	}
+
+	public SlotProfile(
+		@Nonnull ResourceProfile resourceProfile,
+		@Nonnull Collection<TaskManagerLocation> preferredLocations,
+		@Nonnull Collection<AllocationID> preferredAllocations,
+		@Nonnull Set<AllocationID> previousExecutionGraphAllocations) {
 
 		this.resourceProfile = resourceProfile;
 		this.preferredLocations = preferredLocations;
-		this.priorAllocations = priorAllocations;
+		this.preferredAllocations = preferredAllocations;
+		this.previousExecutionGraphAllocations = previousExecutionGraphAllocations;
 	}
 
 	/**
@@ -79,8 +94,18 @@ public class SlotProfile {
 	 * Returns the desired allocation ids for the slot.
 	 */
 	@Nonnull
-	public Collection<AllocationID> getPriorAllocations() {
-		return priorAllocations;
+	public Collection<AllocationID> getPreferredAllocations() {
+		return preferredAllocations;
+	}
+
+	/**
+	 * Returns a set of all previous allocation ids from the execution graph.
+	 *
+	 * This is optional and can be empty if unused.
+	 */
+	@Nonnull
+	public Set<AllocationID> getPreviousExecutionGraphAllocations() {
+		return previousExecutionGraphAllocations;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -400,6 +400,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @param queued Flag to indicate whether the scheduler may queue this task if it cannot
 	 *               immediately deploy it.
 	 * @param locationPreferenceConstraint constraint for the location preferences
+	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
+	 *                                                 Can be empty if the allocation ids are not required for scheduling.
 	 * @return Future which is completed once the Execution has been deployed
 	 */
 	public CompletableFuture<Void> scheduleForExecution(
@@ -446,6 +448,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @param slotProvider to obtain a new slot from
 	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
+	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
+	 *                                                 Can be empty if the allocation ids are not required for scheduling.
 	 * @param allocationTimeout rpcTimeout for allocating a new slot
 	 * @return Future which is completed with this execution once the slot has been assigned
 	 * 			or with an exception if an error occurred.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
@@ -60,6 +61,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistry;
@@ -91,6 +93,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -902,14 +905,14 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	private CompletableFuture<Void> scheduleLazy(SlotProvider slotProvider) {
 
 		final ArrayList<CompletableFuture<Void>> schedulingFutures = new ArrayList<>(numVerticesTotal);
-
 		// simply take the vertices without inputs.
 		for (ExecutionJobVertex ejv : verticesInCreationOrder) {
 			if (ejv.getJobVertex().isInputVertex()) {
 				final CompletableFuture<Void> schedulingJobVertexFuture = ejv.scheduleAll(
 					slotProvider,
 					allowQueuedScheduling,
-					LocationPreferenceConstraint.ALL); // since it is an input vertex, the input based location preferences should be empty
+					LocationPreferenceConstraint.ALL,// since it is an input vertex, the input based location preferences should be empty
+					Collections.emptySet()); // we provide empty set because we currently don't want to trigger a computation in the batch case
 
 				schedulingFutures.add(schedulingJobVertexFuture);
 			}
@@ -939,6 +942,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		// collecting all the slots may resize and fail in that operation without slots getting lost
 		final ArrayList<CompletableFuture<Execution>> allAllocationFutures = new ArrayList<>(getNumberOfExecutionJobVertices());
 
+		// a (temporary) optimization to avoid collecting the previous allocations for all executions again and again
+		final Set<AllocationID> allPreviousAllocationIds =
+			Collections.unmodifiableSet(computeAllPriorAllocationIdsIfRequiredByScheduling());
+
 		// allocate the slots (obtain all their futures
 		for (ExecutionJobVertex ejv : getVerticesTopologically()) {
 			// these calls are not blocking, they only return futures
@@ -946,6 +953,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				slotProvider,
 				queued,
 				LocationPreferenceConstraint.ALL,
+				allPreviousAllocationIds,
 				timeout);
 
 			allAllocationFutures.addAll(allocationFutures);
@@ -1673,6 +1681,35 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			}
 		} catch (Exception e) {
 			LOG.error("Cannot update accumulators for job {}.", getJobID(), e);
+		}
+	}
+
+	/**
+	 * Computes and returns a set with the prior allocation ids from all execution vertices in the graph.
+	 */
+	private Set<AllocationID> computeAllPriorAllocationIds() {
+		HashSet<AllocationID> allPreviousAllocationIds = new HashSet<>(getNumberOfExecutionJobVertices());
+		for (ExecutionVertex executionVertex : getAllExecutionVertices()) {
+			AllocationID latestPriorAllocation = executionVertex.getLatestPriorAllocation();
+			if (latestPriorAllocation != null) {
+				allPreviousAllocationIds.add(latestPriorAllocation);
+			}
+		}
+		return allPreviousAllocationIds;
+	}
+
+	/**
+	 * Returns the result of {@link #computeAllPriorAllocationIds()}, but only if the scheduling really requires it.
+	 * Otherwise this method simply returns an empty set.
+	 */
+	private Set<AllocationID> computeAllPriorAllocationIdsIfRequiredByScheduling() {
+		// This is a temporary optimization to avoid computing all previous allocations if not required
+		// This can go away when we progress with the implementation of the Scheduler.
+		if (slotProvider instanceof SlotPool.ProviderAndOwner
+			&& ((SlotPool.ProviderAndOwner) slotProvider).requiresPreviousAllocationsForScheduling()) {
+			return computeAllPriorAllocationIds();
+		} else {
+			return Collections.emptySet();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -912,7 +912,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 					slotProvider,
 					allowQueuedScheduling,
 					LocationPreferenceConstraint.ALL,// since it is an input vertex, the input based location preferences should be empty
-					Collections.emptySet()); // we provide empty set because we currently don't want to trigger a computation in the batch case
+					Collections.emptySet());
 
 				schedulingFutures.add(schedulingJobVertexFuture);
 			}
@@ -942,7 +942,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		// collecting all the slots may resize and fail in that operation without slots getting lost
 		final ArrayList<CompletableFuture<Execution>> allAllocationFutures = new ArrayList<>(getNumberOfExecutionJobVertices());
 
-		// a (temporary) optimization to avoid collecting the previous allocations for all executions again and again
 		final Set<AllocationID> allPreviousAllocationIds =
 			Collections.unmodifiableSet(computeAllPriorAllocationIdsIfRequiredByScheduling());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -477,6 +477,8 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	 * @param slotProvider to allocate the slots from
 	 * @param queued if the allocations can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
+	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
+	 *                                                 Can be empty if the allocation ids are not required for scheduling.
 	 * @return Future which is completed once all {@link Execution} could be deployed
 	 */
 	public CompletableFuture<Void> scheduleAll(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
@@ -54,6 +55,7 @@ import org.apache.flink.util.SerializedValue;
 
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -64,6 +66,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -479,7 +482,8 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	public CompletableFuture<Void> scheduleAll(
 			SlotProvider slotProvider,
 			boolean queued,
-			LocationPreferenceConstraint locationPreferenceConstraint) {
+			LocationPreferenceConstraint locationPreferenceConstraint,
+			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds) {
 
 		final ExecutionVertex[] vertices = this.taskVertices;
 
@@ -487,7 +491,11 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 
 		// kick off the tasks
 		for (ExecutionVertex ev : vertices) {
-			scheduleFutures.add(ev.scheduleForExecution(slotProvider, queued, locationPreferenceConstraint));
+			scheduleFutures.add(ev.scheduleForExecution(
+				slotProvider,
+				queued,
+				locationPreferenceConstraint,
+				allPreviousExecutionGraphAllocationIds));
 		}
 
 		return FutureUtils.waitForAll(scheduleFutures);
@@ -503,12 +511,14 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	 * @param resourceProvider The resource provider from whom the slots are requested.
 	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
+	 * @param allPreviousExecutionGraphAllocationIds the allocation ids of all previous executions in the execution job graph.
 	 * @param allocationTimeout timeout for allocating the individual slots
 	 */
 	public Collection<CompletableFuture<Execution>> allocateResourcesForAll(
 			SlotProvider resourceProvider,
 			boolean queued,
 			LocationPreferenceConstraint locationPreferenceConstraint,
+			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds,
 			Time allocationTimeout) {
 		final ExecutionVertex[] vertices = this.taskVertices;
 		final CompletableFuture<Execution>[] slots = new CompletableFuture[vertices.length];
@@ -522,6 +532,7 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 				resourceProvider,
 				queued,
 				locationPreferenceConstraint,
+				allPreviousExecutionGraphAllocationIds,
 				allocationTimeout);
 			slots[i] = allocationFuture;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -618,6 +618,8 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 * @param slotProvider to allocate the slots from
 	 * @param queued if the allocation can be queued
 	 * @param locationPreferenceConstraint constraint for the location preferences
+	 * @param allPreviousExecutionGraphAllocationIds set with all previous allocation ids in the job graph.
+	 *                                                 Can be empty if the allocation ids are not required for scheduling.
 	 * @return Future which is completed once the execution is deployed. The future
 	 * can also completed exceptionally.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -56,6 +56,7 @@ import org.apache.flink.util.SerializedValue;
 
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -623,11 +624,13 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	public CompletableFuture<Void> scheduleForExecution(
 			SlotProvider slotProvider,
 			boolean queued,
-			LocationPreferenceConstraint locationPreferenceConstraint) {
+			LocationPreferenceConstraint locationPreferenceConstraint,
+			@Nonnull Set<AllocationID> allPreviousExecutionGraphAllocationIds) {
 		return this.currentExecution.scheduleForExecution(
 			slotProvider,
 			queued,
-			locationPreferenceConstraint);
+			locationPreferenceConstraint,
+			allPreviousExecutionGraphAllocationIds);
 	}
 
 	@VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.instance;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -61,6 +62,11 @@ public class SimpleSlotContext implements SlotContext {
 	@Override
 	public int getPhysicalSlotNumber() {
 		return physicalSlotNumber;
+	}
+
+	@Override
+	public ResourceProfile getResourceProfile() {
+		return ResourceProfile.UNKNOWN;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
@@ -19,9 +19,8 @@
 package org.apache.flink.runtime.instance;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.Preconditions;
 
@@ -62,11 +61,6 @@ public class SimpleSlotContext implements SlotContext {
 	@Override
 	public int getPhysicalSlotNumber() {
 		return physicalSlotNumber;
-	}
-
-	@Override
-	public ResourceProfile getResourceProfile() {
-		return ResourceProfile.UNKNOWN;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
@@ -18,37 +18,14 @@
 
 package org.apache.flink.runtime.jobmaster;
 
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 /**
  * Interface for the context of a {@link LogicalSlot}. This context contains information
  * about the underlying allocated slot and how to communicate with the TaskManager on which
  * it was allocated.
  */
-public interface SlotContext {
-	/**
-	 * Gets the id under which the slot has been allocated on the TaskManager. This id uniquely identifies the
-	 * physical slot.
-	 *
-	 * @return The id under which the slot has been allocated on the TaskManager
-	 */
-	AllocationID getAllocationId();
-
-	/**
-	 * Gets the location info of the TaskManager that offers this slot.
-	 *
-	 * @return The location info of the TaskManager that offers this slot
-	 */
-	TaskManagerLocation getTaskManagerLocation();
-
-	/**
-	 * Gets the number of the slot.
-	 *
-	 * @return The number of the slot on the TaskManager.
-	 */
-	int getPhysicalSlotNumber();
+public interface SlotContext extends SlotInfo {
 
 	/**
 	 * Gets the actor gateway that can be used to send messages to the TaskManager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.jobmaster;
 
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 
 /**
@@ -36,11 +35,4 @@ public interface SlotContext extends SlotInfo {
 	 * @return The gateway that can be used to send messages to the TaskManager.
 	 */
 	TaskManagerGateway getTaskManagerGateway();
-
-	/**
-	 * Returns the resource profile of the slot.
-	 *
-	 * @return the resource profile of the slot.
-	 */
-	ResourceProfile getResourceProfile();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 
 /**
@@ -35,4 +36,11 @@ public interface SlotContext extends SlotInfo {
 	 * @return The gateway that can be used to send messages to the TaskManager.
 	 */
 	TaskManagerGateway getTaskManagerGateway();
+
+	/**
+	 * Returns the resource profile of the slot.
+	 *
+	 * @return the resource profile of the slot.
+	 */
+	ResourceProfile getResourceProfile();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+/**
+ * Interface that provides basic information in the context of a slot.
+ */
+public interface SlotInfo {
+
+	/**
+	 * Gets the id under which the slot has been allocated on the TaskManager. This id uniquely identifies the
+	 * physical slot.
+	 *
+	 * @return The id under which the slot has been allocated on the TaskManager
+	 */
+	AllocationID getAllocationId();
+
+	/**
+	 * Gets the location info of the TaskManager that offers this slot.
+	 *
+	 * @return The location info of the TaskManager that offers this slot
+	 */
+	TaskManagerLocation getTaskManagerLocation();
+
+	/**
+	 * Gets the number of the slot.
+	 *
+	 * @return The number of the slot on the TaskManager.
+	 */
+	int getPhysicalSlotNumber();
+
+	/**
+	 * Returns the resource profile of the slot.
+	 *
+	 * @return the resource profile of the slot.
+	 */
+	ResourceProfile getResourceProfile();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 /**
@@ -48,11 +47,4 @@ public interface SlotInfo {
 	 * @return The number of the slot on the TaskManager.
 	 */
 	int getPhysicalSlotNumber();
-
-	/**
-	 * Returns the resource profile of the slot.
-	 *
-	 * @return the resource profile of the slot.
-	 */
-	ResourceProfile getResourceProfile();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -113,7 +113,6 @@ class AllocatedSlot implements SlotContext {
 	 *
 	 * @return The resource profile of the slot.
 	 */
-	@Override
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -92,6 +92,7 @@ class AllocatedSlot implements SlotContext {
 	 * 
 	 * @return The ID under which the slot is allocated
 	 */
+	@Override
 	public AllocationID getAllocationId() {
 		return allocationId;
 	}
@@ -112,6 +113,7 @@ class AllocatedSlot implements SlotContext {
 	 *
 	 * @return The resource profile of the slot.
 	 */
+	@Override
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
 	}
@@ -121,6 +123,7 @@ class AllocatedSlot implements SlotContext {
 	 *
 	 * @return The location info of the TaskManager that offers this slot
 	 */
+	@Override
 	public TaskManagerLocation getTaskManagerLocation() {
 		return taskManagerLocation;
 	}
@@ -132,6 +135,7 @@ class AllocatedSlot implements SlotContext {
 	 *
 	 * @return The actor gateway that can be used to send messages to the TaskManager.
 	 */
+	@Override
 	public TaskManagerGateway getTaskManagerGateway() {
 		return taskManagerGateway;
 	}
@@ -142,6 +146,7 @@ class AllocatedSlot implements SlotContext {
 	 *
 	 * @return Physical slot number of the allocated slot
 	 */
+	@Override
 	public int getPhysicalSlotNumber() {
 		return physicalSlotNumber;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSchedulingStrategy.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -54,11 +55,26 @@ public class LocationPreferenceSchedulingStrategy implements SchedulingStrategy 
 	@Override
 	public <IN, OUT> OUT findMatchWithLocality(
 			@Nonnull SlotProfile slotProfile,
-			@Nonnull Stream<IN> candidates,
+			@Nonnull Supplier<Stream<IN>> candidates,
 			@Nonnull Function<IN, SlotInfo> contextExtractor,
 			@Nonnull Predicate<IN> additionalRequirementsFilter,
 			@Nonnull BiFunction<IN, Locality, OUT> resultProducer) {
 
+		return doFindMatchWithLocality(
+			slotProfile,
+			candidates.get(),
+			contextExtractor,
+			additionalRequirementsFilter,
+			resultProducer);
+	}
+
+	@Nullable
+	protected  <IN, OUT> OUT doFindMatchWithLocality(
+		@Nonnull SlotProfile slotProfile,
+		@Nonnull Stream<IN> candidates,
+		@Nonnull Function<IN, SlotInfo> contextExtractor,
+		@Nonnull Predicate<IN> additionalRequirementsFilter,
+		@Nonnull BiFunction<IN, Locality, OUT> resultProducer) {
 		Collection<TaskManagerLocation> locationPreferences = slotProfile.getPreferredLocations();
 
 		// if we have no location preferences, we can only filter by the additional requirements.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSchedulingStrategy.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
-import org.apache.flink.runtime.jobmaster.SlotContext;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import javax.annotation.Nonnull;
@@ -55,7 +55,7 @@ public class LocationPreferenceSchedulingStrategy implements SchedulingStrategy 
 	public <IN, OUT> OUT findMatchWithLocality(
 			@Nonnull SlotProfile slotProfile,
 			@Nonnull Stream<IN> candidates,
-			@Nonnull Function<IN, SlotContext> contextExtractor,
+			@Nonnull Function<IN, SlotInfo> contextExtractor,
 			@Nonnull Predicate<IN> additionalRequirementsFilter,
 			@Nonnull BiFunction<IN, Locality, OUT> resultProducer) {
 
@@ -88,7 +88,7 @@ public class LocationPreferenceSchedulingStrategy implements SchedulingStrategy 
 		while (iterator.hasNext()) {
 			IN candidate = iterator.next();
 			if (additionalRequirementsFilter.test(candidate)) {
-				SlotContext slotContext = contextExtractor.apply(candidate);
+				SlotInfo slotContext = contextExtractor.apply(candidate);
 
 				// this gets candidate is local-weigh
 				Integer localWeigh = preferredResourceIDs.getOrDefault(slotContext.getTaskManagerLocation().getResourceID(), 0);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSchedulingStrategy.java
@@ -27,9 +27,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -48,35 +50,68 @@ public class PreviousAllocationSchedulingStrategy extends LocationPreferenceSche
 	@Override
 	public <IN, OUT> OUT findMatchWithLocality(
 			@Nonnull SlotProfile slotProfile,
-			@Nonnull Stream<IN> candidates,
+			@Nonnull Supplier<Stream<IN>> candidates,
 			@Nonnull Function<IN, SlotInfo> contextExtractor,
 			@Nonnull Predicate<IN> additionalRequirementsFilter,
 			@Nonnull BiFunction<IN, Locality, OUT> resultProducer) {
 
-		Collection<AllocationID> priorAllocations = slotProfile.getPriorAllocations();
+		Collection<AllocationID> priorAllocations = slotProfile.getPreferredAllocations();
 
 		if (priorAllocations.isEmpty()) {
-			return super.findMatchWithLocality(slotProfile, candidates, contextExtractor, additionalRequirementsFilter, resultProducer);
+			return super.findMatchWithLocality(
+				slotProfile,
+				candidates,
+				contextExtractor,
+				additionalRequirementsFilter,
+				resultProducer);
 		} else {
-			return findPreviousAllocation(candidates, contextExtractor, additionalRequirementsFilter, resultProducer, priorAllocations);
+			return findPreviousAllocation(
+				slotProfile,
+				candidates,
+				contextExtractor,
+				additionalRequirementsFilter,
+				resultProducer,
+				priorAllocations);
 		}
 	}
 
 	@Nullable
 	private <IN, OUT> OUT findPreviousAllocation(
-			@Nonnull Stream<IN> candidates,
+			@Nonnull SlotProfile slotProfile,
+			@Nonnull Supplier<Stream<IN>> candidates,
 			@Nonnull Function<IN, SlotInfo> contextExtractor,
 			@Nonnull Predicate<IN> additionalRequirementsFilter,
 			@Nonnull BiFunction<IN, Locality, OUT> resultProducer,
-			Collection<AllocationID> priorAllocations) {
-		Predicate<IN> filterByAllocation =
-			(candidate) -> priorAllocations.contains(contextExtractor.apply(candidate).getAllocationId());
+			@Nonnull Collection<AllocationID> priorAllocations) {
 
-		return candidates
+		Predicate<IN> filterByAllocation =
+			(IN candidate) -> priorAllocations.contains(contextExtractor.apply(candidate).getAllocationId());
+
+		OUT previousAllocationCandidate = candidates
+			.get()
 			.filter(filterByAllocation.and(additionalRequirementsFilter))
 			.findFirst()
-			.map((result) -> resultProducer.apply(result, Locality.LOCAL)) // TODO introduce special locality?
+			.map((IN result) -> resultProducer.apply(result, Locality.LOCAL)) // TODO introduce special locality?
 			.orElse(null);
+
+		if (previousAllocationCandidate != null) {
+			return previousAllocationCandidate;
+		}
+
+		Set<AllocationID> blackListedAllocationIDs = slotProfile.getPreviousExecutionGraphAllocations();
+		Stream<IN> candidateStream = candidates.get();
+		if (!blackListedAllocationIDs.isEmpty()) {
+			candidateStream = candidateStream.filter(
+				(IN candidate) -> !blackListedAllocationIDs.contains(
+					contextExtractor.apply(candidate).getAllocationId()));
+		}
+
+		return doFindMatchWithLocality(
+			slotProfile,
+			candidateStream,
+			contextExtractor,
+			additionalRequirementsFilter,
+			resultProducer);
 	}
 
 	public static PreviousAllocationSchedulingStrategy getInstance() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSchedulingStrategy.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
-import org.apache.flink.runtime.jobmaster.SlotContext;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -49,7 +49,7 @@ public class PreviousAllocationSchedulingStrategy extends LocationPreferenceSche
 	public <IN, OUT> OUT findMatchWithLocality(
 			@Nonnull SlotProfile slotProfile,
 			@Nonnull Stream<IN> candidates,
-			@Nonnull Function<IN, SlotContext> contextExtractor,
+			@Nonnull Function<IN, SlotInfo> contextExtractor,
 			@Nonnull Predicate<IN> additionalRequirementsFilter,
 			@Nonnull BiFunction<IN, Locality, OUT> resultProducer) {
 
@@ -65,7 +65,7 @@ public class PreviousAllocationSchedulingStrategy extends LocationPreferenceSche
 	@Nullable
 	private <IN, OUT> OUT findPreviousAllocation(
 			@Nonnull Stream<IN> candidates,
-			@Nonnull Function<IN, SlotContext> contextExtractor,
+			@Nonnull Function<IN, SlotInfo> contextExtractor,
 			@Nonnull Predicate<IN> additionalRequirementsFilter,
 			@Nonnull BiFunction<IN, Locality, OUT> resultProducer,
 			Collection<AllocationID> priorAllocations) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulingStrategy.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -54,7 +55,7 @@ public interface SchedulingStrategy {
 	@Nullable
 	<IN, OUT> OUT findMatchWithLocality(
 		@Nonnull SlotProfile slotProfile,
-		@Nonnull Stream<IN> candidates,
+		@Nonnull Supplier<Stream<IN>> candidates,
 		@Nonnull Function<IN, SlotInfo> contextExtractor,
 		@Nonnull Predicate<IN> additionalRequirementsFilter,
 		@Nonnull BiFunction<IN, Locality, OUT> resultProducer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulingStrategy.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.SlotContext;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,7 +55,7 @@ public interface SchedulingStrategy {
 	<IN, OUT> OUT findMatchWithLocality(
 		@Nonnull SlotProfile slotProfile,
 		@Nonnull Stream<IN> candidates,
-		@Nonnull Function<IN, SlotContext> contextExtractor,
+		@Nonnull Function<IN, SlotInfo> contextExtractor,
 		@Nonnull Predicate<IN> additionalRequirementsFilter,
 		@Nonnull BiFunction<IN, Locality, OUT> resultProducer);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -767,12 +767,17 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 		Throwable cause) {
 
 		log.debug("Releasing slot [{}] because: {}", slotRequestId, cause != null ? cause.getMessage() : "null");
-		return (slotSharingGroupId != null) ?
-			releaseSharedSlot(slotRequestId, slotSharingGroupId, cause) :
+
+		if (slotSharingGroupId != null) {
+			releaseSharedSlot(slotRequestId, slotSharingGroupId, cause);
+		} else {
 			releaseSingleSlot(slotRequestId, cause);
+		}
+
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
-	private CompletableFuture<Acknowledge> releaseSharedSlot(
+	private void releaseSharedSlot(
 		SlotRequestId slotRequestId,
 		@Nonnull SlotSharingGroupId slotSharingGroupId, Throwable cause) {
 
@@ -789,10 +794,9 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 		} else {
 			log.debug("Could not find slot sharing group {}. Ignoring release slot request.", slotSharingGroupId);
 		}
-		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
-	private CompletableFuture<Acknowledge> releaseSingleSlot(SlotRequestId slotRequestId, Throwable cause) {
+	private void releaseSingleSlot(SlotRequestId slotRequestId, Throwable cause) {
 		final PendingRequest pendingRequest = removePendingRequest(slotRequestId);
 
 		if (pendingRequest != null) {
@@ -807,7 +811,6 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 				log.debug("There is no allocated slot [{}]. Ignoring the release slot request.", slotRequestId);
 			}
 		}
-		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -186,7 +186,7 @@ public class SlotSharingManager {
 		Collection<Set<MultiTaskSlot>> resolvedRootSlotsValues = this.resolvedRootSlots.values();
 		return matcher.findMatchWithLocality(
 			slotProfile,
-			resolvedRootSlotsValues.stream().flatMap(Collection::stream),
+			() -> resolvedRootSlotsValues.stream().flatMap(Collection::stream),
 			(MultiTaskSlot multiTaskSlot) -> multiTaskSlot.getSlotContextFuture().join(),
 			(MultiTaskSlot multiTaskSlot) -> !multiTaskSlot.contains(groupId),
 			MultiTaskSlotLocality::of);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotProfileTest.java
@@ -124,18 +124,31 @@ public class SlotProfileTest extends TestLogger {
 	}
 
 	@Test
-	public void matchPreviousLocationNotAvailable() {
+	public void matchPreviousLocationNotAvailableButByLocality() {
 
 		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml4), Collections.singletonList(aidX));
 		SlotContext match = runMatching(slotProfile);
 
-		Assert.assertEquals(null, match);
+		Assert.assertEquals(ssc4, match);
+	}
+
+	@Test
+	public void matchPreviousLocationNotAvailableAndAllBlacklisted() {
+		HashSet<AllocationID> blacklisted = new HashSet<>(4);
+		blacklisted.add(aid1);
+		blacklisted.add(aid2);
+		blacklisted.add(aid3);
+		blacklisted.add(aid4);
+		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml4), Collections.singletonList(aidX), blacklisted);
+		SlotContext match = runMatching(slotProfile);
+
+		Assert.assertNull(match);
 	}
 
 	private SlotContext runMatching(SlotProfile slotProfile) {
 		return schedulingStrategy.findMatchWithLocality(
 			slotProfile,
-			candidates.stream(),
+			candidates::stream,
 			(candidate) -> candidate,
 			(candidate) -> true,
 			(candidate, locality) -> candidate);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotProfileTest.java
@@ -133,7 +133,7 @@ public class SlotProfileTest extends TestLogger {
 	}
 
 	@Test
-	public void matchPreviousLocationNotAvailableAndAllBlacklisted() {
+	public void matchPreviousLocationNotAvailableAndAllOthersBlacklisted() {
 		HashSet<AllocationID> blacklisted = new HashSet<>(4);
 		blacklisted.add(aid1);
 		blacklisted.add(aid2);
@@ -142,7 +142,35 @@ public class SlotProfileTest extends TestLogger {
 		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml4), Collections.singletonList(aidX), blacklisted);
 		SlotContext match = runMatching(slotProfile);
 
+		// there should be no valid option left and we expect null as return
 		Assert.assertNull(match);
+	}
+
+	@Test
+	public void matchPreviousLocationNotAvailableAndSomeOthersBlacklisted() {
+		HashSet<AllocationID> blacklisted = new HashSet<>(3);
+		blacklisted.add(aid1);
+		blacklisted.add(aid3);
+		blacklisted.add(aid4);
+		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml4), Collections.singletonList(aidX), blacklisted);
+		SlotContext match = runMatching(slotProfile);
+
+		// we expect that the candidate that is not blacklisted is returned
+		Assert.assertEquals(ssc2, match);
+	}
+
+	@Test
+	public void matchPreviousLocationAvailableButAlsoBlacklisted() {
+		HashSet<AllocationID> blacklisted = new HashSet<>(4);
+		blacklisted.add(aid1);
+		blacklisted.add(aid2);
+		blacklisted.add(aid3);
+		blacklisted.add(aid4);
+		SlotProfile slotProfile = new SlotProfile(resourceProfile, Collections.singletonList(tml3), Collections.singletonList(aid3), blacklisted);
+		SlotContext match = runMatching(slotProfile);
+
+		// available previous allocation should override blacklisting
+		Assert.assertEquals(ssc3, match);
 	}
 
 	private SlotContext runMatching(SlotProfile slotProfile) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -107,6 +107,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
+			null,
 			TestingUtils.infiniteTime());
 
 		assertFalse(allocationFuture.isDone());
@@ -156,6 +157,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
+			null,
 			TestingUtils.infiniteTime());
 
 		assertTrue(allocationFuture.isDone());
@@ -205,6 +207,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
+			null,
 			TestingUtils.infiniteTime());
 
 		assertTrue(allocationFuture.isDone());
@@ -254,6 +257,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
+			null,
 			TestingUtils.infiniteTime());
 
 		assertThat(allocationFuture.isDone(), is(false));
@@ -357,7 +361,7 @@ public class ExecutionTest extends TestLogger {
 
 		ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
 
-		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY).get();
+		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, null).get();
 
 		Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
 
@@ -417,7 +421,7 @@ public class ExecutionTest extends TestLogger {
 		assertThat(execution.getTaskRestore(), is(notNullValue()));
 
 		// schedule the execution vertex and wait for its deployment
-		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY).get();
+		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, null).get();
 
 		assertThat(execution.getTaskRestore(), is(nullValue()));
 	}
@@ -479,7 +483,8 @@ public class ExecutionTest extends TestLogger {
 			final CompletableFuture<Void> schedulingFuture = execution.scheduleForExecution(
 				slotProvider,
 				false,
-				LocationPreferenceConstraint.ANY);
+				LocationPreferenceConstraint.ANY,
+				null);
 
 			try {
 				schedulingFuture.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -107,7 +107,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
-			null,
+			Collections.emptySet(),
 			TestingUtils.infiniteTime());
 
 		assertFalse(allocationFuture.isDone());
@@ -157,7 +157,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
-			null,
+			Collections.emptySet(),
 			TestingUtils.infiniteTime());
 
 		assertTrue(allocationFuture.isDone());
@@ -207,7 +207,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
-			null,
+			Collections.emptySet(),
 			TestingUtils.infiniteTime());
 
 		assertTrue(allocationFuture.isDone());
@@ -257,7 +257,7 @@ public class ExecutionTest extends TestLogger {
 			slotProvider,
 			false,
 			LocationPreferenceConstraint.ALL,
-			null,
+			Collections.emptySet(),
 			TestingUtils.infiniteTime());
 
 		assertThat(allocationFuture.isDone(), is(false));
@@ -361,7 +361,7 @@ public class ExecutionTest extends TestLogger {
 
 		ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
 
-		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, null).get();
+		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
 
 		Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
 
@@ -421,7 +421,7 @@ public class ExecutionTest extends TestLogger {
 		assertThat(execution.getTaskRestore(), is(notNullValue()));
 
 		// schedule the execution vertex and wait for its deployment
-		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, null).get();
+		executionVertex.scheduleForExecution(slotProvider, false, LocationPreferenceConstraint.ANY, Collections.emptySet()).get();
 
 		assertThat(execution.getTaskRestore(), is(nullValue()));
 	}
@@ -484,7 +484,7 @@ public class ExecutionTest extends TestLogger {
 				slotProvider,
 				false,
 				LocationPreferenceConstraint.ANY,
-				null);
+				Collections.emptySet());
 
 			try {
 				schedulingFuture.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -454,7 +454,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 			// it can occur as the result of races
 			{
 				Scheduler scheduler = mock(Scheduler.class);
-				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL);
+				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
 
 				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 			}
@@ -493,7 +493,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 				setVertexState(vertex, ExecutionState.CANCELING);
 
 				Scheduler scheduler = mock(Scheduler.class);
-				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL);
+				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
 			}
 			catch (Exception e) {
 				fail("should not throw an exception");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import scala.concurrent.ExecutionContext;
 
@@ -454,7 +455,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 			// it can occur as the result of races
 			{
 				Scheduler scheduler = mock(Scheduler.class);
-				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
+				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, Collections.emptySet());
 
 				assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 			}
@@ -493,7 +494,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 				setVertexState(vertex, ExecutionState.CANCELING);
 
 				Scheduler scheduler = mock(Scheduler.class);
-				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
+				vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, Collections.emptySet());
 			}
 			catch (Exception e) {
 				fail("should not throw an exception");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -71,7 +71,7 @@ public class ExecutionVertexSchedulingTest {
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
-			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL);
+			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
 
 			// will have failed
 			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
@@ -103,7 +103,7 @@ public class ExecutionVertexSchedulingTest {
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
-			vertex.scheduleForExecution(scheduler, true, LocationPreferenceConstraint.ALL);
+			vertex.scheduleForExecution(scheduler, true, LocationPreferenceConstraint.ALL, null);
 
 			// future has not yet a slot
 			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
@@ -138,7 +138,7 @@ public class ExecutionVertexSchedulingTest {
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 
 			// try to deploy to the slot
-			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL);
+			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
 			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 		}
 		catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getExecutionVertex;
@@ -71,7 +72,7 @@ public class ExecutionVertexSchedulingTest {
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
-			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
+			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, Collections.emptySet());
 
 			// will have failed
 			assertEquals(ExecutionState.FAILED, vertex.getExecutionState());
@@ -103,7 +104,7 @@ public class ExecutionVertexSchedulingTest {
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
-			vertex.scheduleForExecution(scheduler, true, LocationPreferenceConstraint.ALL, null);
+			vertex.scheduleForExecution(scheduler, true, LocationPreferenceConstraint.ALL, Collections.emptySet());
 
 			// future has not yet a slot
 			assertEquals(ExecutionState.SCHEDULED, vertex.getExecutionState());
@@ -138,7 +139,7 @@ public class ExecutionVertexSchedulingTest {
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 
 			// try to deploy to the slot
-			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, null);
+			vertex.scheduleForExecution(scheduler, false, LocationPreferenceConstraint.ALL, Collections.emptySet());
 			assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 		}
 		catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -157,7 +158,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 
-		ev21.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, null);
+		ev21.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, Collections.emptySet());
 		ev21.getCurrentExecutionAttempt().fail(new Exception("New fail"));
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
@@ -170,7 +171,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		ev11.getCurrentExecutionAttempt().markFinished();
 		ev21.getCurrentExecutionAttempt().markFinished();
-		ev22.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, null);
+		ev22.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, Collections.emptySet());
 		ev22.getCurrentExecutionAttempt().markFinished();
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -157,7 +157,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 
-		ev21.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL);
+		ev21.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, null);
 		ev21.getCurrentExecutionAttempt().fail(new Exception("New fail"));
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
@@ -170,7 +170,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		ev11.getCurrentExecutionAttempt().markFinished();
 		ev21.getCurrentExecutionAttempt().markFinished();
-		ev22.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL);
+		ev22.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, null);
 		ev22.getCurrentExecutionAttempt().markFinished();
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
@@ -313,6 +314,11 @@ public class SingleLogicalSlotTest extends TestLogger {
 		@Override
 		public int getPhysicalSlotNumber() {
 			return 0;
+		}
+
+		@Override
+		public ResourceProfile getResourceProfile() {
+			return ResourceProfile.UNKNOWN;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
@@ -314,11 +313,6 @@ public class SingleLogicalSlotTest extends TestLogger {
 		@Override
 		public int getPhysicalSlotNumber() {
 			return 0;
-		}
-
-		@Override
-		public ResourceProfile getResourceProfile() {
-			return ResourceProfile.UNKNOWN;
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
@@ -41,7 +41,6 @@ import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -50,6 +49,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.configuration.JobManagerOptions.EXECUTION_FAILOVER_STRATEGY;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -72,13 +72,26 @@ public class SchedulingITCase extends TestLogger {
 
 	/**
 	 * Tests that if local recovery is enabled we won't spread
-	 * out tasks when recovering.
+	 * out tasks when recovering for global failover.
 	 */
 	@Test
-	@Ignore("The test should not pass until FLINK-9635 has been fixed")
-	public void testLocalRecovery() throws Exception {
+	public void testLocalRecoveryFull() throws Exception {
+		testLocalRecoveryInternal("full");
+	}
+
+	/**
+	 * Tests that if local recovery is enabled we won't spread
+	 * out tasks when recovering for regional failover.
+	 */
+	@Test
+	public void testLocalRecoveryRegion() throws Exception {
+		testLocalRecoveryInternal("region");
+	}
+
+	private void testLocalRecoveryInternal(String failoverStrategyValue) throws Exception {
 		final Configuration configuration = new Configuration();
 		configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
+		configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), failoverStrategyValue);
 
 		executeSchedulingTest(configuration);
 	}


### PR DESCRIPTION
## What is the purpose of the change

This change fixes the task spread-out problem in scheduling with local recovery. The solution is based on creating a global set of all previous allocation ids as blacklist to avoid, but all other allocation ids are now free to take again.

## Brief change log

This PR contains a subset of the changes from #6898 and focuses almost purely on the fix of local recovery.

## Verifying this change

Improved `SchedulingITCase` should work now, including previously ignored tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
