### PR TITLE
[FLINK-10478] Kafka Producer wrongly formats % for transaction ID

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -55,7 +55,7 @@ public class TransactionalIdsGenerator {
 		checkArgument(safeScaleDownFactor > 0);
 		checkArgument(subtaskIndex >= 0);
 
-		this.prefix = checkNotNull(prefix).replaceAll("%", "%%");
+		this.prefix = checkNotNull(prefix);
 		this.subtaskIndex = subtaskIndex;
 		this.totalNumberOfSubtasks = totalNumberOfSubtasks;
 		this.poolSize = poolSize;
@@ -91,6 +91,6 @@ public class TransactionalIdsGenerator {
 	}
 
 	private String generateTransactionalId(long transactionalId) {
-		return String.format(prefix + "-%d", transactionalId);
+		return String.format(prefix.replaceAll("%", "%%") + "-%d", transactionalId);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -55,7 +55,7 @@ public class TransactionalIdsGenerator {
 		checkArgument(safeScaleDownFactor > 0);
 		checkArgument(subtaskIndex >= 0);
 
-		this.prefix = checkNotNull(prefix);
+		this.prefix = checkNotNull(prefix).replaceAll("%", "%%");
 		this.subtaskIndex = subtaskIndex;
 		this.totalNumberOfSubtasks = totalNumberOfSubtasks;
 		this.poolSize = poolSize;

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
@@ -45,6 +45,24 @@ public class TransactionalIdsGeneratorTest {
 			generator.generateIdsToUse(36));
 	}
 
+	@Test
+	public void testGenerateIdsWithPercentageToUse() {
+		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test%", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("test%-42", "test%-43", "test%-44")),
+			generator.generateIdsToUse(36));
+	}
+
+	@Test
+	public void testGenerateIdsWithMultiplePercentageToUse() {
+		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test%%", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("test%%-42", "test%%-43", "test%%-44")),
+			generator.generateIdsToUse(36));
+	}
+
 	/**
 	 * Ids to abort and to use should never clash between subtasks.
 	 */

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
@@ -47,7 +47,9 @@ public class TransactionalIdsGeneratorTest {
 
 	@Test
 	public void testGenerateIdsWithPercentageToUse() {
-		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test%", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
+		TransactionalIdsGenerator generator =
+			new TransactionalIdsGenerator("test%", 2, SUBTASKS_COUNT, POOL_SIZE,
+				SAFE_SCALE_DOWN_FACTOR);
 
 		assertEquals(
 			new HashSet<>(Arrays.asList("test%-42", "test%-43", "test%-44")),
@@ -56,7 +58,9 @@ public class TransactionalIdsGeneratorTest {
 
 	@Test
 	public void testGenerateIdsWithMultiplePercentageToUse() {
-		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test%%", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
+		TransactionalIdsGenerator generator =
+			new TransactionalIdsGenerator("test%%", 2, SUBTASKS_COUNT,
+				POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
 
 		assertEquals(
 			new HashSet<>(Arrays.asList("test%%-42", "test%%-43", "test%%-44")),

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -91,6 +91,6 @@ public class TransactionalIdsGenerator {
 	}
 
 	private String generateTransactionalId(long transactionalId) {
-		return String.format(prefix + "-%d", transactionalId);
+		return String.format(prefix.replaceAll("%", "%%") + "-%d", transactionalId);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request solve kafka transaction ID wrongly formats % problem.*


## Brief change log

  - Replace all % with %% in prefix


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
