### PR TITLE
[FLINK-11089]Log filecache directory removed messages

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -150,9 +150,10 @@ public class FileCache {
 			for (File dir : storageDirectories) {
 				try {
 					FileUtils.deleteDirectory(dir);
+					LOG.info("removed file cache directory {}", dir.getAbsolutePath());
 				}
 				catch (IOException e) {
-					LOG.error("File cache could not properly clean up storage directory.");
+					LOG.error("File cache could not properly clean up storage directory: {}", dir, e);
 				}
 			}
 


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/FLINK-11089](https://issues.apache.org/jira/browse/FLINK-11089)
When taskmanager exit or shutdown,the filecache directory named "flink-dist-cache*" will be removed,but there is not any log about this action.So I think we should log it for user to check it easy when there are some bugs.

You can see IOManager.java logs the removed messages when taskmanager shutdown, filecache can do the same things.  