### PR TITLE
[FLINK-10943][tests] Fix test failures in flink runtime caused by curator dependency conflicts

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -72,6 +72,12 @@ under the License.
 			<artifactId>flink-shaded-hadoop2</artifactId>
 			<version>${project.version}</version>
 			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-client</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

Hadoop-common of 2.6 + version includes curator dependencies, which would have conflicts with the curator used by Flink runtime and cause test failures (the attachment is the surefire report). 

The curator dependencies tree of flink runtime is as below:

```

flink-shaded-hadoop2 -> hadoop-common -> curator-client & curator-recipes

flink-shaded-curator -> curator-recipes -> curator-framework -> curator-client

```

According to the dependency mechanism, maven would pick the curator-client in flink-shaded-hadoop2, and curator-framework and curator-recipes from flink-shaded-curator.

This PR fixes the test failures in flink runtime caused by curator dependency conflicts. 

## Brief change log

Exclude curator client from the shaded hadoop dependencies in flink-runtime.

## Verifying this change

This change is already covered by existing zookeeper related tests, such as:

- org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStoreTest

This test should work with hadoop 2.6.0 or higher version.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
