### PR TITLE
[FLINK-10825][tests] Increase request-backoff for high-parallelism e2e test

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -125,12 +125,12 @@
         <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>
             <td style="word-wrap: break-word;">100</td>
-            <td>Minimum backoff for partition requests of input channels.</td>
+            <td>Minimum backoff in milliseconds for partition requests of input channels.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.max</h5></td>
             <td style="word-wrap: break-word;">10000</td>
-            <td>Maximum backoff for partition requests of input channels.</td>
+            <td>Maximum backoff in milliseconds for partition requests of input channels.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -316,7 +316,7 @@ public class TaskManagerOptions {
 			key("taskmanager.network.request-backoff.initial")
 			.defaultValue(100)
 			.withDeprecatedKeys("taskmanager.net.request-backoff.initial")
-			.withDescription("Minimum backoff for partition requests of input channels.");
+			.withDescription("Minimum backoff in milliseconds for partition requests of input channels.");
 
 	/**
 	 * Maximum backoff for partition requests of input channels.
@@ -325,7 +325,7 @@ public class TaskManagerOptions {
 			key("taskmanager.network.request-backoff.max")
 			.defaultValue(10000)
 			.withDeprecatedKeys("taskmanager.net.request-backoff.max")
-			.withDescription("Maximum backoff for partition requests of input channels.");
+			.withDescription("Maximum backoff in milliseconds for partition requests of input channels.");
 
 	/**
 	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -34,6 +34,7 @@ set_conf "taskmanager.memory.segment-size" "8kb"
 
 set_conf "taskmanager.network.netty.server.numThreads" "1"
 set_conf "taskmanager.network.netty.client.numThreads" "1"
+set_conf "taskmanager.network.request-backoff.max" "60000"
 
 set_conf "taskmanager.numberOfTaskSlots" "1"
 


### PR DESCRIPTION
## What is the purpose of the change

This PR stabilizes the high-parallelism iterations e2e test.

When a task starts running it requests data (partitions) from other tasks. In case of a timeout the request is retried with a backoff, until the maximum backoff (`taskmanager.network.request-backoff.max`) is reached.
When reached a `PartitionNotFoundException` is thrown as reported in the JIRA that fails the job.

If a job is not fully deployed within the time that it takes 1 task to reach the maximum backoff it is quite likely for this exception to occur.

This PR bumps the maximum backoff to 60 seconds, which should give the job more time to fully deploy.
