### PR TITLE
[FLINK-10754] Enable local recovery for Jepsen based tests

### DIFF
--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -57,7 +57,7 @@
    :taskmanager.numberOfTaskSlots      taskmanager-slots
    :yarn.application-attempts          99999
    :slotmanager.taskmanager-timeout    10000
-   :state.backend.local-recovery       "false"
+   :state.backend.local-recovery       "true"
    :taskmanager.registration.timeout   "30 s"})
 
 (defn write-configuration!


### PR DESCRIPTION
## What is the purpose of the change

Enable local recovery for Jepsen based tests.

## Verifying this change

- Manually tested

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
