### PR TITLE
[FLINK-11047] Fix CoGroupGroupSortTranslationTest by specyfing types

### DIFF
--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupGroupSortTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupGroupSortTranslationTest.scala
@@ -128,7 +128,11 @@ class CoGroupGroupSortTranslationTest extends TestLogger {
         .where(1).equalTo(2)
         .sortFirstGroup(0, Order.DESCENDING)
         .sortSecondGroup(1, Order.ASCENDING).sortSecondGroup(0, Order.DESCENDING)
-        .apply((a, b, c: Collector[(Long, Long)]) => a.foreach(e => c.collect(e)))
+        .apply(
+          (a: Iterator[(Long, Long)],
+            b: Iterator[(Long, Long, Long)],
+            c: Collector[(Long, Long)]) =>
+            a.foreach(e => c.collect(e)))
         .output(new DiscardingOutputFormat[(Long, Long)])
         
       val p = env.createProgramPlan()


### PR DESCRIPTION
## What is the purpose of the change

Adding the parameter types is necessary to compile the CoGroupGroupSortTranslationTest
with Scala 2.12.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
