### PR TITLE
[BP-1.6][FLINK-10906][docker] Don't print configuration in docker-entrypoint.sh

### DIFF
--- a/flink-container/docker/docker-entrypoint.sh
+++ b/flink-container/docker/docker-entrypoint.sh
@@ -32,7 +32,6 @@ if [ "${CMD}" == "--help" -o "${CMD}" == "-h" ]; then
     exit 0
 elif [ "${CMD}" == "${JOB_CLUSTER}" -o "${CMD}" == "${TASK_MANAGER}" ]; then
     echo "Starting the ${CMD}"
-    echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
 
     if [ "${CMD}" == "${TASK_MANAGER}" ]; then
         exec $FLINK_HOME/bin/taskmanager.sh start-foreground "$@"

--- a/flink-contrib/docker-flink/docker-entrypoint.sh
+++ b/flink-contrib/docker-flink/docker-entrypoint.sh
@@ -29,7 +29,6 @@ elif [ "$1" == "jobmanager" ]; then
     echo "Starting Job Manager"
     sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
 
-    echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
     exec $FLINK_HOME/bin/jobmanager.sh start-foreground
 elif [ "$1" == "taskmanager" ]; then
 
@@ -37,7 +36,6 @@ elif [ "$1" == "taskmanager" ]; then
     sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: $(grep -c ^processor /proc/cpuinfo)/g" $FLINK_HOME/conf/flink-conf.yaml
 
     echo "Starting Task Manager"
-    echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
     exec $FLINK_HOME/bin/taskmanager.sh start-foreground
 fi
 


### PR DESCRIPTION
Backport of #7125 to `release-1.6`.