### PR TITLE
[FLINK-10455][Kafka Tx] Close transactional producers in case of failure and termination

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartiti
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchemaWrapper;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -647,6 +648,9 @@ public class FlinkKafkaProducer011<IN>
 
 	@Override
 	public void close() throws FlinkKafka011Exception {
+		pendingTransactions().values().forEach(transaction ->
+			IOUtils.closeQuietly(transaction.producer)
+		);
 		final KafkaTransactionState currentTransaction = currentTransaction();
 		if (currentTransaction != null) {
 			// to avoid exceptions on aborting transactions with some pending records
@@ -713,8 +717,11 @@ public class FlinkKafkaProducer011<IN>
 	@Override
 	protected void commit(KafkaTransactionState transaction) {
 		if (transaction.isTransactional()) {
-			transaction.producer.commitTransaction();
-			recycleTransactionalProducer(transaction.producer);
+			try {
+				transaction.producer.commitTransaction();
+			} finally {
+				recycleTransactionalProducer(transaction.producer);
+			}
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -672,8 +672,8 @@ public class FlinkKafkaProducer011<IN>
 		}
 		// make sure we propagate pending errors
 		checkErroneous();
-		pendingTransactions().values().forEach(transaction ->
-			IOUtils.closeQuietly(transaction.producer)
+		pendingTransactions().forEach(transaction ->
+			IOUtils.closeQuietly(transaction.getValue().producer)
 		);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -648,9 +648,6 @@ public class FlinkKafkaProducer011<IN>
 
 	@Override
 	public void close() throws FlinkKafka011Exception {
-		pendingTransactions().values().forEach(transaction ->
-			IOUtils.closeQuietly(transaction.producer)
-		);
 		final KafkaTransactionState currentTransaction = currentTransaction();
 		if (currentTransaction != null) {
 			// to avoid exceptions on aborting transactions with some pending records
@@ -675,6 +672,9 @@ public class FlinkKafkaProducer011<IN>
 		}
 		// make sure we propagate pending errors
 		checkErroneous();
+		pendingTransactions().values().forEach(transaction ->
+			IOUtils.closeQuietly(transaction.producer)
+		);
 	}
 
 	// ------------------- Logic for handling checkpoint flushing -------------------------- //

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -650,9 +650,6 @@ public class FlinkKafkaProducer<IN>
 
 	@Override
 	public void close() throws FlinkKafkaException {
-		pendingTransactions().values().forEach(transaction ->
-			IOUtils.closeQuietly(transaction.producer)
-		);
 		final FlinkKafkaProducer.KafkaTransactionState currentTransaction = currentTransaction();
 		if (currentTransaction != null) {
 			// to avoid exceptions on aborting transactions with some pending records
@@ -677,6 +674,9 @@ public class FlinkKafkaProducer<IN>
 		}
 		// make sure we propagate pending errors
 		checkErroneous();
+		pendingTransactions().values().forEach(transaction ->
+			IOUtils.closeQuietly(transaction.producer)
+		);
 	}
 
 	// ------------------- Logic for handling checkpoint flushing -------------------------- //

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -674,8 +674,8 @@ public class FlinkKafkaProducer<IN>
 		}
 		// make sure we propagate pending errors
 		checkErroneous();
-		pendingTransactions().values().forEach(transaction ->
-			IOUtils.closeQuietly(transaction.producer)
+		pendingTransactions().forEach(transaction ->
+			IOUtils.closeQuietly(transaction.getValue().producer)
 		);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -39,20 +39,24 @@ import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -148,6 +152,13 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 	@Nullable
 	protected TXN currentTransaction() {
 		return currentTransactionHolder == null ? null : currentTransactionHolder.handle;
+	}
+
+	@Nonnull
+	protected Map<Long, TXN> pendingTransactions() {
+		return pendingCommitTransactions.entrySet().stream()
+			.map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), e.getValue().handle))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	// ------ methods that should be implemented in child class to support two phase commit algorithm ------
@@ -257,6 +268,7 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 
 		Iterator<Map.Entry<Long, TransactionHolder<TXN>>> pendingTransactionIterator = pendingCommitTransactions.entrySet().iterator();
 		checkState(pendingTransactionIterator.hasNext(), "checkpoint completed, but no transaction pending");
+		Throwable lastError = null;
 
 		while (pendingTransactionIterator.hasNext()) {
 			Map.Entry<Long, TransactionHolder<TXN>> entry = pendingTransactionIterator.next();
@@ -270,11 +282,19 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 				name(), checkpointId, pendingTransaction, pendingTransactionCheckpointId);
 
 			logWarningIfTimeoutAlmostReached(pendingTransaction);
-			commit(pendingTransaction.handle);
+			try {
+				commit(pendingTransaction.handle);
+			} catch (Throwable t) {
+				lastError = t;
+			}
 
 			LOG.debug("{} - committed checkpoint transaction {}", name(), pendingTransaction);
 
 			pendingTransactionIterator.remove();
+		}
+
+		if (lastError != null) {
+			throw new FlinkRuntimeException("Committing one of transactions failed", lastError);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses the problem of potential leak of resources associated with unclosed Kafka transactional producers in case of commitment failure or task shutdown.

## Brief change log

  - always close producer even if commit fails in TwoPhaseCommitSinkFunction. notifyCheckpointComplete
  - close pending transactions in close method of Kafka Flink function in case of task shutdown
  - continue trying to commit other transactions in TwoPhaseCommitSinkFunction. notifyCheckpointComplete if any of them failed

## Verifying this change

existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
