### PR TITLE
change accumulator value to be formatted with digit group separator

### DIFF
--- a/flink-runtime-web/web-dashboard/web/partials/jobs/job.plan.node.accumulators.html
+++ b/flink-runtime-web/web-dashboard/web/partials/jobs/job.plan.node.accumulators.html
@@ -33,7 +33,7 @@ limitations under the License.
       <tr ng-repeat="accumulator in accumulators">
         <td width="30%">{{ accumulator.name }}</td>
         <td width="30%">{{ accumulator.type }}</td>
-        <td width="30%">{{ accumulator.value }}</td>
+        <td width="30%">{{ accumulator.value | number | toLocaleString }}</td>
       </tr>
     </tbody>
   </table>
@@ -60,7 +60,7 @@ limitations under the License.
         <tr ng-repeat="accumulator in subtask['user-accumulators']">
           <td width="30%">{{ accumulator.name }}</td>
           <td width="30%">{{ accumulator.type }}</td>
-          <td width="30%">{{ accumulator.value }}</td>
+          <td width="30%">{{ accumulator.value | number | toLocaleString }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request is a small qol change that makes it easier for users to read the values of their accumulator(s).*


## Brief change log

  - *Filter the value of the accumulator with toLocaleString*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) No
  - The serializers: (yes / no / don't know) No
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know) No
  - The S3 file system connector: (yes / no / don't know) No

## Documentation

  - Does this pull request introduce a new feature? (yes / no) No
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
