### PR TITLE
[FLINK-10772][release] Fix create_binary_release.sh

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -78,8 +78,7 @@ make_binary_release() {
   fi
 
   # enable release profile here (to check for the maven version)
-  tools/change-scala-version.sh ${SCALA_VERSION}
-  $MVN clean package $FLAGS -Prelease -pl flink-shaded-hadoop/flink-shaded-hadoop2-uber,flink-dist -am -Dgpg.skip -Dcheckstyle.skip=true -DskipTests -Dmaven.test.skip=true
+  $MVN clean package $FLAGS -Prelease -pl flink-dist -am -Dgpg.skip -Dcheckstyle.skip=true -DskipTests
 
   cd flink-dist/target/flink-*-bin/
   tar czf "${dir_name}.tgz" flink-*


### PR DESCRIPTION
## What is the purpose of the change

Remove the unnecessary call to change_scala_version.sh and remove the
-Dmaven.test.skip=true property. The latter is necessary because this
property suppresses the compilation and packaging of test classes. It,
however, does not suppress the resolution of test dependencies which
will then fail to compile because test dependencies have not been built.

This commit also removes the redundant call to build
flink-shaded/hadoop/flink-shaded-hadoop2-uber which is a dependency
of flink-dist anyway.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
