### PR TITLE
[FLINK-10992][tests] Revise Hadoop configuration.

### DIFF
--- a/flink-jepsen/src/jepsen/flink/utils.clj
+++ b/flink-jepsen/src/jepsen/flink/utils.clj
@@ -51,6 +51,20 @@
          (recur op (assoc keys :retries (dec retries))))
        (success r)))))
 
+(defn find-files!
+  "Lists files recursively given a directory. If the directory does not exist, an empty collection
+  is returned."
+  [dir]
+  (let [files (try
+                (c/exec :find dir :-type :f)
+                (catch Exception e
+                  (if (.contains (.getMessage e) "No such file or directory")
+                    ""
+                    (throw e))))]
+    (->>
+      (clojure.string/split files #"\n")
+      (remove clojure.string/blank?))))
+
 ;;; runit process supervisor (http://smarden.org/runit/)
 
 (def runit-version "2.1.2-3")


### PR DESCRIPTION
## What is the purpose of the change

Revise Hadoop configuration to improve HDFS stability in tests.

## Brief change log
  - *Do not use /tmp directory to place log files or the HDFS data directory.*
  - *Reconfigure dfs.replication to 1 because file availability is irrelevant in tests.*
  - *Increase heap size of HDFS DataNodes and NameNode.*
  - *Change find-files! function to not fail if directory does not exist.*


## Verifying this change

This change is already covered by existing tests, such as *Jepsen tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
