### PR TITLE
[FLINK-10835][network] Remove duplicated round-robin ChannelSelector implementation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RoundRobinChannelSelector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RoundRobinChannelSelector.java
@@ -29,26 +29,12 @@ import org.apache.flink.core.io.IOReadableWritable;
  */
 public class RoundRobinChannelSelector<T extends IOReadableWritable> implements ChannelSelector<T> {
 
-	/**
-	 * Stores the index of the channel to send the next record to.
-	 */
-	private final int[] nextChannelToSendTo = new int[1];
-
-	/**
-	 * Constructs a new default channel selector.
-	 */
-	public RoundRobinChannelSelector() {
-		this.nextChannelToSendTo[0] = 0;
-	}
+	/** Stores the index of the channel to send the next record to. */
+	private final int[] nextChannelToSendTo = new int[] { -1 };
 
 	@Override
 	public int[] selectChannels(final T record, final int numberOfOutputChannels) {
-
-		int newChannel = ++this.nextChannelToSendTo[0];
-		if (newChannel >= numberOfOutputChannels) {
-			this.nextChannelToSendTo[0] = 0;
-		}
-
-		return this.nextChannelToSendTo;
+		nextChannelToSendTo[0] = (nextChannelToSendTo[0] + 1) % numberOfOutputChannels;
+		return nextChannelToSendTo;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/DefaultChannelSelectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/DefaultChannelSelectorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network;
 
+import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
 import org.apache.flink.runtime.io.network.api.writer.RoundRobinChannelSelector;
 import org.apache.flink.types.StringValue;
 
@@ -35,17 +36,22 @@ public class DefaultChannelSelectorTest {
 	 */
 	@Test
 	public void channelSelect() {
-
 		final StringValue dummyRecord = new StringValue("abc");
-		final RoundRobinChannelSelector<StringValue> selector = new RoundRobinChannelSelector<StringValue>();
-		// Test with two channels
-		final int numberOfOutputChannels = 2;
-		int[] selectedChannels = selector.selectChannels(dummyRecord, numberOfOutputChannels);
-		assertEquals(1, selectedChannels.length);
-		assertEquals(1, selectedChannels[0]);
-		selectedChannels = selector.selectChannels(dummyRecord, numberOfOutputChannels);
-		assertEquals(1, selectedChannels.length);
-		assertEquals(0, selectedChannels[0]);
+		final RoundRobinChannelSelector<StringValue> selector = new RoundRobinChannelSelector<>();
+		final int numberOfChannels = 2;
+
+		assertSelectedChannel(selector, dummyRecord, numberOfChannels, 0);
+		assertSelectedChannel(selector, dummyRecord, numberOfChannels, 1);
 	}
 
+	private void assertSelectedChannel(
+		ChannelSelector<StringValue> selector,
+		StringValue record,
+		int numberOfChannels,
+		int expectedChannel) {
+
+		int[] actualResult = selector.selectChannels(record, numberOfChannels);
+		assertEquals(1, actualResult.length);
+		assertEquals(expectedChannel, actualResult[0]);
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -210,7 +210,7 @@ public class RecordWriterTest {
 		TestPooledBufferProvider bufferProvider = new TestPooledBufferProvider(Integer.MAX_VALUE, bufferSize);
 
 		ResultPartitionWriter partitionWriter = new CollectingPartitionWriter(queues, bufferProvider);
-		RecordWriter<ByteArrayIO> writer = new RecordWriter<>(partitionWriter, new RoundRobin<ByteArrayIO>());
+		RecordWriter<ByteArrayIO> writer = new RecordWriter<>(partitionWriter, new RoundRobinChannelSelector<>());
 		CheckpointBarrier barrier = new CheckpointBarrier(Integer.MAX_VALUE + 919192L, Integer.MAX_VALUE + 18828228L, CheckpointOptions.forCheckpointWithDefaultLocation());
 
 		// No records emitted yet, broadcast should not request a buffer
@@ -247,7 +247,7 @@ public class RecordWriterTest {
 		TestPooledBufferProvider bufferProvider = new TestPooledBufferProvider(Integer.MAX_VALUE, bufferSize);
 
 		ResultPartitionWriter partitionWriter = new CollectingPartitionWriter(queues, bufferProvider);
-		RecordWriter<ByteArrayIO> writer = new RecordWriter<>(partitionWriter, new RoundRobin<ByteArrayIO>());
+		RecordWriter<ByteArrayIO> writer = new RecordWriter<>(partitionWriter, new RoundRobinChannelSelector<>());
 		CheckpointBarrier barrier = new CheckpointBarrier(Integer.MAX_VALUE + 1292L, Integer.MAX_VALUE + 199L, CheckpointOptions.forCheckpointWithDefaultLocation());
 
 		// Emit records on some channels first (requesting buffers), then
@@ -590,20 +590,6 @@ public class RecordWriterTest {
 		@Override
 		public void read(DataInputView in) throws IOException {
 			in.readFully(bytes);
-		}
-	}
-
-	/**
-	 * RoundRobin channel selector starting at 0 ({@link RoundRobinChannelSelector} starts at 1).
-	 */
-	private static class RoundRobin<T extends IOReadableWritable> implements ChannelSelector<T> {
-
-		private int[] nextChannel = new int[] { -1 };
-
-		@Override
-		public int[] selectChannels(final T record, final int numberOfOutputChannels) {
-			nextChannel[0] = (nextChannel[0] + 1) % numberOfOutputChannels;
-			return nextChannel;
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*`RoundRobinChannelSelector` exists for default selector in RecordWriter mainly for tests. Another similar `RoundRobin` implementation exists in `RecordWriterTest`, only because the difference in starting channel index for round-robin.*

*We can adjust the test verify logic to keep the same behavior with `RoundRobinChannelSelector`, and then remove the duplicated `RoundRobin`.*

## Brief change log

  - *Remove `RoundRobin` in `RecordWriterTest`*
  - *Simplify the implementation for `RoundRobinChannelSelector`*

## Verifying this change

*This change is already covered by existing tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
