### PR TITLE
[FLINK-10798] Add the version number of Flink 1.7 to MigrationVersion

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/migration/MigrationVersion.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/migration/MigrationVersion.java
@@ -30,7 +30,8 @@ public enum MigrationVersion {
 	v1_3("1.3"),
 	v1_4("1.4"),
 	v1_5("1.5"),
-	v1_6("1.6");
+	v1_6("1.6"),
+	v1_7("1.7");
 
 	private String versionStr;
 


### PR DESCRIPTION
## What is the purpose of the change

*Add the version number of Flink 1.7 to MigrationVersion*


## Brief change log

  - *Add the version number of Flink 1.7 to MigrationVersion*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
