### PR TITLE
[FLINK-10805] Fix failing end-to-end tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -418,7 +418,7 @@ function wait_job_terminal_state {
   echo "Waiting for job ($job) to reach terminal state $terminal_state ..."
 
   while : ; do
-    N=$(grep -o "Job $job reached globally terminal state $terminal_state" $FLINK_DIR/log/*standalonesession*.log | tail -1)
+    N=$(grep -o "Job $job reached globally terminal state $terminal_state" $FLINK_DIR/log/*standalonesession*.log | tail -1 || true)
 
     if [[ -z $N ]]; then
       sleep 1

--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -45,7 +45,7 @@ function wait_elasticsearch_working {
     echo "Waiting for Elasticsearch node to work..."
 
     for ((i=1;i<=60;i++)); do
-        curl -XGET 'http://localhost:9200'
+        curl -XGET 'http://localhost:9200' || true
 
         # make sure the elasticsearch node is actually working
         if [ $? -ne 0 ]; then
@@ -69,7 +69,7 @@ function verify_result_line_number {
     fi
 
     while : ; do
-      curl "localhost:9200/${index}/_search?q=*&pretty&size=21" > $TEST_DATA_DIR/output
+      curl "localhost:9200/${index}/_search?q=*&pretty&size=21" > $TEST_DATA_DIR/output || true
 
       if [ -n "$(grep "\"total\" : $numRecords" $TEST_DATA_DIR/output)" ]; then
           echo "Elasticsearch end to end test pass."
@@ -88,7 +88,7 @@ function verify_result_hash {
   local hash=$4
 
   while : ; do
-    curl "localhost:9200/${index}/_search?q=*&pretty" > $TEST_DATA_DIR/es_output
+    curl "localhost:9200/${index}/_search?q=*&pretty" > $TEST_DATA_DIR/es_output || true
 
     if [ -n "$(grep "\"total\" : $numRecords" $TEST_DATA_DIR/es_output)" ]; then
       break

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 source "$(dirname "$0")"/common.sh
-source "$(dirname "$0")"/kafka-common.sh
+source "$(dirname "$0")"/kafka-common.sh 0.10.2.0 3.2.0 3.2
 
 function verify_output {
   local expected=$(printf $1)


### PR DESCRIPTION
## What is the purpose of the change

Fix test_confluent_schema_registry.sh and test_sql_client.sh end-to-end tests which failed
because of missing arguments for kafka-common.sh and the newly introduce set -e flag.

## Verifying this change

- Manually tested

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
