### PR TITLE
[FLINK-11085][s3] Fix inclusion of presto hadoop classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1478,7 +1478,8 @@ under the License.
 							<shadedArtifactAttached>false</shadedArtifactAttached>
 							<createDependencyReducedPom>true</createDependencyReducedPom>
 							<dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-							<filters>
+							<!-- Filters MUST be appended; merging filters does not work properly, see MSHADE-305 -->
+							<filters combine.children="append">
 								<!-- Globally exclude log4j.properties from our JAR files. -->
 								<filter>
 									<artifact>*</artifact>


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bundling of hadoop classes from `com.facebook.presto.hadoop:hadoop-apache2` in the presto-s3 filesystem module.

As of right now I do not really know why this fixes the issue, but intend to file an issue with MSHADE.

## Brief change log

* reorder filter definitions

## Verifying this change

Manually verified. Ensure that `org\apache\flink\fs\s3presto\shaded\com\facebook\presto\hadoop\` is contained in the jar, and no other contents from this jar are included (for example, `nativelib`).

Optionally you can also run the presto e2e test if you also include the commits from https://github.com/zentol/flink/tree/11100.
