### PR TITLE
[FLINK-10696][Table API & SQL]Add APIs to ExternalCatalog, CrudExternalCatalog and InMemoryCrudExternalCatalog for views and UDFs

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -108,6 +108,70 @@ case class CatalogAlreadyExistException(
 }
 
 /**
+  * Exception for operation on a nonexistent view
+  *
+  * @param catalog catalog name
+  * @param view view name
+  * @param cause the cause
+  */
+case class ViewNotExistException(
+      catalog: String,
+      view: String,
+      cause: Throwable)
+  extends RuntimeException(s"View $view does not exist.", cause) {
+
+  def this(catalog: String, view: String) = this(catalog, view, null)
+}
+
+/**
+  * Exception for adding an already existent view
+  *
+  * @param catalog catalog name
+  * @param view view name
+  * @param cause the cause
+  */
+case class ViewAlreadyExistException(
+      catalog: String,
+      view: String,
+      cause: Throwable)
+  extends RuntimeException(s"View $view already exists.", cause) {
+
+  def this(catalog: String, view: String) = this(catalog, view, null)
+}
+
+/**
+  * Exception for operation on a nonexistent function
+  *
+  * @param catalog catalog name
+  * @param function function name
+  * @param cause the cause
+  */
+case class FunctionNotExistException(
+      catalog: String,
+      function: String,
+      cause: Throwable)
+  extends RuntimeException(s"Function $function does not exist.", cause) {
+
+  def this(catalog: String, function: String) = this(catalog, function, null)
+}
+
+/**
+  * Exception for adding an already existent function
+  *
+  * @param catalog catalog name
+  * @param function function name
+  * @param cause the cause
+  */
+case class FunctionAlreadyExistException(
+      catalog: String,
+      function: String,
+      cause: Throwable)
+  extends RuntimeException(s"Function $function already exists.", cause) {
+
+  def this(catalog: String, function: String) = this(catalog, function, null)
+}
+
+/**
   * Exception for not finding a [[TableFactory]] for the given properties.
   *
   * @param message message that indicates the current matching step

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
@@ -19,9 +19,11 @@
 package org.apache.flink.table.catalog
 
 import org.apache.flink.table.api._
+import org.apache.flink.table.functions.UserDefinedFunction
 
 /**
-  * The CrudExternalCatalog provides methods to create, drop, and alter (sub-)catalogs or tables.
+  * The CrudExternalCatalog provides methods to create, drop, and alter (sub-)catalogs, tables,
+  * views and UDFs.
   */
 trait CrudExternalCatalog extends ExternalCatalog {
 
@@ -103,4 +105,86 @@ trait CrudExternalCatalog extends ExternalCatalog {
   @throws[CatalogNotExistException]
   def alterSubCatalog(name: String, catalog: ExternalCatalog, ignoreIfNotExists: Boolean): Unit
 
+  /**
+    * Adds a view to this catalog.
+    *
+    * @param viewName      The name of the view to add.
+    * @param view          The view to add.
+    * @param ignoreIfExists Flag to specify behavior if a view with the given name already exists:
+    *                       if set to false, throw an exception,
+    *                       if set to true, nothing happens.
+    * @throws ViewAlreadyExistException thrown if view already exists and ignoreIfExists is false
+    */
+  @throws[ViewAlreadyExistException]
+  def createView(viewName: String, view: String, ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes a view from this catalog.
+    *
+    * @param viewName         Name of the view to delete.
+    * @param ignoreIfNotExists Flag to specify behavior if the view does not exist:
+    *                          if set to false, throw an exception,
+    *                          if set to true, nothing happens.
+    * @throws ViewNotExistException    thrown if the view does not exist in the catalog
+    */
+  @throws[ViewNotExistException]
+  def dropView(viewName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Modifies an existing view of this catalog.
+    *
+    * @param viewName         The name of the view to modify.
+    * @param view             The new view which replaces the existing table.
+    * @param ignoreIfNotExists Flag to specify behavior if the view does not exist:
+    *                          if set to false, throw an exception,
+    *                          if set to true, nothing happens.
+    * @throws ViewNotExistException   thrown if the view does not exist in the catalog
+    */
+  @throws[ViewNotExistException]
+  def alterView(viewName: String, view: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Adds a UDF to this catalog.
+    *
+    * @param functionName      The name of the function to add.
+    * @param function          The function to add.
+    * @param ignoreIfExists Flag to specify behavior if function with the given name already exists:
+    *                       if set to false, throw an exception,
+    *                       if set to true, nothing happens.
+    * @throws FunctionAlreadyExistException thrown if function already exists and ignoreIfExists
+    *                                       is false
+    */
+  @throws[FunctionAlreadyExistException]
+  def createFunction(
+    functionName: String,
+    function: UserDefinedFunction,
+    ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes a UDF from this catalog.
+    *
+    * @param functionName         Name of the function to delete.
+    * @param ignoreIfNotExists Flag to specify behavior if the function does not exist:
+    *                          if set to false, throw an exception,
+    *                          if set to true, nothing happens.
+    * @throws FunctionNotExistException    thrown if the function does not exist in the catalog
+    */
+  @throws[FunctionNotExistException]
+  def dropFunction(functionName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Modifies an existing UDF of this catalog.
+    *
+    * @param functionName         The name of the function to modify.
+    * @param function             The new function which replaces the existing table.
+    * @param ignoreIfNotExists Flag to specify behavior if the function does not exist:
+    *                          if set to false, throw an exception,
+    *                          if set to true, nothing happens.
+    * @throws FunctionNotExistException   thrown if the function does not exist in the catalog
+    */
+  @throws[FunctionNotExistException]
+  def alterFunction(
+    functionName: String,
+    function: UserDefinedFunction,
+    ignoreIfNotExists: Boolean): Unit
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CrudExternalCatalog.scala
@@ -134,7 +134,7 @@ trait CrudExternalCatalog extends ExternalCatalog {
     * Modifies an existing view of this catalog.
     *
     * @param viewName         The name of the view to modify.
-    * @param view             The new view which replaces the existing table.
+    * @param view             The new view which replaces the existing view.
     * @param ignoreIfNotExists Flag to specify behavior if the view does not exist:
     *                          if set to false, throw an exception,
     *                          if set to true, nothing happens.
@@ -176,7 +176,7 @@ trait CrudExternalCatalog extends ExternalCatalog {
     * Modifies an existing UDF of this catalog.
     *
     * @param functionName         The name of the function to modify.
-    * @param function             The new function which replaces the existing table.
+    * @param function             The new function which replaces the existing function.
     * @param ignoreIfNotExists Flag to specify behavior if the function does not exist:
     *                          if set to false, throw an exception,
     *                          if set to true, nothing happens.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -21,13 +21,14 @@ package org.apache.flink.table.catalog
 import java.util.{List => JList}
 
 import org.apache.flink.table.api._
+import org.apache.flink.table.functions.UserDefinedFunction
 
 /**
   * An [[ExternalCatalog]] is the connector between an external database catalog and Flink's
   * Table API.
   *
-  * It provides information about catalogs, databases and tables such as names, schema, statistics,
-  * and access information.
+  * It provides information about catalogs, databases, tables, views, UDFs, such as names, schema,
+  * statistics, and access information.
   */
 trait ExternalCatalog {
 
@@ -63,4 +64,37 @@ trait ExternalCatalog {
     */
   def listSubCatalogs(): JList[String]
 
+  /**
+    * Gets a view's definition, which is a string such as "select xxx from yyy", from this catalog.
+    * This might be an oversimplification, but we should be okay for now. In the future,
+    * we may have a class representation such as ExternalCatalogView.
+    *
+    * @param viewName The view's name
+    * @return The view's definition, which is a string such as "select xxx from yyy".
+    */
+  @throws[ViewNotExistException]
+  def getView(viewName: String): String
+
+  /**
+    * Gets the names of all views registered in this catalog.
+    *
+    * @return The list of names of all registered views.
+    */
+  def listViews(): JList[String]
+
+  /**
+    * Gets a UDF from this catalog.
+    *
+    * @param functionName The function's name
+    * @return The requested UDF
+    */
+  @throws[FunctionNotExistException]
+  def getFunction(functionName: String): UserDefinedFunction
+
+  /**
+    * Gets the names of all UDFs registered in this catalog.
+    *
+    * @return The list of names of all registered UDFs.
+    */
+  def listFunctions(): JList[String]
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently Flink's external catalog have APIs for tables only. However, views and UDFs are also common objects in a catalog.

Adding initial APIs and in-memory implementations for views and UDFs to external catalog. These APIs are  required when we store Flink views and UDFs in an external persistent storage. These APIs will evolve as we make progress in Flink-Hive integration.

## Brief change log

- added initial APIs for views and UDFs in `ExternalCatalog` and `CrudExternalCatalog`
- added in-memory implementations  in `InMemoryCrudExternalCatalog`
- added relevant tests

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests in `InMemoryExternalCatalogTest`

## Does this pull request potentially affect one of the following parts:

none

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (JavaDocs)
