### PR TITLE
[hotfix][docs] Correct the parameter type in Operators Overview doc

### DIFF
--- a/docs/dev/stream/operators/index.md
+++ b/docs/dev/stream/operators/index.md
@@ -434,14 +434,14 @@ IterativeStream<Long> iteration = initialStream.iterate();
 DataStream<Long> iterationBody = iteration.map (/*do something*/);
 DataStream<Long> feedback = iterationBody.filter(new FilterFunction<Long>(){
     @Override
-    public boolean filter(Integer value) throws Exception {
+    public boolean filter(Long value) throws Exception {
         return value > 0;
     }
 });
 iteration.closeWith(feedback);
 DataStream<Long> output = iterationBody.filter(new FilterFunction<Long>(){
     @Override
-    public boolean filter(Integer value) throws Exception {
+    public boolean filter(Long value) throws Exception {
         return value <= 0;
     }
 });


### PR DESCRIPTION
## What is the purpose of the change

The parameter type of _filter_ method in the example of **Iterate** transformation in [Operator Overview](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/operators/). This pr just fix it.

## Brief change log

- Correct the parameter type to Long.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
