### PR TITLE
[FLINK-10771] Replace hard code of job graph file path with config option for FileJobGraphRetriever

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -101,6 +101,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
+import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.getDynamicProperties;
@@ -542,6 +543,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		flinkConfiguration.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
 
+		flinkConfiguration.setString(JOB_GRAPH_FILE_PATH, "job.graph");
+
 		ApplicationReport report = startAppMaster(
 			flinkConfiguration,
 			applicationName,
@@ -888,7 +891,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 				}
 
 				Path pathFromYarnURL = setupSingleLocalResource(
-					"job.graph",
+					flinkConfiguration.getString(JOB_GRAPH_FILE_PATH),
 					fs,
 					appId,
 					new Path(fp.toURI()),
@@ -896,7 +899,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 					homeDir,
 					"");
 				paths.add(pathFromYarnURL);
-				classPathBuilder.append("job.graph").append(File.pathSeparator);
+				classPathBuilder.append(flinkConfiguration.getString(JOB_GRAPH_FILE_PATH)).append(File.pathSeparator);
 			} catch (Exception e) {
 				LOG.warn("Add job graph to local resource fail");
 				throw e;


### PR DESCRIPTION
## What is the purpose of the change

*Replace hard code of job graph file path with config option for FileJobGraphRetriever*

## Brief change log

  - *Replace hard code of job graph file path with config option for FileJobGraphRetriever*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
