### PR TITLE
[FLINK-10963][fs-connector, s3] Cleanup tmp S3 objects uploaded as backups of in-progress files.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
@@ -122,6 +122,32 @@ public interface RecoverableWriter {
 	RecoverableFsDataOutputStream recover(ResumeRecoverable resumable) throws IOException;
 
 	/**
+	 * Marks if the writer requires to do any additional cleanup/freeing of resources occupied
+	 * as part of a {@link ResumeRecoverable}, e.g. temporarily files created or objects uploaded
+	 * to external systems.
+	 *
+	 * <p>In case cleanup is required, then {@link #cleanupRecoverableState(ResumeRecoverable)} should
+	 * be called.
+	 *
+	 * @return {@code true} if cleanup is required, {@code false} otherwise.
+	 */
+	boolean requiresCleanupOfRecoverableState();
+
+	/**
+	 * Frees up any resources that were were previously occupied in order to be able to
+	 * recover from a (potential) failure. This can be temporary files that we written or
+	 * objects that were uploaded (e.g. S3).
+	 *
+	 * <p><b>NOTE:</b> This operation should not through an exception if the resumable has already
+	 * been cleaned up and the resources have been freed.
+	 *
+	 * @param resumable The {@link ResumeRecoverable} whose state we want to clean-up.
+	 * @return {@code true} if the resources were successfully freed, {@code false} otherwise
+	 * (e.g. the file to be deleted was not there).
+	 */
+	boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException;
+
+	/**
 	 * Recovers a recoverable stream consistently at the point indicated by the given CommitRecoverable
 	 * for finalizing and committing. This will publish the target file with exactly the data
 	 * that was written up to the point then the CommitRecoverable was created.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
@@ -135,15 +135,15 @@ public interface RecoverableWriter {
 
 	/**
 	 * Frees up any resources that were previously occupied in order to be able to
-	 * recover from a (potential) failure. This can be temporary files that we written or
-	 * objects that were uploaded (e.g. S3).
+	 * recover from a (potential) failure. These can be temporary files that were written
+	 * to the filesystem or objects that were uploaded to S3.
 	 *
 	 * <p><b>NOTE:</b> This operation should not throw an exception if the resumable has already
 	 * been cleaned up and the resources have been freed.
 	 *
 	 * @param resumable The {@link ResumeRecoverable} whose state we want to clean-up.
 	 * @return {@code true} if the resources were successfully freed, {@code false} otherwise
-	 * (e.g. the file to be deleted was not there).
+	 * (e.g. the file to be deleted was not there for any reason - already deleted or never created).
 	 */
 	boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException;
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
@@ -139,7 +139,9 @@ public interface RecoverableWriter {
 	 * to the filesystem or objects that were uploaded to S3.
 	 *
 	 * <p><b>NOTE:</b> This operation should not throw an exception if the resumable has already
-	 * been cleaned up and the resources have been freed.
+	 * been cleaned up and the resources have been freed. But the contract is that it will throw
+	 * an {@link UnsupportedOperationException} if it is called for a {@code RecoverableWriter}
+	 * whose {@link #requiresCleanupOfRecoverableState()} returns {@code false}.
 	 *
 	 * @param resumable The {@link ResumeRecoverable} whose state we want to clean-up.
 	 * @return {@code true} if the resources were successfully freed, {@code false} otherwise

--- a/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RecoverableWriter.java
@@ -134,11 +134,11 @@ public interface RecoverableWriter {
 	boolean requiresCleanupOfRecoverableState();
 
 	/**
-	 * Frees up any resources that were were previously occupied in order to be able to
+	 * Frees up any resources that were previously occupied in order to be able to
 	 * recover from a (potential) failure. This can be temporary files that we written or
 	 * objects that were uploaded (e.g. S3).
 	 *
-	 * <p><b>NOTE:</b> This operation should not through an exception if the resumable has already
+	 * <p><b>NOTE:</b> This operation should not throw an exception if the resumable has already
 	 * been cleaned up and the resources have been freed.
 	 *
 	 * @param resumable The {@link ResumeRecoverable} whose state we want to clean-up.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
@@ -71,6 +71,16 @@ public class LocalRecoverableWriter implements RecoverableWriter {
 	}
 
 	@Override
+	public boolean requiresCleanupOfRecoverableState() {
+		return false;
+	}
+
+	@Override
+	public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+		return false;
+	}
+
+	@Override
 	public Committer recoverForCommit(CommitRecoverable recoverable) throws IOException {
 		if (recoverable instanceof LocalRecoverable) {
 			return new LocalRecoverableFsDataOutputStream.LocalCommitter((LocalRecoverable) recoverable);

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
@@ -77,7 +77,7 @@ public class LocalRecoverableWriter implements RecoverableWriter {
 
 	@Override
 	public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -78,6 +78,16 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 	}
 
 	@Override
+	public boolean requiresCleanupOfRecoverableState() {
+		return false;
+	}
+
+	@Override
+	public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+		return false;
+	}
+
+	@Override
 	public Committer recoverForCommit(CommitRecoverable recoverable) throws IOException {
 		if (recoverable instanceof HadoopFsRecoverable) {
 			return new HadoopRecoverableFsDataOutputStream.HadoopFsCommitter(fs, (HadoopFsRecoverable) recoverable);

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -84,7 +84,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 
 	@Override
 	public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
-import org.apache.flink.fs.s3.common.writer.S3MultiPartUploader;
+import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +141,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 			final String localTmpDirectory = flinkConfig.getString(CoreOptions.TMP_DIRS);
 			final long s3minPartSize = flinkConfig.getLong(PART_UPLOAD_MIN_SIZE);
 			final int maxConcurrentUploads = flinkConfig.getInteger(MAX_CONCURRENT_UPLOADS);
-			final S3MultiPartUploader s3AccessHelper = getS3AccessHelper(fs);
+			final S3AccessHelper s3AccessHelper = getS3AccessHelper(fs);
 
 			return new FlinkS3FileSystem(
 					fs,
@@ -166,6 +166,6 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 		URI fsUri, org.apache.hadoop.conf.Configuration hadoopConfig);
 
 	@Nullable
-	protected abstract S3MultiPartUploader getS3AccessHelper(org.apache.hadoop.fs.FileSystem fs);
+	protected abstract S3AccessHelper getS3AccessHelper(org.apache.hadoop.fs.FileSystem fs);
 }
 

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImpl.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImpl.java
@@ -179,7 +179,7 @@ final class RecoverableMultiPartUploadImpl implements RecoverableMultiPartUpload
 			// they do not fall under the user's global TTL on S3.
 			// Figure out a way to clean them.
 
-			s3AccessHelper.uploadIncompletePart(incompletePartObjectName, inputStream, file.getPos());
+			s3AccessHelper.putObject(incompletePartObjectName, inputStream, file.getPos());
 		}
 		finally {
 			file.release();

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImpl.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImpl.java
@@ -174,11 +174,6 @@ final class RecoverableMultiPartUploadImpl implements RecoverableMultiPartUpload
 		final String incompletePartObjectName = createIncompletePartObjectName();
 		file.retain();
 		try (InputStream inputStream = file.getInputStream()) {
-
-			// TODO: staged incomplete parts are not cleaned up as
-			// they do not fall under the user's global TTL on S3.
-			// Figure out a way to clean them.
-
 			s3AccessHelper.putObject(incompletePartObjectName, inputStream, file.getPos());
 		}
 		finally {

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.UploadPartResult;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -66,10 +67,9 @@ public interface S3AccessHelper {
 	UploadPartResult uploadPart(String key, String uploadId, int partNumber, InputStream file, long length) throws IOException;
 
 	/**
-	 * Uploads a part and associates it with the MPU with the provided {@code uploadId}.
-	 *
-	 * <p>Contrary to the {@link #uploadIncompletePart(String, InputStream, long)}, this part can
-	 * be smaller than the minimum part size imposed by S3.
+	 * Uploads an object to S3. Contrary to the {@link #uploadPart(String, String, int, InputStream, long)} method,
+	 * this object is not going to be associated to any MPU and, as such, it is not subject to the garbage collection
+	 * policies specified for your S3 bucket.
 	 *
 	 * @param key the key used to identify this part.
 	 * @param file the (local) file holding the data to be uploaded.
@@ -77,7 +77,7 @@ public interface S3AccessHelper {
 	 * @return The {@link PutObjectResult result} of the attempt to stage the incomplete part.
 	 * @throws IOException
 	 */
-	PutObjectResult uploadIncompletePart(String key, InputStream file, long length) throws IOException;
+	PutObjectResult putObject(String key, InputStream file, long length) throws IOException;
 
 	/**
 	 * Finalizes a Multi-Part Upload.
@@ -91,6 +91,17 @@ public interface S3AccessHelper {
 	 * @throws IOException
 	 */
 	CompleteMultipartUploadResult commitMultiPartUpload(String key, String uploadId, List<PartETag> partETags, long length, AtomicInteger errorCount) throws IOException;
+
+	/**
+	 * Gets the object associated with the provided {@code key} from S3 and
+	 * puts it in the provided {@code targetLocation}.
+	 *
+	 * @param key the key of the object to fetch.
+	 * @param targetLocation the file to read the object to.
+	 * @return The number of bytes read.
+	 * @throws IOException
+	 */
+	long getObject(String key, File targetLocation) throws IOException;
 
 	/**
 	 * Fetches the metadata associated with a given key on S3.

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
@@ -93,6 +93,16 @@ public interface S3AccessHelper {
 	CompleteMultipartUploadResult commitMultiPartUpload(String key, String uploadId, List<PartETag> partETags, long length, AtomicInteger errorCount) throws IOException;
 
 	/**
+	 * Deletes the object associated with the provided key.
+	 *
+	 * @param key The key to be deleted.
+	 * @return {@code true} if the resources were successfully freed, {@code false} otherwise
+	 * (e.g. the file to be deleted was not there).
+	 * @throws IOException
+	 */
+	boolean deleteObject(String key) throws IOException;
+
+	/**
 	 * Gets the object associated with the provided {@code key} from S3 and
 	 * puts it in the provided {@code targetLocation}.
 	 *

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3AccessHelper.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * the upload with all its parts will be either committed or discarded.
  */
 @Internal
-public interface S3MultiPartUploader {
+public interface S3AccessHelper {
 
 	/**
 	 * Initializes a Multi-Part Upload.

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableMultipartUploadFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableMultipartUploadFactory.java
@@ -43,7 +43,7 @@ final class S3RecoverableMultipartUploadFactory {
 
 	private final org.apache.hadoop.fs.FileSystem fs;
 
-	private final S3MultiPartUploader twoPhaseUploader;
+	private final S3AccessHelper s3AccessHelper;
 
 	private final FunctionWithException<File, RefCountedFile, IOException> tmpFileSupplier;
 
@@ -53,7 +53,7 @@ final class S3RecoverableMultipartUploadFactory {
 
 	S3RecoverableMultipartUploadFactory(
 			final FileSystem fs,
-			final S3MultiPartUploader twoPhaseUploader,
+			final S3AccessHelper s3AccessHelper,
 			final int maxConcurrentUploadsPerStream,
 			final Executor executor,
 			final FunctionWithException<File, RefCountedFile, IOException> tmpFileSupplier) {
@@ -61,14 +61,14 @@ final class S3RecoverableMultipartUploadFactory {
 		this.fs = Preconditions.checkNotNull(fs);
 		this.maxConcurrentUploadsPerStream = maxConcurrentUploadsPerStream;
 		this.executor = executor;
-		this.twoPhaseUploader = twoPhaseUploader;
+		this.s3AccessHelper = s3AccessHelper;
 		this.tmpFileSupplier = tmpFileSupplier;
 	}
 
 	RecoverableMultiPartUpload getNewRecoverableUpload(Path path) throws IOException {
 
 		return RecoverableMultiPartUploadImpl.newUpload(
-				twoPhaseUploader,
+				s3AccessHelper,
 				limitedExecutor(),
 				pathToObjectName(path));
 	}
@@ -77,7 +77,7 @@ final class S3RecoverableMultipartUploadFactory {
 		final Optional<File> incompletePart = downloadLastDataChunk(recoverable);
 
 		return RecoverableMultiPartUploadImpl.recoverUpload(
-				twoPhaseUploader,
+				s3AccessHelper,
 				limitedExecutor(),
 				recoverable.uploadId(),
 				recoverable.getObjectName(),

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableMultipartUploadFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableMultipartUploadFactory.java
@@ -96,14 +96,6 @@ final class S3RecoverableMultipartUploadFactory {
 		final File file = refCountedFile.getFile();
 		final long numBytes = s3AccessHelper.getObject(objectKey, file);
 
-		// some sanity checks
-		if (numBytes != file.length()) {
-			throw new IOException(String.format("Error recovering writer: " +
-							"Downloading the last data chunk file gives incorrect length. " +
-							"File=%d bytes, Stream=%d bytes",
-					file.length(), numBytes));
-		}
-
 		if (numBytes != recoverable.incompleteObjectLength()) {
 			throw new IOException(String.format("Error recovering writer: " +
 							"Downloading the last data chunk file gives incorrect length." +

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableWriter.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/writer/S3RecoverableWriter.java
@@ -129,7 +129,7 @@ public class S3RecoverableWriter implements RecoverableWriter {
 	public static S3RecoverableWriter writer(
 			final FileSystem fs,
 			final FunctionWithException<File, RefCountedFile, IOException> tempFileCreator,
-			final S3MultiPartUploader twoPhaseUploader,
+			final S3AccessHelper s3AccessHelper,
 			final Executor uploadThreadPool,
 			final long userDefinedMinPartSize,
 			final int maxConcurrentUploadsPerStream) {
@@ -139,7 +139,7 @@ public class S3RecoverableWriter implements RecoverableWriter {
 		final S3RecoverableMultipartUploadFactory uploadFactory =
 				new S3RecoverableMultipartUploadFactory(
 						fs,
-						twoPhaseUploader,
+						s3AccessHelper,
 						maxConcurrentUploadsPerStream,
 						uploadThreadPool,
 						tempFileCreator);

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S3EntropyFsFactoryTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S3EntropyFsFactoryTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.fs.s3.common;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.fs.s3.common.writer.S3MultiPartUploader;
+import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -78,7 +78,7 @@ public class S3EntropyFsFactoryTest extends TestLogger {
 
 		@Nullable
 		@Override
-		protected S3MultiPartUploader getS3AccessHelper(FileSystem fs) {
+		protected S3AccessHelper getS3AccessHelper(FileSystem fs) {
 			return null;
 		}
 

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
@@ -22,36 +22,36 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for the {@link RecoverableMultiPartUploadImpl#incompleteObjectNamePrefix(String)}.
+ * Tests for the {@link RecoverableMultiPartUploadImpl#createIncompletePartObjectNamePrefix(String)}.
  */
 public class IncompletePartPrefixTest {
 
 	@Test(expected = NullPointerException.class)
 	public void nullObjectNameShouldThroughException() {
-		RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix(null);
+		RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(null);
 	}
 
 	@Test
 	public void emptyInitialNameShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("");
 		Assert.assertEquals("_tmp_", objectNamePrefix);
 	}
 
 	@Test
 	public void nameWithoutSlashShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("no_slash_path");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("no_slash_path");
 		Assert.assertEquals("_no_slash_path_tmp_", objectNamePrefix);
 	}
 
 	@Test
 	public void nameWithOnlySlashShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("/");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("/");
 		Assert.assertEquals("/_tmp_", objectNamePrefix);
 	}
 
 	@Test
 	public void normalPathShouldSucceed() {
-		String objectNamePrefix = RecoverableMultiPartUploadImpl.incompleteObjectNamePrefix("/root/home/test-file");
+		String objectNamePrefix = RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("/root/home/test-file");
 		Assert.assertEquals("/root/home/_test-file_tmp_", objectNamePrefix);
 	}
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
@@ -347,11 +347,11 @@ public class RecoverableMultiPartUploadImplTest {
 		private final List<RecoverableMultiPartUploadImplTest.TestUploadPartResult> completePartsUploaded = new ArrayList<>();
 		private final List<RecoverableMultiPartUploadImplTest.TestPutObjectResult> incompletePartsUploaded = new ArrayList<>();
 
-		public List<RecoverableMultiPartUploadImplTest.TestUploadPartResult> getCompletePartsUploaded() {
+		List<RecoverableMultiPartUploadImplTest.TestUploadPartResult> getCompletePartsUploaded() {
 			return completePartsUploaded;
 		}
 
-		public List<RecoverableMultiPartUploadImplTest.TestPutObjectResult> getIncompletePartsUploaded() {
+		List<RecoverableMultiPartUploadImplTest.TestPutObjectResult> getIncompletePartsUploaded() {
 			return incompletePartsUploaded;
 		}
 
@@ -367,9 +367,14 @@ public class RecoverableMultiPartUploadImplTest {
 		}
 
 		@Override
-		public PutObjectResult uploadIncompletePart(String key, InputStream file, long length) throws IOException {
+		public PutObjectResult putObject(String key, InputStream file, long length) throws IOException {
 			final byte[] content = getFileContentBytes(file, MathUtils.checkedDownCast(length));
 			return storeAndGetPutObjectResult(key, content);
+		}
+
+		@Override
+		public long getObject(String key, File targetLocation) throws IOException {
+			return 0;
 		}
 
 		@Override

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
@@ -373,6 +373,11 @@ public class RecoverableMultiPartUploadImplTest {
 		}
 
 		@Override
+		public boolean deleteObject(String key) throws IOException {
+			return false;
+		}
+
+		@Override
 		public long getObject(String key, File targetLocation) throws IOException {
 			return 0;
 		}

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
@@ -339,10 +339,10 @@ public class RecoverableMultiPartUploadImplTest {
 	}
 
 	/**
-	 * A {@link S3MultiPartUploader} that simulates uploading part files to S3 by
+	 * A {@link S3AccessHelper} that simulates uploading part files to S3 by
 	 * simply putting complete and incomplete part files in lists for further validation.
 	 */
-	private static class StubMultiPartUploader implements S3MultiPartUploader {
+	private static class StubMultiPartUploader implements S3AccessHelper {
 
 		private final List<RecoverableMultiPartUploadImplTest.TestUploadPartResult> completePartsUploaded = new ArrayList<>();
 		private final List<RecoverableMultiPartUploadImplTest.TestPutObjectResult> incompletePartsUploaded = new ArrayList<>();

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -86,6 +86,11 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 	}
 
 	@Override
+	public boolean deleteObject(String key) throws IOException {
+		return s3a.delete(new org.apache.hadoop.fs.Path('/' + key), false);
+	}
+
+	@Override
 	public long getObject(String key, File targetLocation) throws IOException {
 		long numBytes = 0L;
 		try (

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -101,10 +101,18 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 			final byte[] buffer = new byte[32 * 1024];
 
 			int numRead;
-			while ((numRead = inStream.read(buffer)) > 0) {
+			while ((numRead = inStream.read(buffer)) != -1) {
 				outStream.write(buffer, 0, numRead);
 				numBytes += numRead;
 			}
+		}
+
+		// some sanity checks
+		if (numBytes != targetLocation.length()) {
+			throw new IOException(String.format("Error recovering writer: " +
+							"Downloading the last data chunk file gives incorrect length. " +
+							"File=%d bytes, Stream=%d bytes",
+					targetLocation.length(), numBytes));
 		}
 
 		return numBytes;

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -21,7 +21,7 @@ package org.apache.flink.fs.s3hadoop;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory;
 import org.apache.flink.fs.s3.common.HadoopConfigLoader;
-import org.apache.flink.fs.s3.common.writer.S3MultiPartUploader;
+import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
@@ -96,8 +96,8 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
 
 	@Nullable
 	@Override
-	protected S3MultiPartUploader getS3AccessHelper(FileSystem fs) {
+	protected S3AccessHelper getS3AccessHelper(FileSystem fs) {
 		final S3AFileSystem s3Afs = (S3AFileSystem) fs;
-		return new HadoopS3MultiPartUploader(s3Afs, s3Afs.getConf());
+		return new HadoopS3AccessHelper(s3Afs, s3Afs.getConf());
 	}
 }

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -21,7 +21,7 @@ package org.apache.flink.fs.s3presto;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory;
 import org.apache.flink.fs.s3.common.HadoopConfigLoader;
-import org.apache.flink.fs.s3.common.writer.S3MultiPartUploader;
+import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import com.facebook.presto.hive.PrestoS3FileSystem;
@@ -92,7 +92,7 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
 
 	@Nullable
 	@Override
-	protected S3MultiPartUploader getS3AccessHelper(FileSystem fs) {
+	protected S3AccessHelper getS3AccessHelper(FileSystem fs) {
 		return null;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -23,7 +23,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
-import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +36,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A bucket is the directory organization of the output of the {@link StreamingFileSink}.
@@ -84,13 +86,13 @@ public class Bucket<IN, BucketID> {
 			final PartFileWriter.PartFileFactory<IN, BucketID> partFileFactory,
 			final RollingPolicy<IN, BucketID> rollingPolicy) {
 
-		this.fsWriter = Preconditions.checkNotNull(fsWriter);
+		this.fsWriter = checkNotNull(fsWriter);
 		this.subtaskIndex = subtaskIndex;
-		this.bucketId = Preconditions.checkNotNull(bucketId);
-		this.bucketPath = Preconditions.checkNotNull(bucketPath);
+		this.bucketId = checkNotNull(bucketId);
+		this.bucketPath = checkNotNull(bucketPath);
 		this.partCounter = initialPartCounter;
-		this.partFileFactory = Preconditions.checkNotNull(partFileFactory);
-		this.rollingPolicy = Preconditions.checkNotNull(rollingPolicy);
+		this.partFileFactory = checkNotNull(partFileFactory);
+		this.rollingPolicy = checkNotNull(rollingPolicy);
 
 		this.pendingPartsForCurrentCheckpoint = new ArrayList<>();
 		this.pendingPartsPerCheckpoint = new HashMap<>();
@@ -158,8 +160,8 @@ public class Bucket<IN, BucketID> {
 	}
 
 	void merge(final Bucket<IN, BucketID> bucket) throws IOException {
-		Preconditions.checkNotNull(bucket);
-		Preconditions.checkState(Objects.equals(bucket.bucketPath, bucketPath));
+		checkNotNull(bucket);
+		checkState(Objects.equals(bucket.bucketPath, bucketPath));
 
 		// There should be no pending files in the "to-merge" states.
 		// The reason is that:
@@ -167,8 +169,8 @@ public class Bucket<IN, BucketID> {
 		//    So a snapshot, including the one we are recovering from, will never contain such files.
 		// 2) the files in pendingPartsPerCheckpoint are committed upon recovery (see commitRecoveredPendingFiles()).
 
-		Preconditions.checkState(bucket.pendingPartsForCurrentCheckpoint.isEmpty());
-		Preconditions.checkState(bucket.pendingPartsPerCheckpoint.isEmpty());
+		checkState(bucket.pendingPartsForCurrentCheckpoint.isEmpty());
+		checkState(bucket.pendingPartsPerCheckpoint.isEmpty());
 
 		RecoverableWriter.CommitRecoverable committable = bucket.closePartFile();
 		if (committable != null) {
@@ -257,7 +259,7 @@ public class Bucket<IN, BucketID> {
 	}
 
 	void onSuccessfulCompletionOfCheckpoint(long checkpointId) throws IOException {
-		Preconditions.checkNotNull(fsWriter);
+		checkNotNull(fsWriter);
 
 		Iterator<Map.Entry<Long, List<RecoverableWriter.CommitRecoverable>>> it =
 				pendingPartsPerCheckpoint.entrySet().iterator();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -23,8 +23,8 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
-import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
+import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -138,7 +138,10 @@ public class Bucket<IN, BucketID> {
 		final RecoverableFsDataOutputStream stream = fsWriter.recover(resumable);
 		inProgressPart = partFileFactory.resumeFrom(
 				bucketId, stream, resumable, state.getInProgressFileCreationTime());
-		fsWriter.cleanupRecoverableState(resumable);
+
+		if (fsWriter.requiresCleanupOfRecoverableState()) {
+			fsWriter.cleanupRecoverableState(resumable);
+		}
 	}
 
 	private void commitRecoveredPendingFiles(final BucketState<BucketID> state) throws IOException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -126,15 +126,16 @@ public class Bucket<IN, BucketID> {
 	}
 
 	private void restoreInProgressFile(final BucketState<BucketID> state) throws IOException {
+		if (!state.hasInProgressResumableFile()) {
+			return;
+		}
 
 		// we try to resume the previous in-progress file
-		if (state.hasInProgressResumableFile()) {
-			final RecoverableWriter.ResumeRecoverable resumable = state.getInProgressResumableFile();
-			final RecoverableFsDataOutputStream stream = fsWriter.recover(resumable);
-			inProgressPart = partFileFactory.resumeFrom(
-					bucketId, stream, resumable, state.getInProgressFileCreationTime());
-			fsWriter.cleanupRecoverableState(resumable);
-		}
+		final RecoverableWriter.ResumeRecoverable resumable = state.getInProgressResumableFile();
+		final RecoverableFsDataOutputStream stream = fsWriter.recover(resumable);
+		inProgressPart = partFileFactory.resumeFrom(
+				bucketId, stream, resumable, state.getInProgressFileCreationTime());
+		fsWriter.cleanupRecoverableState(resumable);
 	}
 
 	private void commitRecoveredPendingFiles(final BucketState<BucketID> state) throws IOException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
@@ -79,14 +79,13 @@ final class BulkPartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID> {
 		@Override
 		public PartFileWriter<IN, BucketID> resumeFrom(
 				final BucketID bucketId,
-				final RecoverableWriter fileSystemWriter,
+				final RecoverableFsDataOutputStream stream,
 				final RecoverableWriter.ResumeRecoverable resumable,
 				final long creationTime) throws IOException {
 
-			Preconditions.checkNotNull(fileSystemWriter);
+			Preconditions.checkNotNull(stream);
 			Preconditions.checkNotNull(resumable);
 
-			final RecoverableFsDataOutputStream stream = fileSystemWriter.recover(resumable);
 			final BulkWriter<IN> writer = writerFactory.create(stream);
 			return new BulkPartWriter<>(bucketId, stream, writer, creationTime);
 		}
@@ -94,14 +93,13 @@ final class BulkPartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID> {
 		@Override
 		public PartFileWriter<IN, BucketID> openNew(
 				final BucketID bucketId,
-				final RecoverableWriter fileSystemWriter,
+				final RecoverableFsDataOutputStream stream,
 				final Path path,
 				final long creationTime) throws IOException {
 
-			Preconditions.checkNotNull(fileSystemWriter);
+			Preconditions.checkNotNull(stream);
 			Preconditions.checkNotNull(path);
 
-			final RecoverableFsDataOutputStream stream = fileSystemWriter.open(path);
 			final BulkWriter<IN> writer = writerFactory.create(stream);
 			return new BulkPartWriter<>(bucketId, stream, writer, creationTime);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/PartFileWriter.java
@@ -111,7 +111,7 @@ abstract class PartFileWriter<IN, BucketID> implements PartFileInfo<BucketID> {
 		/**
 		 * Used upon recovery from a failure to recover a {@link PartFileWriter writer}.
 		 * @param bucketId the id of the bucket this writer is writing to.
-		 * @param fileSystemWriter the filesystem-specific writer to use when writing to the filesystem.
+		 * @param stream the filesystem-specific output stream to use when writing to the filesystem.
 		 * @param resumable the state of the stream we are resurrecting.
 		 * @param creationTime the creation time of the stream.
 		 * @return the recovered {@link PartFileWriter writer}.
@@ -119,14 +119,14 @@ abstract class PartFileWriter<IN, BucketID> implements PartFileInfo<BucketID> {
 		 */
 		PartFileWriter<IN, BucketID> resumeFrom(
 			final BucketID bucketId,
-			final RecoverableWriter fileSystemWriter,
+			final RecoverableFsDataOutputStream stream,
 			final RecoverableWriter.ResumeRecoverable resumable,
 			final long creationTime) throws IOException;
 
 		/**
 		 * Used to create a new {@link PartFileWriter writer}.
 		 * @param bucketId the id of the bucket this writer is writing to.
-		 * @param fileSystemWriter the filesystem-specific writer to use when writing to the filesystem.
+		 * @param stream the filesystem-specific output stream to use when writing to the filesystem.
 		 * @param path the part this writer will write to.
 		 * @param creationTime the creation time of the stream.
 		 * @return the new {@link PartFileWriter writer}.
@@ -134,7 +134,7 @@ abstract class PartFileWriter<IN, BucketID> implements PartFileInfo<BucketID> {
 		 */
 		PartFileWriter<IN, BucketID> openNew(
 			final BucketID bucketId,
-			final RecoverableWriter fileSystemWriter,
+			final RecoverableFsDataOutputStream stream,
 			final Path path,
 			final long creationTime) throws IOException;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWisePartWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWisePartWriter.java
@@ -67,28 +67,26 @@ final class RowWisePartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID>
 		@Override
 		public PartFileWriter<IN, BucketID> resumeFrom(
 				final BucketID bucketId,
-				final RecoverableWriter fileSystemWriter,
+				final RecoverableFsDataOutputStream stream,
 				final RecoverableWriter.ResumeRecoverable resumable,
 				final long creationTime) throws IOException {
 
-			Preconditions.checkNotNull(fileSystemWriter);
+			Preconditions.checkNotNull(stream);
 			Preconditions.checkNotNull(resumable);
 
-			final RecoverableFsDataOutputStream stream = fileSystemWriter.recover(resumable);
 			return new RowWisePartWriter<>(bucketId, stream, encoder, creationTime);
 		}
 
 		@Override
 		public PartFileWriter<IN, BucketID> openNew(
 				final BucketID bucketId,
-				final RecoverableWriter fileSystemWriter,
+				final RecoverableFsDataOutputStream stream,
 				final Path path,
 				final long creationTime) throws IOException {
 
-			Preconditions.checkNotNull(fileSystemWriter);
+			Preconditions.checkNotNull(stream);
 			Preconditions.checkNotNull(path);
 
-			final RecoverableFsDataOutputStream stream = fileSystemWriter.open(path);
 			return new RowWisePartWriter<>(bucketId, stream, encoder, creationTime);
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.fs.local.LocalRecoverableWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link Bucket}.
+ */
+public class BucketTest {
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+	@Test
+	public void shouldNotCleanupResumablesThatArePartOfTheAckedCheckpoint() throws IOException {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		bucketUnderTest.write("test-element", 0L);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasActiveInProgressFile());
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
+		assertThat(recoverableWriter, hasCalledDiscard(0)); // it did not discard as this is still valid.
+	}
+
+	@Test
+	public void shouldCleanupOutdatedResumablesOnCheckpointAck() throws IOException {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		bucketUnderTest.write("test-element", 0L);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasActiveInProgressFile());
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
+
+		bucketUnderTest.onReceptionOfCheckpoint(1L);
+		bucketUnderTest.onReceptionOfCheckpoint(2L);
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(2L);
+		assertThat(recoverableWriter, hasCalledDiscard(2)); // that is for checkpoints 0 and 1
+	}
+
+	@Test
+	public void shouldCleanupResumableAfterRestoring() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		bucketUnderTest.write("test-element", 0L);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasActiveInProgressFile());
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(0L);
+
+		final TestRecoverableWriter newRecoverableWriter = getRecoverableWriter(path);
+		restoreBucket(newRecoverableWriter, 0, 1, state);
+
+		assertThat(newRecoverableWriter, hasCalledDiscard(1)); // that is for checkpoints 0 and 1
+	}
+
+	@Test
+	public void shouldNotCallCleanupWithoutInProgressPartFiles() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final Path path = new Path(outDir.toURI());
+
+		final TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		final Bucket<String, String> bucketUnderTest =
+				createBucket(recoverableWriter, path, 0, 0);
+
+		final BucketState<String> state = bucketUnderTest.onReceptionOfCheckpoint(0L);
+		assertThat(state, hasNoActiveInProgressFile());
+
+		bucketUnderTest.onReceptionOfCheckpoint(1L);
+		bucketUnderTest.onReceptionOfCheckpoint(2L);
+
+		bucketUnderTest.onSuccessfulCompletionOfCheckpoint(2L);
+		assertThat(recoverableWriter, hasCalledDiscard(0)); // we have no in-progress file.
+	}
+
+	// ------------------------------- Matchers --------------------------------
+
+	private static TypeSafeMatcher<TestRecoverableWriter> hasCalledDiscard(int times) {
+		return new TypeSafeMatcher<TestRecoverableWriter>() {
+			@Override
+			protected boolean matchesSafely(TestRecoverableWriter writer) {
+				return writer.getCleanupCallCounter() == times;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description
+						.appendText("the TestRecoverableWriter to have called discardRecoverableState() ")
+						.appendValue(times)
+						.appendText(" times.");
+			}
+		};
+	}
+
+	private static TypeSafeMatcher<BucketState<String>> hasActiveInProgressFile() {
+		return new TypeSafeMatcher<BucketState<String>>() {
+			@Override
+			protected boolean matchesSafely(BucketState<String> state) {
+				return state.getInProgressResumableFile() != null;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("a BucketState with active in-progress file.");
+			}
+		};
+	}
+
+	private static TypeSafeMatcher<BucketState<String>> hasNoActiveInProgressFile() {
+		return new TypeSafeMatcher<BucketState<String>>() {
+			@Override
+			protected boolean matchesSafely(BucketState<String> state) {
+				return state.getInProgressResumableFile() == null;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("a BucketState with no active in-progress file.");
+			}
+		};
+	}
+
+	// ------------------------------- Mock Classes --------------------------------
+
+	private static class TestRecoverableWriter extends LocalRecoverableWriter {
+
+		private int cleanupCallCounter = 0;
+
+		TestRecoverableWriter(LocalFileSystem fs) {
+			super(fs);
+		}
+
+		int getCleanupCallCounter() {
+			return cleanupCallCounter;
+		}
+
+		@Override
+		public boolean requiresCleanupOfRecoverableState() {
+			return true;
+		}
+
+		@Override
+		public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
+			cleanupCallCounter++;
+			return super.cleanupRecoverableState(resumable);
+		}
+
+		@Override
+		public String toString() {
+			return "TestRecoverableWriter has called discardRecoverableState() " + cleanupCallCounter + " times.";
+		}
+	}
+
+	// ------------------------------- Utility Methods --------------------------------
+
+	private static final String bucketId = "testing-bucket";
+
+	private static final RollingPolicy<String, String> rollingPolicy = DefaultRollingPolicy.create().build();
+
+	private static final PartFileWriter.PartFileFactory<String, String> partFileFactory =
+			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>());
+
+	private static Bucket<String, String> createBucket(
+			final RecoverableWriter writer,
+			final Path bucketPath,
+			final int subtaskIdx,
+			final int initialPartCounter) {
+
+		return Bucket.getNew(
+				writer,
+				subtaskIdx,
+				bucketId,
+				bucketPath,
+				initialPartCounter,
+				partFileFactory,
+				rollingPolicy);
+	}
+
+	private static Bucket<String, String> restoreBucket(
+			final RecoverableWriter writer,
+			final int subtaskIndex,
+			final long initialPartCounter,
+			final BucketState<String> bucketState) throws Exception {
+
+		return Bucket.restore(
+				writer,
+				subtaskIndex,
+				initialPartCounter,
+				partFileFactory,
+				rollingPolicy,
+				bucketState
+		);
+	}
+
+	private static TestRecoverableWriter getRecoverableWriter(Path path) {
+		try {
+			final FileSystem fs = FileSystem.get(path.toUri());
+			if (!(fs instanceof LocalFileSystem)) {
+				fail("Expected Local FS but got a " + fs.getClass().getName() + " for path: " + path);
+			}
+			return new TestRecoverableWriter((LocalFileSystem) fs);
+		} catch (IOException e) {
+			fail();
+		}
+		return null;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketTest.java
@@ -191,13 +191,14 @@ public class BucketTest {
 
 		@Override
 		public boolean requiresCleanupOfRecoverableState() {
+			// here we return true so that the cleanupRecoverableState() is called.
 			return true;
 		}
 
 		@Override
 		public boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException {
 			cleanupCallCounter++;
-			return super.cleanupRecoverableState(resumable);
+			return false;
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

The S3 `RecoverableWriter` uses the Multipart Upload (MPU) Feature of S3 in order to upload the different part files. This means that a large part is split in chunks of at least 5MB which are uploaded independently, whenever each one of them is ready.

This 5MB minimum size requires special handling of parts that are less than 5MB when a checkpoint barrier arrives. These small files are uploaded as independent objects (not associated with an active MPU). This way, when Flink needs to restore, it simply downloads them and resumes writing to them.

These small objects are currently not cleaned up, thus leading to wasted space on S3.

This PR changes this by cleaning these files upon restoring and also when the "next" checkpoint is successfully acknowledged.

**LIMITATION**: Upon a failure, still there may be objects that were created after the last successful checkpoint but before the failure. These do not belong to the checkpointed state and they are not cleaned up. But this is a more general limitation which will be covered by another JIRA.

## Brief change log

This PR adds the following methods to the RecoverableWriter:
```
boolean cleanupRecoverableState(ResumeRecoverable resumable) throws IOException;

boolean requiresCleanupOfRecoverableState();
```
The second one is just for optimisation purposes.

## Verifying this change

Added the `BucketTest` class and 2 tests in the `HadoopS3RecoverableWriterITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
