### PR TITLE
[FLINK-10974] [table] Add support for flatMap to table API

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1820,6 +1820,7 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
 
 ### Row-based Operations
 
+The row-based operations generate outputs with multiple columns.
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 <table class="table table-bordered">
@@ -1842,11 +1843,27 @@ ScalarFunction func = new MyMapFunction();
 tableEnv.registerFunction("func", func);
 
 Table table = input
-  .map(func("c")).as("a, b")
+  .map("func(c)").as("a, b")
 {% endhighlight %}
       </td>
     </tr>
 
+    <tr>
+      <td>
+        <strong>FlatMap</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+        <p>Performs a flatMap operation with a table function.</p>
+{% highlight java %}
+TableFunction func = new MyFlatMapFunction();
+tableEnv.registerFunction("func", func);
+
+Table table = input
+  .flatMap("func(c)").as("a, b")
+{% endhighlight %}
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -1869,13 +1886,26 @@ Table table = input
         <p>Performs a map operation with a user-defined scalar function or built-in scalar function. The output will be flattened if the output type is a composite type.</p>
 {% highlight scala %}
 val func: ScalarFunction = new MyMapFunction()
-
 val table = input
   .map(func('c)).as('a, 'b)
 {% endhighlight %}
       </td>
     </tr>
 
+    <tr>
+      <td>
+        <strong>FlatMap</strong><br>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+      </td>
+      <td>
+        <p>Performs a flatMap operation with a table function.</p>
+{% highlight scala %}
+val func: TableFunction = new MyFlatMapFunction
+val table = input
+  .flatMap(func('c)).as('a, 'b)
+{% endhighlight %}
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1029,7 +1029,8 @@ public interface Table {
 	Table map(Expression mapFunction);
 
 	/**
-	 * Performs a flatMap operation with a table function.
+	 * Performs a flatMap operation with an user-defined table function or built-in table function.
+	 * The output will be flattened if the output type is a composite type.
 	 *
 	 * <p>Example:
 	 *
@@ -1044,7 +1045,8 @@ public interface Table {
 	Table flatMap(String tableFunction);
 
 	/**
-	 * Performs a flatMap operation with a table function.
+	 * Performs a flatMap operation with an user-defined table function or built-in table function.
+	 * The output will be flattened if the output type is a composite type.
 	 *
 	 * <p>Scala Example:
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1004,7 +1004,8 @@ public interface Table {
 	 * <p>Example:
 	 *
 	 * <pre>
-	 * {@code ScalarFunction func = new MyMapFunction();
+	 * {@code
+	 *   ScalarFunction func = new MyMapFunction();
 	 *   tableEnv.registerFunction("func", func);
 	 *   tab.map("func(c)");
 	 * }
@@ -1019,10 +1020,40 @@ public interface Table {
 	 * <p>Scala Example:
 	 *
 	 * <pre>
-	 * {@code val func = new MyMapFunction()
+	 * {@code
+	 *   val func = new MyMapFunction()
 	 *   tab.map(func('c))
 	 * }
 	 * </pre>
 	 */
 	Table map(Expression mapFunction);
+
+	/**
+	 * Performs a flatMap operation with a table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableFunction func = new MyFlatMapFunction();
+	 *   tableEnv.registerFunction("func", func);
+	 *   table.flatMap("func(c)");
+	 * }
+	 * </pre>
+	 */
+	Table flatMap(String tableFunction);
+
+	/**
+	 * Performs a flatMap operation with a table function.
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   val func = new MyFlatMapFunction
+	 *   table.flatMap(func('c))
+	 * }
+	 * </pre>
+	 */
+	Table flatMap(Expression tableFunction);
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableImpl.scala
@@ -199,5 +199,9 @@ class TableImpl(val tableEnv: TableEnvironment, relNode: RelNode) extends Table 
 
   override def map(mapFunction: Expression): Table = ???
 
+  override def flatMap(tableFunction: String): Table = ???
+
+  override def flatMap(tableFunction: Expression): Table = ???
+
   override def getTableOperation: TableOperation = ???
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.rel.RelNode
 import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.table.expressions.{Expression, ExpressionParser, LookupCallResolver}
 import org.apache.flink.table.functions.{TemporalTableFunction, TemporalTableFunctionImpl}
-import org.apache.flink.table.operations.OperationExpressionsUtils.{extractAggregationsAndProperties}
+import org.apache.flink.table.operations.OperationExpressionsUtils.extractAggregationsAndProperties
 import org.apache.flink.table.operations.{OperationTreeBuilder, TableOperation}
 import org.apache.flink.table.plan.logical._
 import org.apache.flink.table.util.JavaScalaConversionUtil.toJava
@@ -457,6 +457,14 @@ class TableImpl(
 
   override def map(mapFunction: Expression): Table = {
     wrap(operationTreeBuilder.map(mapFunction, operationTree))
+  }
+
+  override def flatMap(tableFunction: String): Table = {
+    flatMap(ExpressionParser.parseExpression(tableFunction))
+  }
+
+  override def flatMap(tableFunction: Expression): Table = {
+    wrap(operationTreeBuilder.flatMap(tableFunction, operationTree))
   }
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
@@ -403,10 +403,10 @@ class OperationTreeBuilder(private val tableEnv: TableEnvironment) {
       BuiltInFunctionDefinitions.AS,
       resolvedTableFunction +: newFieldNames.map(ApiExpressionUtils.valueLiteral(_)): _*)
     val joinNode = joinLateral(child, renamedTableFunction, JoinType.INNER, Optional.empty())
-    val dropNode = dropColumns(
+    val rightNode = dropColumns(
       child.getTableSchema.getFieldNames.map(a => new UnresolvedReferenceExpression(a)).toList,
       joinNode)
-    alias(originFieldNames.map(a => new UnresolvedReferenceExpression(a)), dropNode)
+    alias(originFieldNames.map(a => new UnresolvedReferenceExpression(a)), rightNode)
   }
 
   private def isTableFunction(tableFunction: Expression) = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/operations/OperationTreeBuilder.scala
@@ -23,16 +23,18 @@ import java.util.{Collections, Optional, List => JList}
 import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.table.api._
 import org.apache.flink.table.expressions.ExpressionResolver.resolverFor
-import org.apache.flink.table.expressions.FunctionDefinition.Type.SCALAR_FUNCTION
+import org.apache.flink.table.expressions.FunctionDefinition.Type.{SCALAR_FUNCTION, TABLE_FUNCTION}
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.expressions.catalog.FunctionDefinitionCatalog
 import org.apache.flink.table.expressions.lookups.TableReferenceLookup
+import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
 import org.apache.flink.table.operations.AliasOperationUtils.createAliasList
 import org.apache.flink.table.plan.logical.{Minus => LMinus, _}
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.table.util.JavaScalaConversionUtil.toScala
 import org.apache.flink.util.Preconditions
 
+import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.JavaConverters._
 
 /**
@@ -363,6 +365,53 @@ class OperationTreeBuilder(private val tableEnv: TableEnvironment) {
   private def isScalarFunction(mapFunction: Expression) = {
     mapFunction.isInstanceOf[CallExpression] &&
       mapFunction.asInstanceOf[CallExpression].getFunctionDefinition.getType == SCALAR_FUNCTION
+  }
+
+  def flatMap(tableFunction: Expression, child: TableOperation): TableOperation = {
+
+    val resolver = resolverFor(tableCatalog, functionCatalog, child).build()
+    val resolvedTableFunction = resolveSingleExpression(tableFunction, resolver)
+
+    if (!isTableFunction(resolvedTableFunction)) {
+      throw new ValidationException("Only TableFunction can be used in the flatMap operator.")
+    }
+
+    val originFieldNames: Seq[String] =
+      resolvedTableFunction.asInstanceOf[CallExpression].getFunctionDefinition match {
+        case tfd: TableFunctionDefinition =>
+          UserDefinedFunctionUtils.getFieldInfo(tfd.getResultType)._1
+      }
+
+    def getUniqueName(inputName: String, usedFieldNames: Seq[String]): String = {
+      var i = 0
+      var resultName = inputName
+      while (usedFieldNames.contains(resultName)) {
+        resultName = resultName + "_" + i
+        i += 1
+      }
+      resultName
+    }
+
+    val usedFieldNames = child.asInstanceOf[LogicalNode].output.map(_.name).toBuffer
+    val newFieldNames = originFieldNames.map({ e =>
+      val resultName = getUniqueName(e, usedFieldNames)
+      usedFieldNames.append(resultName)
+      resultName
+    })
+
+    val renamedTableFunction = ApiExpressionUtils.call(
+      BuiltInFunctionDefinitions.AS,
+      resolvedTableFunction +: newFieldNames.map(ApiExpressionUtils.valueLiteral(_)): _*)
+    val joinNode = joinLateral(child, renamedTableFunction, JoinType.INNER, Optional.empty())
+    val dropNode = dropColumns(
+      child.getTableSchema.getFieldNames.map(a => new UnresolvedReferenceExpression(a)).toList,
+      joinNode)
+    alias(originFieldNames.map(a => new UnresolvedReferenceExpression(a)), dropNode)
+  }
+
+  private def isTableFunction(tableFunction: Expression) = {
+    tableFunction.isInstanceOf[CallExpression] &&
+      tableFunction.asInstanceOf[CallExpression].getFunctionDefinition.getType == TABLE_FUNCTION
   }
 
   class NoWindowPropertyChecker(val exceptionMessage: String)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -90,4 +90,51 @@ class CorrelateStringExpressionTest extends TableTestBase {
       "func1(substring(c, 2)) as (s)").select("a, c, s")
     verifyTableEquals(scalaTable, javaTable)
   }
+
+  @Test
+  def testFlatMap(): Unit = {
+
+    val util = streamTestUtil()
+    val sTab = util.addTable[(Int, Long, String)]('a, 'b, 'c)
+    val typeInfo = new RowTypeInfo(Seq(Types.INT, Types.LONG, Types.STRING): _*)
+    val jTab = util.addJavaTable[Row](typeInfo,"MyTab","a, b, c")
+
+    // test flatMap
+    val func1 = new TableFunc1
+    util.javaTableEnv.registerFunction("func1", func1)
+    var scalaTable = sTab.flatMap(func1('c)).as('s).select('s)
+    var javaTable = jTab.flatMap("func1(c)").as("s").select("s")
+    verifyTableEquals(scalaTable, javaTable)
+
+    // test custom result type
+    val func2 = new TableFunc2
+    util.javaTableEnv.registerFunction("func2", func2)
+    scalaTable = sTab.flatMap(func2('c)).as('name, 'len).select('name, 'len)
+    javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len")
+    verifyTableEquals(scalaTable, javaTable)
+
+    // test hierarchy generic type
+    val hierarchy = new HierarchyTableFunction
+    util.javaTableEnv.registerFunction("hierarchy", hierarchy)
+    scalaTable = sTab.flatMap(hierarchy('c)).as('name, 'adult, 'len).select('name, 'len, 'adult)
+    javaTable = jTab.flatMap("hierarchy(c)").as("name, adult, len").select("name, len, adult")
+    verifyTableEquals(scalaTable, javaTable)
+
+    // test pojo type
+    val pojo = new PojoTableFunc
+    util.javaTableEnv.registerFunction("pojo", pojo)
+    scalaTable = sTab.flatMap(pojo('c)).select('name, 'age)
+    javaTable = jTab.flatMap("pojo(c)").select("name, age")
+    verifyTableEquals(scalaTable, javaTable)
+
+    // test with filter
+    scalaTable = sTab.flatMap(func2('c)).as('name, 'len).select('name, 'len).filter('len > 2)
+    javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len").filter("len > 2")
+    verifyTableEquals(scalaTable, javaTable)
+
+    // test with scalar function
+    scalaTable = sTab.flatMap(func1('c.substring(2))).as('s).select('s)
+    javaTable = jTab.flatMap("func1(substring(c, 2))").as("s").select("s")
+    verifyTableEquals(scalaTable, javaTable)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
@@ -21,6 +21,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils._
+import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvg
 import org.apache.flink.table.utils.{ObjectTableFunction, TableFunc1, TableFunc2, TableTestBase}
 import org.junit.Assert.{assertTrue, fail}
 import org.junit.Test
@@ -107,6 +108,52 @@ class CorrelateValidationTest extends TableTestBase {
       .select('c, 's).where('a > 10)
 
     util.verifyTable(result, "")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidMapFunctionTypeAggregation(): Unit = {
+    val util = streamTestUtil()
+    util.addTable[(Int)](
+      "MyTable", 'int)
+      .flatMap('int.sum) // do not support AggregateFunction as input
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidMapFunctionTypeUDAGG(): Unit = {
+    val util = streamTestUtil()
+
+    val weightedAvg = new WeightedAvg
+    util.addTable[(Int)](
+      "MyTable", 'int)
+      .flatMap(weightedAvg('int, 'int)) // do not support AggregateFunction as input
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidMapFunctionTypeUDAGG2(): Unit = {
+    val util = streamTestUtil()
+
+    util.tableEnv.registerFunction("weightedAvg", new WeightedAvg)
+    util.addTable[(Int)](
+      "MyTable", 'int)
+      .flatMap("weightedAvg(int, int)") // do not support AggregateFunction as input
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidMapFunctionTypeScalarFunction(): Unit = {
+    val util = streamTestUtil()
+
+    util.addTable[(String)](
+      "MyTable", 'string)
+      .flatMap(Func15('string)) // do not support ScalarFunction as input
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidFlatMapFunctionTypeFieldReference(): Unit = {
+    val util = batchTestUtil()
+
+    util.addTable[(String)](
+      "MyTable", 'string)
+      .flatMap('string) // Only TableFunction can be used in flatMap
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -316,7 +316,7 @@ class CorrelateITCase extends AbstractTestBase {
       // test non alias
       .flatMap(func2('c))
       .select('f0, 'f1)
-      // test the output field name of flatMap is the same as the field name of input table
+      // test the output field name of flatMap is the same as the field name of the input table
       .flatMap(func2(concat('f0, "#")))
       .as ('f0, 'f1)
       .select('f0, 'f1)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -305,6 +305,36 @@ class CorrelateITCase extends AbstractTestBase {
     )
   }
 
+  @Test
+  def testFlatMap(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = StreamTableEnvironment.create(env)
+    StreamITCase.testResults = mutable.MutableList()
+
+    val func2 = new TableFunc2
+    val ds = testData(env).toTable(tEnv, 'a, 'b, 'c)
+      // test non alias
+      .flatMap(func2('c))
+      .select('f0, 'f1)
+      // test the output field name of flatMap is the same as the field name of input table
+      .flatMap(func2(concat('f0, "#")))
+      .as ('f0, 'f1)
+      .select('f0, 'f1)
+
+    val results = ds.toAppendStream[Row]
+    results.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Jack,4",
+      "22,2",
+      "John,4",
+      "19,2",
+      "Anna,4",
+      "44,2")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
   private def testData(
       env: StreamExecutionEnvironment)
     : DataStream[(Int, Long, String)] = {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds the flatMap operation to the table API.*

## Brief change log

  - *Move the implicit tableFunctionCall2Table from package.scala to expressionDsl.scala*
  - *Add implicit in expressionDsl.scala which can convert a TableFunction to an Expression*
  - *Add flatMap API in table.scala*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added FlatMapTest/FlatMapITCase/FlatMapValidationTest/FlatMapStringExpressionTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
