### PR TITLE
[FLINK-10581][yarn] Increased the threshold for memory verification in YarnConfigurationITCase.testFlinkContainerMemory

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -179,7 +179,12 @@ public class YarnConfigurationITCase extends YarnTestBase {
 
 				final long expectedHeadSize = containeredTaskManagerParameters.taskManagerHeapSizeMB() << 20L;
 
-				assertThat((double) taskManagerInfo.getHardwareDescription().getSizeOfJvmHeap() / (double) expectedHeadSize, is(closeTo(1.0, 0.1)));
+				// We compare here physical memory assigned to a container with the heap memory that we should pass to
+				// jvm as Xmx parameter. Those value might differ significantly due to sytem page size or jvm
+				// implementation therefore we use 15% threshold here.
+				assertThat(
+					(double) taskManagerInfo.getHardwareDescription().getSizeOfJvmHeap() / (double) expectedHeadSize,
+					is(closeTo(1.0, 0.15)));
 			} finally {
 				restClient.shutdown(TIMEOUT);
 				clusterClient.shutdown();


### PR DESCRIPTION
## What is the purpose of the change

Improve YarnConfigurationITCase.testFlinkContainerMemory test stability

## Brief change log

  - Increased memory threshold 
