### PR TITLE
[FLINK-10908][flink-yarn]Add yarn.application.priority in YarnConfigOptions

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.QueueInfo;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
@@ -1033,6 +1034,11 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		appContext.setApplicationType("Apache Flink");
 		appContext.setAMContainerSpec(amContainer);
 		appContext.setResource(capability);
+
+		// Set priority for application
+		int priorityNum = flinkConfiguration.getInteger(YarnConfigOptions.APPLICATION_PRIORITY);
+		Priority priority = Priority.newInstance(priorityNum);
+		appContext.setPriority(priority);
 
 		if (yarnQueue != null) {
 			appContext.setQueue(yarnQueue);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -149,6 +149,17 @@ public class YarnConfigOptions {
 		.defaultValue("")
 		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
+	/**
+	 * The priority of the Flink YARN application.
+	 * Allowed priority values are 5, 4, 3, 2, 1, respectively correspond to VERY_HIGH, HIGH, NORMAL, LOW, VERY_LOW.
+	 *
+	 * By default, we take 3, respectively correspond to NORMAL.
+	 */
+	public static final ConfigOption<Integer> APPLICATION_PRIORITY =
+		key("yarn.application.priority")
+		.defaultValue(3)
+		.withDescription("The priority of the Flink YARN application.");
+
 	// ------------------------------------------------------------------------
 
 	/** This class is not meant to be instantiated. */


### PR DESCRIPTION
## What is the purpose of the change

Add yarn.application.priority in YarnConfigOptions, changes the priority of the Flink YARN application.

Allowed priority values are 5,4,3,2,1, respectively correspond to VERY_HIGH, HIGH, NORMAL, LOW, VERY_LOW.

