### PR TITLE
[FLINK-10793][ttl] Change visibility of TtlValue and TtlSerializer to…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -188,15 +188,17 @@ public class TtlStateFactory<N, SV, S extends State, IS extends S> {
 		}
 	}
 
-	/** Serializer for user state value with TTL. */
-	private static class TtlSerializer<T> extends CompositeSerializer<TtlValue<T>> {
+	/**
+	 * Serializer for user state value with TTL. Visibility is public for usage with external tools.
+	 */
+	public static class TtlSerializer<T> extends CompositeSerializer<TtlValue<T>> {
 		private static final long serialVersionUID = 131020282727167064L;
 
-		TtlSerializer(TypeSerializer<T> userValueSerializer) {
+		public TtlSerializer(TypeSerializer<T> userValueSerializer) {
 			super(true, LongSerializer.INSTANCE, userValueSerializer);
 		}
 
-		TtlSerializer(PrecomputedParameters precomputed, TypeSerializer<?> ... fieldSerializers) {
+		public TtlSerializer(PrecomputedParameters precomputed, TypeSerializer<?> ... fieldSerializers) {
 			super(precomputed, fieldSerializers);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValue.java
@@ -23,28 +23,28 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 /**
- * This class wraps user value of state with TTL.
+ * This class wraps user value of state with TTL. Visibility is public for usage with external tools.
  *
  * @param <T> Type of the user value of state with TTL
  */
-class TtlValue<T> implements Serializable {
+public class TtlValue<T> implements Serializable {
 	private static final long serialVersionUID = 5221129704201125020L;
 
 	@Nullable
 	private final T userValue;
 	private final long lastAccessTimestamp;
 
-	TtlValue(@Nullable T userValue, long lastAccessTimestamp) {
+	public TtlValue(@Nullable T userValue, long lastAccessTimestamp) {
 		this.userValue = userValue;
 		this.lastAccessTimestamp = lastAccessTimestamp;
 	}
 
 	@Nullable
-	T getUserValue() {
+	public T getUserValue() {
 		return userValue;
 	}
 
-	long getLastAccessTimestamp() {
+	public long getLastAccessTimestamp() {
 		return lastAccessTimestamp;
 	}
 }


### PR DESCRIPTION
… public for external tools

## What is the purpose of the change

This PR changes the visibility of `TtlValue` and `TtlSerializer` to `public`, so that they can be more easily used by external tools like Bravo.
