### PR TITLE
[FLINK-10983][queryable state] Increase port range for NonHAQueryableStateFsBackendITCase

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
@@ -44,6 +44,7 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 	// we always use all TaskManagers so that the JM oracle is always properly re-registered
 	private static final int NUM_TMS = 2;
 	private static final int NUM_SLOTS_PER_TM = 2;
+	private static final int NUM_PORT_COUNT = 100;
 
 	private static final int QS_PROXY_PORT_RANGE_START = 9084;
 	private static final int QS_SERVER_PORT_RANGE_START = 9089;
@@ -86,10 +87,10 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 		config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
 		config.setString(
 			QueryableStateOptions.PROXY_PORT_RANGE,
-			QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + 100));
+			QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + NUM_PORT_COUNT));
 		config.setString(
 			QueryableStateOptions.SERVER_PORT_RANGE,
-			QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + 100));
+			QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + NUM_PORT_COUNT));
 		config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
 		return config;
 	}

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
@@ -86,10 +86,10 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 		config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
 		config.setString(
 			QueryableStateOptions.PROXY_PORT_RANGE,
-			QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + NUM_TMS));
+			QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + 100));
 		config.setString(
 			QueryableStateOptions.SERVER_PORT_RANGE,
-			QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + NUM_TMS));
+			QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + 100));
 		config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
 		return config;
 	}


### PR DESCRIPTION

## What is the purpose of the change

NonHAQueryableStateFsBackendITCase failed when run `mvn install`. This pr increases port range for the test case to make it more stable.


## Brief change log

  - Increases port range for NonHAQueryableStateFsBackendITCase


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
