### PR TITLE
[FLINK-10976] [table] Add support for aggregate to table API

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1682,6 +1682,36 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
 
 {% top %}
 
+### Aggregate
+
+Aggregate performs an aggregate operation with an aggregate function. You have to close the
+"aggregate" with a select statement. The output will be flattened if the output type is a
+composite type.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+tableEnv.registerFunction("myAggFunc", new MyAggregateFunction());
+Table table = input
+  .groupBy("key")
+  .aggregate("myAggFunc(a, b) as (x, y, z)")
+  .select("key, x, y, z")
+{% endhighlight %}
+</div>
+ <div data-lang="scala" markdown="1">
+{% highlight scala %}
+val myAggFunc: AggregateFunction[_, _] = new MyAggregateFunction
+
+val table = input
+  .groupBy('key)
+  .aggregate(myAggFunc('a, 'b) as ('x, 'y, 'z))
+  .select('key, 'x, 'y, 'z)
+{% endhighlight %}
+</div>
+</div>
+
+{% top %}
+
 Data Types
 ----------
 

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1684,14 +1684,14 @@ The `OverWindow` defines a range of rows over which aggregates are computed. `Ov
 
 ### Aggregate
 
-Aggregate performs an aggregate operation with an aggregate function. You have to close the
-"aggregate" with a select statement. The output will be flattened if the output type is a
-composite type.
+Aggregate performs an aggregate operation with an aggregate function. You have to close the "aggregate" with a select statement and it does not support aggregate functions in the select statement The output will be flattened if the output type is a composite type.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-tableEnv.registerFunction("myAggFunc", new MyAggregateFunction());
+AggregateFunction myAggFunc = new MyAggregateFunction();
+
+tableEnv.registerFunction("myAggFunc", myAggFunc);
 Table table = input
   .groupBy("key")
   .aggregate("myAggFunc(a, b) as (x, y, z)")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
@@ -445,7 +445,7 @@ object ProjectionTranslator {
 
   def extractFieldNames(expr: Expression): Seq[String] = {
     expr match {
-      case Alias(child, name, extraNames) => Seq(name) ++ extraNames
+      case Alias(_, name, extraNames) => Seq(name) ++ extraNames
       case _ => getFieldInfo(expr.resultType)._1
     }
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/AggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/AggregateTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.batch.table
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.TableTestUtil._
-import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.{CountMinMax, TableTestBase}
 import org.junit.Test
 
 /**
@@ -133,6 +133,88 @@ class AggregateTest extends TableTestBase {
         "COUNT(c) AS TMP_2",
         "SUM($f3) AS TMP_3")
     )
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testSimpleAggregate(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+
+    val testAgg = new CountMinMax
+    val resultTable = table
+      .groupBy('b)
+      .aggregate(testAgg('a))
+      .select('b, 'f0, 'f1)
+
+    val expected =
+      unaryNode(
+        "DataSetCalc",
+        unaryNode(
+          "DataSetAggregate",
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(0),
+            term("select", "b", "a")
+          ),
+          term("groupBy", "b"),
+          term("select", "b", "CountMinMax(a) AS TMP_0")
+        ),
+        term("select", "b", "TMP_0.f0 AS f0", "TMP_0.f1 AS f1")
+      )
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testAggregateWithScalarResult(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+
+    val resultTable = table
+      .groupBy('b)
+      .aggregate('a.count)
+      .select('b, 'f0)
+
+    val expected =
+      unaryNode(
+        "DataSetAggregate",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "b", "a")
+        ),
+        term("groupBy", "b"),
+        term("select", "b", "COUNT(a) AS TMP_0")
+      )
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testAggregateWithAlias(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+
+    val testAgg = new CountMinMax
+    val resultTable = table
+      .groupBy('b)
+      .aggregate(testAgg('a) as ('x, 'y, 'z))
+      .select('b, 'x, 'y)
+
+    val expected =
+      unaryNode(
+        "DataSetCalc",
+        unaryNode(
+          "DataSetAggregate",
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(0),
+            term("select", "b", "a")
+          ),
+          term("groupBy", "b"),
+          term("select", "b", "CountMinMax(a) AS TMP_0")
+        ),
+        term("select", "b", "TMP_0.f0 AS x", "TMP_0.f1 AS y")
+      )
     util.verifyTable(resultTable, expected)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/AggregateStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/AggregateStringExpressionTest.scala
@@ -340,7 +340,7 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
-  def testNonGroupedTableAggregate(): Unit = {
+  def testNonGroupedAggregate(): Unit = {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table", 'a, 'b, 'c)
 
@@ -361,7 +361,7 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
-  def testTableAggregate(): Unit = {
+  def testGroupedAggregate2(): Unit = {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table", 'a, 'b, 'c)
 
@@ -384,7 +384,7 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
-  def testTableAggregateWithAlias(): Unit = {
+  def testAggregateWithAlias(): Unit = {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table", 'a, 'b, 'c)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/validation/AggregateValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/validation/AggregateValidationTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.api.batch.table.validation
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.{ExpressionParserException, ValidationException}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvgWithMergeAndReset
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.{TableFunc0, TableTestBase}
@@ -261,5 +261,18 @@ class AggregateValidationTest extends TableTestBase {
       // must fail. Only AggregateFunction can be used in aggregate
       .aggregate("func(c) as d")
       .select('a, 'd)
+  }
+
+  @Test(expected = classOf[ExpressionParserException])
+  @throws[Exception]
+  def testMultipleAggregateExpressionInAggregate(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Long, Int, String)]("Table", 'a, 'b, 'c)
+
+    util.tableEnv.registerFunction("func", new TableFunc0)
+    table
+      .groupBy('a)
+      // must fail. Only AggregateFunction can be used in aggregate
+      .aggregate("sum(c), count(b)")
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/AggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/AggregateTest.scala
@@ -345,6 +345,36 @@ class AggregateTest extends TableTestBase {
   }
 
   @Test
+  def testSelectStar(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Long, String)](
+      "MyTable", 'a, 'b, 'c)
+
+    val testAgg = new CountMinMax
+    val resultTable = table
+      .groupBy('b)
+      .aggregate(testAgg('a))
+      .select('*)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "b", "a")
+          ),
+          term("groupBy", "b"),
+          term("select", "b", "CountMinMax(a) AS TMP_0")
+        ),
+        term("select", "b", "TMP_0.f0 AS f0", "TMP_0.f1 AS f1", "TMP_0.f2 AS f2")
+      )
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
   def testAggregateWithScalarResult(): Unit = {
     val util = streamTestUtil()
     val table = util.addTable[(Int, Long, String)](

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/AggregateStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/AggregateStringExpressionTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.java.{Tumble => JTumble}
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{WeightedAvg, WeightedAvgWithMergeAndReset}
-import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.{CountMinMax, TableTestBase}
 import org.junit.Test
 
 class AggregateStringExpressionTest extends TableTestBase {
@@ -168,6 +168,73 @@ class AggregateStringExpressionTest extends TableTestBase {
       .select("w1.rowtime as rowtime, string, int.count")
 
     verifyTableEquals(resJava, resScala)
+  }
+
+
+  def testNonGroupedTableAggregate(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('a, 'b, 'c)
+
+    val testAgg = new CountMinMax
+    util.tableEnv.registerFunction("testAgg", testAgg)
+
+    // Expression / Scala API
+    val resScala = t
+      .aggregate(testAgg('a))
+      .select('f0, 'f1)
+
+    // String / Java API
+    val resJava = t
+      .aggregate("testAgg(a)")
+      .select("f0, f1")
+
+    verifyTableEquals(resScala, resJava)
+  }
+
+  @Test
+  def testTableAggregate(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('a, 'b, 'c)
+
+    val testAgg = new CountMinMax
+    util.tableEnv.registerFunction("testAgg", testAgg)
+
+    // Expression / Scala API
+    val resScala = t
+      .groupBy('b)
+      .aggregate(testAgg('a))
+      .select('b, 'f0, 'f1)
+
+    // String / Java API
+    val resJava = t
+      .groupBy("b")
+      .aggregate("testAgg(a)")
+      .select("b, f0, f1")
+
+    verifyTableEquals(resScala, resJava)
+  }
+
+  @Test
+  def testTableAggregateWithAlias(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]('a, 'b, 'c)
+
+    val testAgg = new CountMinMax
+    util.tableEnv.registerFunction("testAgg", testAgg)
+
+    // Expression / Scala API
+    val resScala = t
+      .groupBy('b)
+      .aggregate(testAgg('a) as ('x, 'y, 'z))
+      .select('b, 'x, 'y)
+
+    // String / Java API
+    val resJava = t
+      .groupBy("b")
+      .aggregate("testAgg(a) as (x, y, z)")
+      .select("b, x, y")
+
+    verifyTableEquals(resScala, resJava)
   }
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/AggregateStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/AggregateStringExpressionTest.scala
@@ -171,7 +171,7 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
 
-  def testNonGroupedTableAggregate(): Unit = {
+  def testNonGroupedAggregate2(): Unit = {
     val util = streamTestUtil()
     val t = util.addTable[(Int, Long, String)]('a, 'b, 'c)
 
@@ -192,7 +192,7 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
-  def testTableAggregate(): Unit = {
+  def testGroupedAggregate2(): Unit = {
     val util = streamTestUtil()
     val t = util.addTable[(Int, Long, String)]('a, 'b, 'c)
 
@@ -215,7 +215,7 @@ class AggregateStringExpressionTest extends TableTestBase {
   }
 
   @Test
-  def testTableAggregateWithAlias(): Unit = {
+  def testAggregateWithAlias(): Unit = {
     val util = streamTestUtil()
     val t = util.addTable[(Int, Long, String)]('a, 'b, 'c)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/AggregateValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/AggregateValidationTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.api.stream.table.validation
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.{ExpressionParserException, ValidationException}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.{TableFunc0, TableTestBase}
 import org.junit.Test
@@ -96,5 +96,17 @@ class AggregateValidationTest extends TableTestBase {
       // must fail. Only AggregateFunction can be used in aggregate
       .aggregate("func(c) as d")
       .select('a, 'd)
+  }
+
+  @Test(expected = classOf[ExpressionParserException])
+  def testMultipleAggregateExpressionInAggregate(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Long, Int, String)]('a, 'b, 'c)
+
+    util.tableEnv.registerFunction("func", new TableFunc0)
+    table
+      .groupBy('a)
+      // must fail. Only AggregateFunction can be used in aggregate
+      .aggregate("sum(c), count(b)")
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment, Types}
 import org.apache.flink.table.expressions.Null
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, DataViewTestAgg, WeightedAvg}
 import org.apache.flink.table.runtime.utils.{JavaUserDefinedAggFunctions, StreamITCase, StreamTestData, StreamingWithStateTestBase}
+import org.apache.flink.table.utils.CountMinMax
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -322,5 +323,46 @@ class AggregateITCase extends StreamingWithStateTestBase {
 
     val expected = List("(true,A,1)", "(true,B,2)", "(true,C,3)")
     assertEquals(expected.sorted, RowCollector.getAndClearValues.map(_.toString).sorted)
+  }
+
+  @Test
+  def testNonGroupedAggregate(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val testAgg = new CountMinMax
+    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+      .aggregate(testAgg('a))
+      .select('f0, 'f1, 'f2)
+
+    val results = t.toRetractStream[Row](queryConfig)
+    results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
+    env.execute()
+
+    val expected = List("21,1,21")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testAggregate(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val testAgg = new CountMinMax
+    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
+      .groupBy('b)
+      .aggregate(testAgg('a))
+      .select('b, 'f0, 'f1, 'f2)
+
+    val results = t.toRetractStream[Row](queryConfig)
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("1,1,1,1", "2,2,2,3", "3,3,4,6", "4,4,7,10", "5,5,11,15", "6,6,16,21")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedAggFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedAggFunctions.scala
@@ -20,13 +20,13 @@ package org.apache.flink.table.utils
 
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
-import java.lang.{Integer => JInt}
-import java.lang.{Float => JFloat}
+import java.lang.{Float => JFloat, Integer => JInt, Long => JLong}
 import java.util
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, TupleTypeInfo}
+import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, RowTypeInfo, TupleTypeInfo}
 import org.apache.flink.table.api.Types
+import org.apache.flink.types.Row
 
 /**
   * User-defined aggregation function to compute the top 10 most visited Int IDs
@@ -142,4 +142,46 @@ class NonMergableCount extends AggregateFunction[Long, NonMergableCountAcc] {
   override def createAccumulator(): NonMergableCountAcc = NonMergableCountAcc(0)
 
   override def getValue(acc: NonMergableCountAcc): Long = acc.count
+}
+
+case class CountMinMaxAcc(var count: Long, var min: Int, var max: Int)
+
+class CountMinMax extends AggregateFunction[Row, CountMinMaxAcc] {
+
+  def accumulate(acc: CountMinMaxAcc, value: Int): Unit = {
+    if (acc.count == 0 || value < acc.min) {
+      acc.min = value
+    }
+    if (acc.count == 0 || value > acc.max) {
+      acc.max = value
+    }
+    acc.count += 1
+  }
+
+  def resetAccumulator(acc: CountMinMaxAcc): Unit = {
+    acc.count = 0
+    acc.min = 0
+    acc.max = 0
+  }
+
+  override def createAccumulator(): CountMinMaxAcc = CountMinMaxAcc(0L, 0, 0)
+
+  override def getValue(acc: CountMinMaxAcc): Row = {
+    val min: Int = if (acc.count > 0) {
+      acc.min
+    } else {
+      null.asInstanceOf[Int]
+    }
+
+    val max: Int = if (acc.count > 0) {
+      acc.max
+    } else {
+      null.asInstanceOf[Int]
+    }
+    Row.of(JLong.valueOf(acc.count), JInt.valueOf(min), JInt.valueOf(max))
+  }
+
+  override def getResultType: TypeInformation[Row] = {
+    new RowTypeInfo(Types.LONG, Types.INT, Types.INT)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds the aggregate operation to table API.*

## Brief change log

  - *Adds aggregate API to Table and GroupedTable in table.scala and adds AggregatedTable in table.scala*
  - *Added tests in AggregateTest, AggregateITCase, AggregateStringExpressionTest, AggregateValidationTest*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added tests in AggregateTest, AggregateITCase, AggregateStringExpressionTest, AggregateValidationTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
