### PR TITLE
[FLINK-10856] Take latest checkpoint to resume from in resume from externalized checkpoint e2e test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -111,16 +111,11 @@ else
   cancel_job $DATASTREAM_JOB
 fi
 
-CHECKPOINT_PATH=$(ls -d $CHECKPOINT_DIR/$DATASTREAM_JOB/chk-[1-9]*)
+# take the latest checkpoint
+CHECKPOINT_PATH=$(ls -d $CHECKPOINT_DIR/$DATASTREAM_JOB/chk-[1-9]* | sort -Vr | head -n1)
 
 if [ -z $CHECKPOINT_PATH ]; then
   echo "Expected an externalized checkpoint to be present, but none exists."
-  exit 1
-fi
-
-NUM_CHECKPOINTS=$(echo $CHECKPOINT_PATH | wc -l | tr -d ' ')
-if (( $NUM_CHECKPOINTS > 1 )); then
-  echo "Expected only exactly 1 externalized checkpoint to be present, but $NUM_CHECKPOINTS exists."
   exit 1
 fi
 
@@ -140,6 +135,11 @@ else
 fi
 
 DATASTREAM_JOB=$($JOB_CMD | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+if [ -z $DATASTREAM_JOB ]; then
+    echo "Resuming from externalized checkpoint job could not be started."
+    exit 1
+fi
 
 wait_job_running $DATASTREAM_JOB
 wait_oper_metric_num_in_records SemanticsCheckMapper.0 200


### PR DESCRIPTION
## What is the purpose of the change

Since it can happen that some empty checkpoint directories are left, we have to take the latest
checkpoint directory in order to resume from an externalized checkpoint. This commit changes the
test_resume_externalized_checkpoint.sh to sort the checkpoint directories in descending order and
then takes the head checkpoint directory.

## Verifying this change

- Manually tested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
