### PR TITLE
[FLINK-10768][Table & SQL] Move external catalog related code from TableEnvironment to CatalogManager

### DIFF
--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.ExternalCatalogAlreadyExistException;
+import org.apache.flink.table.api.ExternalCatalogNotExistException;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractTable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The CatalogManager manages all registered {@link ExternalCatalog} instances, and keeps track of all
+ * non-permanent meta objects such as temporary tables and functions.
+ */
+public class CatalogManager {
+	// the catalog to hold all registered and translated tables
+	// we disable caching here to prevent side effects
+	private final CalciteSchema internalSchema = CalciteSchema.createRootSchema(false, false);
+	private final SchemaPlus rootSchema = internalSchema.plus();
+
+	// registered external catalog names -> catalog
+	private final Map<String, ExternalCatalog> externalCatalogs = new HashMap<>();
+
+	private final TableEnvironment tableEnv;
+
+	public CatalogManager(TableEnvironment tableEnvironment) {
+		this.tableEnv = Preconditions.checkNotNull(tableEnvironment);
+	}
+
+	/**
+	 * Gets the rootSchema.
+	 *
+	 * @return The rootSchema
+	 */
+	public SchemaPlus getRootSchema() {
+		return rootSchema;
+	}
+
+	/**
+	 * Gets a schema by path.
+	 *
+	 * @param schemaPath The path of the schema
+	 * @return The SchemaPlus in the path
+	 */
+	public SchemaPlus getSchema(String[] schemaPath) {
+		SchemaPlus schema = rootSchema;
+		for (String schemaName : schemaPath) {
+			schema = schema.getSubSchema(schemaName);
+			if (schema == null) {
+				return schema;
+			}
+		}
+
+		return schema;
+	}
+
+	/**
+	 * Registers an {@link ExternalCatalog} under a unique name in the TableEnvironment's schema.
+	 * All tables registered in the {@link ExternalCatalog} can be accessed.
+	 *
+	 * @param name            The name under which the externalCatalog will be registered
+	 * @param externalCatalog The externalCatalog to register
+	 */
+	public void registerExternalCatalog(String name, ExternalCatalog externalCatalog)
+		throws ExternalCatalogAlreadyExistException {
+		if (rootSchema.getSubSchema(name) != null) {
+			throw new ExternalCatalogAlreadyExistException(name);
+		}
+		externalCatalogs.put(name, externalCatalog);
+		ExternalCatalogSchema.registerCatalog(tableEnv, rootSchema, name, externalCatalog);
+	}
+
+	/**
+	 * Gets a registered {@link ExternalCatalog} by name.
+	 *
+	 * @param name The name to look up the {@link ExternalCatalog}
+	 * @return The {@link ExternalCatalog}
+	 */
+	public ExternalCatalog getRegisteredExternalCatalog(String name)
+		throws ExternalCatalogNotExistException {
+		ExternalCatalog result = externalCatalogs.get(name);
+
+		if (result != null) {
+			return result;
+		} else {
+			throw new ExternalCatalogNotExistException(name);
+		}
+	}
+
+	/**
+	 * Gets the names of all tables registered in this environment.
+	 *
+	 * @return A list of the names of all registered tables.
+	 */
+	public List<String> listTables() {
+		return new ArrayList(rootSchema.getTableNames());
+	}
+
+	/**
+	 * Registers a Calcite {@link AbstractTable} in the TableEnvironment's catalog.
+	 *
+	 * @param name The name under which the table will be registered.
+	 * @param table The table to register in the catalog
+	 * @throws TableException if another table is registered under the provided name.
+	 */
+	public void registerTableInternal(String name, AbstractTable table) throws TableException {
+		if (isRegistered(name)) {
+			throw new TableException(
+				String.format("Table %s already exists. Please, choose a different name.", name));
+		} else {
+			rootSchema.add(name, table);
+		}
+	}
+
+	/**
+	 * Replaces a registered Table with another Table under the same name.
+	 * We use this method to replace a {@link org.apache.flink.table.plan.schema.DataStreamTable}
+	 * with a {@link org.apache.calcite.schema.TranslatableTable}.
+	 *
+	 * @param name Name of the table to replace.
+	 * @param table The table that replaces the previous table.
+	 */
+	public void replaceRegisteredTable(String name, AbstractTable table) throws TableException {
+		if (isRegistered(name)) {
+			rootSchema.add(name, table);
+		} else {
+			throw new TableException(String.format("Table %s is not registered.", name));
+		}
+	}
+
+	/**
+	 * Checks if a table is registered under the given name.
+	 *
+	 * @param name The table name to check.
+	 * @return true, if a table is registered under the name, false otherwise.
+	 */
+	public boolean isRegistered(String name) {
+		return rootSchema.getTableNames().contains(name);
+	}
+
+	/**
+	 * Get a table from either internal or external catalogs.
+	 *
+	 * @param name The name of the table.
+	 * @return The table registered either internally or externally, None otherwise.
+	 */
+	public Optional<Table> getTable(String name) {
+		String[] pathNames = name.split("\\.");
+
+		return getTableFromSchema(rootSchema, new LinkedList<>(Arrays.asList(pathNames)));
+	}
+
+	// recursively fetches a table from a schema.
+	private Optional<Table> getTableFromSchema(SchemaPlus schema, List<String> paths) {
+		Preconditions.checkArgument(paths != null && paths.size() >= 1);
+
+		if (paths.size() == 1) {
+			return Optional.ofNullable(schema.getTable(paths.get(0)));
+		} else {
+			Optional<SchemaPlus> subschema = Optional.ofNullable(schema.getSubSchema(paths.remove(0)));
+
+			if (subschema.isPresent()) {
+				return getTableFromSchema(subschema.get(), paths);
+			} else {
+				return Optional.empty();
+			}
+		}
+	}
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -125,8 +125,12 @@ abstract class StreamTableEnvironment(
                 s"environment. But is: ${execEnv.getStreamTimeCharacteristic}")
         }
 
+        // Have to do like this because Scala 2.11 doesn't support conversion of Java Optional
+        // to Scala option
+        var opt = catalogManager.getTable(name)
+        var table = if (opt.isPresent) Some(opt.get()) else None
         // register
-        getTable(name) match {
+        table match {
 
           // check if a table (source or sink) is registered
           case Some(table: TableSourceSinkTable[_, _]) => table.tableSourceTable match {
@@ -141,7 +145,7 @@ abstract class StreamTableEnvironment(
               val enrichedTable = new TableSourceSinkTable(
                 Some(new StreamTableSourceTable(streamTableSource)),
                 table.tableSinkTable)
-              replaceRegisteredTable(name, enrichedTable)
+              catalogManager.replaceRegisteredTable(name, enrichedTable)
           }
 
           // no table is registered
@@ -149,7 +153,7 @@ abstract class StreamTableEnvironment(
             val newTable = new TableSourceSinkTable(
               Some(new StreamTableSourceTable(streamTableSource)),
               None)
-            registerTableInternal(name, newTable)
+            catalogManager.registerTableInternal(name, newTable)
         }
 
       // not a stream table source
@@ -272,8 +276,12 @@ abstract class StreamTableEnvironment(
       // check for proper batch table sink
       case _: StreamTableSink[_] =>
 
-        // check if a table (source or sink) is registered
-        getTable(name) match {
+        // Have to do like this because Scala 2.11 doesn't support conversion of Java Optional
+        // to Scala option
+        var opt = catalogManager.getTable(name)
+        var table = if (opt.isPresent) Some(opt.get()) else None
+        // register
+        table match {
 
           // table source and/or sink is registered
           case Some(table: TableSourceSinkTable[_, _]) => table.tableSinkTable match {
@@ -288,7 +296,7 @@ abstract class StreamTableEnvironment(
               val enrichedTable = new TableSourceSinkTable(
                 table.tableSourceTable,
                 Some(new TableSinkTable(configuredSink)))
-              replaceRegisteredTable(name, enrichedTable)
+              catalogManager.replaceRegisteredTable(name, enrichedTable)
           }
 
           // no table is registered
@@ -296,7 +304,7 @@ abstract class StreamTableEnvironment(
             val newTable = new TableSourceSinkTable(
               None,
               Some(new TableSinkTable(configuredSink)))
-            registerTableInternal(name, newTable)
+            catalogManager.registerTableInternal(name, newTable)
         }
 
       // not a stream table sink
@@ -522,7 +530,7 @@ abstract class StreamTableEnvironment(
       fieldIndexes,
       fieldNames
     )
-    registerTableInternal(name, dataStreamTable)
+    catalogManager.registerTableInternal(name, dataStreamTable)
   }
 
   /**
@@ -564,7 +572,7 @@ abstract class StreamTableEnvironment(
       indexesWithIndicatorFields,
       namesWithIndicatorFields
     )
-    registerTableInternal(name, dataStreamTable)
+    catalogManager.registerTableInternal(name, dataStreamTable)
   }
 
   /**

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.ExternalCatalogAlreadyExistException;
+import org.apache.flink.table.api.ExternalCatalogNotExistException;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.plan.schema.RelTable;
+import org.apache.flink.table.utils.TableTestBase;
+
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for CatalogManager.
+ */
+public class CatalogManagerTest extends TableTestBase {
+
+	private CatalogManager catalogManager = new CatalogManager(streamTestUtil().tableEnv());
+
+	private static final String TEST_CATALOG = "test_catalog";
+	private static final String TEST_TABLE = "test_table";
+
+	private ExternalCatalog testCatalog = new InMemoryExternalCatalog(TEST_CATALOG);
+	private AbstractTable testTable = new RelTable(null);
+
+	@Before
+	public void init() {
+		catalogManager.registerExternalCatalog(TEST_CATALOG, testCatalog);
+		catalogManager.registerTableInternal(TEST_TABLE, testTable);
+	}
+
+	@Test(expected = ExternalCatalogAlreadyExistException.class)
+	public void testRegisterAlreadyExistCatalog() {
+		catalogManager.registerExternalCatalog(TEST_CATALOG, testCatalog);
+	}
+
+	@Test
+	public void testGetRegisteredCatalog() {
+		assertEquals(testCatalog, catalogManager.getRegisteredExternalCatalog(TEST_CATALOG));
+	}
+
+	@Test(expected = ExternalCatalogNotExistException.class)
+	public void testGetNotExistRegisteredCatalog() {
+		catalogManager.getRegisteredExternalCatalog("missing");
+	}
+
+	@Test
+	public void testListTables() {
+		assertEquals(Arrays.asList(TEST_TABLE), catalogManager.listTables());
+	}
+
+	@Test
+	public void testRegisterTableInternal() {
+		assertEquals(testTable, catalogManager.getRootSchema().getTable(TEST_TABLE));
+	}
+
+	@Test(expected = TableException.class)
+	public void testRegisterTableInternalWithAlreadyExistTable() {
+		catalogManager.registerTableInternal(TEST_TABLE, testTable);
+	}
+
+	@Test
+	public void testReplaceRegisteredTable() {
+		AbstractTable replace = new RelTable(null);
+
+		catalogManager.replaceRegisteredTable(TEST_TABLE, replace);
+
+		Table newTable = catalogManager.getTable(TEST_TABLE).get();
+
+		assertNotNull(newTable);
+		assertNotEquals(testTable, newTable);
+		assertEquals(replace, newTable);
+	}
+
+	@Test(expected = TableException.class)
+	public void testReplaceNotExistTable() {
+		catalogManager.replaceRegisteredTable("missing", null);
+	}
+
+	@Test
+	public void testIsRegistered() {
+		assertTrue(catalogManager.isRegistered(TEST_TABLE));
+		assertFalse(catalogManager.isRegistered("missing"));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

In the design of Flink-Hive integration and external catalog enhancements, we propose using `CatalogManager` to manage all external catalogs and related aspects for a clearer separation. Currently all external catalogs are managed by `TableEnvironment`, which makes TableEnvironment bloated.

Background: there are two parallel efforts going on right now - FLINK-10686, driven by Timo, includes moving external catalogs APIs from flink-table to flink-table-common, also from Scala to Java; FLINK-10744 I'm working on right now to integrate Flink with Hive and enhance external catalog functionality.

As discussed with @twalthr in FLINK-10689, we'd better parallelize these efforts while introducing minimal overhead for integrating them later. Our agreed way is to writing new code/feature related to external catalogs/hive in Java in flink-table first then move to other module like flink-table-common, this way we can minimize migration efforts. If existing classes are modified for a feature we can start migrating them to Java in a separate commit first and then perform the actual feature changes, and migrated classes can be placed in flink-table/src/main/java until we find a better module structure.

This PR moves all EXISTING external catalogs related code from `TableEnvironment` to `CatalogManager`, and it's the initial step for `CatalogManager`. It blocks `[[FLINK-10698]Create CatalogManager class manages all external catalogs and temporary meta objects](https://issues.apache.org/jira/browse/FLINK-10698)`

This PR is a PURE REFACTOR, only moving APIs around, NO change on the behaviors and NO new feature is added. 

## Brief change log

  - added `CatalogManager` in Java
  - moved external catalog related code from `TableEnvironment` to `CatalogManager`
  - added unit tests in `CatalogManagerTest`

## Verifying this change

- This change is already covered by existing tests, such as *TableEnvironmentTest*.
- This change added tests and can be verified as follows:
  - Added unit tests in `CatalogManagerTest`

## Does this pull request potentially affect one of the following parts:

none

## Documentation

  - Does this pull request introduce a new feature? (no)
