### PR TITLE
[FLINK-10883] Failing batch jobs with NoResourceAvailableException when slot request times out

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -911,7 +911,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				final CompletableFuture<Void> schedulingJobVertexFuture = ejv.scheduleAll(
 					slotProvider,
 					allowQueuedScheduling,
-					LocationPreferenceConstraint.ALL,// since it is an input vertex, the input based location preferences should be empty
+					LocationPreferenceConstraint.ALL, // since it is an input vertex, the input based location preferences should be empty
 					Collections.emptySet());
 
 				schedulingFutures.add(schedulingJobVertexFuture);


### PR DESCRIPTION
## What is the purpose of the change

Instead of failing the ExecutionGraph with a generic TimeoutException if a slot request times out,
this commit changes the exception to a more meaningful NoResourceAvailableException.

## Verifying this change

- Added `MiniClusterITCase#testHandleBatchJobsWhenNotEnoughSlot` and tested it manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
