### PR TITLE
[FLINK-9740][Table API &SQL] Support group windows over intervals of months

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionUtils.scala
@@ -44,6 +44,11 @@ object ExpressionUtils {
     case _ => false
   }
 
+  private[flink] def isMonthsIntervalLiteral(expr: Expression): Boolean = expr match {
+    case Literal(_, TimeIntervalTypeInfo.INTERVAL_MONTHS) => true
+    case _ => false
+  }
+
   private[flink] def isRowCountLiteral(expr: Expression): Boolean = expr match {
     case Literal(_, RowIntervalTypeInfo.INTERVAL_ROWS) => true
     case _ => false
@@ -68,6 +73,12 @@ object ExpressionUtils {
   private[flink] def toTime(expr: Expression): FlinkTime = expr match {
     case Literal(value: Long, TimeIntervalTypeInfo.INTERVAL_MILLIS) =>
       FlinkTime.milliseconds(value)
+    case _ => throw new IllegalArgumentException()
+  }
+
+  private[flink] def toMonths(expr: Expression): FlinkTime = expr match {
+    case Literal(value: Long, TimeIntervalTypeInfo.INTERVAL_MONTHS) =>
+      FlinkTime.months(value)
     case _ => throw new IllegalArgumentException()
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
@@ -264,6 +264,10 @@ object DataStreamGroupWindowAggregate {
         if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(size) =>
       stream.window(TumblingEventTimeWindows.of(toTime(size)))
 
+    case TumblingGroupWindow(_, timeField, size)
+      if isRowtimeAttribute(timeField) && isMonthsIntervalLiteral(size) =>
+      stream.window(TumblingEventTimeWindows.of(toMonths(size)))
+
     case TumblingGroupWindow(_, _, size) =>
       // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
       // before applying the  windowing logic. Otherwise, this would be the same as a
@@ -284,6 +288,10 @@ object DataStreamGroupWindowAggregate {
         if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(size)=>
       stream.window(SlidingEventTimeWindows.of(toTime(size), toTime(slide)))
 
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isRowtimeAttribute(timeField) && isMonthsIntervalLiteral(size) =>
+      stream.window(SlidingEventTimeWindows.of(toMonths(size), toMonths(slide)))
+
     case SlidingGroupWindow(_, _, size, slide) =>
       // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
       // before applying the  windowing logic. Otherwise, this would be the same as a
@@ -292,8 +300,12 @@ object DataStreamGroupWindowAggregate {
         "Event-time grouping windows on row intervals are currently not supported.")
 
     case SessionGroupWindow(_, timeField, gap)
-        if isProctimeAttribute(timeField) =>
+      if isProctimeAttribute(timeField) =>
       stream.window(ProcessingTimeSessionWindows.withGap(toTime(gap)))
+
+    case SessionGroupWindow(_, timeField, gap)
+      if isRowtimeAttribute(timeField) && isMonthsIntervalLiteral(gap) =>
+      stream.window(EventTimeSessionWindows.withGap(toMonths(gap)))
 
     case SessionGroupWindow(_, timeField, gap)
         if isRowtimeAttribute(timeField) =>
@@ -318,6 +330,9 @@ object DataStreamGroupWindowAggregate {
     case TumblingGroupWindow(_, _, size) if isTimeInterval(size.resultType) =>
       stream.windowAll(TumblingEventTimeWindows.of(toTime(size)))
 
+    case TumblingGroupWindow(_, _, size) if isMonthsIntervalLiteral(size) =>
+      stream.windowAll(TumblingEventTimeWindows.of(toMonths(size)))
+
     case TumblingGroupWindow(_, _, size) =>
       // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
       // before applying the  windowing logic. Otherwise, this would be the same as a
@@ -338,6 +353,10 @@ object DataStreamGroupWindowAggregate {
         if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(size)=>
       stream.windowAll(SlidingEventTimeWindows.of(toTime(size), toTime(slide)))
 
+    case SlidingGroupWindow(_, timeField, size, slide)
+      if isRowtimeAttribute(timeField) && isMonthsIntervalLiteral(size)=>
+      stream.windowAll(SlidingEventTimeWindows.of(toMonths(size), toMonths(slide)))
+
     case SlidingGroupWindow(_, _, size, slide) =>
       // TODO: EventTimeTumblingGroupWindow should sort the stream on event time
       // before applying the  windowing logic. Otherwise, this would be the same as a
@@ -348,6 +367,10 @@ object DataStreamGroupWindowAggregate {
     case SessionGroupWindow(_, timeField, gap)
         if isProctimeAttribute(timeField) && isTimeIntervalLiteral(gap) =>
       stream.windowAll(ProcessingTimeSessionWindows.withGap(toTime(gap)))
+
+    case SessionGroupWindow(_, timeField, gap)
+      if isProctimeAttribute(timeField) && isMonthsIntervalLiteral(gap) =>
+      stream.windowAll(ProcessingTimeSessionWindows.withGap(toMonths(gap)))
 
     case SessionGroupWindow(_, timeField, gap)
         if isRowtimeAttribute(timeField) && isTimeIntervalLiteral(gap) =>

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/WindowAggregateValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/WindowAggregateValidationTest.scala
@@ -73,7 +73,7 @@ class WindowAggregateValidationTest extends TableTestBase {
   def testVariableWindowSize(): Unit = {
     expectedException.expect(classOf[TableException])
     expectedException.expectMessage(
-      "Only constant window intervals with millisecond resolution are supported")
+      "Only constant window intervals with millisecond and months resolution are supported.")
 
     val sql = "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime, c * INTERVAL '1' MINUTE)"
     streamUtil.verifySql(sql, "n/a")
@@ -90,19 +90,6 @@ class WindowAggregateValidationTest extends TableTestBase {
       "SELECT SUM(a) AS sumA, weightedAvg(a, b) AS wAvg " +
         "FROM MyTable " +
         "GROUP BY TUMBLE(proctime, INTERVAL '2' HOUR, TIME '10:00:00')"
-
-    streamUtil.verifySql(sqlQuery, "n/a")
-  }
-
-  @Test
-  def testWindowWrongWindowParameter(): Unit = {
-    expectedException.expect(classOf[TableException])
-    expectedException.expectMessage(
-      "Only constant window intervals with millisecond resolution are supported")
-
-    val sqlQuery =
-      "SELECT COUNT(*) FROM MyTable " +
-        "GROUP BY TUMBLE(proctime, INTERVAL '2-10' YEAR TO MONTH)"
 
     streamUtil.verifySql(sqlQuery, "n/a")
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -21,12 +21,10 @@ package org.apache.flink.table.runtime.stream.sql
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.descriptors.{Rowtime, Schema}
 import org.apache.flink.table.expressions.utils.Func15
 import org.apache.flink.table.runtime.stream.sql.SqlITCase.TimestampAndWatermarkWithOffset
@@ -34,6 +32,9 @@ import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
 import org.apache.flink.table.runtime.utils.{JavaUserDefinedTableFunctions, StreamITCase, StreamTestData, StreamingWithStateTestBase}
 import org.apache.flink.table.utils.{InMemoryTableFactory, MemoryTableSourceSinkUtil}
 import org.apache.flink.types.Row
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.table.api.TableEnvironment
 import org.junit.Assert._
 import org.junit._
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/time/Time.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/time/Time.java
@@ -124,4 +124,11 @@ public final class Time {
 	public static Time days(long days) {
 		return of(days, TimeUnit.DAYS);
 	}
+
+	/**
+	 * Creates a new {@link Time} that represents the given number of months.
+	 */
+	public static Time months(long months) {
+		return of(months, TimeUnit.DAYS);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*(This PR is designed to solve the problem of Support group windows over intervals of months.)*

## Brief change log

*(for example:)*

- *Increase in `DataStreamLogicalWindowAggregateRule.scala` processing logic of the month*
- *Increase in `DataStreamGroupWindowAggregate.scala` processing logic of the month*
- *Add `isMonthsIntervalLiteral` and `toMonths` functions to `expressionutils.scala`*
- *Add the `month` function in `time.java`*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *I added `TestWindowForMonthsInterval` to `GroupWindowTest`.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)