### PR TITLE
[hotfix] Follow up FLINK-6046 to clean unused variable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -56,7 +56,6 @@ import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -126,19 +125,10 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	private int maxParallelism;
 
 	/**
-	 * Serialized task information which is for all sub tasks the same. Thus, it avoids to
-	 * serialize the same information multiple times in order to create the
-	 * TaskDeploymentDescriptors.
+	 * Either store a serialized task information, which is for all sub tasks the same,
+	 * or the permanent blob key of the offloaded task information BLOB containing
+	 * the serialized task information.
 	 */
-	private SerializedValue<TaskInformation> serializedTaskInformation;
-
-	/**
-	 * The key of the offloaded task information BLOB containing {@link #serializedTaskInformation}
-	 * or <tt>null</tt> if not offloaded.
-	 */
-	@Nullable
-	private PermanentBlobKey taskInformationBlobKey = null;
-
 	private Either<SerializedValue<TaskInformation>, PermanentBlobKey> taskInformationOrBlobKey = null;
 
 	private InputSplitAssigner splitAssigner;
@@ -192,8 +182,6 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		}
 
 		this.parallelism = numTaskVertices;
-
-		this.serializedTaskInformation = null;
 
 		this.taskVertices = new ExecutionVertex[numTaskVertices];
 		this.operatorIDs = Collections.unmodifiableList(jobVertex.getOperatorIDs());


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-6046 5ff07e63d1e9a98959e5edf66872222b847d23d5 resolved, we replaced `serializedTaskInformation` and `taskInformationBlobKey` with `taskInformationOrBlobKey`. This pull requests acts as a follow up to clean the unused variables and update document.

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)

cc @tillrohrmann @zentol 