### PR TITLE
[FLINK-11042][kafka,tests] Drop invalid kafka producer tests

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.fail;
  * IT cases for the {@link FlinkKafkaProducer011}.
  */
 @SuppressWarnings("serial")
-public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
+public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 	protected String transactionalId;
 	protected Properties extraProperties;
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -208,55 +208,6 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		deleteTestTopic(topic);
 	}
 
-	@Test
-	public void testFlinkKafkaProducer011FailTransactionCoordinatorBeforeNotify() throws Exception {
-		String topic = "flink-kafka-producer-fail-transaction-coordinator-before-notify";
-
-		Properties properties = createProperties();
-
-		FlinkKafkaProducer011<Integer> kafkaProducer = new FlinkKafkaProducer011<>(
-			topic,
-			integerKeyedSerializationSchema,
-			properties,
-			EXACTLY_ONCE);
-
-		OneInputStreamOperatorTestHarness<Integer, Object> testHarness1 = new OneInputStreamOperatorTestHarness<>(
-			new StreamSink<>(kafkaProducer),
-			IntSerializer.INSTANCE);
-
-		testHarness1.setup();
-		testHarness1.open();
-		testHarness1.processElement(42, 0);
-		testHarness1.snapshot(0, 1);
-		testHarness1.processElement(43, 2);
-		int transactionCoordinatorId = kafkaProducer.getTransactionCoordinatorId();
-		OperatorSubtaskState snapshot = testHarness1.snapshot(1, 3);
-
-		failBroker(transactionCoordinatorId);
-
-		try {
-			testHarness1.processElement(44, 4);
-			testHarness1.notifyOfCompletedCheckpoint(1);
-			testHarness1.close();
-		}
-		catch (Exception ex) {
-			// Expected... some random exception could be thrown by any of the above operations.
-		}
-		finally {
-			kafkaServer.restartBroker(transactionCoordinatorId);
-		}
-
-		try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness2 = createTestHarness(topic)) {
-			testHarness2.setup();
-			testHarness2.initializeState(snapshot);
-			testHarness2.open();
-		}
-
-		assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43));
-
-		deleteTestTopic(topic);
-	}
-
 	/**
 	 * This tests checks whether FlinkKafkaProducer011 correctly aborts lingering transactions after a failure.
 	 * If such transactions were left alone lingering it consumers would be unable to read committed records

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -119,7 +119,7 @@ import static org.junit.Assert.fail;
  * Abstract test base for all Kafka consumer tests.
  */
 @SuppressWarnings("serial")
-public abstract class KafkaConsumerTestBase extends KafkaTestBase {
+public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
 	@Rule
 	public RetryRule retryRule = new RetryRule();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -66,7 +66,7 @@ import static org.junit.Assert.fail;
  * Abstract test base for all Kafka producer tests.
  */
 @SuppressWarnings("serial")
-public abstract class KafkaProducerTestBase extends KafkaTestBase {
+public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 
 	private static final long KAFKA_READ_TIMEOUT = 60_000L;
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -24,10 +24,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.jmx.JMXReporter;
 import org.apache.flink.runtime.client.JobExecutionException;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
@@ -72,21 +70,9 @@ public abstract class KafkaTestBase extends TestLogger {
 
 	protected static final int NUMBER_OF_KAFKA_SERVERS = 3;
 
-	protected static final int NUM_TMS = 1;
-
-	protected static final int TM_SLOTS = 8;
-
 	protected static String brokerConnectionStrings;
 
 	protected static Properties standardProps;
-
-	@ClassRule
-	public static MiniClusterWithClientResource flink = new MiniClusterWithClientResource(
-		new MiniClusterResourceConfiguration.Builder()
-			.setConfiguration(getFlinkConfiguration())
-			.setNumberTaskManagers(NUM_TMS)
-			.setNumberSlotsPerTaskManager(TM_SLOTS)
-			.build());
 
 	protected static FiniteDuration timeout = new FiniteDuration(10, TimeUnit.SECONDS);
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+
+import org.junit.ClassRule;
+
+/**
+ * The base for the Kafka tests with Flink's MiniCluster.
+ */
+@SuppressWarnings("serial")
+public abstract class KafkaTestBaseWithFlink extends KafkaTestBase {
+
+	protected static final int NUM_TMS = 1;
+
+	protected static final int TM_SLOTS = 8;
+
+	@ClassRule
+	public static MiniClusterWithClientResource flink = new MiniClusterWithClientResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setConfiguration(getFlinkConfiguration())
+			.setNumberTaskManagers(NUM_TMS)
+			.setNumberSlotsPerTaskManager(TM_SLOTS)
+			.build());
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.CommonTestUtils.PipeForwarder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Map.Entry;
+
+import static org.apache.flink.runtime.testutils.CommonTestUtils.getCurrentClasspath;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility class wrapping {@link ProcessBuilder} and pre-configuring it with common options.
+ */
+public class TestProcessBuilder {
+	private final String javaCommand = checkNotNull(getJavaCommandPath());
+
+	private final ArrayList<String> jvmArgs = new ArrayList<>();
+	private final ArrayList<String> mainClassArgs = new ArrayList<>();
+
+	private final String mainClass;
+
+	private MemorySize jvmMemory = MemorySize.parse("80mb");
+
+	public TestProcessBuilder(String mainClass) throws IOException {
+		File tempLogFile = File.createTempFile(getClass().getSimpleName() + "-", "-log4j.properties");
+		tempLogFile.deleteOnExit();
+		CommonTestUtils.printLog4jDebugConfig(tempLogFile);
+
+		jvmArgs.add("-Dlog.level=DEBUG");
+		jvmArgs.add("-Dlog4j.configuration=file:" + tempLogFile.getAbsolutePath());
+		jvmArgs.add("-classpath");
+		jvmArgs.add(getCurrentClasspath());
+
+		this.mainClass = mainClass;
+	}
+
+	public TestProcess start() throws IOException {
+		final ArrayList<String> commands = new ArrayList<>();
+
+		commands.add(javaCommand);
+		commands.add(String.format("-Xms%dm", jvmMemory.getMebiBytes()));
+		commands.add(String.format("-Xmx%dm", jvmMemory.getMebiBytes()));
+		commands.addAll(jvmArgs);
+		commands.add(mainClass);
+		commands.addAll(mainClassArgs);
+
+		StringWriter processOutput = new StringWriter();
+		Process process = new ProcessBuilder(commands).start();
+		new PipeForwarder(process.getErrorStream(), processOutput);
+
+		return new TestProcess(process, processOutput);
+	}
+
+	public TestProcessBuilder setJvmMemory(MemorySize jvmMemory) {
+		this.jvmMemory = jvmMemory;
+		return this;
+	}
+
+	public TestProcessBuilder addMainClassArg(String arg) {
+		mainClassArgs.add(arg);
+		return this;
+	}
+
+	public TestProcessBuilder addConfigAsMainClassArgs(Configuration config) {
+		for (Entry<String, String> keyValue: config.toMap().entrySet()) {
+			addMainClassArg("--" + keyValue.getKey());
+			addMainClassArg(keyValue.getValue());
+		}
+		return this;
+	}
+
+	/**
+	 * {@link Process} with it's {@code processOutput}.
+	 */
+	public static class TestProcess {
+		private final Process process;
+		private final StringWriter processOutput;
+
+		public TestProcess(Process process, StringWriter processOutput) {
+			this.process = process;
+			this.processOutput = processOutput;
+		}
+
+		public Process getProcess() {
+			return process;
+		}
+
+		public StringWriter getOutput() {
+			return processOutput;
+		}
+
+		public void destroy() {
+			process.destroy();
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -29,9 +29,10 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
+import org.apache.flink.test.util.TestProcessBuilder;
+import org.apache.flink.test.util.TestProcessBuilder.TestProcess;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
@@ -43,12 +44,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.runtime.testutils.CommonTestUtils.getCurrentClasspath;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -86,13 +83,9 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 	@Test
 	public void testTaskManagerProcessFailure() throws Exception {
 
-		final StringWriter processOutput1 = new StringWriter();
-		final StringWriter processOutput2 = new StringWriter();
-		final StringWriter processOutput3 = new StringWriter();
-
-		Process taskManagerProcess1 = null;
-		Process taskManagerProcess2 = null;
-		Process taskManagerProcess3 = null;
+		TestProcess taskManagerProcess1 = null;
+		TestProcess taskManagerProcess2 = null;
+		TestProcess taskManagerProcess3 = null;
 
 		File coordinateTempDir = null;
 
@@ -110,6 +103,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 100);
 
 		try (final StandaloneSessionClusterEntrypoint clusterEntrypoint = new StandaloneSessionClusterEntrypoint(config)) {
+
 			// check that we run this test only if the java command
 			// is available on this machine
 			String javaCommand = getJavaCommandPath();
@@ -118,39 +112,18 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 				return;
 			}
 
-			// create a logging file for the process
-			File tempLogFile = File.createTempFile(getClass().getSimpleName() + "-", "-log4j.properties");
-			tempLogFile.deleteOnExit();
-			CommonTestUtils.printLog4jDebugConfig(tempLogFile);
+			clusterEntrypoint.startCluster();
 
 			// coordination between the processes goes through a directory
 			coordinateTempDir = temporaryFolder.newFolder();
 
-			clusterEntrypoint.startCluster();
+			TestProcessBuilder taskManagerProcessBuilder = new TestProcessBuilder(TaskExecutorProcessEntryPoint.class.getName());
 
-			final Map<String, String> keyValues = config.toMap();
-			final ArrayList<String> commands = new ArrayList<>((keyValues.size() << 1) + 8);
-
-			// the TaskManager java command
-			commands.add(javaCommand);
-			commands.add("-Dlog.level=DEBUG");
-			commands.add("-Dlog4j.configuration=file:" + tempLogFile.getAbsolutePath());
-			commands.add("-Xms80m");
-			commands.add("-Xmx80m");
-			commands.add("-classpath");
-			commands.add(getCurrentClasspath());
-			commands.add(AbstractTaskManagerProcessFailureRecoveryTest.TaskExecutorProcessEntryPoint.class.getName());
-
-			for (Map.Entry<String, String> keyValue: keyValues.entrySet()) {
-				commands.add("--" + keyValue.getKey());
-				commands.add(keyValue.getValue());
-			}
+			taskManagerProcessBuilder.addConfigAsMainClassArgs(config);
 
 			// start the first two TaskManager processes
-			taskManagerProcess1 = new ProcessBuilder(commands).start();
-			new CommonTestUtils.PipeForwarder(taskManagerProcess1.getErrorStream(), processOutput1);
-			taskManagerProcess2 = new ProcessBuilder(commands).start();
-			new CommonTestUtils.PipeForwarder(taskManagerProcess2.getErrorStream(), processOutput2);
+			taskManagerProcess1 = taskManagerProcessBuilder.start();
+			taskManagerProcess2 = taskManagerProcessBuilder.start();
 
 			// the program will set a marker file in each of its parallel tasks once they are ready, so that
 			// this coordinating code is aware of this.
@@ -192,8 +165,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 			}
 
 			// start the third TaskManager
-			taskManagerProcess3 = new ProcessBuilder(commands).start();
-			new CommonTestUtils.PipeForwarder(taskManagerProcess3.getErrorStream(), processOutput3);
+			taskManagerProcess3 = taskManagerProcessBuilder.start();
 
 			// kill one of the previous TaskManagers, triggering a failure and recovery
 			taskManagerProcess1.destroy();
@@ -219,16 +191,16 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		}
 		catch (Exception e) {
 			e.printStackTrace();
-			printProcessLog("TaskManager 1", processOutput1.toString());
-			printProcessLog("TaskManager 2", processOutput2.toString());
-			printProcessLog("TaskManager 3", processOutput3.toString());
+			printProcessLog("TaskManager 1", taskManagerProcess1.getOutput().toString());
+			printProcessLog("TaskManager 2", taskManagerProcess1.getOutput().toString());
+			printProcessLog("TaskManager 3", taskManagerProcess1.getOutput().toString());
 			fail(e.getMessage());
 		}
 		catch (Error e) {
 			e.printStackTrace();
-			printProcessLog("TaskManager 1", processOutput1.toString());
-			printProcessLog("TaskManager 2", processOutput2.toString());
-			printProcessLog("TaskManager 3", processOutput3.toString());
+			printProcessLog("TaskManager 1", taskManagerProcess1.getOutput().toString());
+			printProcessLog("TaskManager 2", taskManagerProcess1.getOutput().toString());
+			printProcessLog("TaskManager 3", taskManagerProcess1.getOutput().toString());
 			throw e;
 		}
 		finally {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -51,13 +51,15 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.impl.VoidMetricQueryServiceRetriever;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
+import org.apache.flink.test.recovery.AbstractTaskManagerProcessFailureRecoveryTest.TaskExecutorProcessEntryPoint;
+import org.apache.flink.test.util.TestProcessBuilder;
+import org.apache.flink.test.util.TestProcessBuilder.TestProcess;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.CheckedSupplier;
 
@@ -65,8 +67,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.StringWriter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,7 +74,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.runtime.testutils.CommonTestUtils.getCurrentClasspath;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
@@ -100,11 +99,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
 	@Test
 	public void testCancelingOnProcessFailure() throws Exception {
-		final StringWriter processOutput = new StringWriter();
 		final Time timeout = Time.minutes(2L);
 
 		RestClusterClient<String> clusterClient = null;
-		Process taskManagerProcess = null;
+		TestProcess taskManagerProcess = null;
 		final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
 
 		Configuration config = new Configuration();
@@ -134,16 +132,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
 			// check that we run this test only if the java command
 			// is available on this machine
-			String javaCommand = getJavaCommandPath();
-			if (javaCommand == null) {
+			if (getJavaCommandPath() == null) {
 				System.out.println("---- Skipping Process Failure test : Could not find java executable ----");
 				return;
 			}
-
-			// create a logging file for the process
-			File tempLogFile = File.createTempFile(getClass().getSimpleName() + "-", "-log4j.properties");
-			tempLogFile.deleteOnExit();
-			CommonTestUtils.printLog4jDebugConfig(tempLogFile);
 
 			dispatcherResourceManagerComponent = resourceManagerComponentFactory.create(
 				config,
@@ -159,24 +151,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 			final Map<String, String> keyValues = config.toMap();
 			final ArrayList<String> commands = new ArrayList<>((keyValues.size() << 1) + 8);
 
-			// the TaskManager java command
-			commands.add(javaCommand);
-			commands.add("-Dlog.level=DEBUG");
-			commands.add("-Dlog4j.configuration=file:" + tempLogFile.getAbsolutePath());
-			commands.add("-Xms80m");
-			commands.add("-Xmx80m");
-			commands.add("-classpath");
-			commands.add(getCurrentClasspath());
-			commands.add(AbstractTaskManagerProcessFailureRecoveryTest.TaskExecutorProcessEntryPoint.class.getName());
+			TestProcessBuilder taskManagerProcessBuilder = new TestProcessBuilder(TaskExecutorProcessEntryPoint.class.getName());
+			taskManagerProcessBuilder.addConfigAsMainClassArgs(config);
 
-			for (Map.Entry<String, String> keyValue: keyValues.entrySet()) {
-				commands.add("--" + keyValue.getKey());
-				commands.add(keyValue.getValue());
-			}
-
-			// start the first two TaskManager processes
-			taskManagerProcess = new ProcessBuilder(commands).start();
-			new CommonTestUtils.PipeForwarder(taskManagerProcess.getErrorStream(), processOutput);
+			taskManagerProcess = taskManagerProcessBuilder.start();
 
 			final Throwable[] errorRef = new Throwable[1];
 
@@ -250,11 +228,11 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 			// all seems well :-)
 		}
 		catch (Exception e) {
-			printProcessLog("TaskManager", processOutput.toString());
+			printProcessLog("TaskManager", taskManagerProcess.getOutput().toString());
 			throw e;
 		}
 		catch (Error e) {
-			printProcessLog("TaskManager 1", processOutput.toString());
+			printProcessLog("TaskManager 1", taskManagerProcess.getOutput().toString());
 			throw e;
 		}
 		finally {


### PR DESCRIPTION
Main point of testFlinkKafkaProducerFailTransactionCoordinatorBeforeNotify is to fail transaction coordinator (by using kafkaProducer.getTransactionCoordinatorId(); ) and we expect that this will cause failure of Flink job. However that's not always the case. Maybe because transaction coordinator can be re-elected before KafkaProducer even notices it or for whatever the reason, sometimes the failure is not happening.

Because of a bug in the test, if failure hasn't happened, the test will not fail.

Generally speaking this test is invalid and should be dropped.

## Brief change log

besides dropping the tests there are couple of hotfixes (please check individual commits for more information).

## Verifying this change

This pr is touching only a test code.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
