### PR TITLE
[FLINK-11049] Unable to execute partial DAG

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -55,8 +56,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan p = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		Plan p = createProgramPlan(jobName, sinks);
 		JobWithJars toRun = new JobWithJars(p, this.jarFilesToAttach, this.classpathsToAttach,
 				this.userCodeClassLoader);
 		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointSettings).getJobExecutionResult();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.optimizer.plan.FlinkPlan;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
@@ -53,8 +54,8 @@ public class DetachedEnvironment extends ContextEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan p = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		Plan p = createProgramPlan(jobName, sinks);
 		setDetachedPlan(ClusterClient.getOptimizedPlan(client.compiler, p, getParallelism()));
 		LOG.warn("Job was executed in detached mode, the results will be available on completion.");
 		this.lastJobExecutionResult = DetachedJobExecutionResult.INSTANCE;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.FlinkPlan;
 
@@ -46,8 +47,8 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan plan = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		Plan plan = createProgramPlan(jobName, sinks);
 		this.optimizerPlan = compiler.compile(plan);
 
 		// do not go on with anything now!
@@ -56,7 +57,7 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan plan = createProgramPlan(null, false);
+		Plan plan = createProgramPlan(null, false, new DataSink[0]);
 		this.optimizerPlan = compiler.compile(plan);
 
 		// do not go on with anything now!

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.dag.DataSinkNode;
 
@@ -39,8 +40,8 @@ public final class PreviewPlanEnvironment extends ExecutionEnvironment {
 	Plan plan;
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		this.plan = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		this.plan = createProgramPlan(jobName, sinks);
 		this.previewPlan = Optimizer.createPreOptimizedPlan(plan);
 
 		// do not go on with anything now!

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -73,6 +73,14 @@ under the License.
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<parameter>
+						<excludes combine.children="append">
+							<exclude>org.apache.flink.api.java.ExecutionEnvironment#execute(java.lang.String,org.apache.flink.api.java.operators.DataSink[])</exclude>
+						</excludes>
+					</parameter>
+				</configuration>
+
 			</plugin>
 
 			<!-- Because flink-scala, flink-avro and flink-hadoop-compatibility uses it in tests -->

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.CollectionExecutor;
+import org.apache.flink.api.java.operators.DataSink;
 
 /**
  * Version of {@link ExecutionEnvironment} that allows serial, local, collection-based executions of Flink programs.
@@ -30,8 +31,8 @@ import org.apache.flink.api.common.operators.CollectionExecutor;
 public class CollectionEnvironment extends ExecutionEnvironment {
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		Plan p = createProgramPlan(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		Plan p = createProgramPlan(jobName, sinks);
 
 		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
 		CollectionExecutor exec = new CollectionExecutor(getConfig());

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -409,8 +409,8 @@ public abstract class DataSet<T> {
 		final String id = new AbstractID().toString();
 		final TypeSerializer<T> serializer = getType().createSerializer(getExecutionEnvironment().getConfig());
 
-		this.output(new Utils.CollectHelper<>(id, serializer)).name("collect()");
-		JobExecutionResult res = getExecutionEnvironment().execute();
+		DataSink sink = this.output(new Utils.CollectHelper<>(id, serializer)).name("collect()");
+		JobExecutionResult res = getExecutionEnvironment().execute(sink);
 
 		ArrayList<byte[]> accResult = res.getAccumulatorResult(id);
 		if (accResult != null) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.configuration.Configuration;
 
 /**
@@ -77,12 +78,12 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
 		if (executor == null) {
 			startNewSession();
 		}
 
-		Plan p = createProgramPlan(jobName);
+		Plan p = createProgramPlan(jobName, sinks);
 
 		// Session management is disabled, revert this commit to enable
 		//p.setJobId(jobID);
@@ -96,7 +97,7 @@ public class LocalEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan(null, false);
+		Plan p = createProgramPlan(null, false, new DataSink[0]);
 
 		// make sure that we do not start an executor in any case here.
 		// if one runs, fine, of not, we only create the class but disregard immediately afterwards

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.ShutdownHookUtil;
 
@@ -161,10 +162,10 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
 		PlanExecutor executor = getExecutor();
 
-		Plan p = createProgramPlan(jobName);
+		Plan p = createProgramPlan(jobName, sinks);
 
 		// Session management is disabled, revert this commit to enable
 		//p.setJobId(jobID);
@@ -178,7 +179,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan("plan", false);
+		Plan p = createProgramPlan("plan", false, new DataSink[0]);
 
 		// make sure that we do not start an new executor here
 		// if one runs, fine, of not, we create a local executor (lightweight) and let it

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.api.java.operators.DataSink;
 
 /**
  * A {@link CollectionEnvironment} to be used in tests. The predominant feature of this class is that it allows setting
@@ -43,13 +44,13 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute() throws Exception {
-		return execute("test job");
+	public JobExecutionResult execute(DataSink<?>... sinks) throws Exception {
+		return execute("test job", sinks);
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		JobExecutionResult result = super.execute(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		JobExecutionResult result = super.execute(jobName, sinks);
 		this.lastJobExecutionResult = result;
 		return result;
 	}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.optimizer.DataStatistics;
@@ -105,8 +106,8 @@ public class TestEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public JobExecutionResult execute(String jobName) throws Exception {
-		OptimizedPlan op = compileProgram(jobName);
+	public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+		OptimizedPlan op = compileProgram(jobName, sinks);
 
 		JobGraphGenerator jgg = new JobGraphGenerator();
 		JobGraph jobGraph = jgg.compileJobGraph(op);
@@ -129,8 +130,8 @@ public class TestEnvironment extends ExecutionEnvironment {
 		return jsonGen.getOptimizerPlanAsJSON(op);
 	}
 
-	private OptimizedPlan compileProgram(String jobName) {
-		Plan p = createProgramPlan(jobName);
+	private OptimizedPlan compileProgram(String jobName, DataSink<?>... sinks) {
+		Plan p = createProgramPlan(jobName, sinks);
 
 		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
 		return pc.compile(p);

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ExecutionEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ExecutionEnvironmentITCase.java
@@ -21,18 +21,24 @@ package org.apache.flink.test.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.api.common.io.GenericInputFormat;
+import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -43,6 +49,82 @@ import static org.junit.Assert.assertEquals;
 public class ExecutionEnvironmentITCase extends TestLogger {
 
 	private static final int PARALLELISM = 5;
+
+	private static class TestOutputFormat implements OutputFormat {
+
+		private static Map<String, Integer> countMap = new HashMap<>();
+
+		private String name;
+
+		public TestOutputFormat(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public void configure(Configuration parameters) {
+
+		}
+
+		@Override
+		public void open(int taskNumber, int numTasks) throws IOException {
+			if (countMap.containsKey(name)) {
+				countMap.put(name, countMap.get(name) + 1);
+			} else {
+				countMap.put(name, 1);
+			}
+		}
+
+		@Override
+		public void close() throws IOException {
+
+		}
+
+		@Override
+		public void writeRecord(Object record) throws IOException {
+
+		}
+
+		public int getOpenCount() {
+			if (!countMap.containsKey(name)) {
+				return 0;
+			} else {
+				return countMap.get(name);
+			}
+		}
+	}
+
+	@Test
+	public void testPartialDAG() throws Exception {
+		ExecutionEnvironment benv = ExecutionEnvironment.getExecutionEnvironment();
+		benv.setParallelism(1);
+
+		List<String> sourceData = new ArrayList<>();
+		sourceData.add("hello world");
+		sourceData.add("hello flink");
+		sourceData.add("hello hadoop");
+
+		DataSet<String> data = benv.fromCollection(sourceData);
+		TestOutputFormat outputFormat1 = new TestOutputFormat("sink1");
+		TestOutputFormat outputFormat2 = new TestOutputFormat("sink2");
+		DataSink sink1 = data.output(outputFormat1);
+		DataSink sink2 = data.output(outputFormat2);
+
+		benv.execute(sink1);
+		Assert.assertEquals(1, outputFormat1.getOpenCount());
+		Assert.assertEquals(0, outputFormat2.getOpenCount());
+
+		benv.execute();
+		Assert.assertEquals(1, outputFormat1.getOpenCount());
+		Assert.assertEquals(1, outputFormat2.getOpenCount());
+
+		try {
+			benv.execute();
+			Assert.fail("Should fail to run execute again");
+		} catch (Exception e) {
+			Assert.assertTrue(e.getMessage()
+				.contains("No new data sinks have been defined since the last execution"));
+		}
+	}
 
 	/**
 	 * Ensure that the user can pass a custom configuration object to the LocalEnvironment.

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.examples.java.clustering.KMeans;
 import org.apache.flink.examples.java.graph.ConnectedComponents;
@@ -338,8 +339,8 @@ public class JsonJobGraphGenerationTest {
 		}
 
 		@Override
-		public JobExecutionResult execute(String jobName) throws Exception {
-			Plan plan = createProgramPlan(jobName);
+		public JobExecutionResult execute(String jobName, DataSink<?>... sinks) throws Exception {
+			Plan plan = createProgramPlan(jobName, sinks);
 
 			Optimizer pc = new Optimizer(new Configuration());
 			OptimizedPlan op = pc.compile(plan);


### PR DESCRIPTION
## What is the purpose of the change

This PR allow user to run partial dag which is associated to certain sinks instead of all sinks.

## Brief change log

It add new api in `ExecutionEnvironment` to allow user to specify the target sinks he want to run. 


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - * Add test in `ExecutionEnvironmentITCase.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no) 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) No
