### PR TITLE
[FLINK-10920] Remove Kafka examples from flink-dist

### DIFF
--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -187,48 +187,6 @@ under the License.
 			</excludes>
 		</fileSet>
 
-		<!-- copy jar files of the streaming kafka examples -->
-		<fileSet>
-			<directory>../flink-examples/flink-examples-streaming-kafka/target</directory>
-			<outputDirectory>examples/streaming</outputDirectory>
-			<fileMode>0644</fileMode>
-			<includes>
-				<include>*.jar</include>
-			</includes>
-			<excludes>
-				<exclude>flink-examples-streaming-kafka*.jar</exclude>
-				<exclude>original-*.jar</exclude>
-			</excludes>
-		</fileSet>
-
-		<!-- copy jar files of the streaming kafka 0.10 examples -->
-		<fileSet>
-			<directory>../flink-examples/flink-examples-streaming-kafka-0.10/target</directory>
-			<outputDirectory>examples/streaming</outputDirectory>
-			<fileMode>0644</fileMode>
-			<includes>
-				<include>*.jar</include>
-			</includes>
-			<excludes>
-				<exclude>flink-examples-streaming-kafka*.jar</exclude>
-				<exclude>original-*.jar</exclude>
-			</excludes>
-		</fileSet>
-
-		<!-- copy jar files of the streaming kafka 0.11 examples -->
-		<fileSet>
-			<directory>../flink-examples/flink-examples-streaming-kafka-0.11/target</directory>
-			<outputDirectory>examples/streaming</outputDirectory>
-			<fileMode>0644</fileMode>
-			<includes>
-				<include>*.jar</include>
-			</includes>
-			<excludes>
-				<exclude>flink-examples-streaming-kafka*.jar</exclude>
-				<exclude>original-*.jar</exclude>
-			</excludes>
-		</fileSet>
-
 		<!-- copy jar files of the gelly examples -->
 		<fileSet>
 			<directory>../flink-libraries/flink-gelly-examples/target</directory>


### PR DESCRIPTION
## What is the purpose of the change

In order to decrease the size of Flink's binary distribution, this commit removes
the Kafka examples from it.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
