### PR TITLE
[FLINK-10845][table] Support multiple different DISTINCT aggregates for batch

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -838,6 +838,11 @@ abstract class CodeGenerator(
         val right = operands(1)
         generateEquals(nullCheck, left, right)
 
+      case IS_NOT_DISTINCT_FROM =>
+        val left = operands.head
+        val right = operands(1)
+        generateDistinctFrom(nullCheck, left, right);
+
       case NOT_EQUALS =>
         val left = operands.head
         val right = operands(1)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -841,7 +841,7 @@ abstract class CodeGenerator(
       case IS_NOT_DISTINCT_FROM =>
         val left = operands.head
         val right = operands(1)
-        generateDistinctFrom(nullCheck, left, right);
+        generateIsNotDistinctFrom(left, right);
 
       case NOT_EQUALS =>
         val left = operands.head

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -191,7 +191,17 @@ object ScalarOperators {
           )
         )
     }
-  }  
+  }
+
+  def generateDistinctFrom(
+      nullCheck: Boolean,
+      left: GeneratedExpression,
+      right: GeneratedExpression)
+    : GeneratedExpression = {
+    val newleft = left.copy(nullTerm = GeneratedExpression.NEVER_NULL)
+    val newright = left.copy(nullTerm = GeneratedExpression.NEVER_NULL)
+    generateEquals(nullCheck, newleft, newright)
+  }
   
   def generateEquals(
       nullCheck: Boolean,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -406,6 +406,10 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "((((true) === true) || false).cast(STRING) + 'X ').trim",
       "trueX")
     testTableApi(12.isNull, "12.isNull", "false")
+
+    testSqlApi("f12 IS NOT DISTINCT FROM NULL", "true")
+    testSqlApi("f9 IS NOT DISTINCT FROM NULL", "false")
+    testSqlApi("f9 IS NOT DISTINCT FROM 10", "true")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

This PR tried to support multiple distinct aggregates with different arguments for batch. For other cases such as single distinct or multiple with the same arguments it seemed to have supported. Actually it is the problem of IS_NOT_DISTINCT_FROM codegen support result from calcite rewrite

## Brief change log

  - *CodeGenerator and ScalarOperator*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added AggregateITCase batch test*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
