### PR TITLE
[FLINK-10482] Fix double counting of checkpoint stat

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -1195,11 +1196,16 @@ public class CheckpointCoordinator {
 				currentPeriodicTrigger = null;
 			}
 
-			for (PendingCheckpoint p : pendingCheckpoints.values()) {
+			// take a snapshot of pendingCheckpoints to clear them and prevent aborting them twice
+			// in case of subsequent call of stopCheckpointScheduler()
+			List<PendingCheckpoint> pendingCheckpointsSnapshot =
+				new ArrayList<>(pendingCheckpoints.values());
+			pendingCheckpoints.clear();
+
+			for (PendingCheckpoint p : pendingCheckpointsSnapshot) {
 				p.abortError(new Exception("Checkpoint Coordinator is suspending."));
 			}
 
-			pendingCheckpoints.clear();
 			numUnsuccessfulCheckpointsTriggers.set(0);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -1196,16 +1195,11 @@ public class CheckpointCoordinator {
 				currentPeriodicTrigger = null;
 			}
 
-			// take a snapshot of pendingCheckpoints to clear them and prevent aborting them twice
-			// in case of subsequent call of stopCheckpointScheduler()
-			List<PendingCheckpoint> pendingCheckpointsSnapshot =
-				new ArrayList<>(pendingCheckpoints.values());
-			pendingCheckpoints.clear();
-
-			for (PendingCheckpoint p : pendingCheckpointsSnapshot) {
+			for (PendingCheckpoint p : pendingCheckpoints.values()) {
 				p.abortError(new Exception("Checkpoint Coordinator is suspending."));
 			}
 
+			pendingCheckpoints.clear();
 			numUnsuccessfulCheckpointsTriggers.set(0);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsCounts.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsCounts.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -26,6 +29,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * Counts of checkpoints.
  */
 public class CheckpointStatsCounts implements Serializable {
+	private static final Logger LOG = LoggerFactory.getLogger(CheckpointStatsCounts.class);
 
 	private static final long serialVersionUID = -5229425063269482528L;
 
@@ -147,9 +151,8 @@ public class CheckpointStatsCounts implements Serializable {
 	 * {@link #incrementInProgressCheckpoints()}.
 	 */
 	void incrementCompletedCheckpoints() {
-		if (--numInProgressCheckpoints < 0) {
-			throw new IllegalStateException("Incremented the completed number of checkpoints " +
-				"without incrementing the in progress checkpoints before.");
+		if (assertDecrementOfInProgressCheckpointsNumber()) {
+			numInProgressCheckpoints--;
 		}
 		numCompletedCheckpoints++;
 	}
@@ -161,9 +164,8 @@ public class CheckpointStatsCounts implements Serializable {
 	 * {@link #incrementInProgressCheckpoints()}.
 	 */
 	void incrementFailedCheckpoints() {
-		if (--numInProgressCheckpoints < 0) {
-			throw new IllegalStateException("Incremented the completed number of checkpoints " +
-				"without incrementing the in progress checkpoints before.");
+		if (assertDecrementOfInProgressCheckpointsNumber()) {
+			numInProgressCheckpoints--;
 		}
 		numFailedCheckpoints++;
 	}
@@ -180,5 +182,16 @@ public class CheckpointStatsCounts implements Serializable {
 			numInProgressCheckpoints,
 			numCompletedCheckpoints,
 			numFailedCheckpoints);
+	}
+
+	private boolean assertDecrementOfInProgressCheckpointsNumber() {
+		boolean decrementLeadsToNegativeNumber = numInProgressCheckpoints - 1 < 0;
+		if (decrementLeadsToNegativeNumber) {
+			String errorMessage = "Incremented the completed number of checkpoints " +
+				"without incrementing the in progress checkpoints before.";
+			LOG.warn(errorMessage);
+			LOG.debug("Inconsistent CheckpointStatsCounts", new IllegalStateException(errorMessage));
+		}
+		return !decrementLeadsToNegativeNumber;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsCounts.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsCounts.java
@@ -151,7 +151,7 @@ public class CheckpointStatsCounts implements Serializable {
 	 * {@link #incrementInProgressCheckpoints()}.
 	 */
 	void incrementCompletedCheckpoints() {
-		if (assertDecrementOfInProgressCheckpointsNumber()) {
+		if (canDecrementOfInProgressCheckpointsNumber()) {
 			numInProgressCheckpoints--;
 		}
 		numCompletedCheckpoints++;
@@ -164,7 +164,7 @@ public class CheckpointStatsCounts implements Serializable {
 	 * {@link #incrementInProgressCheckpoints()}.
 	 */
 	void incrementFailedCheckpoints() {
-		if (assertDecrementOfInProgressCheckpointsNumber()) {
+		if (canDecrementOfInProgressCheckpointsNumber()) {
 			numInProgressCheckpoints--;
 		}
 		numFailedCheckpoints++;
@@ -184,13 +184,12 @@ public class CheckpointStatsCounts implements Serializable {
 			numFailedCheckpoints);
 	}
 
-	private boolean assertDecrementOfInProgressCheckpointsNumber() {
+	private boolean canDecrementOfInProgressCheckpointsNumber() {
 		boolean decrementLeadsToNegativeNumber = numInProgressCheckpoints - 1 < 0;
 		if (decrementLeadsToNegativeNumber) {
 			String errorMessage = "Incremented the completed number of checkpoints " +
 				"without incrementing the in progress checkpoints before.";
 			LOG.warn(errorMessage);
-			LOG.debug("Inconsistent CheckpointStatsCounts", new IllegalStateException(errorMessage));
 		}
 		return !decrementLeadsToNegativeNumber;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -970,7 +970,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 				return path;
 			}, getMainThreadExecutor())
 			.exceptionally(throwable -> {
-				if (cancelJob) {
+				if (cancelJob && executionGraph.getState() == JobStatus.RUNNING) {
 					startCheckpointScheduler(checkpointCoordinator);
 				}
 				throw new CompletionException(throwable);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -962,19 +962,18 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		return checkpointCoordinator
 			.triggerSavepoint(System.currentTimeMillis(), targetDirectory)
 			.thenApply(CompletedCheckpoint::getExternalPointer)
-			.thenApplyAsync(path -> {
-				if (cancelJob) {
+			.handleAsync((path, throwable) -> {
+				if (throwable != null) {
+					if (cancelJob) {
+						startCheckpointScheduler(checkpointCoordinator);
+					}
+					throw new CompletionException(throwable);
+				} else if (cancelJob) {
 					log.info("Savepoint stored in {}. Now cancelling {}.", path, jobGraph.getJobID());
 					cancel(timeout);
 				}
 				return path;
-			}, getMainThreadExecutor())
-			.exceptionally(throwable -> {
-				if (cancelJob && executionGraph.getState() == JobStatus.RUNNING) {
-					startCheckpointScheduler(checkpointCoordinator);
-				}
-				throw new CompletionException(throwable);
-			});
+			}, getMainThreadExecutor());
 	}
 
 	private void startCheckpointScheduler(final CheckpointCoordinator checkpointCoordinator) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsCountsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsCountsTest.java
@@ -21,15 +21,16 @@ package org.apache.flink.runtime.checkpoint;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
+/** Test checkpoint statistics counters. */
 public class CheckpointStatsCountsTest {
 
 	/**
 	 * Tests that counts are reported correctly.
 	 */
 	@Test
-	public void testCounts() throws Exception {
+	public void testCounts() {
 		CheckpointStatsCounts counts = new CheckpointStatsCounts();
 		assertEquals(0, counts.getNumberOfRestoredCheckpoints());
 		assertEquals(0, counts.getTotalNumberOfCheckpoints());
@@ -80,19 +81,15 @@ public class CheckpointStatsCountsTest {
 	 * incrementing the in progress checkpoints before throws an Exception.
 	 */
 	@Test
-	public void testCompleteOrFailWithoutInProgressCheckpoint() throws Exception {
+	public void testCompleteOrFailWithoutInProgressCheckpoint() {
 		CheckpointStatsCounts counts = new CheckpointStatsCounts();
-		try {
-			counts.incrementCompletedCheckpoints();
-			fail("Did not throw expected Exception");
-		} catch (IllegalStateException ignored) {
-		}
+		counts.incrementCompletedCheckpoints();
+		assertTrue("Number of checkpoints in progress should never be negative",
+			counts.getNumberOfInProgressCheckpoints() >= 0);
 
-		try {
-			counts.incrementFailedCheckpoints();
-			fail("Did not throw expected Exception");
-		} catch (IllegalStateException ignored) {
-		}
+		counts.incrementFailedCheckpoints();
+		assertTrue("Number of checkpoints in progress should never be negative",
+			counts.getNumberOfInProgressCheckpoints() >= 0);
 	}
 
 	/**
@@ -100,7 +97,7 @@ public class CheckpointStatsCountsTest {
 	 * parent.
 	 */
 	@Test
-	public void testCreateSnapshot() throws Exception {
+	public void testCreateSnapshot() {
 		CheckpointStatsCounts counts = new CheckpointStatsCounts();
 		counts.incrementRestoredCheckpoints();
 		counts.incrementRestoredCheckpoints();


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes double counting of checkpoints in progress in their statistics.

## Brief change log

  - If savepoint fails, restart checkpoint coordinator only if job is still running (prevents from double stop of checkpoint coordinator in case of global failure)
  - clear pending checkpoint in checkpoint coordinator stop method before aborting them (prevents from double aborting them if stop is called inside abort)
  - log error if number of checkpoints in progress is negative but do not throw exception and do not fail the job (prevents stats bugs from failing the job)


## Verifying this change

submit DataStreamAllroundTestProgram in a loop in aws emr, wait for failure, check there was no negative number of checkpoints logs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
