### PR TITLE
[FLINK-10727][network] remove unnecessary synchronization in SingleInputGate#requestPartitions()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -477,26 +477,28 @@ public class SingleInputGate implements InputGate {
 
 	@Override
 	public void requestPartitions() throws IOException, InterruptedException {
+		if (requestedPartitionsFlag) {
+			return;
+		}
+
 		synchronized (requestLock) {
-			if (!requestedPartitionsFlag) {
-				if (isReleased) {
-					throw new IllegalStateException("Already released.");
-				}
-
-				// Sanity checks
-				if (numberOfInputChannels != inputChannels.size()) {
-					throw new IllegalStateException("Bug in input gate setup logic: mismatch between" +
-							"number of total input channels and the currently set number of input " +
-							"channels.");
-				}
-
-				for (InputChannel inputChannel : inputChannels.values()) {
-					inputChannel.requestSubpartition(consumedSubpartitionIndex);
-				}
+			if (isReleased) {
+				throw new IllegalStateException("Already released.");
 			}
 
-			requestedPartitionsFlag = true;
+			// Sanity checks
+			if (numberOfInputChannels != inputChannels.size()) {
+				throw new IllegalStateException("Bug in input gate setup logic: mismatch between" +
+						"number of total input channels and the currently set number of input " +
+						"channels.");
+			}
+
+			for (InputChannel inputChannel : inputChannels.values()) {
+				inputChannel.requestSubpartition(consumedSubpartitionIndex);
+			}
 		}
+
+		requestedPartitionsFlag = true;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

In `SingleInputGate`, for every `getNextBufferOrEvent()`, `requestPartitions()`
is called and this always synchronizes on the `requestLock` before checking the
`requestedPartitionsFlag`.

Since `requestPartitions()` is only called from the same thread (the task thread
getting the record), it is enough to check the `requestedPartitionsFlag` first
before synchronizing for the actual requests (if needed).

`UnionInputGate` already goes the same way in its `requestPartitions()`.

I see these changes in the benchmarks in a local run:

- old:
```
# Run complete. Total time: 00:04:45

Benchmark                                                   (channelsFlushTimeout)   Mode  Cnt      Score     Error   Units
StreamNetworkThroughputBenchmarkExecutor.networkThroughput                 1,100ms  thrpt   30  37084.031 ± 469.149  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput                 100,1ms  thrpt   30  30868.377 ± 599.977  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput                1000,1ms  thrpt   30  19629.520 ± 518.455  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput              1000,100ms  thrpt   30  19934.017 ± 397.357  ops/ms
```

- new:
```
# Run complete. Total time: 00:04:46

Benchmark                                                   (channelsFlushTimeout)   Mode  Cnt      Score     Error   Units
StreamNetworkThroughputBenchmarkExecutor.networkThroughput                 1,100ms  thrpt   30  38703.009 ± 564.847  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput                 100,1ms  thrpt   30  31616.375 ± 444.968  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput                1000,1ms  thrpt   30  20825.225 ± 542.956  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput              1000,100ms  thrpt   30  21585.969 ± 353.394  ops/ms
```

## Brief change log

- adapt `SingleInputGate` to only synchronize on `requestLock` for actual requests

## Verifying this change

This change is already covered by existing tests, such as IT cases for the network stack.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
