### PR TITLE
[FLINK-10811][hcatalog] Add scala suffix

### DIFF
--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-hcatalog</artifactId>
+	<artifactId>flink-hcatalog_${scala.binary.version}</artifactId>
 	<name>flink-hcatalog</name>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
This PR adds a scala suffix to the `flink-hcatalog` module, as required due to the compile dependency on `flink-hadoop-compatibility_${scala.binary.version}`.