### PR TITLE
[FLINK-10826][test] Decrease deployment size of heavy deplyment e2e t…

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
+++ b/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
@@ -25,7 +25,7 @@ TEST=flink-heavy-deployment-stress-test
 TEST_PROGRAM_NAME=HeavyDeploymentStressTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
-set_conf "taskmanager.heap.mb" "256" # 256Mb x 20TMs = 5Gb total heap
+set_conf "taskmanager.heap.mb" "512" # 512Mb x 10TMs = 5Gb total heap
 
 set_conf "taskmanager.memory.size" "8" # 8Mb
 set_conf "taskmanager.network.memory.min" "8mb"
@@ -35,12 +35,12 @@ set_conf "taskmanager.memory.segment-size" "8kb"
 set_conf "taskmanager.numberOfTaskSlots" "10" # 10 slots per TM
 
 start_cluster # this also starts 1TM
-start_taskmanagers 19 # 1TM + 19TM = 20TM a 10 slots = 200 slots
+start_taskmanagers 9 # 1TM + 9TM = 10TM a 10 slots = 100 slots
 
-# This call will result in a deployment with state meta data of 200 x 200 x 50 union states x each 75 entries.
+# This call will result in a deployment with state meta data of 100 x 100 x 50 union states x each 100 entries.
 # We can scale up the numbers to make the test even heavier.
 $FLINK_DIR/bin/flink run ${TEST_PROGRAM_JAR} \
---environment.max_parallelism 1024 --environment.parallelism 200 \
+--environment.max_parallelism 1024 --environment.parallelism 100 \
 --environment.restart_strategy fixed_delay --environment.restart_strategy.fixed_delay.attempts 3 \
 --state_backend.checkpoint_directory ${CHECKPOINT_DIR} \
---heavy_deployment_test.num_list_states_per_op 50 --heavy_deployment_test.num_partitions_per_list_state 75
+--heavy_deployment_test.num_list_states_per_op 50 --heavy_deployment_test.num_partitions_per_list_state 100


### PR DESCRIPTION
## What is the purpose of the change

The previous size of the deployment turned out to be too heavy for Travis, so I tuned the parameters down to some values that should give us a stable test.

