### PR TITLE
FLINK-11050 add lowerBound and upperBound for optimizing RocksDBMapState's entries

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -159,6 +159,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** Determines if a task fails or not if there is an error in writing its checkpoint data. Default: true */
 	private boolean failTaskOnCheckpointError = true;
 
+	/** When state-backend is rocksDB and isIntervalJoinSeekOptimization is true, better seek for intervalJoin */
+	private boolean isIntervalJoinSeekOptimization = false;
+
 	// ------------------------------- User code values --------------------------------------------
 
 	private GlobalJobParameters globalJobParameters;
@@ -891,6 +894,16 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	@Internal
 	public void setFailTaskOnCheckpointError(boolean failTaskOnCheckpointError) {
 		this.failTaskOnCheckpointError = failTaskOnCheckpointError;
+	}
+
+	@PublicEvolving
+	public boolean isIntervalJoinSeekOptimization() {
+		return isIntervalJoinSeekOptimization;
+	}
+
+	@PublicEvolving
+	public void setIntervalJoinSeekOptimization(boolean isIntervalJoinSeekOptimization) {
+		this.isIntervalJoinSeekOptimization = isIntervalJoinSeekOptimization;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MapState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MapState.java
@@ -124,4 +124,16 @@ public interface MapState<UK, UV> extends State {
 	 * @throws Exception Thrown if the system cannot access the state.
 	 */
 	Iterator<Map.Entry<UK, UV>> iterator() throws Exception;
+
+	/**
+	 * Returns all the entries between lowerBound and upperBound in the state.
+	 * <p>
+	 *     Note: Only implement in subclass RocksDBMapState when key is comparable in byte-lexicographical currently.
+	 * </p>
+	 * @param lowerBound The lowerBound of the range. The lowerBound is included.
+	 * @param upperBound The upperBound of the range. The upperBound is excluded.
+	 * @return An iterable view of all the key-value pairs between lowerBound and upperBound in the state.
+	 * @throws Exception
+	 */
+	Iterable<Map.Entry<UK, UV>> filter(UK lowerBound, UK upperBound) throws Exception;
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
@@ -193,6 +193,11 @@ public class TestSharedBuffer<V> extends SharedBuffer<V> {
 				}
 
 				@Override
+				public Iterable<Map.Entry<UK, UV>> filter(UK lowerBound, UK upperBound) throws Exception {
+					throw new UnsupportedOperationException("filter is not supported");
+				}
+
+				@Override
 				public Iterable<UK> keys() throws Exception {
 					if (values == null) {
 						return Collections.emptyList();

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableMapState.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableMapState.java
@@ -82,6 +82,11 @@ public final class ImmutableMapState<K, V> extends ImmutableState implements Map
 		return Collections.unmodifiableSet(state.entrySet());
 	}
 
+	@Override
+	public Iterable<Map.Entry<K, V>> filter(K lowerBound, K upperBound) throws Exception {
+		throw new UnsupportedOperationException("filter is not supported");
+	}
+
 	/**
 	 * Returns all the keys in the state in a {@link Collections#unmodifiableSet(Set)}.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingMapState.java
@@ -79,6 +79,12 @@ class UserFacingMapState<K, V> implements MapState<K, V> {
 	}
 
 	@Override
+	public Iterable<Map.Entry<K, V>> filter(K lowerBound, K upperBound) throws Exception {
+		Iterable<Map.Entry<K, V>> original = originalState.filter(lowerBound, upperBound);
+		return original != null ? original : emptyState.entrySet();
+	}
+
+	@Override
 	public Iterable<K> keys() throws Exception {
 		Iterable<K> original = originalState.keys();
 		return original != null ? original : emptyState.keySet();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -144,6 +144,11 @@ class HeapMapState<K, N, UK, UV>
 	}
 
 	@Override
+	public Iterable<Map.Entry<UK, UV>> filter(UK lowerBound, UK upperBound) throws Exception {
+		throw new UnsupportedOperationException("filter is not supported");
+	}
+
+	@Override
 	public Iterable<UK> keys() {
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
 		return userMap == null ? null : userMap.keySet();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -98,6 +98,11 @@ class TtlMapState<K, N, UK, UV>
 		return entries(e -> e);
 	}
 
+	@Override
+	public Iterable<Map.Entry<UK, UV>> filter(UK lowerBound, UK upperBound) throws Exception {
+		throw new UnsupportedOperationException("filter is not supported");
+	}
+
 	private <R> Iterable<R> entries(
 		Function<Map.Entry<UK, UV>, R> resultMapper) throws Exception {
 		Iterable<Map.Entry<UK, TtlValue<UV>>> withTs = original.entries();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockInternalMapState.java
@@ -72,6 +72,11 @@ public class MockInternalMapState<K, N, UK, UV>
 	}
 
 	@Override
+	public Iterable<Map.Entry<UK, UV>> filter(UK lowerBound, UK upperBound) throws Exception {
+		throw new UnsupportedOperationException("filter is not supported");
+	}
+
+	@Override
 	public Iterable<UK> keys() {
 		return getInternal().keySet();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -536,6 +536,16 @@ public abstract class StreamExecutionEnvironment {
 		return config.getNumberOfExecutionRetries();
 	}
 
+	@PublicEvolving
+	public boolean isIntervalJoinSeekOptimization() {
+		return config.isIntervalJoinSeekOptimization();
+	}
+
+	@PublicEvolving
+	public void setIntervalJoinSeekOptimization(boolean isIntervalJoinSeekOptimization) {
+		config.setIntervalJoinSeekOptimization(isIntervalJoinSeekOptimization);
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Registry for types and serializers
 	// --------------------------------------------------------------------------------------------

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -311,6 +311,15 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   @PublicEvolving
   def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
 
+  @PublicEvolving
+  def isIntervalJoinSeekOptimization: Boolean = {
+    javaEnv.isIntervalJoinSeekOptimization();
+  }
+
+  @PublicEvolving
+  def setIntervalJoinSeekOptimization(isIntervalJoinSeekOptimization: Boolean): Unit = {
+    javaEnv.setIntervalJoinSeekOptimization(isIntervalJoinSeekOptimization)
+  }
   // --------------------------------------------------------------------------------------------
   // Registry for types and serializers
   // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request optimizes the seek of RocksDBMapState's entries by assigning lowerBound and upperBound.


## Brief change log

  - *Add entries(lowerBound, upperBound) in MapState and implement it in RocksDBMapState.
  -*Use entries(lowerBound, upperBound) instead of entries() in IntervalJoin.java when get buffer's values.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)