### PR TITLE
[FLINK-10899] Remove explicit version tag from flink-metrics-availability-test and flink-metrics-reporter-prometheus-test

### DIFF
--- a/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
@@ -22,13 +22,13 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.8-SNAPSHOT</version>
+		<version>1.7-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-metrics-availability-test</artifactId>
-	<version>1.8-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -23,12 +23,12 @@ under the License.
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
 		<version>1.7-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-metrics-reporter-prometheus-test</artifactId>
-	<version>1.7-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Backport of #7104  for `release-1.7`.