### PR TITLE
[hotfix][docs] Add and update description of local-recovery config op…

### DIFF
--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -30,7 +30,7 @@
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>
             <td style="word-wrap: break-word;">false</td>
-            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Some state backends may not support local recovery and ignore this option.</td>
+            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.dir</h5></td>
@@ -50,7 +50,7 @@
         <tr>
             <td><h5>taskmanager.state.local.root-dirs</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. Some state backends may not support local recovery and ignore this option</td>
+            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignore this option</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -30,7 +30,7 @@
         <tr>
             <td><h5>state.backend.local-recovery</h5></td>
             <td style="word-wrap: break-word;">false</td>
-            <td></td>
+            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Some state backends may not support local recovery and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.dir</h5></td>
@@ -50,7 +50,7 @@
         <tr>
             <td><h5>taskmanager.state.local.root-dirs</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td></td>
+            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. Some state backends may not support local recovery and ignore this option</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -73,29 +73,29 @@ public class CheckpointingOptions {
 	 * This option configures local recovery for this state backend. By default, local recovery is deactivated.
 	 *
 	 * <p>Local recovery currently only covers keyed state backends.
-	 * Some state backends may not support local recovery and ignore
+	 * Currently, MemoryStateBackend does not support local recovery and ignore
 	 * this option.
 	 */
 	public static final ConfigOption<Boolean> LOCAL_RECOVERY = ConfigOptions
 			.key("state.backend.local-recovery")
 			.defaultValue(false)
 			.withDescription("This option configures local recovery for this state backend. By default, local recovery is " +
-				"deactivated. Local recovery currently only covers keyed state backends. Some state backends may not " +
-				"support local recovery and ignore this option.");
+				"deactivated. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does " +
+				"not support local recovery and ignore this option.");
 
 	/**
 	 * The config parameter defining the root directories for storing file-based state for local recovery.
 	 *
 	 * <p>Local recovery currently only covers keyed state backends.
-	 * Some state backends may not support local recovery and ignore
+	 * Currently, MemoryStateBackend does not support local recovery and ignore
 	 * this option.
 	 */
 	public static final ConfigOption<String> LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS = ConfigOptions
 			.key("taskmanager.state.local.root-dirs")
 			.noDefaultValue()
 			.withDescription("The config parameter defining the root directories for storing file-based state for local " +
-				"recovery. Local recovery currently only covers keyed state backends. Some state backends may not " +
-				"support local recovery and ignore this option");
+				"recovery. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does " +
+				"not support local recovery and ignore this option");
 
 	// ------------------------------------------------------------------------
 	//  Options specific to the file-system-based state backends

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -71,17 +71,31 @@ public class CheckpointingOptions {
 
 	/**
 	 * This option configures local recovery for this state backend. By default, local recovery is deactivated.
+	 *
+	 * <p>Local recovery currently only covers keyed state backends.
+	 * Some state backends may not support local recovery and ignore
+	 * this option.
 	 */
 	public static final ConfigOption<Boolean> LOCAL_RECOVERY = ConfigOptions
-		.key("state.backend.local-recovery")
-		.defaultValue(false);
+			.key("state.backend.local-recovery")
+			.defaultValue(false)
+			.withDescription("This option configures local recovery for this state backend. By default, local recovery is " +
+				"deactivated. Local recovery currently only covers keyed state backends. Some state backends may not " +
+				"support local recovery and ignore this option.");
 
 	/**
 	 * The config parameter defining the root directories for storing file-based state for local recovery.
+	 *
+	 * <p>Local recovery currently only covers keyed state backends.
+	 * Some state backends may not support local recovery and ignore
+	 * this option.
 	 */
 	public static final ConfigOption<String> LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS = ConfigOptions
-		.key("taskmanager.state.local.root-dirs")
-		.noDefaultValue();
+			.key("taskmanager.state.local.root-dirs")
+			.noDefaultValue()
+			.withDescription("The config parameter defining the root directories for storing file-based state for local " +
+				"recovery. Local recovery currently only covers keyed state backends. Some state backends may not " +
+				"support local recovery and ignore this option");
 
 	// ------------------------------------------------------------------------
 	//  Options specific to the file-system-based state backends


### PR DESCRIPTION
…tions

## What is the purpose of the change

This pr update the javadoc of "state.backend.local-recovery" and "taskmanager.state.local.root-dirs" and add description which cause empty item in checkpointing_configuration.html.

## Brief change log

- Update the javadoc of "state.backend.local-recovery" and "taskmanager.state.local.root-dirs". Append the limitation in current version.
- Add the description to these options, merge the checkpointing_configuration.html by [this guid](https://github.com/apache/flink/blob/master/flink-docs/README.md)
- I also change the number of indents of these two options, make it same with other options. I think it may make the code-style cleaner.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

cc @zentol 
