### PR TITLE
[FLINK-10829][tests] Add support for running jars in FlinkDistribution 

### DIFF
--- a/flink-end-to-end-tests/flink-batch-wordcount-test/pom.xml
+++ b/flink-end-to-end-tests/flink-batch-wordcount-test/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.8-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-batch-wordcount-test</artifactId>
+	<version>1.8-SNAPSHOT</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-end-to-end-tests-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>e2e-batch-wordcount</id>
+			<activation>
+				<property>
+					<name>e2e-misc</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>e2e-batch-wordcount</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<configuration>
+									<includes>
+										<include>**/*ITCase.*</include>
+									</includes>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/flink-end-to-end-tests/flink-batch-wordcount-test/src/test/java/org/apache/flink/api/tests/BatchWordCountITCase.java
+++ b/flink-end-to-end-tests/flink-batch-wordcount-test/src/test/java/org/apache/flink/api/tests/BatchWordCountITCase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.tests;
+
+import org.apache.flink.tests.util.FlinkDistribution;
+import org.apache.flink.util.OperatingSystem;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * End-to-end test for basic batch-job executions.
+ */
+public class BatchWordCountITCase {
+
+	@BeforeClass
+	public static void checkOS() {
+		Assume.assumeFalse("This test does not run on Windows.", OperatingSystem.isWindows());
+	}
+
+	@Rule
+	public final FlinkDistribution dist = new FlinkDistribution();
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testBatchWordcount() throws IOException {
+		dist.startFlinkCluster();
+
+		final Path tmpInputFile = tmp.newFolder("input").toPath().resolve("words");
+		final Path tmpOutputFile = tmp.newFolder("output").toPath().resolve("wc_out");
+
+		Files.write(
+			tmpInputFile,
+			"Hello World how are you, my dear dear world".getBytes(StandardCharsets.UTF_8));
+
+		dist.prepareExampleJob(Paths.get("batch/WordCount.jar"))
+			.setParallelism(1)
+			.addArgument("--input", tmpInputFile.toAbsolutePath().toString())
+			.addArgument("--output", tmpOutputFile.toAbsolutePath().toString())
+			.run();
+
+		final List<String> output = Files.readAllLines(tmpOutputFile);
+
+		Assert.assertEquals(1139286315, output.hashCode());
+	}
+}

--- a/flink-end-to-end-tests/flink-batch-wordcount-test/src/test/resources/log4j-test.properties
+++ b/flink-end-to-end-tests/flink-batch-wordcount-test/src/test/resources/log4j-test.properties
@@ -1,0 +1,27 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=INFO, testlogger
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%m%n

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/AutoClosableProcess.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/AutoClosableProcess.java
@@ -42,6 +42,10 @@ public class AutoClosableProcess implements AutoCloseable {
 		this.process = process;
 	}
 
+	public Process getProcess() {
+		return process;
+	}
+
 	public static AutoClosableProcess runNonBlocking(String step, String... commands) throws IOException {
 		LOG.info("Step Started: " + step);
 		Process process = new ProcessBuilder()

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -60,6 +60,7 @@ under the License.
 		<module>flink-end-to-end-tests-common</module>
 		<module>flink-metrics-reporter-prometheus-test</module>
 		<module>flink-heavy-deployment-stress-test</module>
+		<module>flink-batch-wordcount-test</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
## What is the purpose of the change

This PR extends the `FlinkDistribution` to allow running jars. As a first use-case I've ported the batch-wordcount end-to-end case.

## Brief change log

* extend FlinkDistribution to allow running jars
* port batch-wordcount e2e test to java, contained in new module `flink-batch-wordcount-test`


## Verifying this change

run `mvn verify -De2e-misc -DdistDir=<path_to_flink_dist>` in `flink-end-to-end-tests/flink-batch-wordcount-test`
