### PR TITLE
 [FLINK-9001] [e2e] Add operators with input type that goes through Kryo serialization

### DIFF
--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/avro/AvroEvent.avsc
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/avro/AvroEvent.avsc
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ {"namespace": "org.apache.flink.streaming.tests.avro",
+ "type": "record",
+ "name": "AvroEvent",
+ "fields": [
+     {
+        "name": "key",
+        "type": "int",
+        "default": ""
+     },
+     {
+        "name": "eventTime",
+        "type": "long",
+        "default": ""
+     },
+     {
+        "name": "sequenceNumber",
+        "type": "long",
+        "default": ""
+     },
+     {
+        "name": "payload",
+        "type": "string",
+        "default": ""
+     }
+ ]
+}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -32,6 +33,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.WindowedStream;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -454,5 +456,16 @@ class DataStreamAllroundTestJobFactory {
 			listStateGenerator,
 			listStateGenerator,
 			listStateDescriptor);
+	}
+
+	static <T> DataStream<Event> testSpecificOperatorInputTypeSerialization(
+			DataStream<Event> streamToConvert,
+			MapFunction<Event, T> convertToInputType,
+			MapFunction<T, Event> convertFromInputType,
+			KeySelector<T, Integer> inputTypeKeySelector,
+			String inputTypeId) {
+
+		DataStream<T> convertedStream = streamToConvert.map(convertToInputType);
+		return convertedStream.keyBy(inputTypeKeySelector).map(convertFromInputType).name("InputTypeSerializationTestOperator-" + inputTypeId);
 	}
 }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/CustomKryoEventSerializer.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/CustomKryoEventSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.kryo;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Custom Kryo serializer to be registered for {@link CustomKryoEventSerializer}.
+ */
+public class CustomKryoEventSerializer extends Serializer<CustomSerializedKryoEvent> {
+
+	@Override
+	public void write(Kryo kryo, Output output, CustomSerializedKryoEvent object) {
+		output.writeInt(object.getKey());
+		output.writeLong(object.getEventTime());
+		output.writeLong(object.getSequenceNumber());
+		output.writeString(object.getPayload());
+	}
+
+	@Override
+	public CustomSerializedKryoEvent read(Kryo kryo, Input input, Class<CustomSerializedKryoEvent> type) {
+		return new CustomSerializedKryoEvent(input.readInt(), input.readLong(), input.readLong(), input.readString());
+	}
+}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/CustomSerializedKryoEvent.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/CustomSerializedKryoEvent.java
@@ -16,22 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.tests;
+package org.apache.flink.streaming.tests.kryo;
+
+import org.apache.flink.streaming.tests.Event;
 
 /**
- * The event type of records used in the {@link DataStreamAllroundTestProgram}.
- * This should be a POJO that Flink recognizes.
+ * Variant of {@link Event} that is intended to be used for testing Kryo serialization
+ * (the class is deliberately designed to not be a POJO).
+ *
+ * <p>This is intended to be serialized by Kryo with a custom Kryo serializer {@link CustomKryoEventSerializer}
+ * registered for it.
  */
-public class Event {
+public class CustomSerializedKryoEvent {
 
-	private int key;
-	private long eventTime;
-	private long sequenceNumber;
-	private String payload;
+	private final int key;
+	private final long eventTime;
+	private final long sequenceNumber;
+	private final String payload;
 
-	public Event() {}
-
-	public Event(int key, long eventTime, long sequenceNumber, String payload) {
+	public CustomSerializedKryoEvent(int key, long eventTime, long sequenceNumber, String payload) {
 		this.key = key;
 		this.eventTime = eventTime;
 		this.sequenceNumber = sequenceNumber;
@@ -42,37 +45,21 @@ public class Event {
 		return key;
 	}
 
-	public void setKey(int key) {
-		this.key = key;
-	}
-
 	public long getEventTime() {
 		return eventTime;
-	}
-
-	public void setEventTime(long eventTime) {
-		this.eventTime = eventTime;
 	}
 
 	public long getSequenceNumber() {
 		return sequenceNumber;
 	}
 
-	public void setSequenceNumber(long sequenceNumber) {
-		this.sequenceNumber = sequenceNumber;
-	}
-
 	public String getPayload() {
 		return payload;
 	}
 
-	public void setPayload(String payload) {
-		this.payload = payload;
-	}
-
 	@Override
 	public String toString() {
-		return "Event{" +
+		return "CustomSerializedKryoEvent{" +
 			"key=" + key +
 			", eventTime=" + eventTime +
 			", sequenceNumber=" + sequenceNumber +

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/GenericKryoEvent.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/GenericKryoEvent.java
@@ -16,22 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.tests;
+package org.apache.flink.streaming.tests.kryo;
+
+import org.apache.flink.streaming.tests.Event;
 
 /**
- * The event type of records used in the {@link DataStreamAllroundTestProgram}.
- * This should be a POJO that Flink recognizes.
+ * Variant of {@link Event} that is intended to be used for testing Kryo serialization
+ * (the class is deliberately designed to not be a POJO).
+ *
+ * <p>This is intended to be serialized by Kryo without any class id registration.
  */
-public class Event {
+public class GenericKryoEvent {
 
-	private int key;
-	private long eventTime;
-	private long sequenceNumber;
-	private String payload;
+	private final int key;
+	private final long eventTime;
+	private final long sequenceNumber;
+	private final String payload;
 
-	public Event() {}
-
-	public Event(int key, long eventTime, long sequenceNumber, String payload) {
+	public GenericKryoEvent(int key, long eventTime, long sequenceNumber, String payload) {
 		this.key = key;
 		this.eventTime = eventTime;
 		this.sequenceNumber = sequenceNumber;
@@ -42,37 +44,21 @@ public class Event {
 		return key;
 	}
 
-	public void setKey(int key) {
-		this.key = key;
-	}
-
 	public long getEventTime() {
 		return eventTime;
-	}
-
-	public void setEventTime(long eventTime) {
-		this.eventTime = eventTime;
 	}
 
 	public long getSequenceNumber() {
 		return sequenceNumber;
 	}
 
-	public void setSequenceNumber(long sequenceNumber) {
-		this.sequenceNumber = sequenceNumber;
-	}
-
 	public String getPayload() {
 		return payload;
 	}
 
-	public void setPayload(String payload) {
-		this.payload = payload;
-	}
-
 	@Override
 	public String toString() {
-		return "Event{" +
+		return "GenericKryoEvent{" +
 			"key=" + key +
 			", eventTime=" + eventTime +
 			", sequenceNumber=" + sequenceNumber +

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/RegisteredKryoEvent.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/kryo/RegisteredKryoEvent.java
@@ -1,0 +1,50 @@
+package org.apache.flink.streaming.tests.kryo;
+
+import org.apache.flink.streaming.tests.Event;
+
+/**
+ * Variant of {@link Event} that is intended to be used for testing Kryo serialization
+ * (the class is deliberately designed to not be a POJO).
+ *
+ * <p>This is intended to be serialized by Kryo with the type class registered with a class id.
+ */
+public class RegisteredKryoEvent {
+
+	private final int key;
+	private final long eventTime;
+	private final long sequenceNumber;
+	private final String payload;
+
+	public RegisteredKryoEvent(int key, long eventTime, long sequenceNumber, String payload) {
+		this.key = key;
+		this.eventTime = eventTime;
+		this.sequenceNumber = sequenceNumber;
+		this.payload = payload;
+	}
+
+	public int getKey() {
+		return key;
+	}
+
+	public long getEventTime() {
+		return eventTime;
+	}
+
+	public long getSequenceNumber() {
+		return sequenceNumber;
+	}
+
+	public String getPayload() {
+		return payload;
+	}
+
+	@Override
+	public String toString() {
+		return "RegisteredKryoEvent{" +
+			"key=" + key +
+			", eventTime=" + eventTime +
+			", sequenceNumber=" + sequenceNumber +
+			", payload='" + payload + '\'' +
+			'}';
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on top of #7041. Only the last commit relevant.

This PR extends coverage of our all-round DataStream end-to-end test job to have operators with input types that goes through Kryo serialization:

- Without the data type registered
- With the data type registered
- With the data type registered, also with a custom Kryo serializer

## Verifying this change

All end-to-end tests should still pass with the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

