### PR TITLE
[FLINK-10946] Silent checkpoint async failures in task executor if job is not runnning

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -416,7 +416,9 @@ public abstract class AbstractStreamOperator<OUT>
 			String snapshotFailMessage = "Could not complete snapshot " + checkpointId + " for operator " +
 				getOperatorName() + ".";
 
-			LOG.info(snapshotFailMessage, snapshotException);
+			if (!getContainingTask().isCanceled()) {
+				LOG.info(snapshotFailMessage, snapshotException);
+			}
 			throw new Exception(snapshotFailMessage, snapshotException);
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

When job is canceled, task closable registry is closed asynchronously and checkpoints cannot register with it any more from main thread. This leads to logging error message. The PR changes the behaviour and generates error only if job is still running, assuming that after cancelation checkpoint errors are not relevant any more.

## Brief change log

 - throw exception in AbstractStreamOperator.snapshotState only if job is still running.

## Verifying this change

in loop (failure was flaky):
cd flink-end-to-end-tests
./run-single-test.sh test-scripts/test_resume_externalized_checkpoints.sh 2 4 rocks true true

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
