### PR TITLE
[hotfix][docs] Fix typo and make improvement in Kafka Connectors doc

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -617,7 +617,7 @@ Note that the partitioner implementation must be serializable, as they will be t
 Also, keep in mind that any state in the partitioner will be lost on job failures since the partitioner
 is not part of the producer's checkpointed state.
 
-It is also possible to completely avoid using and kind of partitioner, and simply let Kafka partition
+It is also possible to completely avoid using any kind of partitioner, and simply let Kafka partition
 the written records by their attached key (as determined for each record using the provided serialization schema).
 To do this, provide a `null` custom partitioner when instantiating the producer. It is important
 to provide `null` as the custom partitioner; as explained above, if a custom partitioner is not specified
@@ -681,13 +681,13 @@ chosen by passing appropriate `semantic` parameter to the `FlinkKafkaProducer011
 
 `Semantic.EXACTLY_ONCE` mode relies on the ability to commit transactions
 that were started before taking a checkpoint, after recovering from the said checkpoint. If the time
-between Flink application crash and completed restart is larger then Kafka's transaction timeout
+between Flink application crash and completed restart is larger than Kafka's transaction timeout
 there will be data loss (Kafka will automatically abort transactions that exceeded timeout time).
 Having this in mind, please configure your transaction timeout appropriately to your expected down
 times.
 
 Kafka brokers by default have `transaction.max.timeout.ms` set to 15 minutes. This property will
-not allow to set transaction timeouts for the producers larger then it's value.
+not allow to set transaction timeouts for the producers larger than it's value.
 `FlinkKafkaProducer011` by default sets the `transaction.timeout.ms` property in producer config to
 1 hour, thus `transaction.max.timeout.ms` should be increased before using the
 `Semantic.EXACTLY_ONCE` mode.
@@ -713,14 +713,14 @@ the consumers until `transaction1` is committed or aborted. This has two implica
 **Note**:  `Semantic.EXACTLY_ONCE` mode uses a fixed size pool of KafkaProducers
 per each `FlinkKafkaProducer011` instance. One of each of those producers is used per one
 checkpoint. If the number of concurrent checkpoints exceeds the pool size, `FlinkKafkaProducer011`
-will throw an exception and will fail the whole application. Please configure max pool size and max
-number of concurrent checkpoints accordingly.
+will throw an exception and will fail the whole application. Please configure max pool size(`FlinkKafkaProducer011.kafkaProducersPoolSize`) 
+and max number of concurrent checkpoints(`CheckpointConfig.maxConcurrentCheckpoints`) accordingly.
 
 **Note**: `Semantic.EXACTLY_ONCE` takes all possible measures to not leave any lingering transactions
-that would block the consumers from reading from Kafka topic more then it is necessary. However in the
+that would block the consumers from reading from Kafka topic more than it is necessary. However in the
 event of failure of Flink application before first checkpoint, after restarting such application there
 is no information in the system about previous pool sizes. Thus it is unsafe to scale down Flink
-application before first checkpoint completes, by factor larger then `FlinkKafkaProducer011.SAFE_SCALE_DOWN_FACTOR`.
+application(`getNumberOfParallelSubtasks()`) before first checkpoint completes, by factor larger than `FlinkKafkaProducer011.SAFE_SCALE_DOWN_FACTOR`.
 
 ## Using Kafka timestamps and Flink event time in Kafka 0.10
 

--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -713,14 +713,14 @@ the consumers until `transaction1` is committed or aborted. This has two implica
 **Note**:  `Semantic.EXACTLY_ONCE` mode uses a fixed size pool of KafkaProducers
 per each `FlinkKafkaProducer011` instance. One of each of those producers is used per one
 checkpoint. If the number of concurrent checkpoints exceeds the pool size, `FlinkKafkaProducer011`
-will throw an exception and will fail the whole application. Please configure max pool size(`FlinkKafkaProducer011.kafkaProducersPoolSize`) 
-and max number of concurrent checkpoints(`CheckpointConfig.maxConcurrentCheckpoints`) accordingly.
+will throw an exception and will fail the whole application. Please configure max pool size via the producer constructor
+and max number of concurrent checkpoints accordingly.
 
 **Note**: `Semantic.EXACTLY_ONCE` takes all possible measures to not leave any lingering transactions
 that would block the consumers from reading from Kafka topic more than it is necessary. However in the
 event of failure of Flink application before first checkpoint, after restarting such application there
 is no information in the system about previous pool sizes. Thus it is unsafe to scale down Flink
-application(`getNumberOfParallelSubtasks()`) before first checkpoint completes, by factor larger than `FlinkKafkaProducer011.SAFE_SCALE_DOWN_FACTOR`.
+application before first checkpoint completes, by factor larger than `FlinkKafkaProducer011.SAFE_SCALE_DOWN_FACTOR`.
 
 ## Using Kafka timestamps and Flink event time in Kafka 0.10
 

--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -686,10 +686,9 @@ there will be data loss (Kafka will automatically abort transactions that exceed
 Having this in mind, please configure your transaction timeout appropriately to your expected down
 times.
 
-Kafka brokers by default have `transaction.max.timeout.ms` set to 15 minutes. This property will
-not allow to set transaction timeouts for the producers larger than it's value.
-`FlinkKafkaProducer011` by default sets the `transaction.timeout.ms` property in producer config to
-1 hour, thus `transaction.max.timeout.ms` should be increased before using the
+Kafka will not allow producers to set transactions timeouts greater than the value of `transaction.max.timeout.ms`,
+which by default is set to 15 minutes. As `FlinkKafkaProducer011` sets the `transaction.timeout.ms` property in the
+producer configuration to 1 hour, by default, you should increase `transaction.max.timeout.ms` before using
 `Semantic.EXACTLY_ONCE` mode.
 
 In `read_committed` mode of `KafkaConsumer`, any transactions that were not finished

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -150,7 +150,7 @@ public class FlinkKafkaProducer011<IN>
 	 * <p>The range of available to use transactional ids is:
 	 * {@code [0, getNumberOfParallelSubtasks() * kafkaProducersPoolSize) }
 	 *
-	 * <p>This means that if we decrease {@code getNumberOfParallelSubtasks()} by a factor larger then
+	 * <p>This means that if we decrease {@code getNumberOfParallelSubtasks()} by a factor larger than
 	 * {@code SAFE_SCALE_DOWN_FACTOR} we can have a left some lingering transaction.
 	 */
 	public static final int SAFE_SCALE_DOWN_FACTOR = 5;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -152,7 +152,7 @@ public class FlinkKafkaProducer<IN>
 	 * <p>The range of available to use transactional ids is:
 	 * {@code [0, getNumberOfParallelSubtasks() * kafkaProducersPoolSize) }
 	 *
-	 * <p>This means that if we decrease {@code getNumberOfParallelSubtasks()} by a factor larger then
+	 * <p>This means that if we decrease {@code getNumberOfParallelSubtasks()} by a factor larger than
 	 * {@code SAFE_SCALE_DOWN_FACTOR} we can have a left some lingering transaction.
 	 */
 	public static final int SAFE_SCALE_DOWN_FACTOR = 5;


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix typo and make improvement in Kafka Connectors doc


## Brief change log

- Fix typo in both kafka.md and javadoc of relevant class
- Make the note about **Semantic.EXACTLY_ONCE** more clear.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
