### PR TITLE
[FLINK-10715] Change reporter log level

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -427,10 +427,10 @@ public class MetricRegistryImpl implements MetricRegistry {
 				reporter.report();
 			} catch (Throwable t) {
 				if (LOG.isDebugEnabled()) {
-					LOG.debug("Error while reporting metrics {}", t.getMessage());
+					LOG.debug("Error while reporting metrics {}", t);
 				}
 				else {
-					LOG.warn("Error while reporting metrics", t);
+					LOG.warn("Error while reporting metrics", t.getMessage());
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -426,7 +426,12 @@ public class MetricRegistryImpl implements MetricRegistry {
 			try {
 				reporter.report();
 			} catch (Throwable t) {
-				LOG.warn("Error while reporting metrics", t);
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("Error while reporting metrics {}", t.getMessage());
+				}
+				else {
+					LOG.warn("Error while reporting metrics", t);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

Metric reporters might periodically fail due to transient errors downstream, therefore they should not pollute the log with the full stack trace (unless debug is enabled)

## Brief change log

  - `MetricRegistryImpl` now logs reports failure without the stack trace. (unless log level is debug)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)