### PR TITLE
[FLINK-11011][E2E][JM] Log error messages about null CheckpointCoordinator only if job is running

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -682,7 +682,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 					log.warn("Error while processing checkpoint acknowledgement message", t);
 				}
 			});
-		} else {
+		} else if (executionGraph.getState() == JobStatus.RUNNING) {
 			log.error("Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator",
 					jobGraph.getJobID());
 		}
@@ -701,7 +701,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 					log.error("Error in CheckpointCoordinator while processing {}", decline, e);
 				}
 			});
-		} else {
+		} else if (executionGraph.getState() == JobStatus.RUNNING) {
 			log.error("Received DeclineCheckpoint message for job {} with no CheckpointCoordinator",
 					jobGraph.getJobID());
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -682,9 +682,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 					log.warn("Error while processing checkpoint acknowledgement message", t);
 				}
 			});
-		} else if (executionGraph.getState() == JobStatus.RUNNING) {
-			log.error("Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator",
-					jobGraph.getJobID());
+		} else {
+			String errorMessage = "Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator";
+			if (executionGraph.getState() == JobStatus.RUNNING) {
+				log.error(errorMessage, jobGraph.getJobID());
+			} else {
+				log.debug(errorMessage, jobGraph.getJobID());
+			}
 		}
 	}
 
@@ -701,9 +705,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 					log.error("Error in CheckpointCoordinator while processing {}", decline, e);
 				}
 			});
-		} else if (executionGraph.getState() == JobStatus.RUNNING) {
-			log.error("Received DeclineCheckpoint message for job {} with no CheckpointCoordinator",
-					jobGraph.getJobID());
+		} else {
+			String errorMessage = "Received DeclineCheckpoint message for job {} with no CheckpointCoordinator";
+			if (executionGraph.getState() == JobStatus.RUNNING) {
+				log.error(errorMessage, jobGraph.getJobID());
+			} else {
+				log.debug(errorMessage, jobGraph.getJobID());
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

When Job master gets checkpoint acknowledge or decline message and CheckpointCoordinator is null, it is an error unless job is not running any more. If job is being stopped, it can happen that CheckpointCoordinator has been already closed and null'ed but Job master keeps getting pending checkpoint messages from task executors which do not matter any more.

## Brief change log

Check `JobStatus.RUNNING` in `JobMaster.acknowledgeCheckpoint` and `JobMaster. declineCheckpoint` before outputting `CheckpointCoordinator == null` error

## Verifying this change

Looped originally failed e2e test CI build:
https://travis-ci.org/azagrebin/flink/builds/461783136

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
