### PR TITLE
[FLINK-10419][checkpoint] fix ClassNotFoundException while deserializing user exceptions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -38,7 +38,7 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
 
 	private static final long serialVersionUID = 2094094662279578953L;
 
-	/** The reason why the checkpoint was declined */
+	/** The reason why the checkpoint was declined. */
 	private final Throwable reason;
 
 	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId) {
@@ -68,7 +68,7 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
 
 	/**
 	 * Gets the reason why the checkpoint was declined.
-	 * 
+	 *
 	 * @return The reason why the checkpoint was declined
 	 */
 	public Throwable getReason() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -19,12 +19,6 @@
 package org.apache.flink.runtime.messages.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.checkpoint.decline.AlignmentLimitExceededException;
-import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineOnCancellationBarrierException;
-import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineSubsumedException;
-import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineTaskNotCheckpointingException;
-import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineTaskNotReadyException;
-import org.apache.flink.runtime.checkpoint.decline.InputEndOfStreamException;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.SerializedThrowable;
 
@@ -47,19 +41,12 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
 
 	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, Throwable reason) {
 		super(job, taskExecutionId, checkpointId);
-		
-		if (reason == null ||
-			reason.getClass() == AlignmentLimitExceededException.class ||
-			reason.getClass() == CheckpointDeclineOnCancellationBarrierException.class ||
-			reason.getClass() == CheckpointDeclineSubsumedException.class ||
-			reason.getClass() == CheckpointDeclineTaskNotCheckpointingException.class ||
-			reason.getClass() == CheckpointDeclineTaskNotReadyException.class ||
-			reason.getClass() == InputEndOfStreamException.class)
-		{
-			// null or known common exceptions that cannot reference any dynamically loaded code
+
+		if (reason == null) {
 			this.reason = reason;
 		} else {
-			// some other exception. replace with a serialized throwable, to be on the safe side
+			// exceptions may reference dynamically loaded code (exception itself, cause, suppressed)
+			// -> replace with a serialized throwable, to be on the safe side
 			this.reason = new SerializedThrowable(reason);
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

`DeclineCheckpoint` tries to make sure that it does wrap any exception which can be and/or contain user code into a `SerializedThrowable`. It also contains special handling of a few exceptions that are not wrapped into `SerializedThrowable` (`CheckpointDeclineException` sub-classes are claimed to not contain user-code) but if these carry user-code exceptions as *suppressed* exceptions, the deserialization at the JobManager will fail and the RPC call will not be processed at all - we thus rely on another method to actually get rid of the checkpoint, e.g. a timeout.

## Brief change log

- remove the special handling of `CheckpointDeclineException` sub-classes

## Verifying this change

This change is already covered by existing tests, such as checkpoint tests and IT cases.

I also manually verified that no code is relying on checks such as `instanceof CheckpointDeclineException` or the explicitly mentioned sub-classes, so that it is ok to replace these with `SerializedThrowable` in the RPC.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
