### PR TITLE
[FLINK-10353][kafka] Support change of transactional semantics in Kaf…

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -689,7 +689,7 @@ public class FlinkKafkaProducer011<IN>
 				if (currentTransaction != null && currentTransaction.producer != null) {
 					return new KafkaTransactionState(currentTransaction.producer);
 				}
-				return new KafkaTransactionState(initProducer(true));
+				return new KafkaTransactionState(initNonTransactionalProducer(true));
 			default:
 				throw new UnsupportedOperationException("Not implemented semantic");
 		}
@@ -712,73 +712,46 @@ public class FlinkKafkaProducer011<IN>
 
 	@Override
 	protected void commit(KafkaTransactionState transaction) {
-		switch (semantic) {
-			case EXACTLY_ONCE:
-				transaction.producer.commitTransaction();
-				recycleTransactionalProducer(transaction.producer);
-				break;
-			case AT_LEAST_ONCE:
-			case NONE:
-				break;
-			default:
-				throw new UnsupportedOperationException("Not implemented semantic");
+		if (transaction.isTransactional()) {
+			transaction.producer.commitTransaction();
+			recycleTransactionalProducer(transaction.producer);
 		}
 	}
 
 	@Override
 	protected void recoverAndCommit(KafkaTransactionState transaction) {
-		switch (semantic) {
-			case EXACTLY_ONCE:
-				try (FlinkKafkaProducer<byte[], byte[]> producer =
-						initTransactionalProducer(transaction.transactionalId, false)) {
-					producer.resumeTransaction(transaction.producerId, transaction.epoch);
-					producer.commitTransaction();
-				}
-				catch (InvalidTxnStateException | ProducerFencedException ex) {
-					// That means we have committed this transaction before.
-					LOG.warn("Encountered error {} while recovering transaction {}. " +
+		if (transaction.isTransactional()) {
+			try (
+				FlinkKafkaProducer<byte[], byte[]> producer =
+					initTransactionalProducer(transaction.transactionalId, false)) {
+				producer.resumeTransaction(transaction.producerId, transaction.epoch);
+				producer.commitTransaction();
+			} catch (InvalidTxnStateException | ProducerFencedException ex) {
+				// That means we have committed this transaction before.
+				LOG.warn("Encountered error {} while recovering transaction {}. " +
 						"Presumably this transaction has been already committed before",
-						ex,
-						transaction);
-				}
-				break;
-			case AT_LEAST_ONCE:
-			case NONE:
-				break;
-			default:
-				throw new UnsupportedOperationException("Not implemented semantic");
+					ex,
+					transaction);
+			}
 		}
 	}
 
 	@Override
 	protected void abort(KafkaTransactionState transaction) {
-		switch (semantic) {
-			case EXACTLY_ONCE:
-				transaction.producer.abortTransaction();
-				recycleTransactionalProducer(transaction.producer);
-				break;
-			case AT_LEAST_ONCE:
-			case NONE:
-				break;
-			default:
-				throw new UnsupportedOperationException("Not implemented semantic");
+		if (transaction.isTransactional()) {
+			transaction.producer.abortTransaction();
+			recycleTransactionalProducer(transaction.producer);
 		}
 	}
 
 	@Override
 	protected void recoverAndAbort(KafkaTransactionState transaction) {
-		switch (semantic) {
-			case EXACTLY_ONCE:
-				try (FlinkKafkaProducer<byte[], byte[]> producer =
-						initTransactionalProducer(transaction.transactionalId, false)) {
-					producer.initTransactions();
-				}
-				break;
-			case AT_LEAST_ONCE:
-			case NONE:
-				break;
-			default:
-				throw new UnsupportedOperationException("Not implemented semantic");
+		if (transaction.isTransactional()) {
+			try (
+				FlinkKafkaProducer<byte[], byte[]> producer =
+					initTransactionalProducer(transaction.transactionalId, false)) {
+				producer.initTransactions();
+			}
 		}
 	}
 
@@ -905,9 +878,7 @@ public class FlinkKafkaProducer011<IN>
 
 	private void resetAvailableTransactionalIdsPool(Collection<String> transactionalIds) {
 		availableTransactionalIds.clear();
-		for (String transactionalId : transactionalIds) {
-			availableTransactionalIds.add(transactionalId);
-		}
+		availableTransactionalIds.addAll(transactionalIds);
 	}
 
 	// ----------------------------------- Utilities --------------------------
@@ -954,6 +925,11 @@ public class FlinkKafkaProducer011<IN>
 
 	private FlinkKafkaProducer<byte[], byte[]> initTransactionalProducer(String transactionalId, boolean registerMetrics) {
 		producerConfig.put("transactional.id", transactionalId);
+		return initProducer(registerMetrics);
+	}
+
+	private FlinkKafkaProducer<byte[], byte[]> initNonTransactionalProducer(boolean registerMetrics) {
+		producerConfig.remove("transactional.id");
 		return initProducer(registerMetrics);
 	}
 
@@ -1075,7 +1051,7 @@ public class FlinkKafkaProducer011<IN>
 		}
 
 		KafkaTransactionState(
-				String transactionalId,
+				@Nullable String transactionalId,
 				long producerId,
 				short epoch,
 				FlinkKafkaProducer<byte[], byte[]> producer) {
@@ -1083,6 +1059,10 @@ public class FlinkKafkaProducer011<IN>
 			this.producerId = producerId;
 			this.epoch = epoch;
 			this.producer = producer;
+		}
+
+		boolean isTransactional() {
+			return transactionalId != null;
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaProducer.java
@@ -210,6 +210,7 @@ public class FlinkKafkaProducer<K, V> implements Producer<K, V> {
 		}
 	}
 
+	@Nullable
 	public String getTransactionalId() {
 		return transactionalId;
 	}

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -155,7 +155,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 				testHarness2.open();
 			}
 
-			assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42), 30_000L);
+			assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42));
 			deleteTestTopic(topic);
 		}
 		catch (Exception ex) {
@@ -203,7 +203,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		testHarness.initializeState(snapshot);
 		testHarness.close();
 
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
 
 		deleteTestTopic(topic);
 	}
@@ -252,7 +252,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 			testHarness2.open();
 		}
 
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
 
 		deleteTestTopic(topic);
 	}
@@ -298,7 +298,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		// - aborted transactions with records 44 and 45
 		// - committed transaction with record 46
 		// - pending transaction with record 47
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 46), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 46));
 
 		testHarness.close();
 		deleteTestTopic(topic);
@@ -347,7 +347,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		//now we should have:
 		// - records 42 and 43 in committed transactions
 		// - aborted transactions with records 44 and 45
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
 		deleteTestTopic(topic);
 	}
 
@@ -399,7 +399,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		// - records 42, 43, 44 and 45 in aborted transactions
 		// - committed transaction with record 46
 		// - pending transaction with record 47
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(46), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(46));
 
 		postScaleDownOperator1.close();
 		// ignore ProducerFencedExceptions, because postScaleDownOperator1 could reuse transactional ids.
@@ -468,8 +468,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 			createProperties(),
 			topic,
 			0,
-			IntStream.range(0, parallelism1 + parallelism2 + parallelism3).boxed().collect(Collectors.toList()),
-			30_000L);
+			IntStream.range(0, parallelism1 + parallelism2 + parallelism3).boxed().collect(Collectors.toList()));
 		deleteTestTopic(topic);
 	}
 
@@ -541,7 +540,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		testHarness.initializeState(checkpoint0); // recover state 0 - producerA recover and commit txn 0
 		testHarness.close();
 
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42));
 
 		deleteTestTopic(topic);
 	}
@@ -572,7 +571,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 	public void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
 		String topic = "testMigrateFromAtLeastOnceToExactlyOnce";
 		testRecoverWithChangeSemantics(topic, AT_LEAST_ONCE, EXACTLY_ONCE);
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45));
 		deleteTestTopic(topic);
 	}
 
@@ -580,7 +579,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 	public void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
 		String topic = "testMigrateFromExactlyOnceToAtLeastOnce";
 		testRecoverWithChangeSemantics(topic, EXACTLY_ONCE, AT_LEAST_ONCE);
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47));
 		deleteTestTopic(topic);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -48,11 +48,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011.Semantic;
+import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011.Semantic.AT_LEAST_ONCE;
+import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011.Semantic.EXACTLY_ONCE;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * IT cases for the {@link FlinkKafkaProducer011}.
@@ -87,7 +89,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 
 	@Test
 	public void resourceCleanUpAtLeastOnce() throws Exception {
-		resourceCleanUp(Semantic.AT_LEAST_ONCE);
+		resourceCleanUp(AT_LEAST_ONCE);
 	}
 
 	/**
@@ -183,7 +185,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		try {
 			testHarness.processElement(44, 4);
 			testHarness.snapshot(2, 5);
-			assertFalse(true);
+			fail();
 		}
 		catch (Exception ex) {
 			// expected
@@ -216,7 +218,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 			topic,
 			integerKeyedSerializationSchema,
 			properties,
-			Semantic.EXACTLY_ONCE);
+			EXACTLY_ONCE);
 
 		OneInputStreamOperatorTestHarness<Integer, Object> testHarness1 = new OneInputStreamOperatorTestHarness<>(
 			new StreamSink<>(kafkaProducer),
@@ -367,7 +369,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 				preScaleDownParallelism,
 				preScaleDownParallelism,
 				subtaskIndex,
-				Semantic.EXACTLY_ONCE);
+				EXACTLY_ONCE);
 
 			preScaleDownOperator.setup();
 			preScaleDownOperator.open();
@@ -382,7 +384,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		// there might not be any close)
 
 		// After previous failure simulate restarting application with smaller parallelism
-		OneInputStreamOperatorTestHarness<Integer, Object> postScaleDownOperator1 = createTestHarness(topic, 1, 1, 0, Semantic.EXACTLY_ONCE);
+		OneInputStreamOperatorTestHarness<Integer, Object> postScaleDownOperator1 = createTestHarness(topic, 1, 1, 0, EXACTLY_ONCE);
 
 		postScaleDownOperator1.setup();
 		postScaleDownOperator1.open();
@@ -483,7 +485,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 
 		for (int subtaskIndex = 0; subtaskIndex < parallelism; subtaskIndex++) {
 			OneInputStreamOperatorTestHarness<Integer, Object> testHarness =
-				createTestHarness(topic, maxParallelism, parallelism, subtaskIndex, Semantic.EXACTLY_ONCE);
+				createTestHarness(topic, maxParallelism, parallelism, subtaskIndex, EXACTLY_ONCE);
 			testHarnesses.add(testHarness);
 
 			testHarness.setup();
@@ -566,6 +568,76 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 		deleteTestTopic(topic);
 	}
 
+	@Test
+	public void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
+		String topic = "testMigrateFromAtLeastOnceToExactlyOnce";
+
+		OperatorSubtaskState producerSnapshot;
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, AT_LEAST_ONCE)) {
+			testHarness.setup();
+			testHarness.open();
+			testHarness.processElement(42, 0);
+			testHarness.snapshot(0, 1);
+			testHarness.processElement(43, 2);
+			testHarness.notifyOfCompletedCheckpoint(0);
+			producerSnapshot = testHarness.snapshot(1, 3);
+			testHarness.processElement(44, 4);
+		}
+
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, EXACTLY_ONCE)) {
+			testHarness.setup();
+			// restore from snapshot, all records until here should be persisted
+			testHarness.initializeState(producerSnapshot);
+			testHarness.open();
+
+			// write and commit more records
+			testHarness.processElement(44, 7);
+			testHarness.snapshot(2, 8);
+			testHarness.processElement(45, 9);
+		}
+
+		//now we should have:
+		// - records 42, 43, 44 in directly flushed writes from at-least-once
+		// - aborted transactions with records 44 and 45
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44), 30_000L);
+		deleteTestTopic(topic);
+	}
+
+	@Test
+	public void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
+		String topic = "testMigrateFromExactlyOnceToAtLeastOnce";
+
+		OperatorSubtaskState producerSnapshot;
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, EXACTLY_ONCE)) {
+			testHarness.setup();
+			testHarness.open();
+			testHarness.processElement(42, 0);
+			testHarness.snapshot(0, 1);
+			testHarness.processElement(43, 2);
+			testHarness.notifyOfCompletedCheckpoint(0);
+			producerSnapshot = testHarness.snapshot(1, 3);
+			testHarness.processElement(44, 4);
+		}
+
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, AT_LEAST_ONCE)) {
+			testHarness.setup();
+			// restore from snapshot
+			testHarness.initializeState(producerSnapshot);
+			testHarness.open();
+
+			// write and commit more records, after potentially lingering transactions
+			testHarness.processElement(44, 7);
+			testHarness.snapshot(2, 8);
+			testHarness.processElement(45, 9);
+		}
+
+		//now we should have:
+		// - records 42 and 43 in committed transactions
+		// - aborted transactions with records 44 and 45
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45), 30_000L);
+		deleteTestTopic(topic);
+	}
+
 	// shut down a Kafka broker
 	private void failBroker(int brokerId) {
 		KafkaServer toShutDown = null;
@@ -604,7 +676,13 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 	}
 
 	private OneInputStreamOperatorTestHarness<Integer, Object> createTestHarness(String topic) throws Exception {
-		return createTestHarness(topic, 1, 1, 0, Semantic.EXACTLY_ONCE);
+		return createTestHarness(topic, Semantic.EXACTLY_ONCE);
+	}
+
+	private OneInputStreamOperatorTestHarness<Integer, Object> createTestHarness(
+		String topic,
+		Semantic semantic) throws Exception {
+		return createTestHarness(topic, 1, 1, 0, semantic);
 	}
 
 	private OneInputStreamOperatorTestHarness<Integer, Object> createTestHarness(

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -329,7 +329,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 		}
 
 		TypeInformationSerializationSchema<Integer> schema = new TypeInformationSerializationSchema<>(BasicTypeInfo.INT_TYPE_INFO, new ExecutionConfig());
-		KeyedSerializationSchema<Integer> keyedSerializationSchema = new KeyedSerializationSchemaWrapper(schema);
+		KeyedSerializationSchema<Integer> keyedSerializationSchema = new KeyedSerializationSchemaWrapper<>(schema);
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.enableCheckpointing(500);

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -241,6 +241,14 @@ public abstract class KafkaTestBase extends TestLogger {
 		fail(String.format("Expected to contain all of: <%s>, but was: <%s>", expectedElements, actualElements));
 	}
 
+	protected void assertExactlyOnceForTopic(
+		Properties properties,
+		String topic,
+		int partition,
+		List<Integer> expectedElements) {
+		assertExactlyOnceForTopic(properties, topic, partition, expectedElements, 30_000L);
+	}
+
 	/**
 	 * We manually handle the timeout instead of using JUnit's timeout to return failure instead of timeout error.
 	 * After timeout we assume that there are missing records and there is a bug, not that the test has run out of time.
@@ -250,7 +258,7 @@ public abstract class KafkaTestBase extends TestLogger {
 			String topic,
 			int partition,
 			List<Integer> expectedElements,
-			long timeoutMillis) throws Exception {
+			long timeoutMillis) {
 
 		long startMillis = System.currentTimeMillis();
 		List<Integer> actualElements = new ArrayList<>();

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -151,7 +151,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 				testHarness2.open();
 			}
 
-			assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42), 30_000L);
+			assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42));
 			deleteTestTopic(topic);
 		}
 		catch (Exception ex) {
@@ -199,7 +199,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		testHarness.initializeState(snapshot);
 		testHarness.close();
 
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
 
 		deleteTestTopic(topic);
 	}
@@ -248,7 +248,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 			testHarness2.open();
 		}
 
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
 
 		deleteTestTopic(topic);
 	}
@@ -294,7 +294,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		// - aborted transactions with records 44 and 45
 		// - committed transaction with record 46
 		// - pending transaction with record 47
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 46), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 46));
 
 		testHarness.close();
 		deleteTestTopic(topic);
@@ -343,7 +343,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		//now we should have:
 		// - records 42 and 43 in committed transactions
 		// - aborted transactions with records 44 and 45
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
 		deleteTestTopic(topic);
 	}
 
@@ -395,7 +395,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		// - records 42, 43, 44 and 45 in aborted transactions
 		// - committed transaction with record 46
 		// - pending transaction with record 47
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(46), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(46));
 
 		postScaleDownOperator1.close();
 		// ignore ProducerFencedExceptions, because postScaleDownOperator1 could reuse transactional ids.
@@ -464,8 +464,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 			createProperties(),
 			topic,
 			0,
-			IntStream.range(0, parallelism1 + parallelism2 + parallelism3).boxed().collect(Collectors.toList()),
-			30_000L);
+			IntStream.range(0, parallelism1 + parallelism2 + parallelism3).boxed().collect(Collectors.toList()));
 		deleteTestTopic(topic);
 	}
 
@@ -537,7 +536,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		testHarness.initializeState(checkpoint0); // recover state 0 - producerA recover and commit txn 0
 		testHarness.close();
 
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42));
 
 		deleteTestTopic(topic);
 	}
@@ -568,7 +567,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	public void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
 		String topic = "testMigrateFromAtLeastOnceToExactlyOnce";
 		testRecoverWithChangeSemantics(topic, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE, FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45));
 		deleteTestTopic(topic);
 	}
 
@@ -576,7 +575,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	public void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
 		String topic = "testMigrateFromExactlyOnceToAtLeastOnce";
 		testRecoverWithChangeSemantics(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47), 30_000L);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47));
 		deleteTestTopic(topic);
 	}
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -49,8 +49,8 @@ import java.util.stream.IntStream;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * IT cases for the {@link FlinkKafkaProducer}.
@@ -163,7 +163,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	}
 
 	@Test
-	public void testFlinkKafkaProducer10FailBeforeNotify() throws Exception {
+	public void testFlinkKafkaProducerFailBeforeNotify() throws Exception {
 		String topic = "flink-kafka-producer-fail-before-notify";
 
 		OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic);
@@ -181,7 +181,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		try {
 			testHarness.processElement(44, 4);
 			testHarness.snapshot(2, 5);
-			assertFalse(true);
+			fail();
 		}
 		catch (Exception ex) {
 			// expected
@@ -205,7 +205,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	}
 
 	@Test
-	public void testFlinkKafkaProducer10FailTransactionCoordinatorBeforeNotify() throws Exception {
+	public void testFlinkKafkaProducerFailTransactionCoordinatorBeforeNotify() throws Exception {
 		String topic = "flink-kafka-producer-fail-transaction-coordinator-before-notify";
 
 		Properties properties = createProperties();
@@ -564,6 +564,78 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		deleteTestTopic(topic);
 	}
 
+	@Test
+	public void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
+		String topic = "testMigrateFromAtLeastOnceToExactlyOnce";
+
+		OperatorSubtaskState producerSnapshot;
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE)) {
+			testHarness.setup();
+			testHarness.open();
+			testHarness.processElement(42, 0);
+			testHarness.snapshot(0, 1);
+			testHarness.processElement(43, 2);
+			testHarness.notifyOfCompletedCheckpoint(0);
+			producerSnapshot = testHarness.snapshot(1, 3);
+			testHarness.processElement(44, 4);
+		}
+
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE)) {
+			testHarness.setup();
+			// restore from snapshot, all records until here should be persisted
+			testHarness.initializeState(producerSnapshot);
+			testHarness.open();
+
+			// write and commit more records
+			testHarness.processElement(44, 7);
+			testHarness.snapshot(2, 8);
+			testHarness.processElement(45, 9);
+		}
+
+		//now we should have:
+		// - records 42, 43, 44 in directly flushed writes from at-least-once
+		// - aborted transactions with records 44 and 45
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44), 30_000L);
+		deleteTestTopic(topic);
+	}
+
+	@Test
+	public void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
+		String topic = "testMigrateFromExactlyOnceToAtLeastOnce";
+
+		OperatorSubtaskState producerSnapshot;
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE)) {
+			testHarness.setup();
+			testHarness.open();
+			testHarness.processElement(42, 0);
+			testHarness.snapshot(0, 1);
+			testHarness.processElement(43, 2);
+			testHarness.notifyOfCompletedCheckpoint(0);
+			producerSnapshot = testHarness.snapshot(1, 3);
+			testHarness.processElement(44, 4);
+		}
+
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE)) {
+			testHarness.setup();
+			// restore from snapshot
+			testHarness.initializeState(producerSnapshot);
+			testHarness.open();
+
+			// write and commit more records, after potentially lingering transactions
+			testHarness.processElement(44, 7);
+			testHarness.snapshot(2, 8);
+			testHarness.processElement(45, 9);
+		}
+
+		//now we should have:
+		// - records 42 and 43 in committed transactions
+		// - aborted transactions with records 44 and 45
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45), 30_000L);
+		deleteTestTopic(topic);
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+
 	// shut down a Kafka broker
 	private void failBroker(int brokerId) {
 		KafkaServer toShutDown = null;
@@ -602,7 +674,13 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	}
 
 	private OneInputStreamOperatorTestHarness<Integer, Object> createTestHarness(String topic) throws Exception {
-		return createTestHarness(topic, 1, 1, 0, FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+		return createTestHarness(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+	}
+
+	private OneInputStreamOperatorTestHarness<Integer, Object> createTestHarness(
+		String topic,
+		FlinkKafkaProducer.Semantic semantic) throws Exception {
+		return createTestHarness(topic, 1, 1, 0, semantic);
 	}
 
 	private OneInputStreamOperatorTestHarness<Integer, Object> createTestHarness(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -567,44 +567,25 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	@Test
 	public void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
 		String topic = "testMigrateFromAtLeastOnceToExactlyOnce";
-
-		OperatorSubtaskState producerSnapshot;
-		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE)) {
-			testHarness.setup();
-			testHarness.open();
-			testHarness.processElement(42, 0);
-			testHarness.snapshot(0, 1);
-			testHarness.processElement(43, 2);
-			testHarness.notifyOfCompletedCheckpoint(0);
-			producerSnapshot = testHarness.snapshot(1, 3);
-			testHarness.processElement(44, 4);
-		}
-
-		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE)) {
-			testHarness.setup();
-			// restore from snapshot, all records until here should be persisted
-			testHarness.initializeState(producerSnapshot);
-			testHarness.open();
-
-			// write and commit more records
-			testHarness.processElement(44, 7);
-			testHarness.snapshot(2, 8);
-			testHarness.processElement(45, 9);
-		}
-
-		//now we should have:
-		// - records 42, 43, 44 in directly flushed writes from at-least-once
-		// - aborted transactions with records 44 and 45
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44), 30_000L);
+		testRecoverWithChangeSemantics(topic, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE, FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45), 30_000L);
 		deleteTestTopic(topic);
 	}
 
 	@Test
 	public void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
 		String topic = "testMigrateFromExactlyOnceToAtLeastOnce";
+		testRecoverWithChangeSemantics(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
+		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47), 30_000L);
+		deleteTestTopic(topic);
+	}
 
+	private void testRecoverWithChangeSemantics(
+		String topic,
+		FlinkKafkaProducer.Semantic fromSemantic,
+		FlinkKafkaProducer.Semantic toSemantic) throws Exception {
 		OperatorSubtaskState producerSnapshot;
-		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.EXACTLY_ONCE)) {
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, fromSemantic)) {
 			testHarness.setup();
 			testHarness.open();
 			testHarness.processElement(42, 0);
@@ -615,23 +596,16 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 			testHarness.processElement(44, 4);
 		}
 
-		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, FlinkKafkaProducer.Semantic.AT_LEAST_ONCE)) {
+		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic, toSemantic)) {
 			testHarness.setup();
-			// restore from snapshot
 			testHarness.initializeState(producerSnapshot);
 			testHarness.open();
-
-			// write and commit more records, after potentially lingering transactions
-			testHarness.processElement(44, 7);
+			testHarness.processElement(45, 7);
 			testHarness.snapshot(2, 8);
-			testHarness.processElement(45, 9);
+			testHarness.processElement(46, 9);
+			testHarness.notifyOfCompletedCheckpoint(2);
+			testHarness.processElement(47, 9);
 		}
-
-		//now we should have:
-		// - records 42 and 43 in committed transactions
-		// - aborted transactions with records 44 and 45
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 44, 45), 30_000L);
-		deleteTestTopic(topic);
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -320,9 +320,9 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 
 		state = context.getOperatorStateStore().getListState(stateDescriptor);
 
+		boolean recoveredUserContext = false;
 		if (context.isRestored()) {
 			LOG.info("{} - restoring state", name());
-
 			for (State<TXN, CONTEXT> operatorState : state.get()) {
 				userContext = operatorState.getContext();
 				List<TransactionHolder<TXN>> recoveredTransactions = operatorState.getPendingCommitTransactions();
@@ -337,11 +337,13 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 
 				if (userContext.isPresent()) {
 					finishRecoveringContext();
+					recoveredUserContext = true;
 				}
 			}
 		}
+
 		// if in restore we didn't get any userContext or we are initializing from scratch
-		if (userContext == null) {
+		if (!recoveredUserContext) {
 			LOG.info("{} - no state to restore", name());
 
 			userContext = initializeUserContext();


### PR DESCRIPTION
…ka Producer with existing state

## What is the purpose of the change

This PR changes `FlinkKafkaProducer` and  `FlinkKafkaProducer011` to support a change of transactional semantics when restoring from existing state, e.g. a savepoint.

## Brief change log

- Introduced `KafkaTransactionState#isTransactional` to distinguish which transactional handling should be applied instead of relying on what is currently configured.

- Call `initializeUserContext` in `TwoPhaseCommitSinkFunction` for all cases that did not recover a user context.

- Consider removing tranactional id from the properties when creating a new producer to deactivate transactional semantics if no longer required.


## Verifying this change

Added `FlinkKafkaProducer(11)ITCase#testMigrateFromAtLeastOnceToExactlyOnce` and `#testMigrateFromAtExactlyOnceToAtLeastOnce`

I wonder if we should also add tests from/to the NONE semantics. The tests are pretty heavy weight for what they are doing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
