### PR TITLE
[FLINK-10763][streaming] Cannot union streams of different types in the union method of DataStream class

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -214,7 +214,7 @@ public class DataStream<T> {
 		unionedTransforms.add(this.transformation);
 
 		for (DataStream<T> newStream : streams) {
-			if (!getType().equals(newStream.getType())) {
+			if (!getType().getTypeClass().equals(newStream.getType().getTypeClass())) {
 				throw new IllegalArgumentException("Cannot union streams of different types: "
 						+ getType() + " and " + newStream.getType());
 			}


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/FLINK-10763

When stream is a Scala case class, the TypeInformation will fall back to GenericType in the process function which result in bad performance when union another DataStream