### PR TITLE
[FLINK-11040][docs] fixed the Incorrect generic type in broadcast_state.md

### DIFF
--- a/docs/dev/stream/state/broadcast_state.md
+++ b/docs/dev/stream/state/broadcast_state.md
@@ -94,7 +94,7 @@ The exact type of the function depends on the type of the non-broadcasted stream
 </div>
 
 {% highlight java %}
-DataStream<Match> output = colorPartitionedStream
+DataStream<String> output = colorPartitionedStream
                  .connect(ruleBroadcastStream)
                  .process(
                      
@@ -107,7 +107,7 @@ DataStream<Match> output = colorPartitionedStream
                      new KeyedBroadcastProcessFunction<Color, Item, Rule, String>() {
                          // my matching logic
                      }
-                 )
+                 );
 {% endhighlight %}
 
 ### BroadcastProcessFunction and KeyedBroadcastProcessFunction


### PR DESCRIPTION
## What is the purpose of the change

This pull request correct the generic type of output in the broadcast_state.md

## Brief change log

- Correct the generic type of DataStream instance output in section 'Provided APIs'
- Add a semicolon at the end of this code block


## Verifying this change

This change is a docs cleanup.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
