### PR TITLE
FLINK-10918 fix for checkpoint dir creation error on window. 

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -575,7 +575,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		try {
 			dbRef = RocksDB.open(
 				Preconditions.checkNotNull(dbOptions),
-				Preconditions.checkNotNull(path),
+				Preconditions.checkNotNull(new Path(path).toString()),
 				columnFamilyDescriptors,
 				stateColumnFamilyHandles);
 		} catch (RocksDBException e) {
@@ -2546,7 +2546,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			// create hard links of living files in the snapshot path
 			try (Checkpoint checkpoint = Checkpoint.create(stateBackend.db)) {
-				checkpoint.createCheckpoint(localBackupDirectory.getDirectory().getPath());
+				LOG.info("Checkpoint path is {}.", localBackupDirectory.getDirectory().toString());
+				checkpoint.createCheckpoint(localBackupDirectory.getDirectory().toString());
 			}
 		}
 


### PR DESCRIPTION
FLINK-10918 [flink-state-backaends] fix for checkpoint dir creation error on window. 1 of the 4 failing test on windows are now passing