### PR TITLE
[FLINK-11009] [table] Add support for FILTER clause for non-windowed aggregation in Table API and SQL

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -327,7 +327,7 @@ val result = orders.where('b === "red")
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight java %}
 Table orders = tableEnv.scan("Orders");
-Table result = orders.groupBy("a").select("a, b.sum as d");
+Table result = orders.groupBy("a").select("a, b.sum as d, c.avg.filter(e > 0) as f");
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
       </td>
@@ -448,7 +448,7 @@ Table result = orders.distinct();
         <p>Similar to a SQL GROUP BY clause. Groups the rows on the grouping keys with a following running aggregation operator to aggregate rows group-wise.</p>
 {% highlight scala %}
 val orders: Table = tableEnv.scan("Orders")
-val result = orders.groupBy('a).select('a, 'b.sum as 'd)
+val result = orders.groupBy('a).select('a, 'b.sum as 'd, 'c.avg.filter('e > 0) as 'f)
 {% endhighlight %}
         <p><b>Note:</b> For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size. See <a href="streaming/query_configuration.html">Query Configuration</a> for details.</p>
       </td>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -1044,6 +1044,8 @@ trait ImplicitExpressionConversions {
   implicit def toDistinct[T: TypeInformation, ACC: TypeInformation]
       (agg: AggregateFunction[T, ACC]): DistinctAggregateFunction[T, ACC] =
     DistinctAggregateFunction(agg)
+  implicit def toAggWithFilter(agg: Aggregation): FilterAgg =
+    FilterAgg(agg, null)
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -1021,6 +1021,12 @@ trait ImplicitExpressionConversions {
     def expr = Literal(sqlTimestamp)
   }
 
+  implicit class implicitAggregateOperations(agg: Aggregation) {
+    def filter(condition: Expression): Aggregation = {
+      FilterAgg(agg, condition)
+    }
+  }
+
   implicit def symbol2FieldExpression(sym: Symbol): Expression = UnresolvedFieldReference(sym.name)
   implicit def byte2Literal(b: Byte): Expression = Literal(b)
   implicit def short2Literal(s: Short): Expression = Literal(s)
@@ -1044,8 +1050,6 @@ trait ImplicitExpressionConversions {
   implicit def toDistinct[T: TypeInformation, ACC: TypeInformation]
       (agg: AggregateFunction[T, ACC]): DistinctAggregateFunction[T, ACC] =
     DistinctAggregateFunction(agg)
-  implicit def toAggWithFilter(agg: Aggregation): FilterAgg =
-    FilterAgg(agg, null)
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
@@ -89,9 +89,6 @@ case class DistinctAgg(child: Expression) extends Aggregation {
 
 case class FilterAgg(agg: Expression, filter: Expression) extends Aggregation {
 
-  private[flink] def filter(filter: Expression): Aggregation =
-    FilterAgg(agg, filter)
-
   override private[flink] def resultType: TypeInformation[_] = agg.resultType
 
   override private[flink] def validateInput(): ValidationResult = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/DistinctAggregateFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/DistinctAggregateFunction.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.functions
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.expressions.{AggFunctionCall, DistinctAgg, Expression}
+import org.apache.flink.table.expressions.{AggFunctionCall, Aggregation, DistinctAgg, Expression}
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.{getAccumulatorTypeOfAggregateFunction, getResultTypeOfAggregateFunction}
 
 /**
@@ -28,7 +28,7 @@ import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.{getAccum
 private[flink] case class DistinctAggregateFunction[T: TypeInformation, ACC: TypeInformation]
     (aggFunction: AggregateFunction[T, ACC]) {
 
-  private[flink] def distinct(params: Expression*): Expression = {
+  private[flink] def distinct(params: Expression*): Aggregation = {
     val resultTypeInfo: TypeInformation[_] = getResultTypeOfAggregateFunction(
       aggFunction,
       implicitly[TypeInformation[T]])

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonAggregate.scala
@@ -48,14 +48,21 @@ trait CommonAggregate {
     val groupStrings = grouping.map( inFields(_) )
 
     val aggs = namedAggregates.map(_.getKey)
-    val aggStrings = aggs.map( a => s"${a.getAggregation}(${
+    val filterStrings = aggs.map { a =>
+      if (a.filterArg >= 0) {
+        " FILTER " + inFields(a.filterArg)
+      } else {
+        ""
+      }
+    }
+    val aggStrings = aggs.zipWithIndex.map { case (a, i) => s"${a.getAggregation}(${
       val prefix = if (a.isDistinct) "DISTINCT " else ""
       prefix + (if (a.getArgList.size() > 0) {
         a.getArgList.asScala.map(inFields(_)).mkString(", ")
       } else {
         "*"
       })
-    })")
+    })${filterStrings(i)}"}
 
     val propStrings = namedProperties.map(_.property.toString)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -85,7 +85,7 @@ object AggregateUtil {
       isRowsClause: Boolean)
     : ProcessFunction[CRow, CRow] = {
 
-    val (aggFields, aggregates, isDistinctAggs, accTypes, accSpecs) =
+    val (aggFields, filterArgFields, aggregates, isDistinctAggs, accTypes, accSpecs) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         aggregateInputType,
@@ -104,6 +104,7 @@ object AggregateUtil {
       inputFieldTypeInfo,
       aggregates,
       aggFields,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = true,
@@ -168,7 +169,7 @@ object AggregateUtil {
       generateRetraction: Boolean,
       consumeRetraction: Boolean): ProcessFunction[CRow, CRow] = {
 
-    val (aggFields, aggregates, isDistinctAggs, accTypes, accSpecs) =
+    val (aggFields, filterArgFields, aggregates, isDistinctAggs, accTypes, accSpecs) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         inputRowType,
@@ -187,6 +188,7 @@ object AggregateUtil {
       inputFieldTypes,
       aggregates,
       aggFields,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = true,
@@ -238,7 +240,7 @@ object AggregateUtil {
     : ProcessFunction[CRow, CRow] = {
 
     val needRetract = true
-    val (aggFields, aggregates, isDistinctAggs, accTypes, accSpecs) =
+    val (aggFields, filterArgFields, aggregates, isDistinctAggs, accTypes, accSpecs) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         aggregateInputType,
@@ -258,6 +260,7 @@ object AggregateUtil {
       inputFieldTypeInfo,
       aggregates,
       aggFields,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = true,
@@ -343,11 +346,12 @@ object AggregateUtil {
   : MapFunction[Row, Row] = {
 
     val needRetract = false
-    val (aggFieldIndexes, aggregates, isDistinctAggs, accTypes, _) = transformToAggregateFunctions(
-      namedAggregates.map(_.getKey),
-      inputType,
-      needRetract,
-      tableConfig)
+    val (aggFieldIndexes, filterArgFields, aggregates, isDistinctAggs, accTypes, _) =
+      transformToAggregateFunctions(
+        namedAggregates.map(_.getKey),
+        inputType,
+        needRetract,
+        tableConfig)
 
     val mapReturnType: RowTypeInfo =
       createRowTypeForKeysAndAggregates(
@@ -393,6 +397,7 @@ object AggregateUtil {
       inputFieldTypeInfo,
       aggregates,
       aggFieldIndexes,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = false,
@@ -452,11 +457,12 @@ object AggregateUtil {
     : RichGroupReduceFunction[Row, Row] = {
 
     val needRetract = false
-    val (aggFieldIndexes, aggregates, isDistinctAggs, accTypes, _) = transformToAggregateFunctions(
-      namedAggregates.map(_.getKey),
-      physicalInputRowType,
-      needRetract,
-      tableConfig)
+    val (aggFieldIndexes, filterArgFields, aggregates, isDistinctAggs, accTypes, _) =
+      transformToAggregateFunctions(
+        namedAggregates.map(_.getKey),
+        physicalInputRowType,
+        needRetract,
+        tableConfig)
 
     val returnType: RowTypeInfo = createRowTypeForKeysAndAggregates(
       groupings,
@@ -475,6 +481,7 @@ object AggregateUtil {
           physicalInputTypes,
           aggregates,
           aggFieldIndexes,
+          filterArgFields,
           aggregates.indices.map(_ + groupings.length).toArray,
           isDistinctAggs,
           isStateBackedDataViews = false,
@@ -569,11 +576,12 @@ object AggregateUtil {
     : RichGroupReduceFunction[Row, Row] = {
 
     val needRetract = false
-    val (aggFieldIndexes, aggregates, isDistinctAggs, _, _) = transformToAggregateFunctions(
-      namedAggregates.map(_.getKey),
-      physicalInputRowType,
-      needRetract,
-      tableConfig)
+    val (aggFieldIndexes, filterArgFields, aggregates, isDistinctAggs, _, _) =
+      transformToAggregateFunctions(
+        namedAggregates.map(_.getKey),
+        physicalInputRowType,
+        needRetract,
+        tableConfig)
 
     val aggMapping = aggregates.indices.toArray.map(_ + groupings.length)
 
@@ -582,6 +590,7 @@ object AggregateUtil {
       physicalInputTypes,
       aggregates,
       aggFieldIndexes,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = false,
@@ -600,6 +609,7 @@ object AggregateUtil {
       physicalInputTypes,
       aggregates,
       aggFieldIndexes,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = false,
@@ -726,11 +736,12 @@ object AggregateUtil {
     tableConfig: TableConfig): MapPartitionFunction[Row, Row] = {
 
     val needRetract = false
-    val (aggFieldIndexes, aggregates, isDistinctAggs, accTypes, _) = transformToAggregateFunctions(
-      namedAggregates.map(_.getKey),
-      physicalInputRowType,
-      needRetract,
-      tableConfig)
+    val (aggFieldIndexes, filterArgFields, aggregates, isDistinctAggs, accTypes, _) =
+      transformToAggregateFunctions(
+        namedAggregates.map(_.getKey),
+        physicalInputRowType,
+        needRetract,
+        tableConfig)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
 
@@ -751,6 +762,7 @@ object AggregateUtil {
           physicalInputTypes,
           aggregates,
           aggFieldIndexes,
+          filterArgFields,
           aggMapping,
           isDistinctAggs,
           isStateBackedDataViews = false,
@@ -803,11 +815,12 @@ object AggregateUtil {
     : GroupCombineFunction[Row, Row] = {
 
     val needRetract = false
-    val (aggFieldIndexes, aggregates, isDistinctAggs, accTypes, _) = transformToAggregateFunctions(
-      namedAggregates.map(_.getKey),
-      physicalInputRowType,
-      needRetract,
-      tableConfig)
+    val (aggFieldIndexes, filterArgFields, aggregates, isDistinctAggs, accTypes, _) =
+      transformToAggregateFunctions(
+        namedAggregates.map(_.getKey),
+        physicalInputRowType,
+        needRetract,
+        tableConfig)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
 
@@ -829,6 +842,7 @@ object AggregateUtil {
           physicalInputTypes,
           aggregates,
           aggFieldIndexes,
+          filterArgFields,
           aggMapping,
           isDistinctAggs,
           isStateBackedDataViews = false,
@@ -873,11 +887,12 @@ object AggregateUtil {
         Either[DataSetAggFunction, DataSetFinalAggFunction]) = {
 
     val needRetract = false
-    val (aggInFields, aggregates, isDistinctAggs, accTypes, _) = transformToAggregateFunctions(
-      namedAggregates.map(_.getKey),
-      inputType,
-      needRetract,
-      tableConfig)
+    val (aggInFields, filterArgFields, aggregates, isDistinctAggs, accTypes, _) =
+      transformToAggregateFunctions(
+        namedAggregates.map(_.getKey),
+        inputType,
+        needRetract,
+        tableConfig)
 
     val (gkeyOutMapping, aggOutMapping) = getOutputMappings(
       namedAggregates,
@@ -901,6 +916,7 @@ object AggregateUtil {
         inputFieldTypeInfo,
         aggregates,
         aggInFields,
+        filterArgFields,
         aggregates.indices.map(_ + groupings.length).toArray,
         isDistinctAggs,
         isStateBackedDataViews = false,
@@ -929,6 +945,7 @@ object AggregateUtil {
         inputFieldTypeInfo,
         aggregates,
         aggInFields,
+        filterArgFields,
         aggOutFields,
         isDistinctAggs,
         isStateBackedDataViews = false,
@@ -954,6 +971,7 @@ object AggregateUtil {
         inputFieldTypeInfo,
         aggregates,
         aggInFields,
+        filterArgFields,
         aggOutFields,
         isDistinctAggs,
         isStateBackedDataViews = false,
@@ -1040,7 +1058,7 @@ object AggregateUtil {
     : (DataStreamAggFunction[CRow, Row, Row], RowTypeInfo, RowTypeInfo) = {
 
     val needRetract = false
-    val (aggFields, aggregates, isDistinctAggs, accTypes, _) =
+    val (aggFields, filterArgFields, aggregates, isDistinctAggs, accTypes, _) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         inputType,
@@ -1055,6 +1073,7 @@ object AggregateUtil {
       inputFieldTypeInfo,
       aggregates,
       aggFields,
+      filterArgFields,
       aggMapping,
       isDistinctAggs,
       isStateBackedDataViews = false,
@@ -1090,7 +1109,7 @@ object AggregateUtil {
       aggregateCalls,
       inputType,
       needRetraction = false,
-      tableConfig)._2
+      tableConfig)._3
 
     doAllSupportPartialMerge(aggregateList)
   }
@@ -1176,6 +1195,7 @@ object AggregateUtil {
       tableConfig: TableConfig,
       isStateBackedDataViews: Boolean = false)
   : (Array[Array[Int]],
+    Array[Int],
     Array[TableAggregateFunction[_, _]],
     Array[Boolean],
     Array[TypeInformation[_]],
@@ -1185,10 +1205,12 @@ object AggregateUtil {
     val aggFieldIndexes = new Array[Array[Int]](aggregateCalls.size)
     val aggregates = new Array[TableAggregateFunction[_ <: Any, _ <: Any]](aggregateCalls.size)
     val accTypes = new Array[TypeInformation[_]](aggregateCalls.size)
+    val filterArgIndexes = new Array[Int](aggregateCalls.size)
 
     // create aggregate function instances by function type and aggregate field data type.
     aggregateCalls.zipWithIndex.foreach { case (aggregateCall, index) =>
       val argList: util.List[Integer] = aggregateCall.getArgList
+      filterArgIndexes(index) = aggregateCall.filterArg
 
       if (aggregateCall.getAggregation.isInstanceOf[SqlCountAggFunction]) {
         aggregates(index) = new CountAggFunction
@@ -1509,7 +1531,7 @@ object AggregateUtil {
         }
     }
 
-    (aggFieldIndexes, aggregates, isDistinctAggs, accTypes, accSpecs)
+    (aggFieldIndexes, filterArgIndexes, aggregates, isDistinctAggs, accTypes, accSpecs)
   }
 
   private def createRowTypeForKeysAndAggregates(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/AggregateStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/AggregateStringExpressionTest.scala
@@ -41,6 +41,17 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
+  def testFilterAggregationTypes(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3")
+
+    val t1 = t.select('_1.sum.distinct.filter('_2 > 0), '_1.count.filter('_2 > 0))
+    val t2 = t.select("sum.distinct(_1).filter(_2 > 0), count(_1).filter(_2 > 0)")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
   def testAggregationTypes(): Unit = {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table3")
@@ -142,6 +153,17 @@ class AggregateStringExpressionTest extends TableTestBase {
 
     verifyTableEquals(t1, t2)
     verifyTableEquals(t1, t3)
+  }
+
+  @Test
+  def testFilterGroupedAggregate(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
+
+    val t1 = t.groupBy('b).select('b, 'a.sum.distinct.filter('c === "a"), 'a.sum.filter('c === "a"))
+    val t2 = t.groupBy("b").select("b, a.sum.distinct.filter(c = \"a\"), a.sum.filter(c = \"a\")")
+
+    verifyTableEquals(t1, t2)
   }
 
   @Test
@@ -281,6 +303,24 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
+  def testFilterAggregateWithUDAGG(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
+
+    val myCnt = new CountAggFunction
+    util.tableEnv.registerFunction("myCnt", myCnt)
+    val myWeightedAvg = new WeightedAvgWithMergeAndReset
+    util.tableEnv.registerFunction("myWeightedAvg", myWeightedAvg)
+
+    val t1 = t.select(
+      myCnt.distinct('a).filter('b > 0) as 'aCnt, myWeightedAvg('b, 'a).filter('b < 0) as 'wAvg)
+    val t2 = t.select(
+      "myCnt.distinct(a).filter(b > 0) as aCnt, myWeightedAvg(b, a).filter(b < 0) as wAvg")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
   def testAggregateWithUDAGG(): Unit = {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
@@ -316,6 +356,30 @@ class AggregateStringExpressionTest extends TableTestBase {
     val t2 = t.groupBy("b")
       .select("b, myCnt.distinct(a) + 9 as aCnt, myWeightedAvg.distinct(b, a) * 2 as wAvg, " +
         "myWeightedAvg.distinct(a, a) as distAgg, myWeightedAvg(a, a) as agg")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
+  def testFilterGroupedAggregateWithUDAGG(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
+
+
+    val myCnt = new CountAggFunction
+    util.tableEnv.registerFunction("myCnt", myCnt)
+    val myWeightedAvg = new WeightedAvgWithMergeAndReset
+    util.tableEnv.registerFunction("myWeightedAvg", myWeightedAvg)
+
+    val t1 = t.groupBy('b)
+      .select('b,
+              myCnt.distinct('a).filter('b > 0) + 9 as 'aCnt,
+              myWeightedAvg('b, 'a).filter('b > 0).distinct * 2 as 'wAvg,
+              myWeightedAvg('a, 'a).filter('b < 0) as 'wAvg2)
+    val t2 = t.groupBy("b")
+      .select("b, myCnt.distinct(a).filter(b > 0) + 9 as aCnt," +
+                "myWeightedAvg(b, a).filter(b > 0).distinct * 2 as wAvg, " +
+                "myWeightedAvg(a, a).filter(b < 0) as wAvg2")
 
     verifyTableEquals(t1, t2)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -559,4 +559,23 @@ class AggregateITCase(
 
     TestBaseUtils.compareResultAsText(result.asJava, expected)
   }
+
+  @Test
+  def testGroupedFilterAggregate(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val sqlQuery = "SELECT _2, count(_3) FILTER (WHERE MOD(_1, 2) = 0) FROM MyTable GROUP BY _2"
+
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
+    tEnv.registerTable("MyTable", ds)
+
+    val result = tEnv.sqlQuery(sqlQuery)
+
+    val expected =
+      "1,0\n2,1\n3,2\n4,2\n5,2\n6,3"
+    val results = result.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
@@ -455,6 +455,21 @@ class AggregationsITCase(
     val results = t.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
+
+  @Test
+  def testGroupedFilterAggregate(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val t = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+      .groupBy('e)
+      .select('e, 'c.min.filter('b % 2 === 0))
+
+    val expected = "1,7\n" + "2,1\n" + "3,5\n"
+    val results = t.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
 }
 
 case class WC(word: String, frequency: Long)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add the support of FILTER clause for non-windowed aggregation in Table API and SQL*

## Brief change log

  - *Update AggregateCodeGenerator to add support for FILTER clause*
  - *Add `FilterAgg` operator in expression as aggregation*
  - *Update the aggregation resolve rules in `operators` to resolve aggregation with filter clause*
  - *Modify `ExpressionParser` for Java string-based table API*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for built-in AGG and UDAGG respectively.*
  - *Added unit-test for plan tests*
  - *Added unit-test for syntactic check on both Java and Scala Table APIs*
  - *Backward compatibility for other aggregations are covered with existing unit-test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
