### PR TITLE
[FLINK-9552][iterations] fix not syncing on checkpoint lock before emitting records

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -76,8 +76,10 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 
 			// If timestamps are enabled we make sure to remove cyclic watermark dependencies
 			if (isSerializingTimestamps()) {
-				for (RecordWriterOutput<OUT> output : outputs) {
-					output.emitWatermark(new Watermark(Long.MAX_VALUE));
+				synchronized (getCheckpointLock()) {
+					for (RecordWriterOutput<OUT> output : outputs) {
+						output.emitWatermark(new Watermark(Long.MAX_VALUE));
+					}
 				}
 			}
 
@@ -87,8 +89,10 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 					dataChannel.take();
 
 				if (nextRecord != null) {
-					for (RecordWriterOutput<OUT> output : outputs) {
-						output.collect(nextRecord);
+					synchronized (getCheckpointLock()) {
+						for (RecordWriterOutput<OUT> output : outputs) {
+							output.collect(nextRecord);
+						}
 					}
 				}
 				else {


### PR DESCRIPTION
## What is the purpose of the change

We need to make sure that concurrent access to the `RecordWriter` is protected by a lock or otherwise if multiple threads access a `RecordWriter` instance at the same time, we may get into any type of data corruption which may not be recognised immediately.

It seems that everything but the `StreamIterationHead` was synchronizing on the checkpoint lock and hence we should sync here as well.

## Brief change log

- adapt `StreamIterationHead` to synchronize on the checkpoint lock when emitting records, watermarks, etc.

## Verifying this change

This change is already covered by existing tests, and was tested manually by adding a check that `RecordWriter` interactions hold the checkpoint lock (by default, the `RecordWriter` does not know about this lock).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
