### PR TITLE
[FLINK-10739][tests] Harden ProcessFailureCancelingITCase.testCancelingOnProcessFailure.

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -272,7 +272,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
 			fatalErrorHandler.rethrowError();
 
-			RpcUtils.terminateRpcService(rpcService, Time.seconds(10L));
+			RpcUtils.terminateRpcService(rpcService, Time.seconds(100L));
 		}
 	}
 


### PR DESCRIPTION
This PR is trivial as it simply increase the timeout of the test from `10`sec to `100` sec.