### PR TITLE
[FLINK-10963][fs-connector, s3] Cleanup tmp S3 objects uploaded as backups of in-progress files.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
@@ -122,6 +122,32 @@ public interface RecoverableWriter {
 	RecoverableFsDataOutputStream recover(ResumeRecoverable resumable) throws IOException;
 
 	/**
+	 * Marks if the writer requires to do any additional cleanup/freeing of resources occupied
+	 * as part of a {@link ResumeRecoverable}, e.g. temporarily files created or objects uploaded
+	 * to external systems.
+	 *
+	 * In case cleanup is required, then {@link #cleanupRecoverableState(ResumeRecoverable)} should
+	 * be called.
+	 *
+	 * @return {@code true} if cleanup is required, {@code false} otherwise.
+	 */
+	boolean requiresCleanupOfRecoverableState();
+
+	/**
+	 * Frees up any resources that were were previously occupied in order to be able to
+	 * recover from a (potential) failure. This can be temporary files that we written or
+	 * objects that were uploaded (e.g. S3).
+	 *
+	 * <p><b>NOTE:</b> This operation should not through an exception if the resumable has already
+	 * been cleaned up and the resources have been freed.
+	 *
+	 * @param resumable The {@link ResumeRecoverable} whose state we want to clean-up.
+	 * @return {@code true} if the resources were successfully freed, {@code false} otherwise
+	 * (e.g. the file to be deleted was not there).
+	 */
+	boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException;
+
+	/**
 	 * Recovers a recoverable stream consistently at the point indicated by the given CommitRecoverable
 	 * for finalizing and committing. This will publish the target file with exactly the data
 	 * that was written up to the point then the CommitRecoverable was created.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
@@ -71,6 +71,16 @@ public class LocalRecoverableWriter implements RecoverableWriter {
 	}
 
 	@Override
+	public boolean requiresCleanupOfRecoverableState() {
+		return false;
+	}
+
+	@Override
+	public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+		return false;
+	}
+
+	@Override
 	public Committer recoverForCommit(CommitRecoverable recoverable) throws IOException {
 		if (recoverable instanceof LocalRecoverable) {
 			return new LocalRecoverableFsDataOutputStream.LocalCommitter((LocalRecoverable) recoverable);

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -78,6 +78,16 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 	}
 
 	@Override
+	public boolean requiresCleanupOfRecoverableState() {
+		return false;
+	}
+
+	@Override
+	public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+		return false;
+	}
+
+	@Override
 	public Committer recoverForCommit(CommitRecoverable recoverable) throws IOException {
 		if (recoverable instanceof HadoopFsRecoverable) {
 			return new HadoopRecoverableFsDataOutputStream.HadoopFsCommitter(fs, (HadoopFsRecoverable) recoverable);

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImpl.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImpl.java
@@ -174,11 +174,6 @@ final class RecoverableMultiPartUploadImpl implements RecoverableMultiPartUpload
 		final String incompletePartObjectName = createIncompletePartObjectName();
 		file.retain();
 		try (InputStream inputStream = file.getInputStream()) {
-
-			// TODO: staged incomplete parts are not cleaned up as
-			// they do not fall under the user's global TTL on S3.
-			// Figure out a way to clean them.
-
 			s3AccessHelper.putObject(incompletePartObjectName, inputStream, file.getPos());
 		}
 		finally {

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
@@ -93,6 +93,16 @@ public interface S3AccessHelper {
 	CompleteMultipartUploadResult commitMultiPartUpload(String key, String uploadId, List<PartETag> partETags, long length, AtomicInteger errorCount) throws IOException;
 
 	/**
+	 * Deletes the object associated with the provided key.
+	 *
+	 * @param key The key to be deleted.
+	 * @return {@code true} if the resources were successfully freed, {@code false} otherwise
+	 * (e.g. the file to be deleted was not there).
+	 * @throws IOException
+	 */
+	boolean deleteObject(String key) throws IOException;
+
+	/**
 	 * Gets the object associated with the provided {@code key} from S3 and
 	 * puts it in the provided {@code targetLocation}.
 	 *

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
@@ -22,36 +22,36 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for the {@link RecoverableMultiPartUploadImpl#incompleteObjectNamePrefix(String)}.
+ * Tests for the {@link RecoverableMultiPartUploadImpl#createIncompletePartObjectNamePrefix(String)}.
  */
 public class IncompletePartPrefixTest {
 
 	@Test(expected = NullPointerException.class)
 	public void nullObjectNameShouldThroughException() {
-		RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix(null);
+		RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(null);
 	}
 
 	@Test
 	public void emptyInitialNameShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("");
 		Assert.assertEquals("_tmp_", objectNamePrefix);
 	}
 
 	@Test
 	public void nameWithoutSlashShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("no_slash_path");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("no_slash_path");
 		Assert.assertEquals("_no_slash_path_tmp_", objectNamePrefix);
 	}
 
 	@Test
 	public void nameWithOnlySlashShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("/");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("/");
 		Assert.assertEquals("/_tmp_", objectNamePrefix);
 	}
 
 	@Test
 	public void normalPathShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("/root/home/test-file");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("/root/home/test-file");
 		Assert.assertEquals("/root/home/_test-file_tmp_", objectNamePrefix);
 	}
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
@@ -373,6 +373,11 @@ public class RecoverableMultiPartUploadImplTest {
 		}
 
 		@Override
+		public boolean deleteObject(String key) throws IOException {
+			return false;
+		}
+
+		@Override
 		public long getObject(String key, File targetLocation) throws IOException {
 			return 0;
 		}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -86,6 +86,11 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 	}
 
 	@Override
+	public boolean deleteObject(String key) throws IOException {
+		return s3a.delete(new org.apache.hadoop.fs.Path('/' + key), false);
+	}
+
+	@Override
 	public long getObject(String key, File targetLocation) throws IOException {
 		long numBytes = 0L;
 		try (

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.fs.local.LocalRecoverableWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link Bucket}.
+ */
+public class BucketTest {
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+	@Test
+	public void shouldNotCleanupResumablesThatArePartOfTheAckedCheckpoint() throws IOException {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		bucketUnderTest.write("test-element", 0L);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasActiveInProgressFile());
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
+		assertThat(recoverableWriter, hasCalledDiscard(0)); // it did not discard as this is still valid.
+	}
+
+	@Test
+	public void shouldCleanupOutdatedResumablesOnCheckpointAck() throws IOException {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		bucketUnderTest.write("test-element", 0L);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasActiveInProgressFile());
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
+
+		bucketUnderTest.onReceptionOfCheckpoint(1L);
+		bucketUnderTest.onReceptionOfCheckpoint(2L);
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(2L);
+		assertThat(recoverableWriter, hasCalledDiscard(2)); // that is for checkpoints 0 and 1
+	}
+
+	@Test
+	public void shouldCleanupResumableAfterRestoring() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		bucketUnderTest.write("test-element", 0L);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasActiveInProgressFile());
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
+
+		final TestRecoverableWriter newRecoverableWriter = getRecoverableWriter(path);
+		restoreBucket(newRecoverableWriter, 0, 1, state);
+
+		assertThat(newRecoverableWriter, hasCalledDiscard(1)); // that is for checkpoints 0 and 1
+	}
+
+	@Test
+	public void shouldNotCallCleanupWithoutInProgressPartFiles() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasNoActiveInProgressFile());
+
+		bucketUnderTest.onReceptionOfCheckpoint(1L);
+		bucketUnderTest.onReceptionOfCheckpoint(2L);
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(2L);
+		assertThat(recoverableWriter, hasCalledDiscard(0)); // we have no in-progress file.
+	}
+
+	// ------------------------------- Matchers --------------------------------
+
+	private static TypeSafeMatcher<TestRecoverableWriter> hasCalledDiscard(int times) {
+		return new TypeSafeMatcher<TestRecoverableWriter>() {
+			@Override
+			protected boolean matchesSafely(TestRecoverableWriter writer) {
+				return writer.getCleanupCallCounter() == times;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description
+						.appendText("the TestRecoverableWriter to have called discardRecoverableState() ")
+						.appendValue(times)
+						.appendText(" times.");
+			}
+		};
+	}
+
+	private static TypeSafeMatcher<BucketState<String>> hasActiveInProgressFile() {
+		return new TypeSafeMatcher<BucketState<String>>() {
+			@Override
+			protected boolean matchesSafely(BucketState<String> state) {
+				return state.getInProgressResumableFile() != null;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("a BucketState with active in-progress file.");
+			}
+		};
+	}
+
+	private static TypeSafeMatcher<BucketState<String>> hasNoActiveInProgressFile() {
+		return new TypeSafeMatcher<BucketState<String>>() {
+			@Override
+			protected boolean matchesSafely(BucketState<String> state) {
+				return state.getInProgressResumableFile() == null;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("a BucketState with no active in-progress file.");
+			}
+		};
+	}
+
+	// ------------------------------- Mock Classes --------------------------------
+
+	private static class TestRecoverableWriter extends LocalRecoverableWriter {
+
+		private int cleanupCallCounter = 0;
+
+		TestRecoverableWriter(LocalFileSystem fs) {
+			super(fs);
+		}
+
+		int getCleanupCallCounter() {
+			return cleanupCallCounter;
+		}
+
+		@Override
+		public boolean requiresCleanupOfRecoverableState() {
+			return true;
+		}
+
+		@Override
+		public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+			cleanupCallCounter++;
+			return super.cleanupRecoverableState(resumable);
+		}
+
+		@Override
+		public String toString() {
+			return "TestRecoverableWriter has called discardRecoverableState() " + cleanupCallCounter + " times.";
+		}
+	}
+
+	// ------------------------------- Utility Methods --------------------------------
+
+	private static final String bucketId = "testing-bucket";
+
+	private static final RollingPolicy<String, String> rollingPolicy = DefaultRollingPolicy.create().build();
+
+	private static final PartFileWriter.PartFileFactory<String, String> partFileFactory =
+			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>());
+
+	private static Bucket<String, String> createBucket(
+			final RecoverableWriter writer,
+			final Path bucketPath,
+			final int subtaskIdx,
+			final int initialPartCounter) {
+
+		return Bucket.getNew(
+				writer,
+				subtaskIdx,
+				bucketId,
+				bucketPath,
+				initialPartCounter,
+				partFileFactory,
+				rollingPolicy);
+	}
+
+	private static Bucket<String, String> restoreBucket(
+			final RecoverableWriter writer,
+			final int subtaskIndex,
+			final long initialPartCounter,
+			final BucketState<String> bucketState) throws Exception {
+
+		return Bucket.restore(
+				writer,
+				subtaskIndex,
+				initialPartCounter,
+				partFileFactory,
+				rollingPolicy,
+				bucketState
+		);
+	}
+
+	private static TestRecoverableWriter getRecoverableWriter(Path path) {
+		try {
+			final FileSystem fs = FileSystem.get(path.toUri());
+			if (!(fs instanceof LocalFileSystem)) {
+				fail("Expected Local FS but got a " + fs.getClass().getName() + " for path: " + path);
+			}
+			return new TestRecoverableWriter((LocalFileSystem) fs);
+		} catch (IOException e) {
+			fail();
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The S3 `RecoverableWriter` uses the Multipart Upload (MPU) Feature of S3 in order to upload the different part files. This means that a large part is split in chunks of at least 5MB which are uploaded independently, whenever each one of them is ready.

This 5MB minimum size requires special handling of parts that are less than 5MB when a checkpoint barrier arrives. These small files are uploaded as independent objects (not associated with an active MPU). This way, when Flink needs to restore, it simply downloads them and resumes writing to them.

These small objects are currently not cleaned up, thus leading to wasted space on S3.

This PR changes this by cleaning these files upon restoring and also when the "next" checkpoint is successfully acknowledged. 

LIMITATION: Upon a failure, still there may be objects that were created after the last successful checkpoint but before the failure. These do not belong to the checkpointed state and they are not cleaned up. But this is a more general limitation which will be covered by another JIRA.

## Brief change log

This PR adds the following methods to the `RecoverableWriter`:

```
boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException;

boolean requiresCleanupOfRecoverableState();
```

The second one is just for optimization purposes.

## Verifying this change

Added the `BucketTest` class and 2 tests in the `HadoopS3RecoverableWriterITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
