### PR TITLE
[FLINK-11060][scala-shell] Unable to set number of task manager and slot per task manager in scala shell local mode

### DIFF
--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -23,7 +23,7 @@ import java.io._
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
 import org.apache.flink.client.deployment.ClusterDescriptor
 import org.apache.flink.client.program.ClusterClient
-import org.apache.flink.configuration.{Configuration, GlobalConfiguration, JobManagerOptions}
+import org.apache.flink.configuration._
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.minicluster.{MiniCluster, MiniClusterConfiguration}
 
@@ -148,6 +148,10 @@ object FlinkShell {
 
         val miniClusterConfig = new MiniClusterConfiguration.Builder()
           .setConfiguration(config)
+          .setNumTaskManagers(configuration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
+            ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER))
+          .setNumSlotsPerTaskManager(
+            configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1))
           .build()
         val cluster = new MiniCluster(miniClusterConfig)
         cluster.start()


### PR DESCRIPTION
## What is the purpose of the change

* This PR fix the issue of unable to set number of task manager and slot per task manager in scala shell local mode.


## Brief change log
I will set number of task manager and slot per task manager in `FlinkShell` via `Configuration`

## Verifying this change

Verify it manually, set the following 2 properties in `flink-conf.yaml`, then start scala-shell in local mode and check the jm dashboard.

```
local.number-taskmanager: 2
taskmanager.numberOfTaskSlots: 8
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
