### PR TITLE
[FLINK-10816][cep] Fix LockableTypeSerializer.duplicate() to consider…

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.cep.nfa.sharedbuffer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -109,8 +110,10 @@ public final class Lockable<T> {
 		}
 
 		@Override
-		public TypeSerializer<Lockable<E>> duplicate() {
-			return new LockableTypeSerializer<>(elementSerializer);
+		public LockableTypeSerializer<E> duplicate() {
+			TypeSerializer<E> elementSerializerCopy = elementSerializer.duplicate();
+			return elementSerializerCopy == elementSerializer ?
+				this : new LockableTypeSerializer<>(elementSerializerCopy);
 		}
 
 		@Override
@@ -120,7 +123,7 @@ public final class Lockable<T> {
 
 		@Override
 		public Lockable<E> copy(Lockable<E> from) {
-			return new Lockable<E>(elementSerializer.copy(from.element), from.refCounter);
+			return new Lockable<>(elementSerializer.copy(from.element), from.refCounter);
 		}
 
 		@Override
@@ -218,6 +221,11 @@ public final class Lockable<T> {
 					? CompatibilityResult.requiresMigration()
 					: CompatibilityResult.compatible();
 			}
+		}
+
+		@VisibleForTesting
+		public TypeSerializer<E> getElementSerializer() {
+			return elementSerializer;
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.nfa.sharedbuffer;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.heap.CopyOnWriteStateTableTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link org.apache.flink.cep.nfa.sharedbuffer.Lockable.LockableTypeSerializer}.
+ */
+public class LockableTypeSerializerTest {
+
+	/**
+	 * This tests that {@link Lockable.LockableTypeSerializer#duplicate()} works as expected.
+	 */
+	@Test
+	public void testDuplicate() {
+		IntSerializer nonDuplicatingInnerSerializer = IntSerializer.INSTANCE;
+		Assert.assertSame(nonDuplicatingInnerSerializer, nonDuplicatingInnerSerializer.duplicate());
+		Lockable.LockableTypeSerializer<Integer> candidateTestShallowDuplicate =
+			new Lockable.LockableTypeSerializer<>(nonDuplicatingInnerSerializer);
+		Assert.assertSame(candidateTestShallowDuplicate, candidateTestShallowDuplicate.duplicate());
+
+		CopyOnWriteStateTableTest.TestDuplicateSerializer duplicatingInnerSerializer =
+			new CopyOnWriteStateTableTest.TestDuplicateSerializer();
+
+		Assert.assertNotSame(duplicatingInnerSerializer, duplicatingInnerSerializer.duplicate());
+
+		Lockable.LockableTypeSerializer<Integer> candidateTestDeepDuplicate =
+			new Lockable.LockableTypeSerializer<>(duplicatingInnerSerializer);
+
+		Lockable.LockableTypeSerializer<Integer> deepDuplicate = candidateTestDeepDuplicate.duplicate();
+		Assert.assertNotSame(candidateTestDeepDuplicate, deepDuplicate);
+		Assert.assertNotSame(candidateTestDeepDuplicate.getElementSerializer(), deepDuplicate.getElementSerializer());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -568,7 +568,7 @@ public class CopyOnWriteStateTableTest extends TestLogger {
 	 * Serializer that can be disabled. Duplicates are still enabled, so we can check that
 	 * serializers are duplicated.
 	 */
-	static class TestDuplicateSerializer extends TypeSerializer<Integer> {
+	public static class TestDuplicateSerializer extends TypeSerializer<Integer> {
 
 		private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
… deep duplication of element serializer

## What is the purpose of the change

`LockableTypeSerializer.duplicate()` did not duplicate the nested element serializers. This is fixed by the PR.

I introduced `LockableTypeSerializerTest` to test the change.
