### PR TITLE
[FLINK-10674] [table] Fix DistinctAccumulator.remove lead to NPE.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/DistinctAccumulator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/DistinctAccumulator.scala
@@ -101,13 +101,18 @@ class DistinctAccumulator[ACC](
     * @return true if no instances of the parameters remain in the map, false otherwise.
     */
   def remove(params: Row): Boolean = {
-    val currentCnt = distinctValueMap.get(params)
-    if (currentCnt == 1) {
-      distinctValueMap.remove(params)
+    if (!distinctValueMap.contains(params)) {
       true
     } else {
-      distinctValueMap.put(params, currentCnt - 1L)
-      false
+      val currentCnt = distinctValueMap.get(params)
+
+      if (currentCnt == null || currentCnt <= 1) {
+        distinctValueMap.remove(params)
+        true
+      } else {
+        distinctValueMap.put(params, currentCnt - 1L)
+        false
+      }
     }
   }
 


### PR DESCRIPTION

## What is the purpose of the change
This pull request fixes the problem reported by FLINK-10674 DistinctAccumulator.remove lead to NPE.


## Brief change log
DistinctAccumulator.remove deals with the situation that there is no corresponding instance of the parameters in the distinct map.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) 
    no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
