### PR TITLE
[FLINK-10990][Metric]Pre-check timespan in meterview to avoid NAN

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
@@ -50,6 +50,8 @@ public class MeterView implements Meter, View {
 
 	public MeterView(Counter counter, int timeSpanInSeconds) {
 		this.counter = counter;
+		// the time-span must be larger than the update-interval as otherwise the array has a size of 1,
+		// for which no rate can be computed as no distinct before/after measurement exists.
 		this.timeSpanInSeconds = Math.max(
 			timeSpanInSeconds - (timeSpanInSeconds % UPDATE_INTERVAL_SECONDS),
 			UPDATE_INTERVAL_SECONDS);

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.metrics;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * A MeterView provides an average rate of events per second over a given time period.
  *
@@ -47,20 +44,15 @@ public class MeterView implements Meter, View {
 	/** The last rate we computed. */
 	private double currentRate = 0;
 
-	private static Logger logger = LoggerFactory.getLogger(MeterView.class);
-
 	public MeterView(int timeSpanInSeconds) {
 		this(new SimpleCounter(), timeSpanInSeconds);
 	}
 
 	public MeterView(Counter counter, int timeSpanInSeconds) {
 		this.counter = counter;
-		// timeSpanInSeconds should at least bigger than update interval
-		if (timeSpanInSeconds < UPDATE_INTERVAL_SECONDS) {
-			logger.warn("TimeSpan in meterview should not lower than update interval: {} and is set to {} by default", UPDATE_INTERVAL_SECONDS, UPDATE_INTERVAL_SECONDS);
-			timeSpanInSeconds = UPDATE_INTERVAL_SECONDS;
-		}
-		this.timeSpanInSeconds = timeSpanInSeconds - (timeSpanInSeconds % UPDATE_INTERVAL_SECONDS);
+		this.timeSpanInSeconds = Math.max(
+			timeSpanInSeconds - (timeSpanInSeconds % UPDATE_INTERVAL_SECONDS),
+			UPDATE_INTERVAL_SECONDS);
 		this.values = new long[this.timeSpanInSeconds / UPDATE_INTERVAL_SECONDS + 1];
 	}
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MeterView.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.metrics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A MeterView provides an average rate of events per second over a given time period.
  *
@@ -44,12 +47,19 @@ public class MeterView implements Meter, View {
 	/** The last rate we computed. */
 	private double currentRate = 0;
 
+	private static Logger logger = LoggerFactory.getLogger(MeterView.class);
+
 	public MeterView(int timeSpanInSeconds) {
 		this(new SimpleCounter(), timeSpanInSeconds);
 	}
 
 	public MeterView(Counter counter, int timeSpanInSeconds) {
 		this.counter = counter;
+		// timeSpanInSeconds should at least bigger than update interval
+		if (timeSpanInSeconds < UPDATE_INTERVAL_SECONDS) {
+			logger.warn("TimeSpan in meterview should not lower than update interval: {} and is set to {} by default", UPDATE_INTERVAL_SECONDS, UPDATE_INTERVAL_SECONDS);
+			timeSpanInSeconds = UPDATE_INTERVAL_SECONDS;
+		}
 		this.timeSpanInSeconds = timeSpanInSeconds - (timeSpanInSeconds % UPDATE_INTERVAL_SECONDS);
 		this.values = new long[this.timeSpanInSeconds / UPDATE_INTERVAL_SECONDS + 1];
 	}

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.metrics;
 
 import org.junit.Test;
 
+import static org.apache.flink.metrics.View.UPDATE_INTERVAL_SECONDS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the MeterView.
@@ -97,10 +97,12 @@ public class MeterViewTest {
 	}
 
 	@Test
-	public void testTooSmallTimeSpan() {
-		MeterView m = new MeterView(1);
+	public void testTimeSpanBelowUpdateRate() {
+		int timeSpanInSeconds = 1;
+		MeterView m = new MeterView(timeSpanInSeconds);
+		assert timeSpanInSeconds < UPDATE_INTERVAL_SECONDS;
 		m.markEvent();
 		m.update();
-		assertTrue(0.2 == m.getRate());
+		assertEquals(0.2, m.getRate(), 0.0);
 	}
 }

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/MeterViewTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.metrics;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the MeterView.
@@ -93,5 +94,13 @@ public class MeterViewTest {
 		// values = [480, 480, 480, 480, 480, 480, 480, 480, 480, 480, 480, 480, 480]
 		assertEquals(0.0, m.getRate(), 0.1); // 480 - 480 / 60
 
+	}
+
+	@Test
+	public void testTooSmallTimeSpan() {
+		MeterView m = new MeterView(1);
+		m.markEvent();
+		m.update();
+		assertTrue(0.2 == m.getRate());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

In the metric tool MeterView. If user use the meterview with the timespan smaller than UPDATE_INTERVAL_SECONDS = 5 , the getRate will always return 0/0 = NAN. And this is not friendly , I think we should pre-check it.

## Verifying this change

Added a case to test the timespan lower than the update interval