### PR TITLE
[FLINK-10980][docs] Fix Iterable Scala code in CEP part

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1527,8 +1527,8 @@ The events for a given pattern are ordered by timestamp. The reason for returnin
 
 {% highlight scala %}
 def selectFn(pattern : Map[String, Iterable[IN]]): OUT = {
-    val startEvent = pattern.get("start").get.next
-    val endEvent = pattern.get("end").get.next
+    val startEvent = pattern.get("start").get.head
+    val endEvent = pattern.get("end").get.head
     OUT(startEvent, endEvent)
 }
 {% endhighlight %}
@@ -1539,8 +1539,8 @@ The `flatSelect` method is similar to the `select` method. Their only difference
 
 {% highlight scala %}
 def flatSelectFn(pattern : Map[String, Iterable[IN]], collector : Collector[OUT]) = {
-    val startEvent = pattern.get("start").get.next
-    val endEvent = pattern.get("end").get.next
+    val startEvent = pattern.get("start").get.head
+    val endEvent = pattern.get("end").get.head
     for (i <- 0 to startEvent.getValue) {
         collector.collect(OUT(startEvent, endEvent))
     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix some Iterable Scala code in the CEP part of the doc

## Brief change log

  - *Change the Iterable[T].get.next to Iterable[T].get.head* because Iterable[T].get.next cannot compile.

## Verifying this change

This change is a docs cleanup.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

