### PR TITLE
[FLINK-10925] [python] Fix NPE in PythonPlanStreamer

### DIFF
--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanStreamer.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/plan/PythonPlanStreamer.java
@@ -126,7 +126,9 @@ public class PythonPlanStreamer {
 			process.destroy();
 		} finally {
 			try {
-				server.close();
+				if (server != null) {
+					server.close();
+				}
 			} catch (IOException e) {
 				LOG.error("Failed to close socket.", e);
 			}


### PR DESCRIPTION
## What is the purpose of the change

This pull requests makes it easier to troubleshoot Python Batch API issues that would happen when trying to run a Python Batch API job without Python installed.

## Brief change log

  - added *PythonPlanStreamer* check for null value before calling close method on an instance variable

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

  - Manually verified the change by submitting a Python Batch API job to cluster not having python installed
 - the job failed with an explanatory error message "**Failed to run plan: python does not point to a valid python binary.**"
- prior to this fix the job would fail with a confusing "**Failed to run plan: null**" message.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
