### PR TITLE
[FLINK-10997][formats] Bundle kafka-scheme-registry-client

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -78,10 +78,31 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>io.confluent:*</include>
+									<include>com.fasterxml.jackson.core:*</include>
+									<include>org.apache.zookeeper:zookeeper</include>
+									<include>com.101tec:zkclient</include>
+								</includes>
+							</artifactSet>
 							<relocations combine.children="append">
 								<relocation>
-									<pattern>com.fasterxml.jackson.core</pattern>
-									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.com.fasterxml.jackson.core</shadedPattern>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.com.fasterxml.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.zookeeper</pattern>
+									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.org.apache.zookeeper</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.jute</pattern>
+									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.org.apache.jute</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.I0Itec.zkclient</pattern>
+									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.org.101tec</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+flink-avro-confluent-registry
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
+
+- com.101tec:zkclient:0.10
+- com.fasterxml.jackson.core:jackson-databind:2.8.4
+- com.fasterxml.jackson.core:jackson-annotations:2.8.0
+- com.fasterxml.jackson.core:jackson-core:2.8.4
+- io.confluent:common-utils:3.3.1
+- io.confluent:kafka-schema-registry-client:3.3.1
+- org.apache.zookeeper:zookeeper:3.4.10


### PR DESCRIPTION
## What is the purpose of the change

With this PR `flink-avro-confluent-registry` bundles `kafka-scheme-registry-client` as intended.
The relocation pattern for jackson was additionally modified as it currently only applied to parts of jackson.

## Verifying this change

Manually verified.