### PR TITLE
[FLINK-10361][tests][ES] Properly wait for ES to start

### DIFF
--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -43,10 +43,10 @@ function wait_elasticsearch_working {
     echo "Waiting for Elasticsearch node to work..."
 
     for ((i=1;i<=60;i++)); do
-        curl -XGET 'http://localhost:9200' || true
+        output=$(curl -XGET 'http://localhost:9200' | grep "cluster_name" || true)
 
         # make sure the elasticsearch node is actually working
-        if [ $? -ne 0 ]; then
+        if [ "${output}" = "" ]; then
             sleep 1
         else
             echo "Elasticsearch node is working."


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes `elasticsearch-common.sh#wait_elasticsearch_working` not actually waiting for ES to start up.
In light of the recent move towards `set -e` we no longer rely on the return code and instead grep the curl output for expected contents (the returned JSON contains a cluster_name field).
If not present we continue looping.

## Verifying this change

Locally verified by querying a bogus ports and ensuring that the test fails early.
