### PR TITLE
[FLINK-10134] UTF-16 support for TextInputFormat bug

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/LRUCache.java
+++ b/flink-core/src/main/java/org/apache/flink/util/LRUCache.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A LRUCache by LinkedHashMap.
+ */
+public class LRUCache<K, V> extends LinkedHashMap<K, V> implements java.io.Serializable {
+
+	private final int maxCacheSize;
+
+	public LRUCache(int cacheSize) {
+		super((int) Math.ceil(cacheSize / 0.75) + 1, 0.75f, true);
+		maxCacheSize = cacheSize;
+	}
+
+	@Override
+	protected boolean removeEldestEntry(Map.Entry eldest) {
+		return size() > maxCacheSize;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		for (Map.Entry<K, V> entry : entrySet()) {
+			sb.append(String.format("%s:%s ", entry.getKey(), entry.getValue()));
+		}
+		return sb.toString();
+	}
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java.io;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.io.DelimitedInputFormat;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 
 import java.io.IOException;
@@ -58,16 +59,30 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	// --------------------------------------------------------------------------------------------
 
-	public String getCharsetName() {
-		return charsetName;
-	}
-
 	public void setCharsetName(String charsetName) {
 		if (charsetName == null) {
 			throw new IllegalArgumentException("Charset must not be null.");
 		}
 
 		this.charsetName = charsetName;
+		this.setCharset(charsetName);
+	}
+
+	/**
+	 * Processing for Delimiter special cases.
+	 */
+	private void setSpecialDelimiter() {
+		String delimiterString = "\n";
+		if (this.getDelimiter() != null && this.getDelimiter().length == 1
+			&& this.getDelimiter()[0] == (byte) '\n') {
+			this.setDelimiter(delimiterString);
+		}
+	}
+
+	@Override
+	public void open(FileInputSplit split) throws IOException {
+		super.open(split);
+		setSpecialDelimiter();
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -92,7 +107,7 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 			numBytes -= 1;
 		}
 
-		return new String(bytes, offset, numBytes, this.charsetName);
+		return new String(bytes, offset, numBytes, this.getCharset());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -25,16 +25,20 @@ import org.apache.flink.core.fs.Path;
 
 import org.junit.Test;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -215,4 +219,243 @@ public class TextInputFormatTest {
 		}
 	}
 
+	/**
+	 * Test different file encodings,for example:UTF-8, UTF-8 with bom, UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE.
+	 */
+	@Test
+	public void testFileCharset() {
+		String data = "Hello|ハロー|при\\вет|Bon^*|\\|<>|jour|Сайн. байна уу|안녕*하세요.";
+		// Default separator
+		testAllFileCharset(data);
+		// Specified separator
+		testAllFileCharset(data, "^*|\\|<>|");
+	}
+
+	private void testAllFileCharset(String data) {
+		testAllFileCharset(data, "");
+	}
+
+	private void testAllFileCharset(String data, String delimiter) {
+		try {
+			// test UTF-8, no bom, UTF-8
+			testFileCharset(data, "UTF-8", false, "UTF-8", delimiter);
+			// test UTF-8, have bom, UTF-8
+			testFileCharset(data, "UTF-8", true, "UTF-8", delimiter);
+			// test UTF-16BE, no, UTF-16
+			testFileCharset(data, "UTF-16BE", false, "UTF-16", delimiter);
+			// test UTF-16BE, yes, UTF-16
+			testFileCharset(data, "UTF-16BE", true, "UTF-16", delimiter);
+			// test UTF-16LE, no, UTF-16LE
+			testFileCharset(data, "UTF-16LE", false, "UTF-16LE", delimiter);
+			// test UTF-16LE, yes, UTF-16
+			testFileCharset(data, "UTF-16LE", true, "UTF-16", delimiter);
+			// test UTF-16BE, no, UTF-16BE
+			testFileCharset(data, "UTF-16BE", false, "UTF-16BE", delimiter);
+			// test UTF-16BE, yes, UTF-16LE
+			testFileCharset(data, "UTF-16BE", true, "UTF-16LE", delimiter);
+			// test UTF-16LE, yes, UTF-16BE
+			testFileCharset(data, "UTF-16LE", true, "UTF-16BE", delimiter);
+			// test UTF-32BE, no, UTF-32
+			testFileCharset(data, "UTF-32BE", false, "UTF-32", delimiter);
+			// test UTF-32BE, yes, UTF-32
+			testFileCharset(data, "UTF-32BE", true, "UTF-32", delimiter);
+			// test UTF-32LE, yes, UTF-32
+			testFileCharset(data, "UTF-32LE", true, "UTF-32", delimiter);
+			// test UTF-32LE, no, UTF-32LE
+			testFileCharset(data, "UTF-32LE", false, "UTF-32LE", delimiter);
+			// test UTF-32BE, no, UTF-32BE
+			testFileCharset(data, "UTF-32BE", false, "UTF-32BE", delimiter);
+			// test UTF-32BE, yes, UTF-32LE
+			testFileCharset(data, "UTF-32BE", true, "UTF-32LE", delimiter);
+			// test UTF-32LE, yes, UTF-32BE
+			testFileCharset(data, "UTF-32LE", true, "UTF-32BE", delimiter);
+			//------------------Don't set the charset------------------------
+			// test UTF-8, have bom, Don't set the charset
+			testFileCharset(data, "UTF-8", true, delimiter);
+			// test UTF-8, no bom, Don't set the charset
+			testFileCharset(data, "UTF-8", false, delimiter);
+			// test UTF-16BE, no bom, Don't set the charset
+			testFileCharset(data, "UTF-16BE", false, delimiter);
+			// test UTF-16BE, have bom, Don't set the charset
+			testFileCharset(data, "UTF-16BE", true, delimiter);
+			// test UTF-16LE, have bom, Don't set the charset
+			testFileCharset(data, "UTF-16LE", true, delimiter);
+			// test UTF-32BE, no bom, Don't set the charset
+			testFileCharset(data, "UTF-32BE", false, delimiter);
+			// test UTF-32BE, have bom, Don't set the charset
+			testFileCharset(data, "UTF-32BE", true, delimiter);
+			// test UTF-32LE, have bom, Don't set the charset
+			testFileCharset(data, "UTF-32LE", true, delimiter);
+		} catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			fail("Test erroneous");
+		}
+	}
+
+	/**
+	 * To create UTF EncodedFile.
+	 *
+	 * @param data
+	 * @param fileCharset
+	 * @param hasBom
+	 * @return
+	 */
+	private File createUTFEncodedFile(String data, String fileCharset, boolean hasBom) throws Exception {
+		BufferedWriter bw = null;
+		OutputStreamWriter osw = null;
+		FileOutputStream fos = null;
+
+		byte[] bom = new byte[]{};
+		if (hasBom) {
+			switch (fileCharset) {
+				case "UTF-8":
+					bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+					break;
+				case "UTF-16":
+					bom = new byte[]{(byte) 0xFE, (byte) 0xFF};
+					break;
+				case "UTF-16LE":
+					bom = new byte[]{(byte) 0xFF, (byte) 0xFE};
+					break;
+				case "UTF-16BE":
+					bom = new byte[]{(byte) 0xFE, (byte) 0xFF};
+					break;
+				case "UTF-32":
+					bom = new byte[]{(byte) 0x00, (byte) 0x00, (byte) 0xFE, (byte) 0xFF};
+					break;
+				case "UTF-32LE":
+					bom = new byte[]{(byte) 0xFF, (byte) 0xFE, (byte) 0x00, (byte) 0x00};
+					break;
+				case "UTF-32BE":
+					bom = new byte[]{(byte) 0x00, (byte) 0x00, (byte) 0xFE, (byte) 0xFF};
+					break;
+				default:
+					throw new Exception("can not find the utf code");
+			}
+		}
+
+		// create input file
+		File tempFile = File.createTempFile("TextInputFormatTest", "tmp");
+		tempFile.deleteOnExit();
+		tempFile.setWritable(true);
+		fos = new FileOutputStream(tempFile, true);
+
+		if (tempFile.length() < 1) {
+			if (hasBom) {
+				fos.write(bom);
+			}
+		}
+
+		osw = new OutputStreamWriter(fos, fileCharset);
+		bw = new BufferedWriter(osw);
+		bw.write(data);
+		bw.newLine();
+
+		bw.close();
+		fos.close();
+
+		return tempFile;
+	}
+
+	private void testFileCharset(String data, String fileCharset, Boolean hasBom, String delimiter) {
+		testFileCharset(data, fileCharset, hasBom, null, delimiter);
+	}
+
+	private void testFileCharset(String data, String fileCharset, Boolean hasBom, String specifiedCharset, String delimiter) {
+		try {
+			int offset = 0;
+			String carriageReturn = java.security.AccessController.doPrivileged(
+				new sun.security.action.GetPropertyAction("line.separator"));
+			String delimiterString = delimiter.isEmpty() ? carriageReturn : delimiter;
+			byte[] delimiterBytes = delimiterString.getBytes(fileCharset);
+			String[] utfArray = {"UTF-8", "UTF-16", "UTF-16LE", "UTF-16BE"};
+			if (hasBom) {
+				if (Arrays.asList(utfArray).contains(fileCharset)) {
+					offset = 1;
+				}
+			}
+
+			File tempFile = createUTFEncodedFile(data, fileCharset, hasBom);
+
+			TextInputFormat inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+			if (specifiedCharset != null) {
+				inputFormat.setCharsetName(specifiedCharset);
+			}
+			if (delimiterBytes.length > 0) {
+				inputFormat.setDelimiter(delimiterBytes);
+			}
+
+			Configuration parameters = new Configuration();
+			inputFormat.configure(parameters);
+
+			FileInputSplit[] splits = inputFormat.createInputSplits(1);
+			assertTrue("expected at least one input split", splits.length >= 1);
+			inputFormat.open(splits[0]);
+
+			String result = "";
+			int i = 0;
+			data = data + carriageReturn;
+			String delimiterStr = new String(delimiterBytes, 0, delimiterBytes.length, fileCharset);
+			String[] strArr = data.split(delimiterStr
+				.replace("\\", "\\\\")
+				.replace("^", "\\^")
+				.replace("|", "\\|")
+				.replace("[", "\\[")
+				.replace("*", "\\*")
+				.replace(".", "\\.")
+			);
+
+			while (!inputFormat.reachedEnd()) {
+				if (i < strArr.length) {
+					result = inputFormat.nextRecord("");
+					if (i == 0) {
+						result = result.substring(offset);
+					}
+					if (Charset.forName(fileCharset) != inputFormat.getCharset()) {
+						assertNotEquals(strArr[i], result);
+					} else {
+						assertEquals(strArr[i], result);
+					}
+					i++;
+				} else {
+					inputFormat.nextRecord("");
+				}
+			}
+			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
+		} catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			fail("Test erroneous");
+		}
+	}
+
+	@Test
+	public void testFileCharsetReadByMultiSplits() {
+		String carriageReturn = java.security.AccessController.doPrivileged(
+			new sun.security.action.GetPropertyAction("line.separator"));
+		final String data = "First line" + carriageReturn + "Second line";
+		try {
+			File tempFile = createUTFEncodedFile(data, "UTF-16", false);
+
+			TextInputFormat inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+			inputFormat.setCharsetName("UTF-32");
+
+			Configuration parameters = new Configuration();
+			inputFormat.configure(parameters);
+
+			FileInputSplit[] splits = inputFormat.createInputSplits(3);
+			assertTrue("expected at least one input split", splits.length >= 1);
+			String result = "";
+			for (FileInputSplit split : splits) {
+				inputFormat.open(split);
+				result = inputFormat.nextRecord("");
+			}
+			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
+		} catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			fail("Test erroneous");
+		}
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*(This PR is designed to solve the problem of `TextInputFormat` using UTF-16 encoding to parse files.)*

## Brief change log

*(To solve this bug, I added a file BOM header encoding check to determine the current file encoding, so that when user-defined encoding format and file with a BOM header encoding format conflict processing, specific changes in the following::)*

- I add `getBomFileCharset` function to `DelimitedInputFormat.java` to detect the current file BOM header coding judgment, mainly `UTF-16BE`, `UTF-16LE`, `UTF-8 with BOM header`, `UTF-32BE`, `UTF-32LE` these types, default to `UTF-8`.

- I added the `bomBytes`,`fileBomCharsetMap`,`bomIdentifiedCharset` ,`configuredCharset` variable to the `DelimitedInputFormat.java`, `getBomFileCharset(split)` to the `open` method, and`setBomFileCharset` to set the `bomIdentifiedCharset`,`fileBomCharsetMap` variable.*The file name that has been parsed is used as the key, and the encoded value is inserted as a value into the `fileBomCharsetMap`.

- In the `DelimitedInputFormat.java` method `getCharset()`, the encoding logic is added to obtain the encoding of the current file. I would handle the different charsets with three private fields.

  1.configuredCharset: This is the charset that is configured via setCharset()
  2.bomIdentifiedCharset: This is the charset that is set by setBomFileCharset()
  3.charset: This is the charset that is returned by getCharset(). If not set before (i.e., null), it is set first depending on the configuredCharset and bomIdentifiedCharset.

- In the `DelimitedInputFormat.java` method`GetSpecialCharset` handles both special cases of user input, utf-16 utf-32.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *I added `testFileCharset`  and `testAllFileCharset` and `createUTFEncodedFile` and `testFileCharsetReadByMultiSplits` to `TextInputFormatTest`.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no )
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

## Discuss

The following are the modifications and discussions that have been made by this bug. Thank you for the review by Fabian Hueske

[jira link](https://issues.apache.org/jira/browse/FLINK-10134?focusedCommentId=16652877&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16652877)

[pr6823](https://github.com/apache/flink/pull/6823)

[pr6710](https://github.com/apache/flink/pull/6710)