### PR TITLE
[FLINK-10857][metrics] Cache logical scopes separately for each reporter

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -165,23 +165,22 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @param reporterIndex index of the reporter
 	 * @return logical scope
 	 */
-	public String getLogicalScope(CharacterFilter filter, char delimiter, int reporterIndex) {
+	String getLogicalScope(CharacterFilter filter, char delimiter, int reporterIndex) {
 		if (logicalScopeStrings.length == 0 || (reporterIndex < 0 || reporterIndex >= logicalScopeStrings.length)) {
-			if (parent == null) {
-				return getGroupName(filter);
-			} else {
-				return parent.getLogicalScope(filter, delimiter) + delimiter + getGroupName(filter);
-			}
+			return createLogicalScope(filter, delimiter);
 		} else {
 			if (logicalScopeStrings[reporterIndex] == null) {
-				if (parent == null) {
-					logicalScopeStrings[reporterIndex] = getGroupName(filter);
-				} else {
-					logicalScopeStrings[reporterIndex] = parent.getLogicalScope(filter, delimiter) + delimiter + getGroupName(filter);
-				}
+				logicalScopeStrings[reporterIndex] = createLogicalScope(filter, delimiter);
 			}
 			return logicalScopeStrings[reporterIndex];
 		}
+	}
+
+	private String createLogicalScope(CharacterFilter filter, char delimiter) {
+		final String groupName = getGroupName(filter);
+		return parent == null
+			? groupName
+			: parent.getLogicalScope(filter, delimiter) + delimiter + groupName;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -52,6 +52,6 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 	}
 
 	public String getLogicalScope(CharacterFilter filter, char delimiter) {
-		return parentMetricGroup.getLogicalScope(filter, delimiter);
+		return parentMetricGroup.getLogicalScope(filter, delimiter, this.reporterIndex);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes an issue in the metric system where the logical scope was not cached separately for each reporter. As a result other reporters might access logical scopes for which the wrong filter and/or delimiter was used.

## Brief change log

* cache logicalScopeStrings separately each reporter
* modify `FrontMetricGroup` to inject reporterIndex when computing logical scope

## Verifying this change

This change added tests and can be verified as follows:
* run `AbstractMetricGroupTest#testLogicalScopeCachingForMultipleReporters`
