### PR TITLE
[FLINK-11010] [TABLE] Flink SQL timestamp is inconsistent with currentProcessingTime()

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1449,6 +1449,7 @@ abstract class CodeGenerator(
     val resultCode =
       s"""
         |long $resultTerm = $contextTerm.timerService().currentProcessingTime();
+        |$resultTerm = $resultTerm + java.util.TimeZone.getDefault().getOffset($resultTerm);
         |""".stripMargin
     GeneratedExpression(resultTerm, NEVER_NULL, resultCode, SqlTimeTypeInfo.TIMESTAMP)
   }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -190,7 +190,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 
 					// validate the second here
 					long procSecondTime = procTimestamp.getTime() / 1000;
-					long sysSecondTime = System.currentTimeMillis() / 1000;
+					long sysSecondTime = context.currentProcessingTime() / 1000;
 
 					Assert.assertTrue(procSecondTime == sysSecondTime);
 				}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -34,11 +34,14 @@ import org.apache.flink.table.runtime.utils.StreamITCase;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
 /**
@@ -186,13 +189,18 @@ public class JavaSqlITCase extends AbstractTestBase {
 				@Override
 				public void invoke(Row value, Context context) throws Exception {
 
+					Calendar calendar = Calendar.getInstance();
+
 					Timestamp procTimestamp = (Timestamp) value.getField(0);
+					calendar.setTimeInMillis(procTimestamp.getTime());
+					int procHour = calendar.get(Calendar.HOUR_OF_DAY);
 
-					// validate the second here
-					long procSecondTime = procTimestamp.getTime() / 1000;
-					long sysSecondTime = context.currentProcessingTime() / 1000;
+					calendar.setTimeInMillis(System.currentTimeMillis());
+					int sysHour = calendar.get(Calendar.HOUR_OF_DAY);
 
-					Assert.assertTrue(procSecondTime == sysSecondTime);
+					// just need to validate hour
+					Assert.assertTrue(procHour == sysHour);
+
 				}
 			});
 


### PR DESCRIPTION
## What is the purpose of the change

the ProcessingTime is just implemented by invoking System.currentTimeMillis() but the long value will be automatically wrapped to a Timestamp with the following statement:
`new java.sql.Timestamp(time - TimeZone.getDefault().getOffset(time));`


## Brief change log

  `org.apache.flink.table.codegen.CodeGenerator#generateProctimeTimestamp` 
   add Default TimeZone#offset


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
