### PR TITLE
[FLINK-5697] [kinesis] Add periodic per-shard watermark support

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -232,7 +232,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 
 	/**
 	 * Provide a custom assigner to influence how shards are distributed over subtasks.
-	 * @param shardAssigner
+	 * @param shardAssigner shard assigner
 	 */
 	public void setShardAssigner(KinesisShardAssigner shardAssigner) {
 		this.shardAssigner = checkNotNull(shardAssigner, "function can not be null");
@@ -246,8 +246,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	/**
 	 * Set the assigner that will extract the timestamp from {@link T} and calculate the
 	 * watermark.
-	 *
-	 * @param periodicWatermarkAssigner
+	 * @param periodicWatermarkAssigner periodic watermark assigner
 	 */
 	public void setPeriodicWatermarkAssigner(
 		AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner) {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -90,6 +90,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * ConsumerConfigConstants#SHARD_IDLE_INTERVAL_MILLIS}. By default, shards won't be considered
  * idle and watermark calculation will wait for newer records to arrive from all shards.
  *
+ * <p>Note that re-sharding of the Kinesis stream while an application (that relies on
+ * the Kinesis records for watermarking) is running can lead to incorrect late events.
+ * This depends on how shards are assigned to subtasks and applies regardless of whether watermarks
+ * are generated in the source or a downstream operator.
+ *
  * @param <T> the type of data emitted
  */
 @PublicEvolving

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
@@ -78,6 +79,17 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A custom assigner implementation can be set via {@link #setShardAssigner(KinesisShardAssigner)} to optimize the
  * hash function or use static overrides to limit skew.
  *
+ * <p>In order for the consumer to emit watermarks, a timestamp assigner needs to be set via {@link
+ * #setPeriodicWatermarkAssigner(AssignerWithPeriodicWatermarks)} and the auto watermark emit
+ * interval configured via {@link
+ * org.apache.flink.api.common.ExecutionConfig#setAutoWatermarkInterval(long)}.
+ *
+ * <p>Watermarks can only advance when all shards of a subtask continuously deliver records. To
+ * avoid an inactive or closed shard to block the watermark progress, the idle timeout should be
+ * configured via configuration property {@link
+ * ConsumerConfigConstants#SHARD_IDLE_INTERVAL_MILLIS}. By default, shards won't be considered
+ * idle and watermark calculation will wait for newer records to arrive from all shards.
+ *
  * @param <T> the type of data emitted
  */
 @PublicEvolving
@@ -107,6 +119,8 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	 * The function that determines which subtask a shard should be assigned to.
 	 */
 	private KinesisShardAssigner shardAssigner = KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
+
+	private AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
 
 	// ------------------------------------------------------------------------
 	//  Runtime state
@@ -218,6 +232,22 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	public void setShardAssigner(KinesisShardAssigner shardAssigner) {
 		this.shardAssigner = checkNotNull(shardAssigner, "function can not be null");
 		ClosureCleaner.clean(shardAssigner, true);
+	}
+
+	public AssignerWithPeriodicWatermarks<T> getPeriodicWatermarkAssigner() {
+		return periodicWatermarkAssigner;
+	}
+
+	/**
+	 * Set the assigner that will extract the timestamp from {@link T} and calculate the
+	 * watermark.
+	 *
+	 * @param periodicWatermarkAssigner
+	 */
+	public void setPeriodicWatermarkAssigner(
+		AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner) {
+		this.periodicWatermarkAssigner = periodicWatermarkAssigner;
+		ClosureCleaner.clean(this.periodicWatermarkAssigner, true);
 	}
 
 	// ------------------------------------------------------------------------
@@ -414,7 +444,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 			Properties configProps,
 			KinesisDeserializationSchema<T> deserializationSchema) {
 
-		return new KinesisDataFetcher<>(streams, sourceContext, runtimeContext, configProps, deserializationSchema, shardAssigner);
+		return new KinesisDataFetcher<>(streams, sourceContext, runtimeContext, configProps, deserializationSchema, shardAssigner, periodicWatermarkAssigner);
 	}
 
 	@VisibleForTesting

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -140,6 +140,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The config to turn on adaptive reads from a shard. */
 	public static final String SHARD_USE_ADAPTIVE_READS = "flink.shard.adaptivereads";
 
+	/** The interval after which to consider a shard idle for purposes of watermark generation. */
+	public static final String SHARD_IDLE_INTERVAL_MILLIS = "flink.shard.idle.interval";
 
 	// ------------------------------------------------------------------------
 	//  Default values for consumer configuration
@@ -189,6 +191,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final long DEFAULT_SHARD_DISCOVERY_INTERVAL_MILLIS = 10000L;
 
 	public static final boolean DEFAULT_SHARD_USE_ADAPTIVE_READS = false;
+
+	public static final long DEFAULT_SHARD_IDLE_INTERVAL_MILLIS = -1;
 
 	/**
 	 * To avoid shard iterator expires in {@link ShardConsumer}s, the value for the configured

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -21,7 +21,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.metrics.KinesisConsumerMetricConstants;
@@ -35,7 +38,10 @@ import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
 
 import com.amazonaws.services.kinesis.model.HashKeyRange;
 import com.amazonaws.services.kinesis.model.SequenceNumberRange;
@@ -51,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -182,6 +189,30 @@ public class KinesisDataFetcher<T> {
 
 	private volatile boolean running = true;
 
+	private final AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
+
+	private PeriodicWatermarkEmitter periodicWatermarkEmitter;
+
+	/**
+	 * The watermark related state for each shard consumer. Entries in this map will be created when shards
+	 * are discovered. After recovery, this shard map will be recreated, possibly with different shard index keys,
+	 * since those are transient and not part of checkpointed state.
+	 */
+	private ConcurrentHashMap<Integer, ShardWatermarkState> shardWatermarks = new ConcurrentHashMap<>();
+
+	/**
+	 * The most recent watermark, calculated from the per shard watermarks. The initial value will never be emitted and
+	 * also apply after recovery. The fist watermark that will be emitted is derived from actually consumed records.
+	 * In case of recovery and replay, the watermark will rewind, consistent wth the shard consumer sequence.
+	 */
+	private long lastWatermark = Long.MIN_VALUE;
+
+	/**
+	 * The time span since last consumed record, after which a shard will be considered idle for purpose of watermark
+	 * calculation. A positive value will allow the watermark to progress even when some shards don't receive new records.
+	 */
+	private long shardIdleIntervalMillis = ConsumerConfigConstants.DEFAULT_SHARD_IDLE_INTERVAL_MILLIS;
+
 	/**
 	 * Factory to create Kinesis proxy instances used by a fetcher.
 	 */
@@ -203,7 +234,8 @@ public class KinesisDataFetcher<T> {
 							RuntimeContext runtimeContext,
 							Properties configProps,
 							KinesisDeserializationSchema<T> deserializationSchema,
-							KinesisShardAssigner shardAssigner) {
+							KinesisShardAssigner shardAssigner,
+							AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner) {
 		this(streams,
 			sourceContext,
 			sourceContext.getCheckpointLock(),
@@ -211,6 +243,7 @@ public class KinesisDataFetcher<T> {
 			configProps,
 			deserializationSchema,
 			shardAssigner,
+			periodicWatermarkAssigner,
 			new AtomicReference<>(),
 			new ArrayList<>(),
 			createInitialSubscribedStreamsToLastDiscoveredShardsState(streams),
@@ -225,6 +258,7 @@ public class KinesisDataFetcher<T> {
 								Properties configProps,
 								KinesisDeserializationSchema<T> deserializationSchema,
 								KinesisShardAssigner shardAssigner,
+								AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner,
 								AtomicReference<Throwable> error,
 								List<KinesisStreamShardState> subscribedShardsState,
 								HashMap<String, String> subscribedStreamsToLastDiscoveredShardIds,
@@ -238,6 +272,7 @@ public class KinesisDataFetcher<T> {
 		this.indexOfThisConsumerSubtask = runtimeContext.getIndexOfThisSubtask();
 		this.deserializationSchema = checkNotNull(deserializationSchema);
 		this.shardAssigner = checkNotNull(shardAssigner);
+		this.periodicWatermarkAssigner = periodicWatermarkAssigner;
 		this.kinesisProxyFactory = checkNotNull(kinesisProxyFactory);
 		this.kinesis = kinesisProxyFactory.create(configProps);
 
@@ -337,6 +372,20 @@ public class KinesisDataFetcher<T> {
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
 						registerShardMetrics(consumerMetricGroup, subscribedShardsState.get(seededStateIndex))));
 			}
+		}
+
+        // start periodic watermark emitter, if a watermark assigner was configured
+		if (periodicWatermarkAssigner != null) {
+			long periodicWatermarkIntervalMillis = runtimeContext.getExecutionConfig().getAutoWatermarkInterval();
+			if (periodicWatermarkIntervalMillis > 0) {
+				ProcessingTimeService timerService = ((StreamingRuntimeContext) runtimeContext).getProcessingTimeService();
+				LOG.info("Starting periodic watermark emitter with interval {}", periodicWatermarkIntervalMillis);
+				this.periodicWatermarkEmitter = new PeriodicWatermarkEmitter(timerService, periodicWatermarkIntervalMillis);
+				this.periodicWatermarkEmitter.start();
+			}
+			this.shardIdleIntervalMillis = Long.parseLong(
+				getConsumerConfiguration().getProperty(ConsumerConfigConstants.SHARD_IDLE_INTERVAL_MILLIS,
+					Long.toString(ConsumerConfigConstants.DEFAULT_SHARD_IDLE_INTERVAL_MILLIS)));
 		}
 
 		// ------------------------------------------------------------------------
@@ -546,6 +595,18 @@ public class KinesisDataFetcher<T> {
 	 * @param lastSequenceNumber the last sequence number value to update
 	 */
 	protected void emitRecordAndUpdateState(T record, long recordTimestamp, int shardStateIndex, SequenceNumber lastSequenceNumber) {
+		// track per shard watermarks and emit timestamps extracted from the record,
+		// when a watermark assigner was configured.
+		if (periodicWatermarkAssigner != null) {
+			ShardWatermarkState sws = shardWatermarks.get(shardStateIndex);
+			Preconditions.checkNotNull(
+				sws, "shard watermark state initialized in registerNewSubscribedShardState");
+			recordTimestamp =
+				sws.periodicWatermarkAssigner.extractTimestamp(record, sws.lastRecordTimestamp);
+			sws.lastRecordTimestamp = recordTimestamp;
+			sws.lastUpdated = getCurrentTimeMillis();
+		}
+
 		synchronized (checkpointLock) {
 			if (record != null) {
 				sourceContext.collectWithTimestamp(record, recordTimestamp);
@@ -609,7 +670,119 @@ public class KinesisDataFetcher<T> {
 				this.numberOfActiveShards.incrementAndGet();
 			}
 
-			return subscribedShardsState.size() - 1;
+			int shardStateIndex = subscribedShardsState.size() - 1;
+
+			// track all discovered shards for watermark determination
+			ShardWatermarkState sws = shardWatermarks.get(shardStateIndex);
+			if (sws == null) {
+				sws = new ShardWatermarkState();
+				try {
+					sws.periodicWatermarkAssigner = InstantiationUtil.clone(periodicWatermarkAssigner);
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+				sws.lastUpdated = getCurrentTimeMillis();
+				sws.lastRecordTimestamp = Long.MIN_VALUE;
+				shardWatermarks.put(shardStateIndex, sws);
+			}
+
+			return shardStateIndex;
+		}
+	}
+
+	/**
+	 * Return the current system time. Allow tests to override this to simulate progress for watermark
+	 * logic.
+	 *
+	 * @return
+	 */
+	@VisibleForTesting
+	protected long getCurrentTimeMillis() {
+		return System.currentTimeMillis();
+	}
+
+	/**
+	 * Called periodically to emit a watermark. Checks all shards for the current event time
+	 * watermark, and possibly emits the next watermark.
+	 *
+	 * <p>Shards that have not received an update for a certain interval are considered inactive so as
+	 * to not hold back the watermark indefinitely. When all shards are inactive, the subtask will be
+	 * marked as temporarily idle to not block downstream operators.
+	 */
+	@VisibleForTesting
+	protected void emitWatermark() {
+		LOG.debug(
+			"###evaluating watermark for subtask {} time {}",
+			indexOfThisConsumerSubtask,
+			getCurrentTimeMillis());
+		long potentialWatermark = Long.MAX_VALUE;
+		long idleTime =
+			(shardIdleIntervalMillis > 0)
+				? getCurrentTimeMillis() - shardIdleIntervalMillis
+				: Long.MAX_VALUE;
+
+		for (Map.Entry<Integer, ShardWatermarkState> e : shardWatermarks.entrySet()) {
+			// consider only active shards, or those that would advance the watermark
+			Watermark w = e.getValue().periodicWatermarkAssigner.getCurrentWatermark();
+			if (w != null && (e.getValue().lastUpdated >= idleTime || w.getTimestamp() > lastWatermark)) {
+				potentialWatermark = Math.min(potentialWatermark, w.getTimestamp());
+			}
+		}
+
+		// advance watermark if possible (watermarks can only be ascending)
+		if (potentialWatermark == Long.MAX_VALUE) {
+			if (shardWatermarks.isEmpty() || shardIdleIntervalMillis > 0) {
+				LOG.debug(
+					"###No active shard for subtask {}, marking the source idle.",
+					indexOfThisConsumerSubtask);
+				// no active shard, signal downstream operators to not wait for a watermark
+				sourceContext.markAsTemporarilyIdle();
+			}
+		} else if (potentialWatermark > lastWatermark) {
+			LOG.debug(
+				"###emitting watermark {} from subtask {}",
+				potentialWatermark,
+				indexOfThisConsumerSubtask);
+			sourceContext.emitWatermark(new Watermark(potentialWatermark));
+			lastWatermark = potentialWatermark;
+		}
+	}
+
+	/** Per shard tracking of watermark and last activity. */
+	private static class ShardWatermarkState<T> {
+		private AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
+		private volatile long lastRecordTimestamp;
+		private volatile long lastUpdated;
+	}
+
+	/**
+	 * The periodic watermark emitter. In its given interval, it checks all shards for the current
+	 * event time watermark, and possibly emits the next watermark.
+	 */
+	private class PeriodicWatermarkEmitter implements ProcessingTimeCallback {
+
+		private final ProcessingTimeService timerService;
+		private final long interval;
+
+		// -------------------------------------------------
+
+		PeriodicWatermarkEmitter(ProcessingTimeService timerService, long autoWatermarkInterval) {
+			this.timerService = checkNotNull(timerService);
+			this.interval = autoWatermarkInterval;
+		}
+
+		// -------------------------------------------------
+
+		public void start() {
+			LOG.debug("registering periodic watermark timer with interval {}", interval);
+			timerService.registerTimer(timerService.getCurrentProcessingTime() + interval, this);
+		}
+
+		@Override
+		public void onProcessingTime(long timestamp) {
+			emitWatermark();
+			// schedule the next watermark
+			timerService.registerTimer(timerService.getCurrentProcessingTime() + interval, this);
 		}
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -676,7 +676,7 @@ public class KinesisDataFetcher<T> {
 				try {
 					sws.periodicWatermarkAssigner = InstantiationUtil.clone(periodicWatermarkAssigner);
 				} catch (Exception e) {
-					throw new RuntimeException(e);
+					throw new RuntimeException("Failed to instantiate new WatermarkAssigner", e);
 				}
 				sws.lastUpdated = getCurrentTimeMillis();
 				sws.lastRecordTimestamp = Long.MIN_VALUE;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -691,7 +691,7 @@ public class KinesisDataFetcher<T> {
 	 * Return the current system time. Allow tests to override this to simulate progress for watermark
 	 * logic.
 	 *
-	 * @return
+	 * @return current processing time
 	 */
 	@VisibleForTesting
 	protected long getCurrentTimeMillis() {
@@ -708,10 +708,7 @@ public class KinesisDataFetcher<T> {
 	 */
 	@VisibleForTesting
 	protected void emitWatermark() {
-		LOG.debug(
-			"###evaluating watermark for subtask {} time {}",
-			indexOfThisConsumerSubtask,
-			getCurrentTimeMillis());
+		LOG.debug("Evaluating watermark for subtask {} time {}", indexOfThisConsumerSubtask, getCurrentTimeMillis());
 		long potentialWatermark = Long.MAX_VALUE;
 		long idleTime =
 			(shardIdleIntervalMillis > 0)
@@ -729,15 +726,13 @@ public class KinesisDataFetcher<T> {
 		// advance watermark if possible (watermarks can only be ascending)
 		if (potentialWatermark == Long.MAX_VALUE) {
 			if (shardWatermarks.isEmpty() || shardIdleIntervalMillis > 0) {
-				LOG.debug(
-					"###No active shard for subtask {}, marking the source idle.",
+				LOG.debug("No active shard for subtask {}, marking the source idle.",
 					indexOfThisConsumerSubtask);
 				// no active shard, signal downstream operators to not wait for a watermark
 				sourceContext.markAsTemporarilyIdle();
 			}
 		} else if (potentialWatermark > lastWatermark) {
-			LOG.debug(
-				"###emitting watermark {} from subtask {}",
+			LOG.debug("Emitting watermark {} from subtask {}",
 				potentialWatermark,
 				indexOfThisConsumerSubtask);
 			sourceContext.emitWatermark(new Watermark(potentialWatermark));

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -191,8 +191,6 @@ public class KinesisDataFetcher<T> {
 
 	private final AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner;
 
-	private PeriodicWatermarkEmitter periodicWatermarkEmitter;
-
 	/**
 	 * The watermark related state for each shard consumer. Entries in this map will be created when shards
 	 * are discovered. After recovery, this shard map will be recreated, possibly with different shard index keys,
@@ -380,8 +378,7 @@ public class KinesisDataFetcher<T> {
 			if (periodicWatermarkIntervalMillis > 0) {
 				ProcessingTimeService timerService = ((StreamingRuntimeContext) runtimeContext).getProcessingTimeService();
 				LOG.info("Starting periodic watermark emitter with interval {}", periodicWatermarkIntervalMillis);
-				this.periodicWatermarkEmitter = new PeriodicWatermarkEmitter(timerService, periodicWatermarkIntervalMillis);
-				this.periodicWatermarkEmitter.start();
+				new PeriodicWatermarkEmitter(timerService, periodicWatermarkIntervalMillis).start();
 			}
 			this.shardIdleIntervalMillis = Long.parseLong(
 				getConsumerConfiguration().getProperty(ConsumerConfigConstants.SHARD_IDLE_INTERVAL_MILLIS,

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -761,14 +761,10 @@ public class KinesisDataFetcher<T> {
 		private final ProcessingTimeService timerService;
 		private final long interval;
 
-		// -------------------------------------------------
-
 		PeriodicWatermarkEmitter(ProcessingTimeService timerService, long autoWatermarkInterval) {
 			this.timerService = checkNotNull(timerService);
 			this.interval = autoWatermarkInterval;
 		}
-
-		// -------------------------------------------------
 
 		public void start() {
 			LOG.debug("registering periodic watermark timer with interval {}", interval);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
@@ -418,7 +418,7 @@ public class FlinkKinesisConsumerMigrationTest {
 				HashMap<StreamShardMetadata, SequenceNumber> testStateSnapshot,
 				List<StreamShardHandle> testInitialDiscoveryShards) {
 
-			super(streams, sourceContext, runtimeContext, configProps, deserializationSchema, DEFAULT_SHARD_ASSIGNER);
+			super(streams, sourceContext, runtimeContext, configProps, deserializationSchema, DEFAULT_SHARD_ASSIGNER, null);
 
 			this.testStateSnapshot = testStateSnapshot;
 			this.testInitialDiscoveryShards = testInitialDiscoveryShards;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -286,6 +286,9 @@ public class FlinkKinesisConsumerTest {
 		// mock fetcher
 		// ----------------------------------------------------------------------
 
+		// TODO: to debug the travis build issue
+		System.out.println(java.util.Arrays.asList(KinesisDataFetcher.class.getDeclaredConstructors()));
+
 		KinesisDataFetcher mockedFetcher = Mockito.mock(KinesisDataFetcher.class);
 		List<StreamShardHandle> shards = new ArrayList<>();
 		shards.addAll(fakeRestoredState.keySet());

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -820,7 +820,7 @@ public class FlinkKinesisConsumerTest {
 	private void awaitRecordCount(ConcurrentLinkedQueue<? extends Object> queue, int count) throws Exception {
 		long timeoutMillis = System.currentTimeMillis() + 10_000;
 		while (System.currentTimeMillis() < timeoutMillis && queue.size() < count) {
-			Thread.sleep(100);
+			Thread.sleep(10);
 		}
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
@@ -22,20 +22,25 @@ import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConsta
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.util.Preconditions;
 
 import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.HashKeyRange;
 import com.amazonaws.services.kinesis.model.Record;
+import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -100,6 +105,10 @@ public class FakeKinesisBehavioursFactory {
 			final long millisBehindLatest) {
 		return new SingleShardEmittingAdaptiveNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls,
 				millisBehindLatest);
+	}
+
+	public static KinesisProxyInterface blockingQueueGetRecords(Map<String, List<BlockingQueue<String>>> streamsToShardQueues) {
+		return new BlockingQueueKinesis(streamsToShardQueues);
 	}
 
 	private static class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis extends SingleShardEmittingFixNumOfRecordsKinesis {
@@ -387,4 +396,85 @@ public class FakeKinesisBehavioursFactory {
 			return null;
 		}
 	}
+
+	private static class BlockingQueueKinesis implements KinesisProxyInterface {
+
+		private Map<String, List<StreamShardHandle>> streamsWithListOfShards = new HashMap<>();
+		private Map<String, BlockingQueue<String>> shardIteratorToQueueMap = new HashMap<>();
+
+		private static String getShardIterator(StreamShardHandle shardHandle) {
+			return shardHandle.getStreamName() + "-" + shardHandle.getShard().getShardId();
+		}
+
+		public BlockingQueueKinesis(Map<String, List<BlockingQueue<String>>> streamsToShardCount) {
+			for (Map.Entry<String, List<BlockingQueue<String>>> streamToShardQueues : streamsToShardCount.entrySet()) {
+				String streamName = streamToShardQueues.getKey();
+				int shardCount = streamToShardQueues.getValue().size();
+
+				if (shardCount == 0) {
+					// don't do anything
+				} else {
+					List<StreamShardHandle> shardsOfStream = new ArrayList<>(shardCount);
+					for (int i = 0; i < shardCount; i++) {
+						StreamShardHandle shardHandle = new StreamShardHandle(
+							streamName,
+							new Shard().withShardId(KinesisShardIdGenerator.generateFromShardOrder(i))
+								.withSequenceNumberRange(new SequenceNumberRange().withStartingSequenceNumber("0"))
+								.withHashKeyRange(new HashKeyRange().withStartingHashKey("0").withEndingHashKey("0")));
+						shardsOfStream.add(shardHandle);
+						shardIteratorToQueueMap.put(getShardIterator(shardHandle), streamToShardQueues.getValue().get(i));
+					}
+					streamsWithListOfShards.put(streamName, shardsOfStream);
+				}
+			}
+		}
+
+		@Override
+		public GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds) {
+			GetShardListResult result = new GetShardListResult();
+			for (Map.Entry<String, List<StreamShardHandle>> streamsWithShards : streamsWithListOfShards.entrySet()) {
+				String streamName = streamsWithShards.getKey();
+				for (StreamShardHandle shard : streamsWithShards.getValue()) {
+					if (streamNamesWithLastSeenShardIds.get(streamName) == null) {
+						result.addRetrievedShardToStream(streamName, shard);
+					} else {
+						if (StreamShardHandle.compareShardIds(
+							shard.getShard().getShardId(), streamNamesWithLastSeenShardIds.get(streamName)) > 0) {
+							result.addRetrievedShardToStream(streamName, shard);
+						}
+					}
+				}
+			}
+			return result;
+		}
+
+		@Override
+		public String getShardIterator(StreamShardHandle shard, String shardIteratorType, Object startingMarker) {
+			return getShardIterator(shard);
+		}
+
+		@Override
+		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) {
+			BlockingQueue<String> queue = Preconditions.checkNotNull(this.shardIteratorToQueueMap.get(shardIterator),
+			"no queue for iterator %s", shardIterator);
+			List<Record> records = Collections.emptyList();
+			try {
+				String data = queue.take();
+				Record record = new Record()
+					.withData(
+						ByteBuffer.wrap(String.valueOf(data).getBytes(ConfigConstants.DEFAULT_CHARSET)))
+					.withPartitionKey(UUID.randomUUID().toString())
+					.withApproximateArrivalTimestamp(new Date(System.currentTimeMillis()))
+					.withSequenceNumber(String.valueOf(0));
+				records = Collections.singletonList(record);
+			} catch (InterruptedException e) {
+				shardIterator = null;
+			}
+			return new GetRecordsResult()
+				.withRecords(records)
+				.withMillisBehindLatest(0L)
+				.withNextShardIterator(shardIterator);
+		}
+	}
+
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -69,6 +69,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 			fakeConfiguration,
 			deserializationSchema,
 			DEFAULT_SHARD_ASSIGNER,
+			null,
 			thrownErrorUnderTest,
 			subscribedShardsStateUnderTest,
 			subscribedStreamsToLastDiscoveredShardIdsStateUnderTest,

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ under the License.
 		<avro.version>1.8.2</avro.version>
 		<junit.version>4.12</junit.version>
 		<mockito.version>2.21.0</mockito.version>
-		<powermock.version>2.0.0-beta.5</powermock.version>
+		<powermock.version>2.0.0-RC.1</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<japicmp.skip>false</japicmp.skip>
 		<codebase>new</codebase>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ under the License.
 		<avro.version>1.8.2</avro.version>
 		<junit.version>4.12</junit.version>
 		<mockito.version>2.21.0</mockito.version>
-		<powermock.version>2.0.0-RC.1</powermock.version>
+		<powermock.version>2.0.0-RC.4</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<japicmp.skip>false</japicmp.skip>
 		<codebase>new</codebase>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Adds support for periodic per-shard watermarks to the Kinesis consumer. This functionality is off by default and can be enabled by setting an optional watermark assigner on the consumer. When enabled, the watermarking also optionally supports idle shard detection based on configurable interval of inactivity.

## Brief change log

* Add watermark assigner to consumer
* Modify data fetcher to track watermark state per shard
* Modify emitRecordAndUpdateState to extract timestamp and update watermark
* Timer driven periodic watermark emit

## Verifying this change

This change added tests and can be verified as follows:

Added a unit test and planning to add more test coverage with subsequent work for shared watermark state and emit queue as discussed on ML. This change is ported from Lyft internal codebase that is used in production. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
