### PR TITLE
[FLINK-11048] Ability to programmatically execute streaming pipeline with savepoint restore

### DIFF
--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteStreamEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteStreamEnvironment.java
@@ -18,14 +18,13 @@
 
 package org.apache.flink.api.java;
 
-import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironmentFactory;
-import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,30 +67,21 @@ public class ScalaShellRemoteStreamEnvironment extends RemoteStreamEnvironment {
 		this.flinkILoop = flinkILoop;
 	}
 
-	/**
-	 * Executes the remote job.
-	 *
-	 * @param streamGraph
-	 *            Stream Graph to execute
-	 * @param jarFiles
-	 * 			  List of jar file URLs to ship to the cluster
-	 * @return The result of the job execution, containing elapsed time and accumulators.
-	 */
-	@Override
-	protected JobExecutionResult executeRemotely(StreamGraph streamGraph, List<URL> jarFiles) throws ProgramInvocationException {
+	protected List<URL> getJarFiles() throws ProgramInvocationException {
 		URL jarUrl;
 		try {
 			jarUrl = flinkILoop.writeFilesToDisk().getAbsoluteFile().toURI().toURL();
 		} catch (MalformedURLException e) {
+			// TODO: we don't have the actual jobID at this point
 			throw new ProgramInvocationException("Could not write the user code classes to disk.",
-				streamGraph.getJobGraph().getJobID(), e);
+				new JobID(), e);
 		}
 
+		List<URL> jarFiles = super.getJarFiles();
 		List<URL> allJarFiles = new ArrayList<>(jarFiles.size() + 1);
 		allJarFiles.addAll(jarFiles);
 		allJarFiles.add(jarUrl);
-
-		return super.executeRemotely(streamGraph, allJarFiles);
+		return allJarFiles;
 	}
 
 	public void setAsContext() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -174,14 +174,6 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Set savepoint restore settings that will be used when executing the job.
-	 * @param savepointRestoreSettings savepoint restore settings
-	 */
-	public void setSavepointRestoreSettings(SavepointRestoreSettings savepointRestoreSettings) {
-		this.savepointRestoreSettings = savepointRestoreSettings;
-	}
-
-	/**
 	 * Executes the job remotely.
 	 *
 	 * <p>This method can be used independent of the {@link StreamExecutionEnvironment} type.
@@ -281,6 +273,14 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		streamGraph.setJobName(jobName);
 		transformations.clear();
 		return executeRemotely(streamGraph, jarFiles);
+	}
+
+	/**
+	 * Execute the job with savepoint restore.
+	 */
+	public JobExecutionResult execute(String jobName, SavepointRestoreSettings savepointRestoreSettings) throws ProgramInvocationException {
+		this.savepointRestoreSettings = savepointRestoreSettings;
+		return execute(jobName);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -66,6 +66,8 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	/** The classpaths that need to be attached to each job. */
 	private final List<URL> globalClasspaths;
 
+	private SavepointRestoreSettings savepointRestoreSettings;
+
 	/**
 	 * Creates a new RemoteStreamEnvironment that points to the master
 	 * (JobManager) described by the given host name and port.
@@ -174,6 +176,10 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		return jarFiles;
 	}
 
+	public void setSavepointRestoreSettings(SavepointRestoreSettings savepointRestoreSettings) {
+		this.savepointRestoreSettings = savepointRestoreSettings;
+	}
+
 	/**
 	 * Executes the remote job.
 	 *
@@ -221,6 +227,10 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
 		client.setPrintStatusDuringExecution(streamExecutionEnvironment.getConfig().isSysoutLoggingEnabled());
 
+		if (savepointRestoreSettings == null) {
+			savepointRestoreSettings = SavepointRestoreSettings.none();
+		}
+
 		try {
 			return client.run(streamGraph, jarFiles, globalClasspaths, usercodeClassLoader, savepointRestoreSettings)
 				.getJobExecutionResult();
@@ -246,7 +256,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws ProgramInvocationException {
 		try {
 			return RemoteStreamEnvironment.executeRemotely(this,
-				getJarFiles(), host, port, clientConfiguration, globalClasspaths, jobName, SavepointRestoreSettings.none());
+				getJarFiles(), host, port, clientConfiguration, globalClasspaths, jobName, savepointRestoreSettings);
 		} finally {
 			transformations.clear();
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -333,5 +333,4 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	public Configuration getClientConfiguration() {
 		return clientConfiguration;
 	}
-
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -242,14 +242,14 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	 * @throws ProgramInvocationException
 	 */
 	private static JobExecutionResult executeRemotely(StreamGraph streamGraph,
-													ClassLoader envClassLoader,
-													ExecutionConfig executionConfig,
-													List<URL> jarFiles,
-													String host,
-													int port,
-													Configuration clientConfiguration,
-													List<URL> globalClasspaths,
-													SavepointRestoreSettings savepointRestoreSettings
+		ClassLoader envClassLoader,
+		ExecutionConfig executionConfig,
+		List<URL> jarFiles,
+		String host,
+		int port,
+		Configuration clientConfiguration,
+		List<URL> globalClasspaths,
+		SavepointRestoreSettings savepointRestoreSettings
 	) throws ProgramInvocationException {
 		if (LOG.isInfoEnabled()) {
 			LOG.info("Running remotely at {}:{}", host, port);
@@ -319,6 +319,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	 * 			  List of jar file URLs to ship to the cluster
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 */
+	@Deprecated
 	protected JobExecutionResult executeRemotely(StreamGraph streamGraph, List<URL> jarFiles) throws ProgramInvocationException {
 		return executeRemotely(streamGraph,
 			this.getClass().getClassLoader(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -211,6 +212,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	 * <p>This method can be used independent of the {@link StreamExecutionEnvironment} type.
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 */
+	@PublicEvolving
 	public static JobExecutionResult executeRemotely(StreamExecutionEnvironment streamExecutionEnvironment,
 		List<URL> jarFiles,
 		String host,
@@ -310,6 +312,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 	/**
 	 * Executes the remote job.
 	 *
+	 * <p>Note: This method exposes stream graph internal in the public API, but cannot be removed for backward compatibility.
 	 * @param streamGraph
 	 *            Stream Graph to execute
 	 * @param jarFiles

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -77,18 +77,19 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 
 	@Test
 	public void testRemoteExecutionWithSavepoint() throws Exception {
-		RemoteStreamEnvironment env = new RemoteStreamEnvironment("fakeHost", 1);
+		SavepointRestoreSettings restoreSettings = SavepointRestoreSettings.forPath("fakePath");
+		RemoteStreamEnvironment env = new RemoteStreamEnvironment("fakeHost", 1,
+			null, new String[]{}, null, restoreSettings);
 		env.fromElements(1).map(x -> x * 2);
 
 		RestClusterClient mockedClient = Mockito.mock(RestClusterClient.class);
 		JobExecutionResult expectedResult = new JobExecutionResult(null, 0, null);
-		SavepointRestoreSettings restoreSettings = SavepointRestoreSettings.forPath("fakePath");
 
 		PowerMockito.whenNew(RestClusterClient.class).withAnyArguments().thenReturn(mockedClient);
 		when(mockedClient.run(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(restoreSettings)))
 			.thenReturn(expectedResult);
 
-		JobExecutionResult actualResult = env.execute("fakeJobName", restoreSettings);
+		JobExecutionResult actualResult = env.execute("fakeJobName");
 		Assert.assertEquals(expectedResult, actualResult);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -83,13 +83,12 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		RestClusterClient mockedClient = Mockito.mock(RestClusterClient.class);
 		JobExecutionResult expectedResult = new JobExecutionResult(null, 0, null);
 		SavepointRestoreSettings restoreSettings = SavepointRestoreSettings.forPath("fakePath");
-		env.setSavepointRestoreSettings(restoreSettings);
 
 		PowerMockito.whenNew(RestClusterClient.class).withAnyArguments().thenReturn(mockedClient);
 		when(mockedClient.run(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(restoreSettings)))
 			.thenReturn(expectedResult);
 
-		JobExecutionResult actualResult = env.execute("fakeJobName");
+		JobExecutionResult actualResult = env.execute("fakeJobName", restoreSettings);
 		Assert.assertEquals(expectedResult, actualResult);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -61,8 +61,8 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 				Object[] args = invocation.getArguments();
 				Configuration config = (Configuration) args[0];
 
-				Assert.assertEquals(config.getString(RestOptions.ADDRESS), host);
-				Assert.assertEquals(config.getInteger(RestOptions.PORT), port);
+				Assert.assertEquals(host, config.getString(RestOptions.ADDRESS));
+				Assert.assertEquals(port, config.getInteger(RestOptions.PORT));
 				return mockedClient;
 			}
 		);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -18,53 +18,79 @@
 
 package org.apache.flink.streaming.api.environment;
 
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.runtime.minicluster.MiniCluster;
-import org.apache.flink.runtime.testutils.MiniClusterResource;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Iterator;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link RemoteStreamEnvironment}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({RemoteStreamEnvironment.class})
 public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
-
-	@ClassRule
-	public static final MiniClusterResource MINI_CLUSTER_RESOURCE = new MiniClusterResource(
-		new MiniClusterResourceConfiguration.Builder()
-			.setNumberTaskManagers(1)
-			.setNumberSlotsPerTaskManager(1)
-			.build());
 
 	/**
 	 * Verifies that the port passed to the RemoteStreamEnvironment is used for connecting to the cluster.
 	 */
 	@Test
 	public void testPortForwarding() throws Exception {
+
+		String host = "fakeHost";
+		int port = 99;
+		JobExecutionResult expectedResult = new JobExecutionResult(null, 0, null);
+
+		RestClusterClient mockedClient = Mockito.mock(RestClusterClient.class);
+		when(mockedClient.run(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+			.thenReturn(expectedResult);
+
+		PowerMockito.whenNew(RestClusterClient.class).withAnyArguments().thenAnswer((invocation) -> {
+				Object[] args = invocation.getArguments();
+				Configuration config = (Configuration) args[0];
+
+				Assert.assertEquals(config.getString(RestOptions.ADDRESS), host);
+				Assert.assertEquals(config.getInteger(RestOptions.PORT), port);
+				return mockedClient;
+			}
+		);
+
 		final Configuration clientConfiguration = new Configuration();
-		clientConfiguration.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 0);
-
-		final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(
-			miniCluster.getRestAddress().getHost(),
-			miniCluster.getRestAddress().getPort(),
-			clientConfiguration);
-
-		final DataStream<Integer> resultStream = env.fromElements(1)
-			.map(x -> x * 2);
-
-		final Iterator<Integer> result = DataStreamUtils.collect(resultStream);
-		Assert.assertTrue(result.hasNext());
-		Assert.assertEquals(2, result.next().intValue());
-		Assert.assertFalse(result.hasNext());
+			host, port, clientConfiguration);
+		env.fromElements(1).map(x -> x * 2);
+		JobExecutionResult actualResult = env.execute("fakeJobName");
+		Assert.assertEquals(expectedResult, actualResult);
 	}
+
+	@Test
+	public void testRemoteExecutionWithSavepoint() throws Exception {
+		RemoteStreamEnvironment env = new RemoteStreamEnvironment("fakeHost", 1);
+		env.fromElements(1).map(x -> x * 2);
+
+		RestClusterClient mockedClient = Mockito.mock(RestClusterClient.class);
+		JobExecutionResult expectedResult = new JobExecutionResult(null, 0, null);
+		SavepointRestoreSettings restoreSettings = SavepointRestoreSettings.forPath("fakePath");
+		env.setSavepointRestoreSettings(restoreSettings);
+
+		PowerMockito.whenNew(RestClusterClient.class).withAnyArguments().thenReturn(mockedClient);
+		when(mockedClient.run(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(restoreSettings)))
+			.thenReturn(expectedResult);
+
+		JobExecutionResult actualResult = env.execute("fakeJobName");
+		Assert.assertEquals(expectedResult, actualResult);
+	}
+
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -92,5 +92,4 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		JobExecutionResult actualResult = env.execute("fakeJobName");
 		Assert.assertEquals(expectedResult, actualResult);
 	}
-
 }


### PR DESCRIPTION
## What is the purpose of the change

Adds the ability to programmatically execute a job with savepoint restore option.

https://lists.apache.org/thread.html/6fff05d4a8444d1c6fa139d63605d51f610caff46605a4cdbb35cd50@%3Cdev.flink.apache.org%3E

The number of parameters to *executeRemotely* is a bit higher than what we might have expected. The change to ScalaShellRemoteStreamEnvironment needs a closer look. It needs to override the jar file list, but do we really need the *ProgramInvocationException* there?

## Brief change log
  -  executeRemotely changed to static method that can be used with any StreamExecutionEnvironment

## Verifying this change

No added test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
