### PR TITLE
[BP-1.7][FLINK-11047] Fix CoGroupGroupSortTranslationTest by specyfing types

### DIFF
--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupGroupSortTranslationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/translation/CoGroupGroupSortTranslationTest.scala
@@ -128,7 +128,11 @@ class CoGroupGroupSortTranslationTest extends TestLogger {
         .where(1).equalTo(2)
         .sortFirstGroup(0, Order.DESCENDING)
         .sortSecondGroup(1, Order.ASCENDING).sortSecondGroup(0, Order.DESCENDING)
-        .apply((a, b, c: Collector[(Long, Long)]) => a.foreach(e => c.collect(e)))
+        .apply(
+          (a: Iterator[(Long, Long)],
+            b: Iterator[(Long, Long, Long)],
+            c: Collector[(Long, Long)]) =>
+            a.foreach(e => c.collect(e)))
         .output(new DiscardingOutputFormat[(Long, Long)])
         
       val p = env.createProgramPlan()


### PR DESCRIPTION
Backport of #7217 for `release-1.7`.