### PR TITLE
[FLINK-10941] Keep slots which contain unconsumed result partitions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -328,6 +328,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		}
 
 		availableReaders.clear();
+		readersToClose.clear();
 		allReaders.clear();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -377,6 +377,13 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		}
 	}
 
+	/**
+	 * Whether this partition is released (all subpartitions are consumed).
+	 */
+	public boolean isReleased() {
+		return isReleased.get();
+	}
+
 	@Override
 	public String toString() {
 		return "ResultPartition " + partitionId.toString() + " [" + partitionType + ", "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -378,7 +378,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	}
 
 	/**
-	 * Whether this partition is released (all subpartitions are consumed).
+	 * Whether this partition is released, e.g. all subpartitions are consumed or task is cancelled.
 	 */
 	public boolean isReleased() {
 		return isReleased.get();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -902,6 +902,15 @@ public class SlotManager implements AutoCloseable {
 			// first retrieve the timed out TaskManagers
 			for (TaskManagerRegistration taskManagerRegistration : taskManagerRegistrations.values()) {
 				if (currentTime - taskManagerRegistration.getIdleSince() >= taskManagerTimeout.toMilliseconds()) {
+					// checking whether TaskManagers can be safely removed
+					final TaskExecutorGateway taskExecutorGateway = taskManagerRegistration.getTaskManagerConnection().getTaskExecutorGateway();
+					if (!taskExecutorGateway.canBeReleased()) {
+						LOG.debug("Task executor {} can not be released", taskExecutorGateway.getAddress());
+						continue;
+					} else {
+						LOG.debug("Task executor {} can be released", taskExecutorGateway.getAddress());
+					}
+
 					// we collect the instance ids first in order to avoid concurrent modifications by the
 					// ResourceActions.releaseResource call
 					timedOutTaskManagerIds.add(taskManagerRegistration.getInstanceId());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -254,6 +254,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.currentRegistrationTimeoutId = null;
 	}
 
+	@Override
+	public boolean canBeReleased() {
+		return this.taskSlotTable.canBeReleased();
+	}
+
 	// ------------------------------------------------------------------------
 	//  Life cycle
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -256,7 +256,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	@Override
 	public boolean canBeReleased() {
-		return this.taskSlotTable.canBeReleased();
+		return taskSlotTable.canBeReleased();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -195,4 +195,10 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @return Future which is completed with the {@link TransientBlobKey} of the uploaded file.
 	 */
 	CompletableFuture<TransientBlobKey> requestFileUpload(FileType fileType, @RpcTimeout Time timeout);
+
+	/**
+	 * Checks whether this can be released. This cannot be released if there're unconsumed result partitions
+	 * @return whether this can be released
+	 */
+	boolean canBeReleased();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -276,6 +276,22 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	}
 
 	/**
+	 * This can be safely released if all slots can be released.
+	 * @return
+	 */
+	public boolean canBeReleased() {
+		for (TaskSlot taskSlot : taskSlots) {
+			if (!taskSlot.canBeReleased()) {
+				LOG.debug("TaskSlotTable can not be released.");
+				return false;
+			}
+		}
+
+		LOG.debug("TaskSlotTable can be released.");
+		return true;
+	}
+
+	/**
 	 * Try to free the slot. If the slot is empty it will set the state of the task slot to free
 	 * and return its index. If the slot is not empty, then it will set the state of the task slot
 	 * to releasing, fail all tasks and return -1.
@@ -509,7 +525,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 			taskSlot.remove(task.getExecutionId());
 
-			if (taskSlot.isReleasing() && taskSlot.isEmpty()) {
+			if (taskSlot.isReleasing() && taskSlot.isEmpty() && taskSlot.canBeReleased()) {
 				slotActions.freeSlot(taskSlot.getAllocationId());
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -277,7 +277,6 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 	/**
 	 * This can be safely released if all slots can be released.
-	 * @return
 	 */
 	public boolean canBeReleased() {
 		for (TaskSlot taskSlot : taskSlots) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -875,11 +875,11 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 	public boolean canBeReleased() {
 		for (ResultPartition producedPartition : producedPartitions) {
 			if (!producedPartition.isReleased()) {
-				LOG.debug("Task can NOT be released, execution ID {}", this.getExecutionId());
+				LOG.debug("Task can NOT be released, execution ID {}", getExecutionId());
 				return false;
 			}
 		}
-		LOG.debug("Task can be released, execution ID {}", this.getExecutionId());
+		LOG.debug("Task can be released, execution ID {}", getExecutionId());
 		return true;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -869,6 +869,20 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		}
 	}
 
+	/**
+	 * This task can only be safely released after all produced partitions are consumed.
+	 */
+	public boolean canBeReleased() {
+		for (ResultPartition producedPartition : producedPartitions) {
+			if (!producedPartition.isReleased()) {
+				LOG.debug("Task can NOT be released, execution ID {}", this.getExecutionId());
+				return false;
+			}
+		}
+		LOG.debug("Task can be released, execution ID {}", this.getExecutionId());
+		return true;
+	}
+
 	private ClassLoader createUserCodeClassloader() throws Exception {
 		long startDownloadTime = System.currentTimeMillis();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -159,6 +160,7 @@ public class ResultPartitionTest {
 			partition.release();
 			// partition.add() silently drops the bufferConsumer but recycles it
 			partition.addBufferConsumer(bufferConsumer, 0);
+			assertTrue(partition.isReleased());
 		} finally {
 			if (!bufferConsumer.isRecycled()) {
 				bufferConsumer.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -150,6 +150,11 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	}
 
 	@Override
+	public boolean canBeReleased() {
+		return true;
+	}
+
+	@Override
 	public String getAddress() {
 		return address;
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR fixes the issue described in [1] that slots will be prematurely released which still contain unconsumed data.

[1] https://issues.apache.org/jira/browse/FLINK-10941


## Brief change log

- Add methods to determine whether tasks/slots/slot table can be released
- Release reader in TM after confirming from writers

## Verifying this change

This change is already covered by existing tests, such as SlotManagerTest.

We load tested in 1000 TMs, and it worked as expected (TMs containing unconsumed RSs will not released. Once the RSs are consumed, TMs will be released after timeout.)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no