### PR TITLE
[FLINK-9702][State Backends, Checkpointing] Improvement in (de)serialization of keys and values for RocksDB state

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 
@@ -112,7 +111,7 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
 	}
 
 	@Override
-	public void close() throws IOException {
+	public void close() {
 	}
 
 	public byte[] getBuf() {

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.core.memory;
 
+import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -348,6 +350,11 @@ public class DataOutputSerializer implements DataOutputView {
 
 		source.readFully(this.buffer, this.position, numBytes);
 		this.position += numBytes;
+	}
+
+	public void setPosition(int position) {
+		Preconditions.checkArgument(position >= 0 && position <= this.position, "Position out of bounds.");
+		this.position = position;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -56,10 +56,10 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	protected final TypeSerializer<K> keySerializer;
 
 	/** The currently active key. */
-	private K currentKey;
+	protected K currentKey;
 
 	/** The key group of the currently active key. */
-	private int currentKeyGroup;
+	protected int currentKeyGroup;
 
 	/** So that we can give out state when the user uses the same key. */
 	private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -59,7 +59,7 @@ public abstract class AbstractRocksDBState<K, N, V, S extends State> implements 
 	final TypeSerializer<V> valueSerializer;
 
 	/** The current namespace, which the next value methods will refer to. */
-	private N currentNamespace;
+	protected N currentNamespace;
 
 	/** Backend that holds the actual RocksDB instance where we store state. */
 	protected RocksDBKeyedStateBackend<K> backend;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -119,9 +119,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 			// merge the sources to the target
 			for (N source : sources) {
 				if (source != null) {
-					writeKeyWithGroupAndNamespace(keyGroup, key, source, dataOutputView);
-
-					final byte[] sourceKey = dataOutputView.getCopyOfBuffer();
+					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
@@ -142,9 +140,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
 				// create the target full-binary-key
-				writeKeyWithGroupAndNamespace(keyGroup, key, target, dataOutputView);
-
-				final byte[] targetKey = dataOutputView.getCopyOfBuffer();
+				final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
 				if (targetValueBytes != null) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -109,16 +109,13 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 			return;
 		}
 
-		// cache key and namespace
-		final K key = backend.getCurrentKey();
-		final int keyGroup = backend.getCurrentKeyGroupIndex();
-
 		try {
 			ACC current = null;
 
 			// merge the sources to the target
 			for (N source : sources) {
 				if (source != null) {
+					setCurrentNamespace(source);
 					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
@@ -139,6 +136,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
 
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
+				setCurrentNamespace(target);
 				// create the target full-binary-key
 				final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
@@ -23,6 +23,8 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 
 /**
@@ -80,8 +82,12 @@ public class RocksDBKeySerializationUtils {
 		}
 	}
 
+	public static boolean isSerializerTypeVariableSized(@Nonnull TypeSerializer<?> serializer) {
+		return serializer.getLength() < 0;
+	}
+
 	public static boolean isAmbiguousKeyPossible(TypeSerializer keySerializer, TypeSerializer namespaceSerializer) {
-		return (keySerializer.getLength() < 0) && (namespaceSerializer.getLength() < 0);
+		return (isSerializerTypeVariableSized(keySerializer) && isSerializerTypeVariableSized(namespaceSerializer));
 	}
 
 	public static void writeKeyGroup(
@@ -108,7 +114,7 @@ public class RocksDBKeySerializationUtils {
 		}
 	}
 
-	private static void readVariableIntBytes(DataInputView inputView, int value) throws IOException {
+	public static void readVariableIntBytes(DataInputView inputView, int value) throws IOException {
 		do {
 			inputView.readByte();
 			value >>>= 8;
@@ -122,7 +128,7 @@ public class RocksDBKeySerializationUtils {
 		writeVariableIntBytes(length, keySerializationDateDataOutputView);
 	}
 
-	private static void writeVariableIntBytes(
+	public static void writeVariableIntBytes(
 		int value,
 		DataOutputView keySerializationDateDataOutputView)
 		throws IOException {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -102,16 +102,13 @@ class RocksDBReducingState<K, N, V>
 			return;
 		}
 
-		// cache key and namespace
-		final K key = backend.getCurrentKey();
-		final int keyGroup = backend.getCurrentKeyGroupIndex();
-
 		try {
 			V current = null;
 
 			// merge the sources to the target
 			for (N source : sources) {
 				if (source != null) {
+					setCurrentNamespace(source);
 					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
@@ -133,6 +130,7 @@ class RocksDBReducingState<K, N, V>
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
 				// create the target full-binary-key
+				setCurrentNamespace(target);
 				final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -112,10 +112,7 @@ class RocksDBReducingState<K, N, V>
 			// merge the sources to the target
 			for (N source : sources) {
 				if (source != null) {
-
-					writeKeyWithGroupAndNamespace(keyGroup, key, source, dataOutputView);
-
-					final byte[] sourceKey = dataOutputView.getCopyOfBuffer();
+					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
@@ -136,9 +133,7 @@ class RocksDBReducingState<K, N, V>
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
 				// create the target full-binary-key
-				writeKeyWithGroupAndNamespace(keyGroup, key, target, dataOutputView);
-
-				final byte[] targetKey = dataOutputView.getCopyOfBuffer();
+				final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
 				if (targetValueBytes != null) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+
+/**
+ * Responsible for serialization of currentKey, currentGroup and namespace.
+ * Will reuse the previous serialized currentKeyed if possible.
+ * @param <K> type of the key.
+ */
+@NotThreadSafe
+class RocksDBSerializedCompositeKeyBuilder<K> {
+	@Nonnull
+	private final TypeSerializer<K> keySerializer;
+	@Nonnull
+	private final DataOutputSerializer keyOutView;
+	@Nonnegative
+	private final int keyGroupPrefixBytes;
+	private final boolean keySerializerTypeVariableSized;
+	@Nonnegative
+	private int keyMark;
+
+	RocksDBSerializedCompositeKeyBuilder(
+		@Nonnull TypeSerializer<K> keySerializer,
+		@Nonnegative int keyGroupPrefixBytes,
+		@Nonnegative int initialSize) {
+		this.keySerializer = keySerializer;
+		this.keyOutView = new DataOutputSerializer(initialSize);
+		this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+		this.keySerializerTypeVariableSized = RocksDBKeySerializationUtils.isSerializerTypeVariableSized(keySerializer);
+		this.keyMark = 0;
+	}
+
+	void setKeyAndKeyGroup(@Nonnull K key, @Nonnegative int keyGroupId) {
+		try {
+			serializeKeyGroupAndKey(key, keyGroupId);
+		} catch (IOException shouldNeverHappen) {
+			throw new FlinkRuntimeException(shouldNeverHappen);
+		}
+	}
+
+	<N> byte[] buildCompositeKeyNamespace(@Nonnull N namespace, @Nonnull TypeSerializer<N> namespaceSerializer) {
+		try {
+			serializeNamespace(namespace, namespaceSerializer);
+			final byte[] result = keyOutView.getCopyOfBuffer();
+			resetToKey();
+			return result;
+		} catch (IOException shouldNeverHappen) {
+			throw new FlinkRuntimeException(shouldNeverHappen);
+		}
+	}
+
+	<N, UK> byte[] buildCompositeKeyNamesSpaceUserKey(
+		@Nonnull N namespace,
+		@Nonnull TypeSerializer<N> namespaceSerializer,
+		@Nonnull UK userKey,
+		@Nonnull TypeSerializer<UK> userKeySerializer) throws IOException {
+		serializeNamespace(namespace, namespaceSerializer);
+		userKeySerializer.serialize(userKey, keyOutView);
+		byte[] result = keyOutView.getCopyOfBuffer();
+		resetToKey();
+		return result;
+	}
+
+	private void serializeKeyGroupAndKey(K key, int keyGroupId) throws IOException {
+		resetFully();
+		// write key-group
+		RocksDBKeySerializationUtils.writeKeyGroup(
+			keyGroupId,
+			keyGroupPrefixBytes,
+			keyOutView);
+		// write key
+		keySerializer.serialize(key, keyOutView);
+		keyMark = keyOutView.length();
+	}
+
+	private <N> void serializeNamespace(
+		@Nonnull N namespace,
+		@Nonnull TypeSerializer<N> namespaceSerializer) throws IOException {
+		assert isKeyWritten();
+		final boolean ambiguousKeyPossible =
+			keySerializerTypeVariableSized &
+				RocksDBKeySerializationUtils.isSerializerTypeVariableSized(namespaceSerializer);
+		if (ambiguousKeyPossible) {
+			RocksDBKeySerializationUtils.writeVariableIntBytes(
+				keyMark - keyGroupPrefixBytes,
+				keyOutView);
+		}
+		RocksDBKeySerializationUtils.writeNameSpace(
+			namespace,
+			namespaceSerializer,
+			keyOutView,
+			ambiguousKeyPossible);
+	}
+
+	private void resetFully() {
+		keyMark = 0;
+		keyOutView.clear();
+	}
+
+	private void resetToKey() {
+		this.keyOutView.setPosition(keyMark);
+	}
+
+	private boolean isKeyWritten() {
+		return keyMark > 0;
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -80,9 +80,9 @@ class RocksDBValueState<K, N, V>
 	@Override
 	public V value() {
 		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = dataOutputView.getCopyOfBuffer();
-			byte[] valueBytes = backend.db.get(columnFamily, key);
+			byte[] valueBytes = backend.db.get(columnFamily,
+				serializeCurrentKeyWithGroupAndNamespace());
+
 			if (valueBytes == null) {
 				return getDefaultValue();
 			}
@@ -101,11 +101,9 @@ class RocksDBValueState<K, N, V>
 		}
 
 		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = dataOutputView.getCopyOfBuffer();
-			dataOutputView.clear();
-			valueSerializer.serialize(value, dataOutputView);
-			backend.db.put(columnFamily, writeOptions, key, dataOutputView.getCopyOfBuffer());
+			backend.db.put(columnFamily, writeOptions,
+				serializeCurrentKeyWithGroupAndNamespace(),
+				serializeValue(value));
 		} catch (Exception e) {
 			throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksValueDeserializer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksValueDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.IOException;
+
+/**
+ * RocksValueDeserializer.
+ */
+public class RocksValueDeserializer {
+	private final DataInputViewStreamWrapper inView;
+	private final ByteArrayInputStreamWithPos inStream;
+	private final DataOutputViewStreamWrapper outView;
+	private final ByteArrayOutputStreamWithPos outStream;
+
+	public RocksValueDeserializer() {
+		this.inStream = new ByteArrayInputStreamWithPos();
+		this.inView = new DataInputViewStreamWrapper(inStream);
+		this.outStream = new ByteArrayOutputStreamWithPos();
+		this.outView = new DataOutputViewStreamWrapper(outStream);
+	}
+
+	<V> byte[] serializeValue(V value, TypeSerializer<V> valueSerializer) throws IOException {
+		valueSerializer.serialize(value, outView);
+		final byte[] result = outStream.toByteArray();
+		outStream.reset();
+		return result;
+	}
+
+	<V> V deserializeValue(byte[] data, TypeSerializer<V> valueSerializer) throws IOException {
+		return deserializeValue(data, 0, data.length, valueSerializer);
+	}
+
+	<V> V deserializeValue(byte[] data, int off, int len, TypeSerializer<V> valueSerializer) throws IOException {
+		inStream.setBuffer(data, off, len);
+		return valueSerializer.deserialize(inView);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

When Flink interacts with state in RocksDB, object (de)serialization often contributes significantly to performance overhead. In particular, currently every state has to serialize the backen's current key before each state access. This PR wants to  reduce this effort by sharing serialized key bytes across all state interactions. 

## Verifying this change

This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
