### PR TITLE
[FLINK-10817] Upgrade presto dependency to support path-style access

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -2551,12 +2551,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.facebook.presto:presto-hive:0.185
+- com.facebook.presto:presto-hive:0.187
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1
 - com.google.guava:guava:21.0
-- io.airlift:configuration:0.148
-- io.airlift:log:0.148
-- io.airlift:stats:0.148
+- io.airlift:configuration:0.153
+- io.airlift:log:0.153
+- io.airlift:stats:0.153
 - io.airlift:units:1.0
 - io.airlift:slice:0.31
 - com.fasterxml.jackson.core:jackson-annotations:2.8.1

--- a/docs/ops/filesystems.md
+++ b/docs/ops/filesystems.md
@@ -54,7 +54,7 @@ including any NFS or SAN that is mounted into that local file system.
     the classpath to use them. Both internally use some Hadoop code, but "shade away" all classes to avoid any dependency conflicts.
 
     - `flink-s3-fs-presto`, registered under the scheme *"s3://"* and *"s3p://"*, is based on code from the [Presto project](https://prestodb.io/).
-      You can configure it the same way you can [configure the Presto file system](https://prestodb.io/docs/0.185/connector/hive.html#amazon-s3-configuration).
+      You can configure it the same way you can [configure the Presto file system](https://prestodb.io/docs/0.187/connector/hive.html#amazon-s3-configuration).
       
     - `flink-s3-fs-hadoop`, registered under *"s3://"* and *"s3a://"*, based on code from the [Hadoop Project](https://hadoop.apache.org/).
       The file system can be [configured exactly like Hadoop's s3a](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#S3A).

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<presto.version>0.185</presto.version>
+		<presto.version>0.187</presto.version>
 	</properties>
 
 	<dependencies>
@@ -133,6 +133,10 @@ under the License.
 				<exclusion>
 					<groupId>io.airlift</groupId>
 					<artifactId>aircompressor</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>log-manager</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>javax.inject</groupId>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -24,7 +24,7 @@ import org.apache.flink.fs.s3.common.HadoopConfigLoader;
 import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import com.facebook.presto.hive.PrestoS3FileSystem;
+import com.facebook.presto.hive.s3.PrestoS3FileSystem;
 import org.apache.hadoop.fs.FileSystem;
 
 import javax.annotation.Nullable;

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.facebook.presto:presto-hive:0.185
+- com.facebook.presto:presto-hive:0.187
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1
 - com.google.guava:guava:21.0
-- io.airlift:configuration:0.148
-- io.airlift:log:0.148
-- io.airlift:stats:0.148
+- io.airlift:configuration:0.153
+- io.airlift:log:0.153
+- io.airlift:stats:0.153
 - io.airlift:units:1.0
 - io.airlift:slice:0.31
 - com.fasterxml.jackson.core:jackson-annotations:2.8.1

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
@@ -34,16 +34,16 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import static com.facebook.presto.hive.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
+import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 /**
- * Unit tests for the S3 file system support via Presto's {@link com.facebook.presto.hive.PrestoS3FileSystem}.
+ * Unit tests for the S3 file system support via Presto's {@link com.facebook.presto.hive.s3.PrestoS3FileSystem}.
  *
  * <p><strong>BEWARE</strong>: tests must take special care of S3's
  * <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel">consistency guarantees</a>
- * and what the {@link com.facebook.presto.hive.PrestoS3FileSystem} offers.
+ * and what the {@link com.facebook.presto.hive.s3.PrestoS3FileSystem} offers.
  */
 @RunWith(Parameterized.class)
 public class PrestoS3FileSystemITCase extends AbstractHadoopFileSystemITTest {

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.fs.s3.common.HadoopConfigLoader;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.facebook.presto.hive.PrestoS3FileSystem;
+import com.facebook.presto.hive.s3.PrestoS3FileSystem;
 import org.junit.Test;
 
 import java.lang.reflect.Field;


### PR DESCRIPTION
## What is the purpose of the change

Update to newer Presto to allow path-style access.

## Brief change log
  - Bump presto version from 0.185 to 0.186

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
