### PR TITLE
[FLINK-10924] [javadoc] StreamExecutionEnvironment method javadocs in…

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -384,7 +384,7 @@ public abstract class ExecutionEnvironment {
 
 	/**
 	 * Creates a {@link DataSet} that represents the Strings produced by reading the given file line wise.
-	 * The file will be read with the system's default character set.
+	 * The file will be read with the UTF-8 character set.
 	 *
 	 * @param filePath The path of the file, as a URI (e.g., "file:///some/local/file" or "hdfs://host:port/file/path").
 	 * @return A {@link DataSet} that represents the data read from the given file as text lines.
@@ -419,7 +419,7 @@ public abstract class ExecutionEnvironment {
 	 * {@link StringValue} objects, rather than Java Strings. StringValues can be used to tune implementations
 	 * to be less object and garbage collection heavy.
 	 *
-	 * <p>The file will be read with the system's default character set.
+	 * <p>The file will be read with the UTF-8 character set.
 	 *
 	 * @param filePath The path of the file, as a URI (e.g., "file:///some/local/file" or "hdfs://host:port/file/path").
 	 * @return A {@link DataSet} that represents the data read from the given file as text lines.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -923,7 +923,7 @@ public abstract class StreamExecutionEnvironment {
 
 	/**
 	 * Reads the given file line-by-line and creates a data stream that contains a string with the
-	 * contents of each such line. The file will be read with the system's default character set.
+	 * contents of each such line. The file will be read with the UTF-8 character set.
 	 *
 	 * <p><b>NOTES ON CHECKPOINTING: </b> The source monitors the path, creates the
 	 * {@link org.apache.flink.core.fs.FileInputSplit FileInputSplits} to be processed, forwards


### PR DESCRIPTION
…correct in regards to used charset

## What is the purpose of the change

Various methods of the `StreamExecutionEnvironment` (like `readTextFile`) are documented to be using the system's default charset if none is specified.

This is incorrect as they default to UTF-8 instead. The javadocs should be updated to reflect this.

## Brief change log

Correct the corresponding javadoc("the system's default character set" to "the UTF-8 character set").


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:(**yes, just its javadocs**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive):(**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)

cc @zentol 