### PR TITLE
[FLINK-9002] [e2e] Add operators with input type that goes through Avro serialization

### DIFF
--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/avro/AvroEvent.avsc
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/avro/AvroEvent.avsc
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ {"namespace": "org.apache.flink.streaming.tests.avro",
+ "type": "record",
+ "name": "AvroEvent",
+ "fields": [
+     {
+        "name": "key",
+        "type": "int",
+        "default": ""
+     },
+     {
+        "name": "eventTime",
+        "type": "long",
+        "default": ""
+     },
+     {
+        "name": "sequenceNumber",
+        "type": "long",
+        "default": ""
+     },
+     {
+        "name": "payload",
+        "type": "string",
+        "default": ""
+     }
+ ]
+}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/avro/AvroEvent.avsc
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/avro/AvroEvent.avsc
@@ -22,22 +22,18 @@
      {
         "name": "key",
         "type": "int",
-        "default": ""
      },
      {
         "name": "eventTime",
         "type": "long",
-        "default": ""
      },
      {
         "name": "sequenceNumber",
         "type": "long",
-        "default": ""
      },
      {
         "name": "payload",
         "type": "string",
-        "default": ""
      }
  ]
 }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -466,6 +466,8 @@ class DataStreamAllroundTestJobFactory {
 			String inputTypeId) {
 
 		DataStream<T> convertedStream = streamToConvert.map(convertToInputType);
+
+		// apply a keyBy so that we have a non-chained operator with T as input type that goes through serialization
 		return convertedStream.keyBy(inputTypeKeySelector).map(convertFromInputType).name("InputTypeSerializationTestOperator-" + inputTypeId);
 	}
 }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -32,6 +33,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.WindowedStream;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -454,5 +456,16 @@ class DataStreamAllroundTestJobFactory {
 			listStateGenerator,
 			listStateGenerator,
 			listStateDescriptor);
+	}
+
+	static <T> DataStream<Event> testSpecificOperatorInputTypeSerialization(
+			DataStream<Event> streamToConvert,
+			MapFunction<Event, T> convertToInputType,
+			MapFunction<T, Event> convertFromInputType,
+			KeySelector<T, Integer> inputTypeKeySelector,
+			String inputTypeId) {
+
+		DataStream<T> convertedStream = streamToConvert.map(convertToInputType);
+		return convertedStream.keyBy(inputTypeKeySelector).map(convertFromInputType).name("InputTypeSerializationTestOperator-" + inputTypeId);
 	}
 }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestProgram.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestProgram.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.tests;
 
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
@@ -160,13 +161,13 @@ public class DataStreamAllroundTestProgram {
 		eventStream3 = testSpecificOperatorInputTypeSerialization(
 			eventStream3,
 			in -> {
-				GenericRecord record = new GenericData.Record(AvroEvent.SCHEMA$);
-				record.put("key", in.getKey());
-				record.put("eventTime", in.getEventTime());
-				record.put("sequenceNumber", in.getSequenceNumber());
-				record.put("payload", in.getPayload());
+				GenericRecordBuilder recordBuilder = new GenericRecordBuilder(AvroEvent.SCHEMA$);
+				recordBuilder.set("key", in.getKey());
+				recordBuilder.set("eventTime", in.getEventTime());
+				recordBuilder.set("sequenceNumber", in.getSequenceNumber());
+				recordBuilder.set("payload", in.getPayload());
 
-				return record;
+				return recordBuilder.build();
 			},
 			in -> new Event((Integer) in.get("key"), (Long) in.get("eventTime"), (Long) in.get("sequenceNumber"), (String) in.get("payload")),
 			in -> (Integer) in.get("key"),


### PR DESCRIPTION
## What is the purpose of the change

This PR extends coverage of our all-round DataStream end-to-end test job to have operators with input types that goes through Avro serialization (both for Avro specific / generic records).

## Verifying this change

All end-to-end tests should still pass with the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)
