### PR TITLE
[FLINK-10757] [tests] Avoid port conflicts in AbstractTaskManagerProc…

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
@@ -98,6 +99,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		Configuration config = new Configuration();
 		config.setString(AkkaOptions.ASK_TIMEOUT, "100 s");
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
+		config.setInteger(RestOptions.PORT, 0);
 		config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 500L);
 		config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 10000L);
 		config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");


### PR DESCRIPTION
…essFailureRecoveryTest

## What is the purpose of the change

Harden `AbstractTaskManagerProcessFailureRecoveryTest` by avoid port conflicts.

The relative log is https://api.travis-ci.org/v3/job/449439623/log.txt and test fails on

> Caused by: java.net.BindException: Address already in use

thus start the cluster with rest port 0 to avoid possible port conflict.

## Verifying this change

This change is a trivial rework and it itself is a test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)

cc @zentol @tillrohrmann 