### PR TITLE
[FLINK-11024]Overwrite yarn configuration by setting configuration started with "flink.yarn." in flink-conf.yaml

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -592,4 +592,24 @@ public final class Utils {
 		}
 	}
 
+	/**
+	 * Overwrite YARN config by flink.yarn.* in flink-conf.yaml.
+	 *
+	 * @param config	flink configuration
+	 * @param yarnConf		yarn configuration
+	 */
+	public static void overwriteYarnConf(
+		org.apache.flink.configuration.Configuration config,
+		YarnConfiguration yarnConf) {
+		Map<String, String> flinkYarnConf = new HashMap();
+		for (String key : config.keySet()) {
+			if (key.startsWith("flink.yarn")) {
+				flinkYarnConf.put(key.substring(13), config.getString(key, ""));
+			}
+		}
+		for (String key : flinkYarnConf.keySet()) {
+			yarnConf.set(key, flinkYarnConf.get(key));
+		}
+	}
+
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -84,6 +84,7 @@ import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.runtime.concurrent.Executors.directExecutionContext;
+import static org.apache.flink.yarn.Utils.overwriteYarnConf;
 import static org.apache.flink.yarn.Utils.require;
 
 /**
@@ -257,6 +258,7 @@ public class YarnApplicationMasterRunner {
 
 			// Hadoop/Yarn configuration (loads config data automatically from classpath files)
 			final YarnConfiguration yarnConfig = new YarnConfiguration();
+			overwriteYarnConf(config, yarnConfig);
 
 			final int taskManagerContainerMemory;
 			final int numInitialTaskManagers;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -67,6 +67,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static org.apache.flink.yarn.Utils.overwriteYarnConf;
+
 /**
  * The yarn implementation of the resource manager. Used when the system is started
  * via the resource framework YARN.
@@ -148,6 +150,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			jobManagerMetricGroup);
 		this.flinkConfig  = flinkConfig;
 		this.yarnConfig = new YarnConfiguration();
+		overwriteYarnConf(flinkConfig, yarnConfig);
 		this.env = env;
 		this.workerNodeMap = new ConcurrentHashMap<>();
 		final int yarnHeartbeatIntervalMS = flinkConfig.getInteger(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -41,6 +41,7 @@ import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.AbstractYarnClusterDescriptor;
+import org.apache.flink.yarn.Utils;
 import org.apache.flink.yarn.YarnClusterDescriptor;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -164,6 +165,8 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 	private final YarnConfiguration yarnConfiguration;
 
+	private static final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
+
 	public FlinkYarnSessionCli(
 			Configuration configuration,
 			String configurationDirectory,
@@ -262,6 +265,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		}
 
 		this.yarnConfiguration = new YarnConfiguration();
+		Utils.overwriteYarnConf(flinkConfiguration, yarnConfiguration);
 	}
 
 	private AbstractYarnClusterDescriptor createDescriptor(


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/FLINK-11024](https://issues.apache.org/jira/browse/FLINK-11024)
Overwrite yarn configuration by setting configuration started with "flink.yarn." in flink-conf.yaml as spark implement this feature by setting configuration started with "spark.hadoop." in spark-defaults.conf. It is convenient for users to set yarn config,because they can only focus on flink configuration files.
