### PR TITLE
[FLINK-8159] [cep] Pattern(Flat)SelectFunctions should support RichFunction interface

### DIFF
--- a/flink-libraries/flink-cep-scala/src/test/scala/org/apache/flink/cep/scala/pattern/PatternTest.scala
+++ b/flink-libraries/flink-cep-scala/src/test/scala/org/apache/flink/cep/scala/pattern/PatternTest.scala
@@ -113,7 +113,7 @@ class PatternTest {
 
     assertTrue(pattern.getCondition.isDefined)
     assertTrue(previous.getCondition.isDefined)
-    assertFalse(preprevious.getCondition.isDefined)
+    assertTrue(preprevious.getCondition.isDefined)
 
     assertEquals(pattern.getName, "end")
     assertEquals(previous.getName, "next")

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/CepRuntimeContext.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.accumulators.DoubleCounter;
+import org.apache.flink.api.common.accumulators.Histogram;
+import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.accumulators.LongCounter;
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.metrics.MetricGroup;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A wrapper class for pattern select function and iterative condition function's {@link RuntimeContext}.
+ * The runtime context only supports basic operations. Consequently, state access, accumulators,
+ * broadcast variables and the distributed cache are disabled.
+ */
+public class CepRuntimeContext implements RuntimeContext {
+
+	private final RuntimeContext runtimeContext;
+
+	public CepRuntimeContext(RuntimeContext runtimeContext) {
+		this.runtimeContext = runtimeContext;
+	}
+
+	@Override
+	public String getTaskName() {
+		return runtimeContext.getTaskName();
+	}
+
+	@Override
+	public MetricGroup getMetricGroup() {
+		return runtimeContext.getMetricGroup();
+	}
+
+	@Override
+	public int getNumberOfParallelSubtasks() {
+		return runtimeContext.getNumberOfParallelSubtasks();
+	}
+
+	@Override
+	public int getMaxNumberOfParallelSubtasks() {
+		return runtimeContext.getMaxNumberOfParallelSubtasks();
+	}
+
+	@Override
+	public int getIndexOfThisSubtask() {
+		return runtimeContext.getIndexOfThisSubtask();
+	}
+
+	@Override
+	public int getAttemptNumber() {
+		return runtimeContext.getAttemptNumber();
+	}
+
+	@Override
+	public String getTaskNameWithSubtasks() {
+		return runtimeContext.getTaskNameWithSubtasks();
+	}
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return runtimeContext.getExecutionConfig();
+	}
+
+	@Override
+	public ClassLoader getUserCodeClassLoader() {
+		return runtimeContext.getUserCodeClassLoader();
+	}
+
+	// -----------------------------------------------------------------------------------
+	// Unsupported operations
+	// -----------------------------------------------------------------------------------
+
+	@Override
+	public <V, A extends Serializable> void addAccumulator(
+		String name, Accumulator<V, A> accumulator) {
+		throw new UnsupportedOperationException("Accumulators are not supported.");
+	}
+
+	@Override
+	public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
+		throw new UnsupportedOperationException("Accumulators are not supported.");
+	}
+
+	@Override
+	public Map<String, Accumulator<?, ?>> getAllAccumulators() {
+		throw new UnsupportedOperationException("Accumulators are not supported.");
+	}
+
+	@Override
+	public IntCounter getIntCounter(String name) {
+		throw new UnsupportedOperationException("Int counters are not supported.");
+	}
+
+	@Override
+	public LongCounter getLongCounter(String name) {
+		throw new UnsupportedOperationException("Long counters are not supported.");
+	}
+
+	@Override
+	public DoubleCounter getDoubleCounter(String name) {
+		throw new UnsupportedOperationException("Double counters are not supported.");
+	}
+
+	@Override
+	public Histogram getHistogram(String name) {
+		throw new UnsupportedOperationException("Histograms are not supported.");
+	}
+
+	@Override
+	public boolean hasBroadcastVariable(String name) {
+		throw new UnsupportedOperationException("Broadcast variables are not supported.");
+	}
+
+	@Override
+	public <RT> List<RT> getBroadcastVariable(String name) {
+		throw new UnsupportedOperationException("Broadcast variables are not supported.");
+	}
+
+	@Override
+	public <T, C> C getBroadcastVariableWithInitializer(
+		String name, BroadcastVariableInitializer<T, C> initializer) {
+		throw new UnsupportedOperationException("Broadcast variables are not supported.");
+	}
+
+	@Override
+	public DistributedCache getDistributedCache() {
+		throw new UnsupportedOperationException("Distributed cache is not supported.");
+	}
+
+	@Override
+	public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
+		throw new UnsupportedOperationException("State is not supported.");
+	}
+
+	@Override
+	public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
+		throw new UnsupportedOperationException("State is not supported.");
+	}
+
+	@Override
+	public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
+		throw new UnsupportedOperationException("State is not supported.");
+	}
+
+	@Override
+	public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
+		throw new UnsupportedOperationException("State is not supported.");
+	}
+
+	@Override
+	public <T, ACC> FoldingState<T, ACC> getFoldingState(FoldingStateDescriptor<T, ACC> stateProperties) {
+		throw new UnsupportedOperationException("State is not supported.");
+	}
+
+	@Override
+	public <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties) {
+		throw new UnsupportedOperationException("State is not supported.");
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/RichPatternFlatSelectFunction.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/RichPatternFlatSelectFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rich variant of the {@link PatternFlatSelectFunction}. As a {@link RichFunction}, it gives access to the
+ * {@link org.apache.flink.api.common.functions.RuntimeContext} and provides setup and teardown methods:
+ * {@link RichFunction#open(org.apache.flink.configuration.Configuration)} and
+ * {@link RichFunction#close()}.
+ *
+ * @param <IN> Type of the input elements
+ * @param <OUT> Type of the output element
+ */
+public abstract class RichPatternFlatSelectFunction<IN, OUT>
+		extends AbstractRichFunction
+		implements PatternFlatSelectFunction<IN, OUT> {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void setRuntimeContext(RuntimeContext runtimeContext) {
+		Preconditions.checkNotNull(runtimeContext);
+
+		if (runtimeContext instanceof CepRuntimeContext) {
+			super.setRuntimeContext(runtimeContext);
+		} else {
+			super.setRuntimeContext(new CepRuntimeContext(runtimeContext));
+		}
+	}
+
+	public abstract void flatSelect(Map<String, List<IN>> pattern, Collector<OUT> out) throws Exception;
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/RichPatternSelectFunction.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/RichPatternSelectFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rich variant of the {@link PatternSelectFunction}. As a {@link RichFunction}, it gives access to the
+ * {@link org.apache.flink.api.common.functions.RuntimeContext} and provides setup and teardown methods:
+ * {@link RichFunction#open(org.apache.flink.configuration.Configuration)} and
+ * {@link RichFunction#close()}.
+ *
+ * @param <IN> Type of the input elements
+ * @param <OUT> Type of the output element
+ */
+public abstract class RichPatternSelectFunction<IN, OUT>
+		extends AbstractRichFunction
+		implements PatternSelectFunction<IN, OUT> {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void setRuntimeContext(RuntimeContext runtimeContext) {
+		Preconditions.checkNotNull(runtimeContext);
+
+		if (runtimeContext instanceof CepRuntimeContext) {
+			super.setRuntimeContext(runtimeContext);
+		} else {
+			super.setRuntimeContext(new CepRuntimeContext(runtimeContext));
+		}
+	}
+
+	public abstract OUT select(Map<String, List<IN>> pattern) throws Exception;
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.cep.operator;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
@@ -33,10 +34,14 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.NFA.MigratedNFA;
 import org.apache.flink.cep.nfa.NFAState;
 import org.apache.flink.cep.nfa.NFAStateSerializer;
+import org.apache.flink.cep.nfa.State;
+import org.apache.flink.cep.nfa.StateTransition;
 import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBuffer;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferAccessor;
+import org.apache.flink.cep.pattern.conditions.IterativeCondition;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -185,6 +190,15 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 				this);
 
 		this.nfa = nfaFactory.createNFA();
+
+		openNFA(nfa);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+
+		closeNFA(nfa);
 	}
 
 	@Override
@@ -392,6 +406,26 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 			Collection<Tuple2<Map<String, List<IN>>, Long>> timedOut =
 				nfa.advanceTime(sharedBufferAccessor, nfaState, timestamp);
 			processTimedOutSequences(timedOut, timestamp);
+		}
+	}
+
+	private void openNFA(NFA<IN> nfa) throws Exception {
+		Configuration conf = new Configuration();
+		for (State<IN> state : nfa.getStates()) {
+			for (StateTransition<IN> transition : state.getStateTransitions()) {
+				IterativeCondition condition = transition.getCondition();
+				FunctionUtils.setFunctionRuntimeContext(condition, getRuntimeContext());
+				FunctionUtils.openFunction(condition, conf);
+			}
+		}
+	}
+
+	private void closeNFA(NFA<IN> nfa) throws Exception {
+		for (State<IN> state : nfa.getStates()) {
+			for (StateTransition<IN> transition : state.getStateTransitions()) {
+				IterativeCondition condition = transition.getCondition();
+				FunctionUtils.closeFunction(condition);
+			}
 		}
 	}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
@@ -23,9 +23,9 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
 import org.apache.flink.cep.pattern.Quantifier.ConsumingStrategy;
 import org.apache.flink.cep.pattern.Quantifier.Times;
-import org.apache.flink.cep.pattern.conditions.AndCondition;
 import org.apache.flink.cep.pattern.conditions.IterativeCondition;
-import org.apache.flink.cep.pattern.conditions.OrCondition;
+import org.apache.flink.cep.pattern.conditions.RichAndCondition;
+import org.apache.flink.cep.pattern.conditions.RichOrCondition;
 import org.apache.flink.cep.pattern.conditions.SubtypeCondition;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.Preconditions;
@@ -154,7 +154,7 @@ public class Pattern<T, F extends T> {
 		if (this.condition == null) {
 			this.condition = condition;
 		} else {
-			this.condition = new AndCondition<>(this.condition, condition);
+			this.condition = new RichAndCondition<>(this.condition, condition);
 		}
 		return this;
 	}
@@ -177,7 +177,7 @@ public class Pattern<T, F extends T> {
 		if (this.condition == null) {
 			this.condition = condition;
 		} else {
-			this.condition = new OrCondition<>(this.condition, condition);
+			this.condition = new RichOrCondition<>(this.condition, condition);
 		}
 		return this;
 	}
@@ -196,7 +196,7 @@ public class Pattern<T, F extends T> {
 		if (condition == null) {
 			this.condition = new SubtypeCondition<F>(subtypeClass);
 		} else {
-			this.condition = new AndCondition<>(condition, new SubtypeCondition<F>(subtypeClass));
+			this.condition = new RichAndCondition<>(condition, new SubtypeCondition<F>(subtypeClass));
 		}
 
 		@SuppressWarnings("unchecked")

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
@@ -23,6 +23,7 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
 import org.apache.flink.cep.pattern.Quantifier.ConsumingStrategy;
 import org.apache.flink.cep.pattern.Quantifier.Times;
+import org.apache.flink.cep.pattern.conditions.BooleanConditions;
 import org.apache.flink.cep.pattern.conditions.IterativeCondition;
 import org.apache.flink.cep.pattern.conditions.RichAndCondition;
 import org.apache.flink.cep.pattern.conditions.RichOrCondition;
@@ -105,7 +106,11 @@ public class Pattern<T, F extends T> {
 	}
 
 	public IterativeCondition<F> getCondition() {
-		return condition;
+		if (condition != null) {
+			return condition;
+		} else {
+			return BooleanConditions.trueFunction();
+		}
 	}
 
 	public IterativeCondition<F> getUntilCondition() {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
-import org.apache.flink.util.Preconditions;
-
 /**
  * A {@link IterativeCondition condition} which combines two conditions with a logical
  * {@code AND} and returns {@code true} if both are {@code true}.
@@ -34,13 +32,13 @@ public class AndCondition<T> extends IterativeCondition<T> {
 	private final IterativeCondition<T> right;
 
 	public AndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
-		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+		this.left = left;
+		this.right = right;
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		return left.filter(value, ctx) && right.filter(value, ctx);
+		return (left == null || left.filter(value, ctx)) && (right == null || right.filter(value, ctx));
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
@@ -18,12 +18,19 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
 /**
  * A {@link IterativeCondition condition} which combines two conditions with a logical
  * {@code AND} and returns {@code true} if both are {@code true}.
  *
  * @param <T> Type of the element to filter
+ * @deprecated Please use {@link RichAndCondition} instead. This class exists just for
+ * backwards compatibility and will be removed in FLINK-10113.
  */
+@Internal
+@Deprecated
 public class AndCondition<T> extends IterativeCondition<T> {
 
 	private static final long serialVersionUID = -2471892317390197319L;
@@ -32,13 +39,13 @@ public class AndCondition<T> extends IterativeCondition<T> {
 	private final IterativeCondition<T> right;
 
 	public AndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = left;
-		this.right = right;
+		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");;
+		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");;
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		return (left == null || left.filter(value, ctx)) && (right == null || right.filter(value, ctx));
+		return left.filter(value, ctx) && right.filter(value, ctx);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
@@ -39,8 +39,8 @@ public class AndCondition<T> extends IterativeCondition<T> {
 	private final IterativeCondition<T> right;
 
 	public AndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");;
-		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");;
+		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
+		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/BooleanConditions.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/BooleanConditions.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * Utility class containing an {@link IterativeCondition} that always returns
  * {@code true} and one that always returns {@code false}.
  */
+@Internal
 public class BooleanConditions {
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
@@ -18,12 +18,18 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * A {@link IterativeCondition condition} which negates the condition it wraps
  * and returns {@code true} if the original condition returns {@code false}.
  *
  * @param <T> Type of the element to filter
+ * @deprecated Please use {@link RichNotCondition} instead. This class exists just for
+ * backwards compatibility and will be removed in FLINK-10113.
  */
+@Internal
+@Deprecated
 public class NotCondition<T> extends IterativeCondition<T> {
 	private static final long serialVersionUID = -2109562093871155005L;
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
-import org.apache.flink.util.Preconditions;
-
 /**
  * A {@link IterativeCondition condition} which combines two conditions with a logical
  * {@code OR} and returns {@code true} if at least one is {@code true}.
@@ -34,13 +32,13 @@ public class OrCondition<T> extends IterativeCondition<T> {
 	private final IterativeCondition<T> right;
 
 	public OrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
-		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+		this.left = left;
+		this.right = right;
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		return left.filter(value, ctx) || right.filter(value, ctx);
+		return left == null || right == null || left.filter(value, ctx) || right.filter(value, ctx);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
@@ -18,12 +18,19 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
 /**
  * A {@link IterativeCondition condition} which combines two conditions with a logical
  * {@code OR} and returns {@code true} if at least one is {@code true}.
  *
  * @param <T> Type of the element to filter
+ * @deprecated Please use {@link RichOrCondition} instead. This class exists just for
+ * backwards compatibility and will be removed in FLINK-10113.
  */
+@Internal
+@Deprecated
 public class OrCondition<T> extends IterativeCondition<T> {
 
 	private static final long serialVersionUID = 2554610954278485106L;
@@ -32,13 +39,13 @@ public class OrCondition<T> extends IterativeCondition<T> {
 	private final IterativeCondition<T> right;
 
 	public OrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = left;
-		this.right = right;
+		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");;
+		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");;
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		return left == null || right == null || left.filter(value, ctx) || right.filter(value, ctx);
+		return left.filter(value, ctx) || right.filter(value, ctx);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
@@ -39,8 +39,8 @@ public class OrCondition<T> extends IterativeCondition<T> {
 	private final IterativeCondition<T> right;
 
 	public OrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");;
-		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");;
+		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
+		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichAndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichAndCondition.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A {@link RichIterativeCondition condition} which combines two conditions with a logical
+ * {@code AND} and returns {@code true} if both are {@code true}.
+ *
+ * @param <T> Type of the element to filter
+ */
+public class RichAndCondition<T> extends RichIterativeCondition<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final IterativeCondition<T> left;
+	private final IterativeCondition<T> right;
+
+	public RichAndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
+		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
+		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		FunctionUtils.setFunctionRuntimeContext(left, t);
+		FunctionUtils.setFunctionRuntimeContext(right, t);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		FunctionUtils.openFunction(left, parameters);
+		FunctionUtils.openFunction(right, parameters);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		FunctionUtils.closeFunction(left);
+		FunctionUtils.closeFunction(right);
+	}
+
+	@Override
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return left.filter(value, ctx) && right.filter(value, ctx);
+	}
+
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getLeft() {
+		return left;
+	}
+
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getRight() {
+		return right;
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichAndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichAndCondition.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
-import org.apache.flink.util.Preconditions;
-
 /**
  * A {@link RichIterativeCondition condition} which combines two conditions with a logical
  * {@code AND} and returns {@code true} if both are {@code true}.
@@ -31,16 +29,14 @@ public class RichAndCondition<T> extends RichCompositeIterativeCondition<T> {
 	private static final long serialVersionUID = 1L;
 
 	public RichAndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		super(
-			Preconditions.checkNotNull(left, "The condition cannot be null."),
-			Preconditions.checkNotNull(right, "The condition cannot be null."));
+		super(left, right);
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
 		IterativeCondition<T> left = getLeft();
 		IterativeCondition<T> right = getRight();
-		return left.filter(value, ctx) && right.filter(value, ctx);
+		return (left == null || left.filter(value, ctx)) && (right == null || right.filter(value, ctx));
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichAndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichAndCondition.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * A {@link RichIterativeCondition condition} which combines two conditions with a logical
  * {@code AND} and returns {@code true} if both are {@code true}.
  *
  * @param <T> Type of the element to filter
  */
+@Internal
 public class RichAndCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	private static final long serialVersionUID = 1L;
@@ -34,9 +37,7 @@ public class RichAndCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		IterativeCondition<T> left = getLeft();
-		IterativeCondition<T> right = getRight();
-		return (left == null || left.filter(value, ctx)) && (right == null || right.filter(value, ctx));
+		return getLeft().filter(value, ctx) && getRight().filter(value, ctx);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichCompositeIterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichCompositeIterativeCondition.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * A base class of composite {@link IterativeCondition} conditions such as {@link RichAndCondition},
+ * {@link RichOrCondition} and {@link RichNotCondition}, etc. It handles the open, close and
+ * setRuntimeContext for the nested {@link IterativeCondition} conditions.
+ *
+ * @param <T> Type of the element to filter
+ */
+public abstract class RichCompositeIterativeCondition<T> extends RichIterativeCondition<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final IterativeCondition<T>[] nestedConditions;
+
+	@SafeVarargs
+	public RichCompositeIterativeCondition(final IterativeCondition<T>... nestedConditions) {
+		this.nestedConditions = nestedConditions;
+	}
+
+	public IterativeCondition<T>[] getNestedConditions() {
+		return nestedConditions;
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+
+		for (IterativeCondition<T> nestedCondition : nestedConditions) {
+			if (nestedCondition != null) {
+				FunctionUtils.setFunctionRuntimeContext(nestedCondition, t);
+			}
+		}
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		for (IterativeCondition<T> nestedCondition : nestedConditions) {
+			if (nestedCondition != null) {
+				FunctionUtils.openFunction(nestedCondition, parameters);
+			}
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		for (IterativeCondition<T> nestedCondition : nestedConditions) {
+			if (nestedCondition != null) {
+				FunctionUtils.closeFunction(nestedCondition);
+			}
+		}
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichCompositeIterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichCompositeIterativeCondition.java
@@ -21,6 +21,7 @@ package org.apache.flink.cep.pattern.conditions;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A base class of composite {@link IterativeCondition} conditions such as {@link RichAndCondition},
@@ -37,6 +38,9 @@ public abstract class RichCompositeIterativeCondition<T> extends RichIterativeCo
 
 	@SafeVarargs
 	public RichCompositeIterativeCondition(final IterativeCondition<T>... nestedConditions) {
+		for (IterativeCondition<T> condition : nestedConditions) {
+			Preconditions.checkNotNull(condition, "The condition cannot be null.");
+		}
 		this.nestedConditions = nestedConditions;
 	}
 
@@ -49,9 +53,7 @@ public abstract class RichCompositeIterativeCondition<T> extends RichIterativeCo
 		super.setRuntimeContext(t);
 
 		for (IterativeCondition<T> nestedCondition : nestedConditions) {
-			if (nestedCondition != null) {
-				FunctionUtils.setFunctionRuntimeContext(nestedCondition, t);
-			}
+			FunctionUtils.setFunctionRuntimeContext(nestedCondition, t);
 		}
 	}
 
@@ -59,9 +61,7 @@ public abstract class RichCompositeIterativeCondition<T> extends RichIterativeCo
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
 		for (IterativeCondition<T> nestedCondition : nestedConditions) {
-			if (nestedCondition != null) {
-				FunctionUtils.openFunction(nestedCondition, parameters);
-			}
+			FunctionUtils.openFunction(nestedCondition, parameters);
 		}
 	}
 
@@ -69,9 +69,7 @@ public abstract class RichCompositeIterativeCondition<T> extends RichIterativeCo
 	public void close() throws Exception {
 		super.close();
 		for (IterativeCondition<T> nestedCondition : nestedConditions) {
-			if (nestedCondition != null) {
-				FunctionUtils.closeFunction(nestedCondition);
-			}
+			FunctionUtils.closeFunction(nestedCondition);
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichIterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichIterativeCondition.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.IterationRuntimeContext;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.cep.CepRuntimeContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Rich variant of the {@link IterativeCondition}. As a {@link RichFunction}, it gives access to the
+ * {@link org.apache.flink.api.common.functions.RuntimeContext} and provides setup and teardown methods:
+ * {@link RichFunction#open(org.apache.flink.configuration.Configuration)} and
+ * {@link RichFunction#close()}.
+ */
+public abstract class RichIterativeCondition<T>
+		extends IterativeCondition<T>
+		implements RichFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	// --------------------------------------------------------------------------------------------
+	//  Runtime context access
+	// --------------------------------------------------------------------------------------------
+
+	private transient RuntimeContext runtimeContext;
+
+	@Override
+	public void setRuntimeContext(RuntimeContext runtimeContext) {
+		Preconditions.checkNotNull(runtimeContext);
+
+		if (runtimeContext instanceof CepRuntimeContext) {
+			this.runtimeContext = runtimeContext;
+		} else {
+			this.runtimeContext = new CepRuntimeContext(runtimeContext);
+		}
+	}
+
+	@Override
+	public RuntimeContext getRuntimeContext() {
+		if (this.runtimeContext != null) {
+			return this.runtimeContext;
+		} else {
+			throw new IllegalStateException("The runtime context has not been initialized.");
+		}
+	}
+
+	@Override
+	public IterationRuntimeContext getIterationRuntimeContext() {
+		throw new UnsupportedOperationException("Not support to get the IterationRuntimeContext in IterativeCondition.");
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Default life cycle methods
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public void open(Configuration parameters) throws Exception {}
+
+	@Override
+	public void close() throws Exception {}
+
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichNotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichNotCondition.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * A {@link RichIterativeCondition condition} which negates the condition it wraps
  * and returns {@code true} if the original condition returns {@code false}.
  *
  * @param <T> Type of the element to filter
  */
+@Internal
 public class RichNotCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	private static final long serialVersionUID = 1L;
@@ -34,7 +37,6 @@ public class RichNotCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		IterativeCondition<T> original = getNestedConditions()[0];
-		return original != null && !original.filter(value, ctx);
+		return !getNestedConditions()[0].filter(value, ctx);
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichNotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichNotCondition.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * A {@link RichIterativeCondition condition} which negates the condition it wraps
+ * and returns {@code true} if the original condition returns {@code false}.
+ *
+ * @param <T> Type of the element to filter
+ */
+public class RichNotCondition<T> extends RichIterativeCondition<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final IterativeCondition<T> original;
+
+	public RichNotCondition(final IterativeCondition<T> original) {
+		this.original = original;
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		if (original != null) {
+			FunctionUtils.setFunctionRuntimeContext(original, t);
+		}
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		if (original != null) {
+			FunctionUtils.openFunction(original, parameters);
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		if (original != null) {
+			FunctionUtils.closeFunction(original);
+		}
+	}
+
+	@Override
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return original != null && !original.filter(value, ctx);
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichNotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichNotCondition.java
@@ -18,52 +18,23 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.functions.util.FunctionUtils;
-import org.apache.flink.configuration.Configuration;
-
 /**
  * A {@link RichIterativeCondition condition} which negates the condition it wraps
  * and returns {@code true} if the original condition returns {@code false}.
  *
  * @param <T> Type of the element to filter
  */
-public class RichNotCondition<T> extends RichIterativeCondition<T> {
+public class RichNotCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	private static final long serialVersionUID = 1L;
 
-	private final IterativeCondition<T> original;
-
 	public RichNotCondition(final IterativeCondition<T> original) {
-		this.original = original;
-	}
-
-	@Override
-	public void setRuntimeContext(RuntimeContext t) {
-		super.setRuntimeContext(t);
-		if (original != null) {
-			FunctionUtils.setFunctionRuntimeContext(original, t);
-		}
-	}
-
-	@Override
-	public void open(Configuration parameters) throws Exception {
-		super.open(parameters);
-		if (original != null) {
-			FunctionUtils.openFunction(original, parameters);
-		}
-	}
-
-	@Override
-	public void close() throws Exception {
-		super.close();
-		if (original != null) {
-			FunctionUtils.closeFunction(original);
-		}
+		super(original);
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
+		IterativeCondition<T> original = getNestedConditions()[0];
 		return original != null && !original.filter(value, ctx);
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A {@link RichIterativeCondition condition} which combines two conditions with a logical
+ * {@code OR} and returns {@code true} if at least one is {@code true}.
+ *
+ * @param <T> Type of the element to filter
+ */
+public class RichOrCondition<T> extends RichIterativeCondition<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final IterativeCondition<T> left;
+	private final IterativeCondition<T> right;
+
+	public RichOrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
+		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
+		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		FunctionUtils.setFunctionRuntimeContext(left, t);
+		FunctionUtils.setFunctionRuntimeContext(right, t);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		FunctionUtils.openFunction(left, parameters);
+		FunctionUtils.openFunction(right, parameters);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		FunctionUtils.closeFunction(left);
+		FunctionUtils.closeFunction(right);
+	}
+
+	@Override
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return left.filter(value, ctx) || right.filter(value, ctx);
+	}
+
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getLeft() {
+		return left;
+	}
+
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getRight() {
+		return right;
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * A {@link RichIterativeCondition condition} which combines two conditions with a logical
  * {@code OR} and returns {@code true} if at least one is {@code true}.
  *
  * @param <T> Type of the element to filter
  */
+@Internal
 public class RichOrCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	private static final long serialVersionUID = 1L;
@@ -34,9 +37,7 @@ public class RichOrCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
-		IterativeCondition<T> left = getLeft();
-		IterativeCondition<T> right = getRight();
-		return left == null || right == null || left.filter(value, ctx) || right.filter(value, ctx);
+		return getLeft().filter(value, ctx) || getRight().filter(value, ctx);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.functions.util.FunctionUtils;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -29,41 +26,20 @@ import org.apache.flink.util.Preconditions;
  *
  * @param <T> Type of the element to filter
  */
-public class RichOrCondition<T> extends RichIterativeCondition<T> {
+public class RichOrCondition<T> extends RichCompositeIterativeCondition<T> {
 
 	private static final long serialVersionUID = 1L;
 
-	private final IterativeCondition<T> left;
-	private final IterativeCondition<T> right;
-
 	public RichOrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
-		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
-	}
-
-	@Override
-	public void setRuntimeContext(RuntimeContext t) {
-		super.setRuntimeContext(t);
-		FunctionUtils.setFunctionRuntimeContext(left, t);
-		FunctionUtils.setFunctionRuntimeContext(right, t);
-	}
-
-	@Override
-	public void open(Configuration parameters) throws Exception {
-		super.open(parameters);
-		FunctionUtils.openFunction(left, parameters);
-		FunctionUtils.openFunction(right, parameters);
-	}
-
-	@Override
-	public void close() throws Exception {
-		super.close();
-		FunctionUtils.closeFunction(left);
-		FunctionUtils.closeFunction(right);
+		super(
+			Preconditions.checkNotNull(left, "The condition cannot be null."),
+			Preconditions.checkNotNull(right, "The condition cannot be null."));
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
+		IterativeCondition<T> left = getLeft();
+		IterativeCondition<T> right = getRight();
 		return left.filter(value, ctx) || right.filter(value, ctx);
 	}
 
@@ -71,13 +47,13 @@ public class RichOrCondition<T> extends RichIterativeCondition<T> {
 	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
 	 */
 	public IterativeCondition<T> getLeft() {
-		return left;
+		return getNestedConditions()[0];
 	}
 
 	/**
 	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
 	 */
 	public IterativeCondition<T> getRight() {
-		return right;
+		return getNestedConditions()[1];
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichOrCondition.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
-import org.apache.flink.util.Preconditions;
-
 /**
  * A {@link RichIterativeCondition condition} which combines two conditions with a logical
  * {@code OR} and returns {@code true} if at least one is {@code true}.
@@ -31,16 +29,14 @@ public class RichOrCondition<T> extends RichCompositeIterativeCondition<T> {
 	private static final long serialVersionUID = 1L;
 
 	public RichOrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
-		super(
-			Preconditions.checkNotNull(left, "The condition cannot be null."),
-			Preconditions.checkNotNull(right, "The condition cannot be null."));
+		super(left, right);
 	}
 
 	@Override
 	public boolean filter(T value, Context<T> ctx) throws Exception {
 		IterativeCondition<T> left = getLeft();
 		IterativeCondition<T> right = getRight();
-		return left.filter(value, ctx) || right.filter(value, ctx);
+		return left == null || right == null || left.filter(value, ctx) || right.filter(value, ctx);
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SimpleCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SimpleCondition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.FilterFunction;
 
 /**
@@ -28,6 +29,7 @@ import org.apache.flink.api.common.functions.FilterFunction;
  * previously accepted elements in the pattern. Conditions that extend this class are simple {@code filter(...)}
  * functions that decide based on the properties of the element at hand.
  */
+@Internal
 public abstract class SimpleCondition<T> extends IterativeCondition<T> implements FilterFunction<T> {
 
 	private static final long serialVersionUID = 4942618239408140245L;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SubtypeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SubtypeCondition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -26,6 +27,7 @@ import org.apache.flink.util.Preconditions;
  *
  * @param <T> Type of the elements to be filtered
  */
+@Internal
 public class SubtypeCondition<T> extends SimpleCondition<T> {
 	private static final long serialVersionUID = -2990017519957561355L;
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -19,13 +19,17 @@
 package org.apache.flink.cep;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.RichIterativeCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
@@ -35,6 +39,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Either;
+import org.apache.flink.util.Collector;
 
 import org.junit.Test;
 
@@ -715,5 +720,168 @@ public class CEPITCase extends AbstractTestBase {
 		List<Tuple2<Integer, String>> expected = Arrays.asList(Tuple2.of(1, "a"), Tuple2.of(3, "a"));
 
 		assertEquals(expected, resultList);
+	}
+
+	@Test
+	public void testRichPatternFlatSelectFunction() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStream<Event> input = env.fromElements(
+			new Event(1, "barfoo", 1.0),
+			new Event(2, "start", 2.0),
+			new Event(3, "foobar", 3.0),
+			new SubEvent(4, "foo", 4.0, 1.0),
+			new Event(5, "middle", 5.0),
+			new SubEvent(6, "middle", 6.0, 2.0),
+			new SubEvent(7, "bar", 3.0, 3.0),
+			new Event(42, "42", 42.0),
+			new Event(8, "end", 1.0)
+		);
+
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new RichIterativeCondition<Event>() {
+
+			@Override
+			public boolean filter(Event value, Context<Event> ctx) throws Exception {
+				return value.getName().equals("start");
+			}
+		}).followedByAny("middle").subtype(SubEvent.class).where(
+			new SimpleCondition<SubEvent>() {
+
+				@Override
+				public boolean filter(SubEvent value) throws Exception {
+					return value.getName().equals("middle");
+				}
+			}
+		).followedByAny("end").where(new SimpleCondition<Event>() {
+
+			@Override
+			public boolean filter(Event value) throws Exception {
+				return value.getName().equals("end");
+			}
+		});
+
+		DataStream<String> result =
+			CEP.pattern(input, pattern).flatSelect(new RichPatternFlatSelectFunction<Event, String>() {
+
+				@Override
+				public void open(Configuration config) {
+					try {
+						getRuntimeContext().getMapState(new MapStateDescriptor<>(
+							"test",
+							LongSerializer.INSTANCE,
+							LongSerializer.INSTANCE));
+						throw new RuntimeException("Expected getMapState to fail with unsupported operation exception.");
+					} catch (UnsupportedOperationException e) {
+						// ignore, expected
+					}
+
+					getRuntimeContext().getUserCodeClassLoader();
+				}
+
+				@Override
+				public void flatSelect(Map<String, List<Event>> p, Collector<String> o) throws Exception {
+					StringBuilder builder = new StringBuilder();
+
+					builder.append(p.get("start").get(0).getId()).append(",")
+						.append(p.get("middle").get(0).getId()).append(",")
+						.append(p.get("end").get(0).getId());
+
+					o.collect(builder.toString());
+				}
+			}, Types.STRING);
+
+		List<String> resultList = new ArrayList<>();
+
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
+
+		assertEquals(Arrays.asList("2,6,8"), resultList);
+	}
+
+	@Test
+	public void testRichPatternSelectFunction() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(2);
+
+		DataStream<Event> input = env.fromElements(
+			new Event(1, "barfoo", 1.0),
+			new Event(2, "start", 2.0),
+			new Event(3, "start", 2.1),
+			new Event(3, "foobar", 3.0),
+			new SubEvent(4, "foo", 4.0, 1.0),
+			new SubEvent(3, "middle", 3.2, 1.0),
+			new Event(42, "start", 3.1),
+			new SubEvent(42, "middle", 3.3, 1.2),
+			new Event(5, "middle", 5.0),
+			new SubEvent(2, "middle", 6.0, 2.0),
+			new SubEvent(7, "bar", 3.0, 3.0),
+			new Event(42, "42", 42.0),
+			new Event(3, "end", 2.0),
+			new Event(2, "end", 1.0),
+			new Event(42, "end", 42.0)
+		).keyBy(new KeySelector<Event, Integer>() {
+
+			@Override
+			public Integer getKey(Event value) throws Exception {
+				return value.getId();
+			}
+		});
+
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new RichIterativeCondition<Event>() {
+
+			@Override
+			public boolean filter(Event value, Context<Event> ctx) throws Exception {
+				return value.getName().equals("start");
+			}
+		}).followedByAny("middle").subtype(SubEvent.class).where(
+			new SimpleCondition<SubEvent>() {
+
+				@Override
+				public boolean filter(SubEvent value) throws Exception {
+					return value.getName().equals("middle");
+				}
+			}
+		).followedByAny("end").where(new SimpleCondition<Event>() {
+
+				@Override
+				public boolean filter(Event value) throws Exception {
+					return value.getName().equals("end");
+				}
+			});
+
+		DataStream<String> result = CEP.pattern(input, pattern).select(new RichPatternSelectFunction<Event, String>() {
+			@Override
+			public void open(Configuration config) {
+				try {
+					getRuntimeContext().getMapState(new MapStateDescriptor<>(
+						"test",
+						LongSerializer.INSTANCE,
+						LongSerializer.INSTANCE));
+					throw new RuntimeException("Expected getMapState to fail with unsupported operation exception.");
+				} catch (UnsupportedOperationException e) {
+					// ignore, expected
+				}
+
+				getRuntimeContext().getUserCodeClassLoader();
+			}
+
+			@Override
+			public String select(Map<String, List<Event>> p) throws Exception {
+				StringBuilder builder = new StringBuilder();
+
+				builder.append(p.get("start").get(0).getId()).append(",")
+					.append(p.get("middle").get(0).getId()).append(",")
+					.append(p.get("end").get(0).getId());
+
+				return builder.toString();
+			}
+		});
+
+		List<String> resultList = new ArrayList<>();
+
+		DataStreamUtils.collect(result).forEachRemaining(resultList::add);
+
+		resultList.sort(String::compareTo);
+
+		assertEquals(Arrays.asList("2,2,2", "3,3,3", "42,42,42"), resultList);
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CepRuntimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CepRuntimeContextTest.java
@@ -53,9 +53,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Test cases for {@link RichPatternSelectFunction} and {@link RichPatternFlatSelectFunction}.
+ * Test cases for {@link CepRuntimeContext}.
  */
-public class RichPatternSelectFunctionTest {
+public class CepRuntimeContextTest {
 
 	@Test
 	public void testRichPatternSelectFunction() throws Exception {

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CepRuntimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CepRuntimeContextTest.java
@@ -58,91 +58,19 @@ import static org.mockito.Mockito.when;
 public class CepRuntimeContextTest {
 
 	@Test
-	public void testRichPatternSelectFunction() throws Exception {
-		RichPatternSelectFunction<Integer, Integer> function = new RichPatternSelectFunction<Integer, Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public Integer select(Map<String, List<Integer>> pattern) throws Exception {
-				return null;
-			}
-		};
-
-		verifyRuntimeContext(function);
-	}
-
-	@Test
-	public void testRichPatternFlatSelectFunction() throws Exception {
-		RichPatternFlatSelectFunction<Integer, Integer> function =
-			new RichPatternFlatSelectFunction<Integer, Integer>() {
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				public void flatSelect(Map<String, List<Integer>> pattern, Collector<Integer> out) throws Exception {
-					// no op
-				}
-			};
-
-		verifyRuntimeContext(function);
-	}
-
-	@Test
-	public void testRichIterativeConditionFunction() throws Exception {
-		RichIterativeCondition<Integer> function = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
-
-		verifyRuntimeContext(function);
-	}
-
-	@Test
 	public void testRichCompositeIterativeCondition() throws Exception {
-		RichIterativeCondition<Integer> first = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
+		RichIterativeCondition<Integer> first = new TestRichIterativeCondition();
+		RichIterativeCondition<Integer> second = new TestRichIterativeCondition();
+		RichIterativeCondition<Integer> third = new TestRichIterativeCondition();
 
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
-
-		RichIterativeCondition<Integer> second = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
-
-		RichIterativeCondition<Integer> third = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
-
-		RichIterativeCondition<Integer> fourth = null;
-
-		RichCompositeIterativeCondition function = new RichCompositeIterativeCondition(first, second, third, fourth) {
+		RichCompositeIterativeCondition function = new RichCompositeIterativeCondition(first, second, third) {
 			@Override
 			public boolean filter(Object value, Context ctx) throws Exception {
 				return false;
 			}
 		};
+		function.setRuntimeContext(mock(RuntimeContext.class));
 
-		verifyRuntimeContext(function);
 		assertTrue(first.getRuntimeContext() instanceof CepRuntimeContext);
 		assertTrue(second.getRuntimeContext() instanceof CepRuntimeContext);
 		assertTrue(third.getRuntimeContext() instanceof CepRuntimeContext);
@@ -150,81 +78,54 @@ public class CepRuntimeContextTest {
 
 	@Test
 	public void testRichAndCondition() throws Exception {
-		RichIterativeCondition<Integer> left = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
-
-		RichIterativeCondition<Integer> right = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
+		RichIterativeCondition<Integer> left = new TestRichIterativeCondition();
+		RichIterativeCondition<Integer> right = new TestRichIterativeCondition();
 
 		RichAndCondition function = new RichAndCondition<>(left, right);
+		function.setRuntimeContext(mock(RuntimeContext.class));
 
-		verifyRuntimeContext(function);
 		assertTrue(left.getRuntimeContext() instanceof CepRuntimeContext);
 		assertTrue(right.getRuntimeContext() instanceof CepRuntimeContext);
 	}
 
 	@Test
 	public void testRichOrCondition() throws Exception {
-		RichIterativeCondition<Integer> left = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
-
-		RichIterativeCondition<Integer> right = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
+		RichIterativeCondition<Integer> left = new TestRichIterativeCondition();
+		RichIterativeCondition<Integer> right = new TestRichIterativeCondition();
 
 		RichOrCondition function = new RichOrCondition<>(left, right);
+		function.setRuntimeContext(mock(RuntimeContext.class));
 
-		verifyRuntimeContext(function);
 		assertTrue(left.getRuntimeContext() instanceof CepRuntimeContext);
 		assertTrue(right.getRuntimeContext() instanceof CepRuntimeContext);
 	}
 
 	@Test
-	public void testRichNotCondition() throws Exception {
-		RichIterativeCondition<Integer> original = new RichIterativeCondition<Integer>() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public boolean filter(
-				Integer value, Context<Integer> ctx) throws Exception {
-				return false;
-			}
-		};
+	public void testRichNotCondition() {
+		RichIterativeCondition<Integer> original = new TestRichIterativeCondition();
 
 		RichNotCondition function = new RichNotCondition<>(original);
+		function.setRuntimeContext(mock(RuntimeContext.class));
 
-		verifyRuntimeContext(function);
 		assertTrue(original.getRuntimeContext() instanceof CepRuntimeContext);
 	}
 
-	private void verifyRuntimeContext(final RichFunction function) throws Exception {
+	@Test
+	public void testRichPatternSelectFunction() {
+		verifyRuntimeContext(new TestRichPatternSelectFunction());
+	}
+
+	@Test
+	public void testRichPatternFlatSelectFunction() {
+		verifyRuntimeContext(new TestRichPatternFlatSelectFunction());
+	}
+
+	@Test
+	public void testRichIterativeCondition() {
+		verifyRuntimeContext(new TestRichIterativeCondition());
+	}
+
+	private void verifyRuntimeContext(final RichFunction function) {
 		final String taskName = "foobarTask";
 		final MetricGroup metricGroup = new UnregisteredMetricsGroup();
 		final int numberOfParallelSubtasks = 42;
@@ -281,14 +182,10 @@ public class CepRuntimeContextTest {
 		}
 
 		try {
-			runtimeContext.getReducingState(new ReducingStateDescriptor<>("foobar", new ReduceFunction<Integer>() {
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				public Integer reduce(Integer value1, Integer value2) throws Exception {
-					return value1;
-				}
-			}, Integer.class));
+			runtimeContext.getReducingState(new ReducingStateDescriptor<>(
+				"foobar",
+				mock(ReduceFunction.class),
+				Integer.class));
 			fail("Expected getReducingState to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {
 			// expected
@@ -297,31 +194,7 @@ public class CepRuntimeContextTest {
 		try {
 			runtimeContext.getAggregatingState(new AggregatingStateDescriptor<>(
 				"foobar",
-				new AggregateFunction<Integer, Integer, Integer>() {
-					@Override
-					public Integer createAccumulator() {
-						return null;
-					}
-
-					@Override
-					public Integer add(
-						Integer value,
-						Integer accumulator) {
-						return null;
-					}
-
-					@Override
-					public Integer getResult(Integer accumulator) {
-						return null;
-					}
-
-					@Override
-					public Integer merge(
-						Integer a,
-						Integer b) {
-						return null;
-					}
-				},
+				mock(AggregateFunction.class),
 				Integer.class));
 			fail("Expected getAggregatingState to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {
@@ -332,14 +205,7 @@ public class CepRuntimeContextTest {
 			runtimeContext.getFoldingState(new FoldingStateDescriptor<>(
 				"foobar",
 				0,
-				new FoldFunction<Integer, Integer>() {
-					@Override
-					public Integer fold(
-						Integer accumulator,
-						Integer value) throws Exception {
-						return accumulator;
-					}
-				},
+				mock(FoldFunction.class),
 				Integer.class));
 			fail("Expected getFoldingState to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {
@@ -354,34 +220,7 @@ public class CepRuntimeContextTest {
 		}
 
 		try {
-			runtimeContext.addAccumulator("foobar", new Accumulator<Integer, Integer>() {
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				public void add(Integer value) {
-					// no op
-				}
-
-				@Override
-				public Integer getLocalValue() {
-					return null;
-				}
-
-				@Override
-				public void resetLocal() {
-
-				}
-
-				@Override
-				public void merge(Accumulator<Integer, Integer> other) {
-
-				}
-
-				@Override
-				public Accumulator<Integer, Integer> clone() {
-					return null;
-				}
-			});
+			runtimeContext.addAccumulator("foobar", mock(Accumulator.class));
 			fail("Expected addAccumulator to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {
 			// expected
@@ -446,15 +285,37 @@ public class CepRuntimeContextTest {
 		try {
 			runtimeContext.getBroadcastVariableWithInitializer(
 				"foobar",
-				new BroadcastVariableInitializer<Object, Object>() {
-					@Override
-					public Object initializeBroadcastVariable(Iterable<Object> data) {
-						return null;
-					}
-				});
+				mock(BroadcastVariableInitializer.class));
 			fail("Expected getBroadcastVariableWithInitializer to fail with unsupported operation exception.");
 		} catch (UnsupportedOperationException e) {
 			// expected
+		}
+	}
+
+	private static class TestRichIterativeCondition extends RichIterativeCondition<Integer> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public boolean filter(Integer value, Context<Integer> ctx) throws Exception {
+			return false;
+		}
+	}
+
+	private static class TestRichPatternSelectFunction extends RichPatternSelectFunction<Integer, Integer> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer select(Map<String, List<Integer>> pattern) throws Exception {
+			return null;
+		}
+	}
+
+	private static class TestRichPatternFlatSelectFunction extends RichPatternFlatSelectFunction<Integer, Integer> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void flatSelect(Map<String, List<Integer>> pattern, Collector<Integer> out) throws Exception {
+			// no op
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/RichPatternSelectFunctionTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/RichPatternSelectFunctionTest.java
@@ -1,0 +1,460 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.cep.pattern.conditions.RichAndCondition;
+import org.apache.flink.cep.pattern.conditions.RichCompositeIterativeCondition;
+import org.apache.flink.cep.pattern.conditions.RichIterativeCondition;
+import org.apache.flink.cep.pattern.conditions.RichNotCondition;
+import org.apache.flink.cep.pattern.conditions.RichOrCondition;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.Collector;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link RichPatternSelectFunction} and {@link RichPatternFlatSelectFunction}.
+ */
+public class RichPatternSelectFunctionTest {
+
+	@Test
+	public void testRichPatternSelectFunction() throws Exception {
+		RichPatternSelectFunction<Integer, Integer> function = new RichPatternSelectFunction<Integer, Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Integer select(Map<String, List<Integer>> pattern) throws Exception {
+				return null;
+			}
+		};
+
+		verifyRuntimeContext(function);
+	}
+
+	@Test
+	public void testRichPatternFlatSelectFunction() throws Exception {
+		RichPatternFlatSelectFunction<Integer, Integer> function =
+			new RichPatternFlatSelectFunction<Integer, Integer>() {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void flatSelect(Map<String, List<Integer>> pattern, Collector<Integer> out) throws Exception {
+					// no op
+				}
+			};
+
+		verifyRuntimeContext(function);
+	}
+
+	@Test
+	public void testRichIterativeConditionFunction() throws Exception {
+		RichIterativeCondition<Integer> function = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		verifyRuntimeContext(function);
+	}
+
+	@Test
+	public void testRichCompositeIterativeCondition() throws Exception {
+		RichIterativeCondition<Integer> first = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichIterativeCondition<Integer> second = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichIterativeCondition<Integer> third = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichIterativeCondition<Integer> fourth = null;
+
+		RichCompositeIterativeCondition function = new RichCompositeIterativeCondition(first, second, third, fourth) {
+			@Override
+			public boolean filter(Object value, Context ctx) throws Exception {
+				return false;
+			}
+		};
+
+		verifyRuntimeContext(function);
+		assertTrue(first.getRuntimeContext() instanceof CepRuntimeContext);
+		assertTrue(second.getRuntimeContext() instanceof CepRuntimeContext);
+		assertTrue(third.getRuntimeContext() instanceof CepRuntimeContext);
+	}
+
+	@Test
+	public void testRichAndCondition() throws Exception {
+		RichIterativeCondition<Integer> left = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichIterativeCondition<Integer> right = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichAndCondition function = new RichAndCondition<>(left, right);
+
+		verifyRuntimeContext(function);
+		assertTrue(left.getRuntimeContext() instanceof CepRuntimeContext);
+		assertTrue(right.getRuntimeContext() instanceof CepRuntimeContext);
+	}
+
+	@Test
+	public void testRichOrCondition() throws Exception {
+		RichIterativeCondition<Integer> left = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichIterativeCondition<Integer> right = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichOrCondition function = new RichOrCondition<>(left, right);
+
+		verifyRuntimeContext(function);
+		assertTrue(left.getRuntimeContext() instanceof CepRuntimeContext);
+		assertTrue(right.getRuntimeContext() instanceof CepRuntimeContext);
+	}
+
+	@Test
+	public void testRichNotCondition() throws Exception {
+		RichIterativeCondition<Integer> original = new RichIterativeCondition<Integer>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean filter(
+				Integer value, Context<Integer> ctx) throws Exception {
+				return false;
+			}
+		};
+
+		RichNotCondition function = new RichNotCondition<>(original);
+
+		verifyRuntimeContext(function);
+		assertTrue(original.getRuntimeContext() instanceof CepRuntimeContext);
+	}
+
+	private void verifyRuntimeContext(final RichFunction function) throws Exception {
+		final String taskName = "foobarTask";
+		final MetricGroup metricGroup = new UnregisteredMetricsGroup();
+		final int numberOfParallelSubtasks = 42;
+		final int indexOfSubtask = 43;
+		final int attemptNumber = 1337;
+		final String taskNameWithSubtask = "barfoo";
+		final ExecutionConfig executionConfig = mock(ExecutionConfig.class);
+		final ClassLoader userCodeClassLoader = mock(ClassLoader.class);
+
+		RuntimeContext mockedRuntimeContext = mock(RuntimeContext.class);
+
+		when(mockedRuntimeContext.getTaskName()).thenReturn(taskName);
+		when(mockedRuntimeContext.getMetricGroup()).thenReturn(metricGroup);
+		when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(numberOfParallelSubtasks);
+		when(mockedRuntimeContext.getIndexOfThisSubtask()).thenReturn(indexOfSubtask);
+		when(mockedRuntimeContext.getAttemptNumber()).thenReturn(attemptNumber);
+		when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenReturn(taskNameWithSubtask);
+		when(mockedRuntimeContext.getExecutionConfig()).thenReturn(executionConfig);
+		when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(userCodeClassLoader);
+
+		function.setRuntimeContext(mockedRuntimeContext);
+
+		RuntimeContext runtimeContext = function.getRuntimeContext();
+
+		assertTrue(runtimeContext instanceof CepRuntimeContext);
+		assertEquals(taskName, runtimeContext.getTaskName());
+		assertEquals(metricGroup, runtimeContext.getMetricGroup());
+		assertEquals(numberOfParallelSubtasks, runtimeContext.getNumberOfParallelSubtasks());
+		assertEquals(indexOfSubtask, runtimeContext.getIndexOfThisSubtask());
+		assertEquals(attemptNumber, runtimeContext.getAttemptNumber());
+		assertEquals(taskNameWithSubtask, runtimeContext.getTaskNameWithSubtasks());
+		assertEquals(executionConfig, runtimeContext.getExecutionConfig());
+		assertEquals(userCodeClassLoader, runtimeContext.getUserCodeClassLoader());
+
+		try {
+			runtimeContext.getDistributedCache();
+			fail("Expected getDistributedCached to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getState(new ValueStateDescriptor<>("foobar", Integer.class, 42));
+			fail("Expected getState to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getListState(new ListStateDescriptor<>("foobar", Integer.class));
+			fail("Expected getListState to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getReducingState(new ReducingStateDescriptor<>("foobar", new ReduceFunction<Integer>() {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public Integer reduce(Integer value1, Integer value2) throws Exception {
+					return value1;
+				}
+			}, Integer.class));
+			fail("Expected getReducingState to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getAggregatingState(new AggregatingStateDescriptor<>(
+				"foobar",
+				new AggregateFunction<Integer, Integer, Integer>() {
+					@Override
+					public Integer createAccumulator() {
+						return null;
+					}
+
+					@Override
+					public Integer add(
+						Integer value,
+						Integer accumulator) {
+						return null;
+					}
+
+					@Override
+					public Integer getResult(Integer accumulator) {
+						return null;
+					}
+
+					@Override
+					public Integer merge(
+						Integer a,
+						Integer b) {
+						return null;
+					}
+				},
+				Integer.class));
+			fail("Expected getAggregatingState to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getFoldingState(new FoldingStateDescriptor<>(
+				"foobar",
+				0,
+				new FoldFunction<Integer, Integer>() {
+					@Override
+					public Integer fold(
+						Integer accumulator,
+						Integer value) throws Exception {
+						return accumulator;
+					}
+				},
+				Integer.class));
+			fail("Expected getFoldingState to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getMapState(new MapStateDescriptor<>("foobar", Integer.class, String.class));
+			fail("Expected getMapState to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.addAccumulator("foobar", new Accumulator<Integer, Integer>() {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void add(Integer value) {
+					// no op
+				}
+
+				@Override
+				public Integer getLocalValue() {
+					return null;
+				}
+
+				@Override
+				public void resetLocal() {
+
+				}
+
+				@Override
+				public void merge(Accumulator<Integer, Integer> other) {
+
+				}
+
+				@Override
+				public Accumulator<Integer, Integer> clone() {
+					return null;
+				}
+			});
+			fail("Expected addAccumulator to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getAccumulator("foobar");
+			fail("Expected getAccumulator to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getAllAccumulators();
+			fail("Expected getAllAccumulators to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getIntCounter("foobar");
+			fail("Expected getIntCounter to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getLongCounter("foobar");
+			fail("Expected getLongCounter to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getDoubleCounter("foobar");
+			fail("Expected getDoubleCounter to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getHistogram("foobar");
+			fail("Expected getHistogram to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.hasBroadcastVariable("foobar");
+			fail("Expected hasBroadcastVariable to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getBroadcastVariable("foobar");
+			fail("Expected getBroadcastVariable to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+
+		try {
+			runtimeContext.getBroadcastVariableWithInitializer(
+				"foobar",
+				new BroadcastVariableInitializer<Object, Object>() {
+					@Override
+					public Object initializeBroadcastVariable(Iterable<Object> data) {
+						return null;
+					}
+				});
+			fail("Expected getBroadcastVariableWithInitializer to fail with unsupported operation exception.");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+	}
+}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.cep.pattern;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
 import org.apache.flink.cep.pattern.Quantifier.ConsumingStrategy;
+import org.apache.flink.cep.pattern.conditions.IterativeCondition;
+import org.apache.flink.cep.pattern.conditions.RichAndCondition;
 import org.apache.flink.cep.pattern.conditions.RichOrCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.cep.pattern.conditions.SubtypeCondition;
@@ -33,6 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for constructing {@link Pattern}.
@@ -193,6 +196,19 @@ public class PatternTest extends TestLogger {
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "or");
 		assertEquals(previous2.getName(), "start");
+	}
+
+	@Test
+	public void testRichCondition() {
+		Pattern<Event, Event> pattern =
+			Pattern.<Event>begin("start")
+				.where(mock(IterativeCondition.class))
+				.where(mock(IterativeCondition.class))
+			.followedBy("end")
+				.where(mock(IterativeCondition.class))
+				.or(mock(IterativeCondition.class));
+		assertTrue(pattern.getCondition() instanceof RichOrCondition);
+		assertTrue(pattern.getPrevious().getCondition() instanceof RichAndCondition);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.cep.pattern;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
 import org.apache.flink.cep.pattern.Quantifier.ConsumingStrategy;
-import org.apache.flink.cep.pattern.conditions.OrCondition;
+import org.apache.flink.cep.pattern.conditions.RichOrCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.cep.pattern.conditions.SubtypeCondition;
 import org.apache.flink.util.TestLogger;
@@ -187,8 +187,8 @@ public class PatternTest extends TestLogger {
 		assertNull(previous2.getPrevious());
 
 		assertEquals(ConsumingStrategy.SKIP_TILL_NEXT, pattern.getQuantifier().getConsumingStrategy());
-		assertFalse(previous.getCondition() instanceof OrCondition);
-		assertTrue(previous2.getCondition() instanceof OrCondition);
+		assertFalse(previous.getCondition() instanceof RichOrCondition);
+		assertTrue(previous2.getCondition() instanceof RichOrCondition);
 
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "or");

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
@@ -105,7 +105,7 @@ public class PatternTest extends TestLogger {
 
 		assertNotNull(pattern.getCondition());
 		assertNotNull(previous.getCondition());
-		assertNull(previous2.getCondition());
+		assertNotNull(previous2.getCondition());
 
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "next");


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add rich support for Pattern(Flat)SelectFunctions and IterativeCondition*

## Brief change log

  - *New RichPatternFlatSelectionFunction, RichPatternSelectFunction, RichIterativeCondition, RichNotCondition, RichOrCondition, RichAndCondition*
  - *Update AbstractKeyedCEPPatternOperator to open the RichIterativeCondition functions when open*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
