### PR TITLE
[FLINK-7209] [table] Support DataView in Tuple and Case Class as the ACC type of AggregateFunction

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/dataview/DataViewSpec.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/dataview/DataViewSpec.scala
@@ -31,6 +31,7 @@ import org.apache.flink.table.dataview.{ListViewTypeInfo, MapViewTypeInfo}
 trait DataViewSpec[ACC <: DataView] {
   def stateId: String
   def field: Field
+  def fieldType: Class[_] // the type get from field may be Object
   def toStateDescriptor: StateDescriptor[_ <: State, _]
 }
 
@@ -42,6 +43,8 @@ case class ListViewSpec[T](
 
   override def toStateDescriptor: StateDescriptor[_ <: State, _] =
     new ListStateDescriptor[T](stateId, listViewTypeInfo.elementType)
+
+  override def fieldType: Class[_] = listViewTypeInfo.getTypeClass
 }
 
 case class MapViewSpec[K, V](
@@ -52,4 +55,6 @@ case class MapViewSpec[K, V](
 
   override def toStateDescriptor: StateDescriptor[_ <: State, _] =
     new MapStateDescriptor[K, V](stateId, mapViewTypeInfo.keyType, mapViewTypeInfo.valueType)
+
+  override def fieldType: Class[_] = mapViewTypeInfo.getTypeClass
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
@@ -326,7 +326,8 @@ class AggregationCodeGenerator(
         desc: StateDescriptor[_, _],
         aggIndex: Int): Unit = {
       val dataViewField = spec.field
-      val dataViewTypeTerm = dataViewField.getType.getCanonicalName
+      val dataViewFiledType = spec.fieldType
+      val dataViewTypeTerm = dataViewFiledType.getCanonicalName
 
       // define the DataView variables
       val serializedData = EncodingUtils.encodeObjectToString(desc)
@@ -348,14 +349,14 @@ class AggregationCodeGenerator(
            |        $descClassQualifier.class,
            |        $contextTerm.getUserCodeClassLoader());
            |""".stripMargin
-      val createDataView = if (dataViewField.getType == classOf[MapView[_, _]]) {
+      val createDataView = if (dataViewFiledType == classOf[MapView[_, _]]) {
         s"""
            |    $descDeserializeCode
            |    $dataViewFieldTerm = new ${classOf[StateMapView[_, _]].getCanonicalName}(
            |      $contextTerm.getMapState(
            |        (${classOf[MapStateDescriptor[_, _]].getCanonicalName}) $descFieldTerm));
            |""".stripMargin
-      } else if (dataViewField.getType == classOf[ListView[_]]) {
+      } else if (dataViewFiledType == classOf[ListView[_]]) {
         s"""
            |    $descDeserializeCode
            |    $dataViewFieldTerm = new ${classOf[StateListView[_]].getCanonicalName}(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/NullSerializer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/dataview/NullSerializer.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataview
+
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
+class NullSerializer extends TypeSerializerSingleton[Any] {
+
+  override def isImmutableType = true
+
+  override def createInstance(): Any = null
+
+  override def copy(from: Any): Any = null
+
+  override def copy(from: Any, reuse: Any): Any = null
+
+  override def getLength = 0
+
+  override def serialize(record: Any, target: DataOutputView): Unit = {
+  }
+
+  override def deserialize(source: DataInputView): Any = {
+    null
+  }
+
+  override def deserialize(reuse: Any, source: DataInputView): Any = {
+    null
+  }
+
+  override def copy(source: DataInputView, target: DataOutputView): Unit = {
+  }
+
+  override def canEqual(obj: scala.Any): Boolean = {
+    obj.isInstanceOf[NullSerializer]
+  }
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
@@ -349,4 +349,53 @@ public class JavaUserDefinedAggFunctions {
 			isCloseCalled = true;
 		}
 	}
+
+	/**
+	 * CountDistinct aggregate with acc type of Tuple.
+	 */
+	public static class CountDistinctWithTupleAcc
+			extends AggregateFunction<Long, Tuple2<MapView<String, Integer>, Long>> {
+
+		@Override
+		public Tuple2<MapView<String, Integer>, Long> createAccumulator() {
+			return Tuple2.of(new MapView<>(Types.STRING, Types.INT), 0L);
+		}
+
+		//Overloaded accumulate method
+		public void accumulate(Tuple2<MapView<String, Integer>, Long> accumulator, String id) {
+			try {
+				Integer cnt = accumulator.f0.get(id);
+				if (cnt != null) {
+					cnt += 1;
+					accumulator.f0.put(id, cnt);
+				} else {
+					accumulator.f0.put(id, 1);
+					accumulator.f1 += 1;
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+
+		//Overloaded accumulate method
+		public void accumulate(Tuple2<MapView<String, Integer>, Long> accumulator, long id) {
+			try {
+				Integer cnt = accumulator.f0.get(String.valueOf(id));
+				if (cnt != null) {
+					cnt += 1;
+					accumulator.f0.put(String.valueOf(id), cnt);
+				} else {
+					accumulator.f0.put(String.valueOf(id), 1);
+					accumulator.f1 += 1;
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+
+		@Override
+		public Long getValue(Tuple2<MapView<String, Integer>, Long> accumulator) {
+			return accumulator.f1;
+		}
+	}
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -26,8 +26,9 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.StreamITCase.RetractingSink
 import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment, Types}
 import org.apache.flink.table.expressions.Null
-import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, DataViewTestAgg, WeightedAvg}
+import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions._
 import org.apache.flink.table.runtime.utils.{JavaUserDefinedAggFunctions, StreamITCase, StreamTestData, StreamingWithStateTestBase}
+import org.apache.flink.table.utils.CountDistinctWithCaseClassAcc
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -278,16 +279,18 @@ class AggregateITCase extends StreamingWithStateTestBase {
     data.+=((12, 5L, "B"))
 
     val distinct = new CountDistinct
+    val distinct2 = new CountDistinctWithTupleAcc
+    val distinct3 = new CountDistinctWithCaseClassAcc
     val testAgg = new DataViewTestAgg
     val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
       .groupBy('b)
-      .select('b, distinct('c), testAgg('c, 'b))
+      .select('b, distinct('c), distinct2('c), distinct3('c), testAgg('c, 'b))
 
     val results = t.toRetractStream[Row](queryConfig)
     results.addSink(new StreamITCase.RetractingSink)
     env.execute()
 
-    val expected = List("1,1,2", "2,1,5", "3,1,10", "4,4,20", "5,2,12")
+    val expected = List("1,1,1,1,2", "2,1,1,1,5", "3,1,1,1,10", "4,4,4,4,20", "5,2,2,2,12")
     assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
 
     // verify agg close is called


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds support of DataView in Tuple and Case Class as the accumulator type of AggregateFunction*

## Brief change log

  - *Updates UserDefinedFunctionUtils#removeStateViewFieldsFromAccTypeInfo to process TupleTypeInfo and CaseClassTypeInfo for DataView*
  - *Updates MapViewTypeInfo and ListViewTypeInfo to use NullSerializer for serialization when state backend is used*

## Verifying this change

This change added tests and can be verified as follows:

  - *Updated tests of AggregateITCase#testGroupAggregateWithStateBackend*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
