### PR TITLE
[FLINK-10743] [runtime] Use 0 processExitCode for ApplicationStatus.CANCELED

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
@@ -32,7 +32,7 @@ public enum ApplicationStatus {
 	FAILED(1443),
 	
 	/** Application was canceled or killed on request */
-	CANCELED(1444),
+	CANCELED(0),
 
 	/** Application status is not known */
 	UNKNOWN(1445);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ApplicationStatusTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ApplicationStatusTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.Test;
+
+public class ApplicationStatusTest {
+
+	private static final int SUCCESS_EXIT_CODE = 0;
+
+	@Test
+	public void succeededStatusMapsToSuccessExitCode() {
+		int exitCode = ApplicationStatus.SUCCEEDED.processExitCode();
+		assertThat(exitCode, is(equalTo(SUCCESS_EXIT_CODE)));
+	}
+
+	@Test
+	public void cancelledStatusMapsToSuccessExitCode() {
+		int exitCode = ApplicationStatus.CANCELED.processExitCode();
+		assertThat(exitCode, is(equalTo(SUCCESS_EXIT_CODE)));
+	}
+
+	@Test
+	public void notSucceededNorCancelledStatusMapsToNonSuccessExitCode() {
+		Iterable<Integer> exitCodes = exitCodes(notSucceededNorCancelledStatus());
+		assertThat(exitCodes, not(contains(SUCCESS_EXIT_CODE)));
+	}
+
+	private static Iterable<Integer> exitCodes(Iterable<ApplicationStatus> statuses) {
+		return StreamSupport.stream(statuses.spliterator(), false)
+			.map(ApplicationStatus::processExitCode)
+			.collect(Collectors.toList());
+	}
+
+	private static Iterable<ApplicationStatus> notSucceededNorCancelledStatus() {
+		return Arrays.stream(ApplicationStatus.values())
+			.filter(ApplicationStatusTest::isNotSucceededNorCancelled)
+			.collect(Collectors.toList());
+	}
+
+	private static boolean isNotSucceededNorCancelled(ApplicationStatus status) {
+		return status != ApplicationStatus.SUCCEEDED && status != ApplicationStatus.CANCELED;
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request changes the process exit code of `ApplicationStatus.CANCELED` to `0`. This handles cancellation as successful termination since it is triggered by a user.

We map the Flink internal `JobStatus` to `ApplicationStatus` and use the attached exit code to terminate the entry point.

## Brief change log

- Change `processExitCode` to `0` of `ApplicationStatus.CANCELED`
- Add test for successful vs. non-successful ApplicationStatus exit codes

## Verifying this change

- You can verify this change by running the `StandaloneJobClusterEntryPoint` in Kubernetes as documented in [flink-container](https://github.com/apache/flink/tree/master/flink-container/kubernetes). Before this change, cancellation leads to immediate restart of the job. With this fix, the job terminates properly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: Potentially **yes**. Other cluster frameworks might still expect the non-zero exit code. The tests don't cover this. Therefore, I'm assuming that it does not effect them.
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable