### PR TITLE
[FLINK-10916] [DataStream API] Include duplicated user-specified uid into error message

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphHasherV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphHasherV2.java
@@ -177,7 +177,8 @@ public class StreamGraphHasherV2 implements StreamGraphHasher {
 
 			for (byte[] previousHash : hashes.values()) {
 				if (Arrays.equals(previousHash, hash)) {
-					throw new IllegalArgumentException("Hash collision on user-specified ID. " +
+					throw new IllegalArgumentException("Hash collision on user-specified ID " +
+							"\"" + userSpecifiedHash + "\". " +
 							"Most likely cause is a non-unique ID. Please check that all IDs " +
 							"specified via `uid(String)` are unique.");
 				}


### PR DESCRIPTION
## What is the purpose of the change

Make it easier for user to find duplicated user-provided stream uids. 

## Brief change log

Include uid in error message

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
