### PR TITLE
[FLINK-10946] Silent checkpoint async failures in task executor if job is not running

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -415,7 +415,9 @@ public abstract class AbstractStreamOperator<OUT>
 			String snapshotFailMessage = "Could not complete snapshot " + checkpointId + " for operator " +
 				getOperatorName() + ".";
 
-			LOG.info(snapshotFailMessage, snapshotException);
+			if (!getContainingTask().isCanceled()) {
+				LOG.info(snapshotFailMessage, snapshotException);
+			}
 			throw new Exception(snapshotFailMessage, snapshotException);
 		}
 


### PR DESCRIPTION
release 1.6 back port of #7154
cc @tillrohrmann 