### PR TITLE
FLINK-10991 [docker] Added libc6-compat package to all alpine-based Flink imag…

### DIFF
--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -19,7 +19,7 @@
 FROM java:8-jre-alpine
 
 # Install requirements
-RUN apk add --no-cache bash snappy
+RUN apk add --no-cache bash snappy libc6-compat
 
 # Flink environment variables
 ENV FLINK_INSTALL_PATH=/opt

--- a/flink-container/docker/Dockerfile
+++ b/flink-container/docker/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 # Install requirements
 RUN apk add --no-cache bash snappy libc6-compat

--- a/flink-contrib/docker-flink/Dockerfile
+++ b/flink-contrib/docker-flink/Dockerfile
@@ -19,7 +19,7 @@
 FROM java:8-jre-alpine
 
 # Install requirements
-RUN apk add --no-cache bash snappy
+RUN apk add --no-cache bash snappy libc6-compat
 
 # Flink environment variables
 ENV FLINK_INSTALL_PATH=/opt

--- a/flink-contrib/docker-flink/Dockerfile
+++ b/flink-contrib/docker-flink/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 # Install requirements
 RUN apk add --no-cache bash snappy libc6-compat


### PR DESCRIPTION
## What is the purpose of the change

Flink images based on Dockerfile in the Flink repository should work with RocksDB out-of-the-box.

## Brief change log

* Added libc6-compat package to all alpine-based Flink images for RocksDB statebackend 
* Switched from deprecated "library/java" to "library/openjdk" docker base image

## Verifying this change

Verified by building the image and running a job with RocksDBStatebackend. There are apparently no tests for flink-container yet and it seems out-of-scope for this change to add those.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
