### PR TITLE
[FLINK-10631] Set number of slots per TM to 3 for Jepsen tests

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -42,7 +42,7 @@
 (def deb-mesos-package "1.5.0-2.0.2")
 (def deb-marathon-package "1.6.322")
 
-(def taskmanager-slots 1)
+(def taskmanager-slots 3)
 
 (defn flink-configuration
   [test node]
@@ -293,7 +293,6 @@
        "-Djobmanager.rpc.port=6123 "
        "-Dmesos.resourcemanager.tasks.mem=2048 "
        "-Dtaskmanager.heap.mb=2048 "
-       "-Dtaskmanager.numberOfTaskSlots=2 "
        "-Dmesos.resourcemanager.tasks.cpus=1 "
        "-Drest.bind-address=$(hostname -f) "))
 

--- a/flink-jepsen/src/jepsen/flink/mesos.clj
+++ b/flink-jepsen/src/jepsen/flink/mesos.clj
@@ -68,7 +68,8 @@
                         (str "--log_dir=" log-dir)
                         (str "--master=" (zookeeper-uri test zk-namespace))
                         (str "--recovery_timeout=30secs")
-                        (str "--work_dir=" slave-dir)]))
+                        (str "--work_dir=" slave-dir)
+                        (str "--resources='cpus:8'")]))
 
 (defn create-mesos-master-supervised-service!
   [test node]


### PR DESCRIPTION
## What is the purpose of the change

Set the number of slots per `TaskManager` to `3` for the Jepsen tests. This makes sure that we also test the multi slot scenario for which we added support in Flink 1.7.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

- Tested manually by running the Jepsen tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
