### PR TITLE
[FLINK-7208] [table] Optimize Min/MaxWithRetractAggFunction with DataView

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
@@ -74,10 +74,11 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
       val v = value.asInstanceOf[T]
 
       var count = acc.map.get(v)
-      count -= 1L
-      if (count == 0) {
+      if (count == null || count == 1) {
         //remove the key v from the map if the number of appearance of the value v is 0
-        acc.map.remove(v)
+        if (count != null) {
+          acc.map.remove(v)
+        }
         //if the total count is 0, we could just simply set the f0(max) to the initial value
         acc.distinctCount -= 1
         if (acc.distinctCount == 0) {
@@ -88,17 +89,21 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
         // value to replace v as the max value
         if (v == acc.max) {
           val iterator = acc.map.keys.iterator()
-          var key = iterator.next()
-          acc.max = key
+          var hasMax = false
           while (iterator.hasNext) {
-            key = iterator.next()
-            if (ord.compare(acc.max, key) < 0) {
+            val key = iterator.next()
+            if (!hasMax || ord.compare(acc.max, key) < 0) {
               acc.max = key
+              hasMax = true
             }
+          }
+
+          if (!hasMax) {
+            acc.distinctCount = 0L
           }
         }
       } else {
-        acc.map.put(v, count)
+        acc.map.put(v, count - 1)
       }
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
@@ -73,7 +73,7 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
     if (value != null) {
       val v = value.asInstanceOf[T]
 
-      var count = acc.map.get(v)
+      val count = acc.map.get(v)
       if (count == null || count == 1) {
         //remove the key v from the map if the number of appearance of the value v is 0
         if (count != null) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
@@ -18,19 +18,20 @@
 package org.apache.flink.table.functions.aggfunctions
 
 import java.math.BigDecimal
-import java.util.{HashMap => JHashMap}
-import java.lang.{Iterable => JIterable}
+import java.lang.{Iterable => JIterable, Long => JLong}
 import java.sql.{Date, Time, Timestamp}
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
-import org.apache.flink.api.java.typeutils.{MapTypeInfo, TupleTypeInfo}
-import org.apache.flink.table.api.Types
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation, Types}
+import org.apache.flink.table.api.dataview.MapView
 import org.apache.flink.table.functions.aggfunctions.Ordering._
 import org.apache.flink.table.functions.AggregateFunction
 
 /** The initial accumulator for Max with retraction aggregate function */
-class MaxWithRetractAccumulator[T] extends JTuple2[T, JHashMap[T, Long]]
+class MaxWithRetractAccumulator[T] {
+  var max: T = _
+  var distinctCount: JLong = _
+  var map: MapView[T, JLong] = _
+}
 
 /**
   * Base class for built-in Max with retraction aggregate function
@@ -42,8 +43,10 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
 
   override def createAccumulator(): MaxWithRetractAccumulator[T] = {
     val acc = new MaxWithRetractAccumulator[T]
-    acc.f0 = getInitValue //max
-    acc.f1 = new JHashMap[T, Long]() //store the count for each value
+    acc.max = getInitValue //max
+    acc.distinctCount = 0L
+    acc.map = new MapView(getValueTypeInfo, Types.LONG)
+      .asInstanceOf[MapView[T, JLong]] //store the count for each value
     acc
   }
 
@@ -51,16 +54,17 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
     if (value != null) {
       val v = value.asInstanceOf[T]
 
-      if (acc.f1.size() == 0 || (ord.compare(acc.f0, v) < 0)) {
-        acc.f0 = v
+      if (acc.distinctCount == 0 || (ord.compare(acc.max, v) < 0)) {
+        acc.max = v
       }
 
-      if (!acc.f1.containsKey(v)) {
-        acc.f1.put(v, 1L)
+      var count = acc.map.get(v)
+      if (count == null) {
+        acc.map.put(v, 1L)
+        acc.distinctCount += 1
       } else {
-        var count = acc.f1.get(v)
         count += 1L
-        acc.f1.put(v, count)
+        acc.map.put(v, count)
       }
     }
   }
@@ -69,39 +73,40 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
     if (value != null) {
       val v = value.asInstanceOf[T]
 
-      var count = acc.f1.get(v)
+      var count = acc.map.get(v)
       count -= 1L
       if (count == 0) {
         //remove the key v from the map if the number of appearance of the value v is 0
-        acc.f1.remove(v)
+        acc.map.remove(v)
         //if the total count is 0, we could just simply set the f0(max) to the initial value
-        if (acc.f1.size() == 0) {
-          acc.f0 = getInitValue
+        acc.distinctCount -= 1
+        if (acc.distinctCount == 0) {
+          acc.max = getInitValue
           return
         }
         //if v is the current max value, we have to iterate the map to find the 2nd biggest
         // value to replace v as the max value
-        if (v == acc.f0) {
-          val iterator = acc.f1.keySet().iterator()
+        if (v == acc.max) {
+          val iterator = acc.map.keys.iterator()
           var key = iterator.next()
-          acc.f0 = key
+          acc.max = key
           while (iterator.hasNext) {
             key = iterator.next()
-            if (ord.compare(acc.f0, key) < 0) {
-              acc.f0 = key
+            if (ord.compare(acc.max, key) < 0) {
+              acc.max = key
             }
           }
         }
       } else {
-        acc.f1.put(v, count)
+        acc.map.put(v, count)
       }
     }
 
   }
 
   override def getValue(acc: MaxWithRetractAccumulator[T]): T = {
-    if (acc.f1.size() != 0) {
-      acc.f0
+    if (acc.distinctCount != 0) {
+      acc.max
     } else {
       null.asInstanceOf[T]
     }
@@ -112,19 +117,23 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
     val iter = its.iterator()
     while (iter.hasNext) {
       val a = iter.next()
-      if (a.f1.size() != 0) {
+      if (a.distinctCount != 0) {
         // set max element
-        if (ord.compare(acc.f0, a.f0) < 0) {
-          acc.f0 = a.f0
+        if (ord.compare(acc.max, a.max) < 0) {
+          acc.max = a.max
         }
         // merge the count for each key
-        val iterator = a.f1.keySet().iterator()
+        val iterator = a.map.entries.iterator()
         while (iterator.hasNext) {
-          val key = iterator.next()
-          if (acc.f1.containsKey(key)) {
-            acc.f1.put(key, acc.f1.get(key) + a.f1.get(key))
+          val entry = iterator.next()
+          val key = entry.getKey
+          val value = entry.getValue
+          val count = acc.map.get(key)
+          if (count != null) {
+            acc.map.put(key, count + value)
           } else {
-            acc.f1.put(key, a.f1.get(key))
+            acc.map.put(key, value)
+            acc.distinctCount += 1
           }
         }
       }
@@ -132,15 +141,9 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
   }
 
   def resetAccumulator(acc: MaxWithRetractAccumulator[T]): Unit = {
-    acc.f0 = getInitValue
-    acc.f1.clear()
-  }
-
-  override def getAccumulatorType: TypeInformation[MaxWithRetractAccumulator[T]] = {
-    new TupleTypeInfo(
-      classOf[MaxWithRetractAccumulator[T]],
-      getValueTypeInfo,
-      new MapTypeInfo(getValueTypeInfo, BasicTypeInfo.LONG_TYPE_INFO))
+    acc.max = getInitValue
+    acc.distinctCount = 0L
+    acc.map.clear()
   }
 
   def getInitValue: T

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
@@ -18,19 +18,20 @@
 package org.apache.flink.table.functions.aggfunctions
 
 import java.math.BigDecimal
-import java.util.{HashMap => JHashMap}
-import java.lang.{Iterable => JIterable}
+import java.lang.{Iterable => JIterable, Long => JLong}
 import java.sql.{Date, Time, Timestamp}
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
-import org.apache.flink.api.java.typeutils.{MapTypeInfo, TupleTypeInfo}
-import org.apache.flink.table.api.Types
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation, Types}
+import org.apache.flink.table.api.dataview.MapView
 import org.apache.flink.table.functions.aggfunctions.Ordering._
 import org.apache.flink.table.functions.AggregateFunction
 
 /** The initial accumulator for Min with retraction aggregate function */
-class MinWithRetractAccumulator[T] extends JTuple2[T, JHashMap[T, Long]]
+class MinWithRetractAccumulator[T] {
+  var min: T = _
+  var distinctCount: JLong = _
+  var map: MapView[T, JLong] = _
+}
 
 /**
   * Base class for built-in Min with retraction aggregate function
@@ -42,8 +43,10 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T])
 
   override def createAccumulator(): MinWithRetractAccumulator[T] = {
     val acc = new MinWithRetractAccumulator[T]
-    acc.f0 = getInitValue //min
-    acc.f1 = new JHashMap[T, Long]() //store the count for each value
+    acc.min = getInitValue //min
+    acc.distinctCount = 0L
+    acc.map = new MapView(getValueTypeInfo, Types.LONG)
+      .asInstanceOf[MapView[T, JLong]] //store the count for each value
     acc
   }
 
@@ -51,16 +54,17 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T])
     if (value != null) {
       val v = value.asInstanceOf[T]
 
-      if (acc.f1.size() == 0 || (ord.compare(acc.f0, v) > 0)) {
-        acc.f0 = v
+      if (acc.distinctCount == 0 || (ord.compare(acc.min, v) > 0)) {
+        acc.min = v
       }
 
-      if (!acc.f1.containsKey(v)) {
-        acc.f1.put(v, 1L)
+      var count = acc.map.get(v)
+      if (count == null) {
+        acc.map.put(v, 1L)
+        acc.distinctCount += 1
       } else {
-        var count = acc.f1.get(v)
         count += 1L
-        acc.f1.put(v, count)
+        acc.map.put(v, count)
       }
     }
   }
@@ -69,39 +73,40 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T])
     if (value != null) {
       val v = value.asInstanceOf[T]
 
-      var count = acc.f1.get(v)
+      var count = acc.map.get(v)
       count -= 1L
       if (count == 0) {
         //remove the key v from the map if the number of appearance of the value v is 0
-        acc.f1.remove(v)
+        acc.map.remove(v)
         //if the total count is 0, we could just simply set the f0(min) to the initial value
-        if (acc.f1.size() == 0) {
-          acc.f0 = getInitValue
+        acc.distinctCount -= 1
+        if (acc.distinctCount == 0) {
+          acc.min = getInitValue
           return
         }
         //if v is the current min value, we have to iterate the map to find the 2nd smallest
         // value to replace v as the min value
-        if (v == acc.f0) {
-          val iterator = acc.f1.keySet().iterator()
+        if (v == acc.min) {
+          val iterator = acc.map.keys.iterator()
           var key = iterator.next()
-          acc.f0 = key
+          acc.min = key
           while (iterator.hasNext) {
             key = iterator.next()
-            if (ord.compare(acc.f0, key) > 0) {
-              acc.f0 = key
+            if (ord.compare(acc.min, key) > 0) {
+              acc.min = key
             }
           }
         }
       } else {
-        acc.f1.put(v, count)
+        acc.map.put(v, count)
       }
     }
 
   }
 
   override def getValue(acc: MinWithRetractAccumulator[T]): T = {
-    if (acc.f1.size() != 0) {
-      acc.f0
+    if (acc.distinctCount != 0) {
+      acc.min
     } else {
       null.asInstanceOf[T]
     }
@@ -112,19 +117,23 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T])
     val iter = its.iterator()
     while (iter.hasNext) {
       val a = iter.next()
-      if (a.f1.size() != 0) {
+      if (a.distinctCount != 0) {
         // set min element
-        if (ord.compare(acc.f0, a.f0) > 0) {
-          acc.f0 = a.f0
+        if (ord.compare(acc.min, a.min) > 0) {
+          acc.min = a.min
         }
         // merge the count for each key
-        val iterator = a.f1.keySet().iterator()
+        val iterator = a.map.entries.iterator()
         while (iterator.hasNext) {
-          val key = iterator.next()
-          if (acc.f1.containsKey(key)) {
-            acc.f1.put(key, acc.f1.get(key) + a.f1.get(key))
+          val entry = iterator.next()
+          val key = entry.getKey
+          val value = entry.getValue
+          val count = acc.map.get(key)
+          if (count != null) {
+            acc.map.put(key, count + value)
           } else {
-            acc.f1.put(key, a.f1.get(key))
+            acc.map.put(key, value)
+            acc.distinctCount += 1
           }
         }
       }
@@ -132,15 +141,9 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T])
   }
 
   def resetAccumulator(acc: MinWithRetractAccumulator[T]): Unit = {
-    acc.f0 = getInitValue
-    acc.f1.clear()
-  }
-
-  override def getAccumulatorType: TypeInformation[MinWithRetractAccumulator[T]] = {
-    new TupleTypeInfo(
-      classOf[MinWithRetractAccumulator[T]],
-      getValueTypeInfo,
-      new MapTypeInfo(getValueTypeInfo, BasicTypeInfo.LONG_TYPE_INFO))
+    acc.min = getInitValue
+    acc.distinctCount = 0L
+    acc.map.clear()
   }
 
   def getInitValue: T

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
@@ -73,7 +73,7 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T])
     if (value != null) {
       val v = value.asInstanceOf[T]
 
-      var count = acc.map.get(v)
+      val count = acc.map.get(v)
       if (count == null || count == 1) {
         //remove the key v from the map if the number of appearance of the value v is 0
         if (count != null) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -1250,23 +1250,17 @@ object AggregateUtil {
       aggregateInputTypes,
       tableConfig)
 
-    val (accumulatorType, accSpecs) = aggregateFunction match {
-      case collect: SqlAggFunction if collect.getKind == SqlKind.COLLECT =>
-        removeStateViewFieldsFromAccTypeInfo(
-          uniqueIdWithinAggregate,
-          aggregate,
-          aggregate.getAccumulatorType,
-          isStateBackedDataViews)
+    val (accumulatorType, accSpecs) = {
+      val accType = aggregateFunction match {
+        case udagg: AggSqlFunction => udagg.accType
+        case _ => getAccumulatorTypeOfAggregateFunction(aggregate)
+      }
 
-      case udagg: AggSqlFunction =>
-        removeStateViewFieldsFromAccTypeInfo(
-          uniqueIdWithinAggregate,
-          aggregate,
-          udagg.accType,
-          isStateBackedDataViews)
-
-      case _ =>
-        (getAccumulatorTypeOfAggregateFunction(aggregate), None)
+      removeStateViewFieldsFromAccTypeInfo(
+        uniqueIdWithinAggregate,
+        aggregate,
+        accType,
+        isStateBackedDataViews)
     }
 
     // create distinct accumulator filter argument

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggfunctions/AggFunctionTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggfunctions/AggFunctionTestBase.scala
@@ -23,7 +23,7 @@ import java.math.BigDecimal
 import java.util.{ArrayList => JArrayList, List => JList}
 
 import org.apache.flink.table.functions.AggregateFunction
-import org.apache.flink.table.functions.aggfunctions.{DecimalAvgAccumulator, DecimalSumWithRetractAccumulator}
+import org.apache.flink.table.functions.aggfunctions.{DecimalAvgAccumulator, DecimalSumWithRetractAccumulator, MaxWithRetractAccumulator, MinWithRetractAccumulator}
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -137,6 +137,12 @@ abstract class AggFunctionTestBase[T, ACC] {
       case (e: BigDecimal, r: BigDecimal) =>
         // BigDecimal.equals() value and scale but we are only interested in value.
         assert(e.compareTo(r) == 0)
+      case (e: MinWithRetractAccumulator[_], r: MinWithRetractAccumulator[_]) =>
+        assertEquals(e.min, r.min)
+        assertEquals(e.distinctCount, r.distinctCount)
+      case (e: MaxWithRetractAccumulator[_], r: MaxWithRetractAccumulator[_]) =>
+        assertEquals(e.max, r.max)
+        assertEquals(e.distinctCount, r.distinctCount)
       case _ =>
         assertEquals(expected, result)
     }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -203,13 +203,13 @@ class AggregateITCase extends StreamingWithStateTestBase {
       .groupBy('b)
       .select('a.count as 'cnt, 'b)
       .groupBy('cnt)
-      .select('cnt, 'b.count as 'freq)
+      .select('cnt, 'b.count as 'freq, 'b.min as 'min, 'b.max as 'max)
 
     val results = t.toRetractStream[Row](queryConfig)
 
     results.addSink(new RetractingSink)
     env.execute()
-    val expected = List("1,1", "2,1", "3,1", "4,1", "5,1", "6,1")
+    val expected = List("1,1,1,1", "2,1,2,2", "3,1,3,3", "4,1,4,4", "5,1,5,5", "6,1,6,6")
     assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request optimizes the performance of Min/MaxWithRetractAggFunction with DataView*

## Brief change log

  - *Optimize Min/MaxAggFunctionWithRetract with DataView*

## Verifying this change

This change is already covered by existing tests, such as *MinWithRetractAggFunctionTest/MaxWithRetractAggFunctionTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
