### PR TITLE
[FLINK-10814][examples] Add scala suffix for Kafka example module

### DIFF
--- a/flink-examples/flink-examples-streaming-kafka-0.10/pom.xml
+++ b/flink-examples/flink-examples-streaming-kafka-0.10/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-examples-streaming-kafka-base</artifactId>
+			<artifactId>flink-examples-streaming-kafka-base_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 

--- a/flink-examples/flink-examples-streaming-kafka-0.10/pom.xml
+++ b/flink-examples/flink-examples-streaming-kafka-0.10/pom.xml
@@ -27,7 +27,8 @@ under the License.
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-examples-streaming-kafka-0.10</artifactId>
+	<artifactId>flink-examples-streaming-kafka-0.10_${scala.binary.version}</artifactId>
+	<name>flink-examples-streaming-kafka-0.10</name>
 
 	<dependencies>
 		<dependency>
@@ -50,6 +51,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -57,6 +64,44 @@ under the License.
 
 	<build>
 		<plugins>
+
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+						scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>add-source</goal>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+						 scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Scala Code Style, most of the configuration done via plugin management -->
+			<plugin>
+				<groupId>org.scalastyle</groupId>
+				<artifactId>scalastyle-maven-plugin</artifactId>
+				<configuration>
+					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
+				</configuration>
+			</plugin>
+
 			<!-- Use the shade plugin to build a fat jar for the kafka connector test -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-examples/flink-examples-streaming-kafka-0.10/src/main/scala/org/apache/flink/streaming/scala/examples/kafka/Kafka010Example.scala
+++ b/flink-examples/flink-examples-streaming-kafka-0.10/src/main/scala/org/apache/flink/streaming/scala/examples/kafka/Kafka010Example.scala
@@ -21,7 +21,7 @@ package org.apache.flink.streaming.scala.examples.kafka
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.api.common.serialization.SimpleStringSchema
 import org.apache.flink.api.java.utils.ParameterTool
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.scala._
 import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaConsumer010, FlinkKafkaProducer010}
 
 /**

--- a/flink-examples/flink-examples-streaming-kafka-0.11/pom.xml
+++ b/flink-examples/flink-examples-streaming-kafka-0.11/pom.xml
@@ -27,14 +27,14 @@ under the License.
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-examples-streaming-kafka-0.11</artifactId>
+	<artifactId>flink-examples-streaming-kafka-0.11_${scala.binary.version}</artifactId>
 	<name>flink-examples-streaming-kafka-0.11</name>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-examples-streaming-kafka-base</artifactId>
+			<artifactId>flink-examples-streaming-kafka-base_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 

--- a/flink-examples/flink-examples-streaming-kafka-base/pom.xml
+++ b/flink-examples/flink-examples-streaming-kafka-base/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-examples-streaming-kafka-base</artifactId>
+	<artifactId>flink-examples-streaming-kafka-base_${scala.binary.version}</artifactId>
 	<name>flink-examples-streaming-kafka-base</name>
 
 	<packaging>jar</packaging>

--- a/flink-examples/flink-examples-streaming-kafka/pom.xml
+++ b/flink-examples/flink-examples-streaming-kafka/pom.xml
@@ -27,13 +27,13 @@ under the License.
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-examples-streaming-kafka</artifactId>
+	<artifactId>flink-examples-streaming-kafka_${scala.binary.version}</artifactId>
 	<name>flink-examples-streaming-kafka</name>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-examples-streaming-kafka-base</artifactId>
+			<artifactId>flink-examples-streaming-kafka-base_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 


### PR DESCRIPTION

## What is the purpose of the change

The kafka examples need Scala suffixes just like flink-examples-batch and flink-examples-streaming.
This pr adds Scala suffix for Kafka example module.


## Brief change log

  - Add Scala suffix for Kafka example module
  - Add Scala Compiler in the pom
  - Import scala environment and classes instead of java.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
