### PR TITLE
[FLINK-10907] Fix Flink JobManager metrics from getting stuck after a job recovery.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -61,16 +61,17 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 	public JobManagerJobMetricGroup addJob(JobGraph job) {
 		JobID jobId = job.getJobID();
 		String jobName = job.getName();
-		// get or create a jobs metric group
-		JobManagerJobMetricGroup currentJobGroup;
 		synchronized (this) {
 			if (!isClosed()) {
-				currentJobGroup = jobs.get(jobId);
+				JobManagerJobMetricGroup currentJobGroup = jobs.get(jobId);
 
-				if (currentJobGroup == null || currentJobGroup.isClosed()) {
-					currentJobGroup = new JobManagerJobMetricGroup(registry, this, jobId, jobName);
-					jobs.put(jobId, currentJobGroup);
+				if (currentJobGroup != null) {
+					currentJobGroup.close();
 				}
+
+				currentJobGroup = new JobManagerJobMetricGroup(registry, this, jobId, jobName);
+				jobs.put(jobId, currentJobGroup);
+
 				return currentJobGroup;
 			} else {
 				return null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -58,13 +59,15 @@ public class JobManagerGroupTest extends TestLogger {
 		JobManagerJobMetricGroup jmJobGroup12 = group.addJob(new JobGraph(jid1, jobName1));
 		JobManagerJobMetricGroup jmJobGroup21 = group.addJob(new JobGraph(jid2, jobName2));
 
-		assertEquals(jmJobGroup11, jmJobGroup12);
+		assertNotEquals(jmJobGroup11, jmJobGroup12);
+		assertTrue(jmJobGroup11.isClosed());
+		assertTrue(!jmJobGroup12.isClosed());
 
 		assertEquals(2, group.numRegisteredJobMetricGroups());
 
 		group.removeJob(jid1);
 
-		assertTrue(jmJobGroup11.isClosed());
+		assertTrue(jmJobGroup12.isClosed());
 		assertEquals(1, group.numRegisteredJobMetricGroups());
 
 		group.removeJob(jid2);


### PR DESCRIPTION
- JobManager loses and regains leadership if it loses connection to ZooKeeper.
- When it regains the leadership, it tries to recover the job graph.
- During the recovery, it will try to reuse the existing JobManagerMetricGroup
  to register new counters and gauges under the same metric name, which causes
  the new counters and gauges to be registered incorrectly.
- The old counters and gauges will continue to report the stale values and
  the new counters and gauges will not report the latest metric.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Fix Flink JobManager metrics from getting stuck after a job recovery.


## Brief change log
- Close the existing JobManagerJobMetricGroup associated with the job.
- Create a new JobManagerJobMetricGroup in JobManagerMetricGroup.


## Verifying this change
This change is already covered by existing tests in JobManagerGroupTest.java
A test is modified to ensure that new JobManagerJobMetricGroup is used.

This change was also tested against a running Flink job by causing the scenario described in the JIRA ticket. Before the fix, we can reliably reproduce the issue. After the fix, JobManager metrics are reported correctly.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no
