### PR TITLE
[FLINK-10711] [e2e] Allow basic error handling with bash

### DIFF
--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -47,6 +47,8 @@ In order to add a new test case you need add it to either `test-scripts/run-nigh
 
 _Note: If you want to parameterize your tests please do so by adding multiple test cases with parameters as arguments to the nightly / pre-commit test suites. This allows the test runner to do a cleanup in between each individual test and also to fail those tests individually._
 
+_Note: While developing a new test case make sure to enable bash's error handling in `test-scripts/test-runner-common.sh` by uncommenting `set -Eexuo pipefail` and commenting the current default `set` call. If your test is implemented properly, add `set -Eeuo pipefail` on the very top of your test script (before any `common` script)._
+
 ### Passing your test
 A test is considered to have passed if it:
 - has exit code 0

--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -17,8 +17,6 @@
 # limitations under the License.
 ################################################################################
 
-set -o pipefail
-
 if [[ -z $TEST_DATA_DIR ]]; then
   echo "Must run common.sh before elasticsearch-common.sh."
   exit 1

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -17,10 +17,6 @@
 # limitations under the License.
 ################################################################################
 
-set -e
-set -u
-set -o pipefail
-
 if [[ -z $TEST_DATA_DIR ]]; then
   echo "Must run common.sh before kafka-common.sh."
   exit 1

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka.sh
@@ -17,9 +17,7 @@
 # limitations under the License.
 ################################################################################
 
-set -e
-set -u
-set -o pipefail
+set -Eeuo pipefail
 
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/kafka-common.sh 2.0.0 5.0.0 5.0

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
@@ -17,6 +17,8 @@
 # limitations under the License.
 ################################################################################
 
+set -Eeuo pipefail
+
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/kafka-common.sh 0.10.2.0 3.2.0 3.2
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka_common.sh
@@ -17,10 +17,6 @@
 # limitations under the License.
 ################################################################################
 
-set -e
-set -u
-set -o pipefail
-
 KAFKA_EXAMPLE_JAR="$1"
 
 setup_kafka_dist


### PR DESCRIPTION
## What is the purpose of the change

This commit modifies the test infrastructure to allow bash's basic
error handling mechanism with `set -e`. Many tests are not
ready for a globally defined strict error handling. For now, at
least newly developed tests should consider this flag. If a test
causes an error, a test fails with `"[FAIL] Test script contains errors"`.


## Brief change log

- Make it possible to enable `set -e`


## Verifying this change

Run `./run-single-test.sh ./test-scripts/test_batch_allround.sh` as an example with the `set` command uncommented.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
