### PR TITLE
[FLINK-10951][tests] Set yarn.nodemanager.vmem-check-enabled to false

### DIFF
--- a/flink-jepsen/src/jepsen/flink/hadoop.clj
+++ b/flink-jepsen/src/jepsen/flink/hadoop.clj
@@ -40,11 +40,14 @@
 
 (defn yarn-site-config
   [test]
-  {:yarn.resourcemanager.hostname        (resource-manager (:nodes test))
-   :yarn.log-aggregation-enable          "true"
+  {:yarn.log-aggregation-enable          "true"
+
+   :yarn.nodemanager.log-dirs            yarn-log-dir
    :yarn.nodemanager.resource.cpu-vcores "8"
+   :yarn.nodemanager.vmem-check-enabled  "false"
+
    :yarn.resourcemanager.am.max-attempts "99999"
-   :yarn.nodemanager.log-dirs            yarn-log-dir})
+   :yarn.resourcemanager.hostname        (resource-manager (:nodes test))})
 
 (defn core-site-config
   [test]


### PR DESCRIPTION
## What is the purpose of the change

*The Jepsen YARN tests sporadically fail because TM containers are exceeding their virtual memory limits. This PR disables the virtual memory check.*


## Brief change log

  - *Set yarn.nodemanager.vmem-check-enabled to false*
  - *Re-order config keys alphabetically*

## Verifying this change

This change is already covered by existing tests, such as *Jepsen test suite*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
