### PR TITLE
[hotfix][test][streaming] Fix BucketStateSerializerTest failures on Windows7

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
@@ -115,7 +115,7 @@ public class BucketStateSerializerTest {
 		Assert.assertEquals(1L, statuses.length);
 		Assert.assertTrue(
 				statuses[0].getPath().getPath().startsWith(
-						(new Path(testBucket.getParent(), ".test.inprogress")).toString())
+						(new Path(testBucket.getParent(), ".test.inprogress")).getPath())
 		);
 	}
 
@@ -184,7 +184,7 @@ public class BucketStateSerializerTest {
 
 		for (int i = 0; i < noOfTasks; i++) {
 			for (int j = 0; j < 2 + i; j++) {
-				final String part = new Path(bucketPath, "part-" + i + '-' + j).toString();
+				final String part = new Path(bucketPath, "part-" + i + '-' + j).getPath();
 				Assert.assertTrue(paths.contains(part));
 				paths.remove(part);
 			}
@@ -195,7 +195,7 @@ public class BucketStateSerializerTest {
 
 		// verify that the in-progress file is still there
 		Assert.assertTrue(paths.iterator().next().startsWith(
-				(new Path(testBucket.getParent(), ".test-2.inprogress").toString())));
+				(new Path(testBucket.getParent(), ".test-2.inprogress").getPath())));
 	}
 
 	@Test
@@ -258,7 +258,7 @@ public class BucketStateSerializerTest {
 
 		for (int i = 0; i < noOfTasks; i++) {
 			for (int j = 0; j < 2 + i; j++) {
-				final String part = new Path(bucketPath, "test-" + i + '-' + j).toString();
+				final String part = new Path(bucketPath, "test-" + i + '-' + j).getPath();
 				Assert.assertTrue(paths.contains(part));
 				paths.remove(part);
 			}


### PR DESCRIPTION
```
Running org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest
Tests run: 4, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.294 sec <<< FAILURE! - in org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest
testSerializationOnlyInProgress(org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest)  Time elapsed: 0.087 sec  <<< FAILURE!
java.lang.AssertionError: null
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest.testSerializationOnlyInProgress(BucketStateSerializerTest.java:116)

testSerializationNullInProgress(org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest)  Time elapsed: 0.07 sec  <<< FAILURE!
java.lang.AssertionError: null
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest.testSerializationNullInProgress(BucketStateSerializerTest.java:262)

testSerializationFull(org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest)  Time elapsed: 0.052 sec  <<< FAILURE!
java.lang.AssertionError: null
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at org.apache.flink.streaming.api.functions.sink.filesystem.BucketStateSerializerTest.testSerializationFull(BucketStateSerializerTest.java:188)


Results :

Failed tests:
  BucketStateSerializerTest.testSerializationFull:188 null
  BucketStateSerializerTest.testSerializationNullInProgress:262 null
  BucketStateSerializerTest.testSerializationOnlyInProgress:116 null
```

`Path#toString` is not equal to `Path#getPath` on Windows env which is the cause of the failure.
```
Path#toString=C:/Users/xxx/junit8367621191438463907/.test.inprogress
Path#getPath=/C:/Users/xxx/junit8367621191438463907/.test.inprogress
```