### PR TITLE
[FLINK-10750][tests] Harden SocketClientSinkTest

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/SocketClientSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/SocketClientSinkTest.java
@@ -24,11 +24,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.BindException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.Callable;
@@ -279,7 +281,12 @@ public class SocketClientSinkTest extends TestLogger {
 			retryLatch.countDown();
 
 			// Restart the server
-			serverSocket[0] = new ServerSocket(port);
+			try {
+				serverSocket[0] = new ServerSocket(port);
+			} catch (BindException be) {
+				// some other process may be using this port now
+				throw new AssumptionViolatedException("Could not bind server to previous port.", be);
+			}
 			Socket socket = serverSocket[0].accept();
 
 			BufferedReader reader = new BufferedReader(new InputStreamReader(


### PR DESCRIPTION
## What is the purpose of the change

The tests attempts to re-bind a server to a specific port. If the port is taken the test will fail.
The test is now skipped instead if this happens.

## Verifying this change

Manually verified. Pause the test before the second socket is started and start some other application on that port. Continue the test; it will not be marked as failed.