### PR TITLE
[FLINK-10726] [table] Include flink-table-common in flink-table jar

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -282,6 +282,7 @@ under the License.
 									<include>commons-lang:*</include>
 
 									<!-- flink-table dependencies -->
+									<include>org.apache.flink:flink-table-common</include>
 									<include>commons-codec:*</include>
 									<include>org.apache.commons:commons-lang3</include>
 									<include>org.codehaus.janino:*</include>


### PR DESCRIPTION
## What is the purpose of the change

`flink-table-common` is not included in the `flink-table` jar which leads to failure in the streaming SQL e2e test.


## Brief change log

- Inclusion added


## Verifying this change

Run `./run-single-test.sh ./test-scripts/test_streaming_sql.sh`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
