### PR TITLE
[FLINK-11017][table] Throw exception if constant with YEAR TO MONTH resolution was used for group windows

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamLogicalWindowAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamLogicalWindowAggregateRule.scala
@@ -22,7 +22,7 @@ import java.math.{BigDecimal => JBigDecimal}
 
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
-import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.sql.`type`.{SqlTypeFamily, SqlTypeName}
 import org.apache.flink.table.api.scala.{Session, Slide, Tumble}
 import org.apache.flink.table.api.{TableException, ValidationException, Window}
 import org.apache.flink.table.calcite.FlinkTypeFactory
@@ -68,8 +68,10 @@ class DataStreamLogicalWindowAggregateRule
 
     def getOperandAsLong(call: RexCall, idx: Int): Long =
       call.getOperands.get(idx) match {
-        case v: RexLiteral => v.getValue.asInstanceOf[JBigDecimal].longValue()
-        case _ => throw new TableException("Only constant window descriptors are supported.")
+        case v: RexLiteral if v.getTypeName.getFamily == SqlTypeFamily.INTERVAL_DAY_TIME =>
+          v.getValue.asInstanceOf[JBigDecimal].longValue()
+        case _ => throw new TableException(
+          "Only constant window descriptors with DAY TO SECOND resolution are supported.")
       }
 
     def getOperandAsTimeIndicator(call: RexCall, idx: Int): ResolvedFieldReference =

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/WindowAggregateValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/WindowAggregateValidationTest.scala
@@ -30,8 +30,11 @@ class WindowAggregateValidationTest extends TableTestBase {
   streamUtil.addTable[(Int, String, Long)](
     "MyTable", 'a, 'b, 'c, 'proctime.proctime, 'rowtime.rowtime)
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testTumbleWindowNoOffset(): Unit = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage("TUMBLE window with alignment is not supported yet")
+
     val sqlQuery =
       "SELECT SUM(a) AS sumA, COUNT(b) AS cntB " +
         "FROM MyTable " +
@@ -40,8 +43,11 @@ class WindowAggregateValidationTest extends TableTestBase {
     streamUtil.verifySql(sqlQuery, "n/a")
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testHopWindowNoOffset(): Unit = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage("HOP window with alignment is not supported yet")
+
     val sqlQuery =
       "SELECT SUM(a) AS sumA, COUNT(b) AS cntB " +
         "FROM MyTable " +
@@ -50,8 +56,11 @@ class WindowAggregateValidationTest extends TableTestBase {
     streamUtil.verifySql(sqlQuery, "n/a")
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testSessionWindowNoOffset(): Unit = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage("SESSION window with alignment is not supported yet")
+
     val sqlQuery =
       "SELECT SUM(a) AS sumA, COUNT(b) AS cntB " +
         "FROM MyTable " +
@@ -60,20 +69,27 @@ class WindowAggregateValidationTest extends TableTestBase {
     streamUtil.verifySql(sqlQuery, "n/a")
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testVariableWindowSize() = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage("Only constant window descriptors with DAY TO SECOND " +
+      "resolution are supported")
+
     val sql = "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, c * INTERVAL '1' MINUTE)"
     streamUtil.verifySql(sql, "n/a")
   }
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testWindowUdAggInvalidArgs(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("Given parameters of function do not match any signature")
+
     streamUtil.tableEnv.registerFunction("weightedAvg", new WeightedAvgWithMerge)
 
     val sqlQuery =
       "SELECT SUM(a) AS sumA, weightedAvg(a, b) AS wAvg " +
         "FROM MyTable " +
-        "GROUP BY TUMBLE(proctime(), INTERVAL '2' HOUR, TIME '10:00:00')"
+        "GROUP BY TUMBLE(proctime, INTERVAL '2' HOUR, TIME '10:00:00')"
 
     streamUtil.verifySql(sqlQuery, "n/a")
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/WindowAggregateValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/WindowAggregateValidationTest.scala
@@ -93,4 +93,17 @@ class WindowAggregateValidationTest extends TableTestBase {
 
     streamUtil.verifySql(sqlQuery, "n/a")
   }
+
+  @Test
+  def testWindowWrongWindowParameter(): Unit = {
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage("Only constant window descriptors with DAY TO SECOND " +
+      "resolution are supported")
+
+    val sqlQuery =
+      "SELECT COUNT(*) FROM MyTable " +
+        "GROUP BY TUMBLE(proctime, INTERVAL '2-10' YEAR TO MONTH)"
+
+    streamUtil.verifySql(sqlQuery, "n/a")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

* Checking if a proper resolution was used for group window parameter. Without this check `INTERVAL '2-10' YEAR TO MONTH` would be a valid window size that would be translated to 34 milliseconds window.

## Brief change log

  - add check for proper `SqlTypeFamily`
  - fixed test so that they check if the expected exception was thrown (before `testWindowUdAggInvalidArgs` was passing because of wrong usage of `proctime()`)


## Verifying this change
`org.apache.flink.table.api.stream.sql.validation.WindowAggregateValidationTest#testWindowWrongWindowParameter`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
