### PR TITLE
[FLINK-10628][E2E][SSL] Enable mutual REST SSL auth in e2e tests

### DIFF
--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -198,7 +198,7 @@ This example shows how to create a simple keystore / truststore pair. The trusts
 be shared with other applications. In this example, *myhost.company.org / ip:10.0.2.15* is the node (or service) for the Flink master.
 
 {% highlight bash %}
-keytool -genkeypair -alias flink.rest -keystore rest.keystore -dname "CN=myhost.company.org" -ext "SAN=dns:myhost.company.org,ip:10.0.2.15" -storepass rest_keystore_password -keypass rest_key_password -keyalg RSA -keysize 4096
+keytool -genkeypair -alias flink.rest -keystore rest.keystore -dname "CN=myhost.company.org" -ext "SAN=dns:myhost.company.org,ip:10.0.2.15" -storepass rest_keystore_password -keypass rest_key_password -keyalg RSA -keysize 4096 -storetype PKCS12
 
 keytool -exportcert -keystore rest.keystore -alias flink.rest -storepass rest_keystore_password -file flink.cer
 
@@ -219,7 +219,7 @@ security.ssl.rest.key-password: rest_key_password
 Execute the following keytool commands to create a truststore with a self signed CA.
 
 {% highlight bash %}
-keytool -genkeypair -alias ca -keystore ca.keystore -dname "CN=Sample CA" -storepass ca_keystore_password -keypass ca_key_password -keyalg RSA -keysize 4096 -ext "bc=ca:true"
+keytool -genkeypair -alias ca -keystore ca.keystore -dname "CN=Sample CA" -storepass ca_keystore_password -keypass ca_key_password -keyalg RSA -keysize 4096 -ext "bc=ca:true" -storetype PKCS12
 
 keytool -exportcert -keystore ca.keystore -alias ca -storepass ca_keystore_password -file ca.cer
 
@@ -230,7 +230,7 @@ Now create a keystore for the REST endpoint with a certificate signed by the abo
 Let *flink.company.org / ip:10.0.2.15* be the hostname of the Flink master (JobManager).
 
 {% highlight bash %}
-keytool -genkeypair -alias flink.rest -keystore rest.signed.keystore -dname "CN=flink.company.org" -ext "SAN=dns:flink.company.org" -storepass rest_keystore_password -keypass rest_key_password -keyalg RSA -keysize 4096
+keytool -genkeypair -alias flink.rest -keystore rest.signed.keystore -dname "CN=flink.company.org" -ext "SAN=dns:flink.company.org" -storepass rest_keystore_password -keypass rest_key_password -keyalg RSA -keysize 4096 -storetype PKCS12
 
 keytool -certreq -alias flink.rest -keystore rest.signed.keystore -storepass rest_keystore_password -keypass rest_key_password -file rest.csr
 
@@ -252,6 +252,25 @@ security.ssl.rest.key-password: rest_key_password
 security.ssl.rest.truststore-password: ca_truststore_password
 {% endhighlight %}
 
+**Tips to query REST Endpoint with curl utility**
+
+You can convert the keystore into the `PEM` format using `openssl`:
+
+{% highlight bash %}
+openssl pkcs12 -passin pass:rest_keystore_password -in rest.keystore -out rest.pem -nodes
+{% endhighlight %}
+
+Then you can query REST Endpoint with `curl`:
+
+{% highlight bash %}
+curl --cacert rest.pem flink_url
+{% endhighlight %}
+
+If mutual SSL is enabled:
+
+{% highlight bash %}
+curl --cacert rest.pem --cert rest.pem flink_url
+{% endhighlight %}
 
 ## Tips for YARN / Mesos Deployment
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -212,22 +212,19 @@ function start_local_zk {
 function wait_dispatcher_running {
   # wait at most 10 seconds until the dispatcher is up
   local QUERY_URL="${REST_PROTOCOL}://${NODENAME}:8081/taskmanagers"
-  local TIMEOUT=10
-  for i in $(seq 1 ${TIMEOUT}); do
+  for i in {1..10}; do
     # without the || true this would exit our script if the JobManager is not yet up
     QUERY_RESULT=$(curl ${CURL_SSL_ARGS} "$QUERY_URL" 2> /dev/null || true)
 
     # ensure the taskmanagers field is there at all and is not empty
     if [[ ${QUERY_RESULT} =~ \{\"taskmanagers\":\[.+\]\} ]]; then
       echo "Dispatcher REST endpoint is up."
-      return
+      break
     fi
 
     echo "Waiting for dispatcher REST endpoint to come up..."
     sleep 1
   done
-  echo "Dispatcher REST endpoint has not started within a timeout of ${TIMEOUT} sec"
-  exit 1
 }
 
 function start_cluster {
@@ -265,12 +262,10 @@ function start_and_wait_for_tm {
       echo "TaskManager is not yet up."
     else
       echo "TaskManager is up."
-      return
+      break
     fi
     sleep 4
   done
-  echo "TaskManager has not started within a timeout"
-  exit 1
 }
 
 function check_logs_for_errors {
@@ -381,20 +376,17 @@ function wait_for_job_state_transition {
 }
 
 function wait_job_running {
-  local TIMEOUT=10
-  for i in $(seq 1 ${TIMEOUT}); do
+  for i in {1..10}; do
     JOB_LIST_RESULT=$("$FLINK_DIR"/bin/flink list -r | grep "$1")
 
     if [[ "$JOB_LIST_RESULT" == "" ]]; then
       echo "Job ($1) is not yet running."
     else
       echo "Job ($1) is running."
-      return
+      break
     fi
     sleep 1
   done
-  echo "Job ($1) has not started within a timeout of ${TIMEOUT} sec"
-  exit 1
 }
 
 function wait_job_terminal_state {

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -41,12 +41,19 @@ echo "Flink dist directory: $FLINK_DIR"
 
 FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>/\1/p')
 
-USE_SSL=OFF # set via set_conf_ssl(), reset via revert_default_config()
 TEST_ROOT=`pwd -P`
 TEST_INFRA_DIR="$END_TO_END_DIR/test-scripts/"
 cd $TEST_INFRA_DIR
 TEST_INFRA_DIR=`pwd -P`
 cd $TEST_ROOT
+
+NODENAME=`hostname -f`
+
+# REST_PROTOCOL and CURL_SSL_ARGS can be modified in common_ssl.sh if SSL is activated
+# they should be used in curl command to query Flink REST API
+REST_PROTOCOL="http"
+CURL_SSL_ARGS=""
+source "${TEST_INFRA_DIR}/common_ssl.sh"
 
 function print_mem_use_osx {
     declare -a mem_types=("active" "inactive" "wired down")
@@ -87,7 +94,8 @@ function revert_default_config() {
         mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
     fi
 
-    USE_SSL=OFF
+    REST_PROTOCOL="http"
+    CURL_SSL_ARGS=""
 }
 
 function set_conf() {
@@ -170,46 +178,6 @@ function get_node_ip {
     echo ${ip_addr}
 }
 
-function set_conf_ssl {
-
-    # clean up the dir that will be used for SSL certificates and trust stores
-    if [ -e "${TEST_DATA_DIR}/ssl" ]; then
-       echo "File ${TEST_DATA_DIR}/ssl exists. Deleting it..."
-       rm -rf "${TEST_DATA_DIR}/ssl"
-    fi
-    mkdir -p "${TEST_DATA_DIR}/ssl"
-
-    NODENAME=`hostname -f`
-    SANSTRING="dns:${NODENAME}"
-    for NODEIP in $(get_node_ip) ; do
-        SANSTRING="${SANSTRING},ip:${NODEIP}"
-    done
-
-    echo "Using SAN ${SANSTRING}"
-
-    # create certificates
-    keytool -genkeypair -alias ca -keystore "${TEST_DATA_DIR}/ssl/ca.keystore" -dname "CN=Sample CA" -storepass password -keypass password -keyalg RSA -ext bc=ca:true
-    keytool -keystore "${TEST_DATA_DIR}/ssl/ca.keystore" -storepass password -alias ca -exportcert > "${TEST_DATA_DIR}/ssl/ca.cer"
-    keytool -importcert -keystore "${TEST_DATA_DIR}/ssl/ca.truststore" -alias ca -storepass password -noprompt -file "${TEST_DATA_DIR}/ssl/ca.cer"
-
-    keytool -genkeypair -alias node -keystore "${TEST_DATA_DIR}/ssl/node.keystore" -dname "CN=${NODENAME}" -ext SAN=${SANSTRING} -storepass password -keypass password -keyalg RSA
-    keytool -certreq -keystore "${TEST_DATA_DIR}/ssl/node.keystore" -storepass password -alias node -file "${TEST_DATA_DIR}/ssl/node.csr"
-    keytool -gencert -keystore "${TEST_DATA_DIR}/ssl/ca.keystore" -storepass password -alias ca -ext SAN=${SANSTRING} -infile "${TEST_DATA_DIR}/ssl/node.csr" -outfile "${TEST_DATA_DIR}/ssl/node.cer"
-    keytool -importcert -keystore "${TEST_DATA_DIR}/ssl/node.keystore" -storepass password -file "${TEST_DATA_DIR}/ssl/ca.cer" -alias ca -noprompt
-    keytool -importcert -keystore "${TEST_DATA_DIR}/ssl/node.keystore" -storepass password -file "${TEST_DATA_DIR}/ssl/node.cer" -alias node -noprompt
-
-    # adapt config
-    # (here we rely on security.ssl.enabled enabling SSL for all components and internal as well as
-    # external communication channels)
-    set_conf security.ssl.enabled true
-    set_conf security.ssl.keystore ${TEST_DATA_DIR}/ssl/node.keystore
-    set_conf security.ssl.keystore-password password
-    set_conf security.ssl.key-password password
-    set_conf security.ssl.truststore ${TEST_DATA_DIR}/ssl/ca.truststore
-    set_conf security.ssl.truststore-password password
-    USE_SSL=ON
-}
-
 function start_ha_cluster {
     create_ha_config
     start_local_zk
@@ -243,16 +211,11 @@ function start_local_zk {
 
 function wait_dispatcher_running {
   # wait at most 10 seconds until the dispatcher is up
-  local QUERY_URL
-  if [ "x$USE_SSL" = "xON" ]; then
-    QUERY_URL="http://localhost:8081/taskmanagers"
-  else
-    QUERY_URL="https://localhost:8081/taskmanagers"
-  fi
+  local QUERY_URL="${REST_PROTOCOL}://${NODENAME}:8081/taskmanagers"
   local TIMEOUT=10
   for i in $(seq 1 ${TIMEOUT}); do
     # without the || true this would exit our script if the JobManager is not yet up
-    QUERY_RESULT=$(curl "$QUERY_URL" 2> /dev/null || true)
+    QUERY_RESULT=$(curl ${CURL_SSL_ARGS} "$QUERY_URL" 2> /dev/null || true)
 
     # ensure the taskmanagers field is there at all and is not empty
     if [[ ${QUERY_RESULT} =~ \{\"taskmanagers\":\[.+\]\} ]]; then
@@ -282,8 +245,9 @@ function start_taskmanagers {
 }
 
 function start_and_wait_for_tm {
+  local url="${REST_PROTOCOL}://${NODENAME}:8081/taskmanagers"
 
-  tm_query_result=$(curl -s "http://localhost:8081/taskmanagers")
+  tm_query_result=$(curl ${CURL_SSL_ARGS} -s "${url}")
 
   # we assume that the cluster is running
   if ! [[ ${tm_query_result} =~ \{\"taskmanagers\":\[.*\]\} ]]; then
@@ -291,12 +255,12 @@ function start_and_wait_for_tm {
     exit 1
   fi
 
-  running_tms=`curl -s "http://localhost:8081/taskmanagers" | grep -o "id" | wc -l`
+  running_tms=`curl ${CURL_SSL_ARGS} -s "${url}" | grep -o "id" | wc -l`
 
   ${FLINK_DIR}/bin/taskmanager.sh start
 
   for i in {1..10}; do
-    local new_running_tms=`curl -s "http://localhost:8081/taskmanagers" | grep -o "id" | wc -l`
+    local new_running_tms=`curl ${CURL_SSL_ARGS} -s "${url}" | grep -o "id" | wc -l`
     if [ $((new_running_tms-running_tms)) -eq 0 ]; then
       echo "TaskManager is not yet up."
     else
@@ -548,7 +512,7 @@ function get_job_metric {
   local job_id=$1
   local metric_name=$2
 
-  local json=$(curl -s http://localhost:8081/jobs/${job_id}/metrics?get=${metric_name})
+  local json=$(curl ${CURL_SSL_ARGS} -s ${REST_PROTOCOL}://${NODENAME}:8081/jobs/${job_id}/metrics?get=${metric_name})
   local metric_value=$(echo ${json} | sed -n 's/.*"value":"\(.*\)".*/\1/p')
 
   echo ${metric_value}

--- a/flink-end-to-end-tests/test-scripts/common_ssl.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ssl.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# NOTE: already sourced in common.sh
+
+function _set_conf_ssl_helper {
+    local type=$1 # 'internal' or external 'rest'
+    local ssl_dir="${TEST_DATA_DIR}/ssl/${type}"
+    local password="${type}.password"
+
+    if [ "${type}" != "internal" ] && [ "${type}" != "rest" ]; then
+        echo "Unknown type of ssl connectivity: ${type}. It can be either 'internal' or external 'rest'"
+        exit 1
+    fi
+
+    # clean up the dir that will be used for SSL certificates and trust stores
+    if [ -e "${ssl_dir}" ]; then
+       echo "File ${ssl_dir} exists. Deleting it..."
+       rm -rf "${ssl_dir}"
+    fi
+    mkdir -p "${ssl_dir}"
+
+    SANSTRING="dns:${NODENAME}"
+    for NODEIP in $(get_node_ip) ; do
+        SANSTRING="${SANSTRING},ip:${NODEIP}"
+    done
+
+    echo "Using SAN ${SANSTRING}"
+
+    # create certificates
+    keytool -genkeypair -alias ca -keystore "${ssl_dir}/ca.keystore" -dname "CN=Sample CA" -storepass ${password} -keypass ${password} -keyalg RSA -ext bc=ca:true -storetype PKCS12
+    keytool -keystore "${ssl_dir}/ca.keystore" -storepass ${password} -alias ca -exportcert > "${ssl_dir}/ca.cer"
+    keytool -importcert -keystore "${ssl_dir}/ca.truststore" -alias ca -storepass ${password} -noprompt -file "${ssl_dir}/ca.cer"
+
+    keytool -genkeypair -alias node -keystore "${ssl_dir}/node.keystore" -dname "CN=${NODENAME}" -ext SAN=${SANSTRING} -storepass ${password} -keypass ${password} -keyalg RSA -storetype PKCS12
+    keytool -certreq -keystore "${ssl_dir}/node.keystore" -storepass ${password} -alias node -file "${ssl_dir}/node.csr"
+    keytool -gencert -keystore "${ssl_dir}/ca.keystore" -storepass ${password} -alias ca -ext SAN=${SANSTRING} -infile "${ssl_dir}/node.csr" -outfile "${ssl_dir}/node.cer"
+    keytool -importcert -keystore "${ssl_dir}/node.keystore" -storepass ${password} -file "${ssl_dir}/ca.cer" -alias ca -noprompt
+    keytool -importcert -keystore "${ssl_dir}/node.keystore" -storepass ${password} -file "${ssl_dir}/node.cer" -alias node -noprompt
+
+    # keystore is converted into a pem format to use it as node.pem with curl in Flink REST API queries, see also $CURL_SSL_ARGS
+    openssl pkcs12 -passin pass:${password} -in "${ssl_dir}/node.keystore" -out "${ssl_dir}/node.pem" -nodes
+
+    # adapt config
+    # (here we rely on security.ssl.enabled enabling SSL for all components and internal as well as
+    # external communication channels)
+    set_conf security.ssl.${type}.enabled true
+    set_conf security.ssl.${type}.keystore ${ssl_dir}/node.keystore
+    set_conf security.ssl.${type}.keystore-password ${password}
+    set_conf security.ssl.${type}.key-password ${password}
+    set_conf security.ssl.${type}.truststore ${ssl_dir}/ca.truststore
+    set_conf security.ssl.${type}.truststore-password ${password}
+}
+
+function _set_conf_mutual_rest_ssl {
+    local auth="${1:-server}" # only 'server' or 'mutual'
+    local mutual="false"
+    local ssl_dir="${TEST_DATA_DIR}/ssl/rest"
+    if [ "${auth}" == "mutual" ]; then
+        CURL_SSL_ARGS="${CURL_SSL_ARGS} --cert ${ssl_dir}/node.pem"
+        mutual="true";
+    fi
+    echo "Mutual ssl auth: ${mutual}"
+    set_conf security.ssl.rest.authentication-enabled ${mutual}
+}
+
+function set_conf_rest_ssl {
+    local auth="${1:-server}" # only 'server' or 'mutual'
+    local ssl_dir="${TEST_DATA_DIR}/ssl/rest"
+    _set_conf_ssl_helper "rest"
+    _set_conf_mutual_rest_ssl ${auth}
+    REST_PROTOCOL="https"
+    CURL_SSL_ARGS="${CURL_SSL_ARGS} --cacert ${ssl_dir}/node.pem"
+}
+
+function set_conf_ssl {
+    local auth="${1:-server}" # only 'server' or 'mutual'
+    _set_conf_ssl_helper "internal"
+    set_conf_rest_ssl ${auth}
+}

--- a/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
@@ -29,7 +29,7 @@ echo "Run DataSet-Allround-Test Program"
 echo "taskmanager.network.memory.min: 10485760" >> $FLINK_DIR/conf/flink-conf.yaml
 echo "taskmanager.network.memory.max: 10485760" >> $FLINK_DIR/conf/flink-conf.yaml
 
-set_conf_ssl
+set_conf_ssl "server"
 start_cluster
 start_taskmanagers 3
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -22,6 +22,8 @@ OUT_TYPE="${1:-local}" # other type: s3
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_s3.sh
 
+set_conf_ssl "mutual"
+
 OUT=out
 OUTPUT_PATH="$TEST_DATA_DIR/$OUT"
 S3_OUTPUT_PATH="s3://$ARTIFACTS_AWS_BUCKET/$OUT"


### PR DESCRIPTION
## What is the purpose of the change

This PR enables mutual SSL authentication in batch all around and streaming file sink end-to-end tests. It also splits deprecated ssl configs into separate SSL configuration for internal and external REST communication. The curl commands, which query Flink REST API, are fixed with relevant SSL args to check and provide certificates where needed.

## Brief change log

  - separate common_ssl.sh from common.sh
  - switch to storetype PKCS12 because of deprecation messages from keytool about original JKS format, it also simplifies usage of openssl to convert keystore to PEM format
  - fix curls with SSL in common.sh which query external Flink REST API
  - enable mutual SSL authentication in test_batch_allround.sh and test_streaming_file_sink.sh

## Verifying this change

build Flink and run:
FLINK_DIR=./build-target ./flink-end-to-end-tests/run-single-test.sh ./flink-end-to-end-tests/test-scripts/test_batch_allround.sh
FLINK_DIR=./build-target ./flink-end-to-end-tests/run-single-test.sh ./flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
