### PR TITLE
[FLINK-10763] [streaming] Fix interval join return type in Scala

### DIFF
--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -201,7 +201,10 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
       * @return Returns a DataStream
       */
     @PublicEvolving
-    def process[OUT](processJoinFunction: ProcessJoinFunction[IN1, IN2, OUT]): DataStream[OUT] = {
+    def process[OUT: TypeInformation](
+        processJoinFunction: ProcessJoinFunction[IN1, IN2, OUT])
+      : DataStream[OUT] = {
+
       val javaJoined = new KeyedJavaStream.IntervalJoined[IN1, IN2, KEY](
         firstStream.javaStream.asInstanceOf[KeyedJavaStream[IN1, KEY]],
         secondStream.javaStream.asInstanceOf[KeyedJavaStream[IN2, KEY]],
@@ -209,7 +212,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
         upperBound,
         lowerBoundInclusive,
         upperBoundInclusive)
-      asScalaStream(javaJoined.process(processJoinFunction))
+      asScalaStream(javaJoined.process(processJoinFunction, implicitly[TypeInformation[OUT]]))
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the wrong result type of interval joins in the DataStream Scala API. The API did not call the Scala type extraction stack but was using the default one offered by the DataStream Java API.

## Brief change log

- Use Scala implicit type extraction instead

## Verifying this change

Existing test modified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
