### PR TITLE
[FLINK-10751] [runtime] Retain checkpoints on suspension

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointProperties.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointProperties.java
@@ -246,7 +246,7 @@ public class CheckpointProperties implements Serializable {
 			true,  // Delete on success
 			true,  // Delete on cancellation
 			true,  // Delete on failure
-			true); // Delete on suspension
+			false); // Retain on suspension
 
 	private static final CheckpointProperties CHECKPOINT_RETAINED_ON_FAILURE = new CheckpointProperties(
 			false,
@@ -255,7 +255,7 @@ public class CheckpointProperties implements Serializable {
 			true,  // Delete on success
 			true,  // Delete on cancellation
 			false, // Retain on failure
-			true); // Delete on suspension
+			false); // Retain on suspension
 
 	private static final CheckpointProperties CHECKPOINT_RETAINED_ON_CANCELLATION = new CheckpointProperties(
 			false,
@@ -265,7 +265,6 @@ public class CheckpointProperties implements Serializable {
 			false,  // Retain on cancellation
 			false,  // Retain on failure
 			false); // Retain on suspension
-
 
 	/**
 	 * Creates the checkpoint properties for a (manually triggered) savepoint.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointPropertiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointPropertiesTest.java
@@ -42,7 +42,7 @@ public class CheckpointPropertiesTest {
 		assertTrue(props.discardOnJobFinished());
 		assertTrue(props.discardOnJobCancelled());
 		assertFalse(props.discardOnJobFailed());
-		assertTrue(props.discardOnJobSuspended());
+		assertFalse(props.discardOnJobSuspended());
 
 		props = CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.RETAIN_ON_CANCELLATION);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
@@ -83,8 +83,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
 
 		store.shutdown(JobStatus.SUSPENDED);
 		assertEquals(0, store.getNumberOfRetainedCheckpoints());
-		assertTrue(checkpoint.isDiscarded());
-		verifyCheckpointDiscarded(taskStates);
+		assertFalse(checkpoint.isDiscarded());
 	}
 	
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Retain checkpoints in case of terminal job status `SUSPENDED`. Note that this does **not actually effect** the retention behavior currently, because we special case this terminal state in `ZooKeeperCompletedCheckpointStore` and don't suspend jobs when running with `StandaloneCompletedCheckpointStore`.

The proposed change is more of a proactive guard to avoid confusion in the future (e.g. if we stop special casing or accidentally use `StandaloneCompletedCheckpointStore` in HA mode).

I'm also OK with closing this PR without merging since it is not clear how the `SUSPENDED` state will evolve in the future. Currently `SUSPENDED` is an "internal" terminal state to which we transition on lost leadership. If we plan to change this in the future (e.g. let users trigger this transition), it might be worthwhile to keep the current behavior.

## Brief change log

- Update `CheckpointProperties` to retain on suspension

## Verifying this change

- This change is already covered by existing HA tests
- The modified `StandaloneCompletedCheckpointStoreTest` was essentially testing behavior of an illegal state


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no (see comments above)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
