### PR TITLE
[FLINK-11081] Support binding port range for REST server

### DIFF
--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -23,6 +23,11 @@
             <td>The address that the server binds itself.</td>
         </tr>
         <tr>
+            <td><h5>rest.bind-port</h5></td>
+            <td style="word-wrap: break-word;">"8081"</td>
+            <td>The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple Rest servers are running on the same machine.</td>
+        </tr>
+        <tr>
             <td><h5>rest.client.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
             <td>The maximum content length in bytes that the client will handle.</td>
@@ -40,7 +45,7 @@
         <tr>
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
-            <td>The port that the server listens on / the client connects to.</td>
+            <td>The port that the client connects to.</td>
         </tr>
         <tr>
             <td><h5>rest.retry.delay</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -124,8 +124,8 @@ public class LocalExecutor extends PlanExecutor {
 	}
 
 	private JobExecutorService createJobExecutorService(Configuration configuration) throws Exception {
-		if (!configuration.contains(RestOptions.PORT)) {
-			configuration.setInteger(RestOptions.PORT, 0);
+		if (!configuration.contains(RestOptions.BIND_PORT)) {
+			configuration.setString(RestOptions.BIND_PORT, "0");
 		}
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -43,6 +43,7 @@ public class RestOptions {
 	public static final ConfigOption<String> BIND_PORT =
 		key("rest.bind-port")
 			.defaultValue("8081")
+			.withDeprecatedKeys("rest.port", WebOptions.PORT.key(), ConfigConstants.JOB_MANAGER_WEB_PORT_KEY)
 			.withDescription("The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges" +
 				" (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid" +
 				" collisions when multiple Rest servers are running on the same machine.");

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -45,7 +45,8 @@ public class RestOptions {
 	public static final ConfigOption<String> BIND_PORT =
 		key("rest.bind-port")
 			.defaultValue("8081")
-			.withDeprecatedKeys(REST_PORT_KEY, WebOptions.PORT.key(), ConfigConstants.JOB_MANAGER_WEB_PORT_KEY)
+			.withFallbackKeys(REST_PORT_KEY)
+			.withDeprecatedKeys(WebOptions.PORT.key(), ConfigConstants.JOB_MANAGER_WEB_PORT_KEY)
 			.withDescription("The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges" +
 				" (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid" +
 				" collisions when multiple Rest servers are running on the same machine.");

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -38,6 +38,17 @@ public class RestOptions {
 			.withDescription("The address that the server binds itself.");
 
 	/**
+	 * The port range that the server could bind itself to.
+	 */
+	public static final ConfigOption<String> BIND_PORT =
+		key("rest.bind-port")
+			.defaultValue("8081")
+			.withDescription("The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges" +
+				" (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid" +
+				" collisions when multiple Rest servers are running on the same machine.");
+
+
+	/**
 	 * The address that should be used by clients to connect to the server.
 	 */
 	public static final ConfigOption<String> ADDRESS =
@@ -47,13 +58,13 @@ public class RestOptions {
 			.withDescription("The address that should be used by clients to connect to the server.");
 
 	/**
-	 * The port that the server listens on / the client connects to.
+	 * The port that the client connects to.
 	 */
 	public static final ConfigOption<Integer> PORT =
 		key("rest.port")
 			.defaultValue(8081)
 			.withDeprecatedKeys("web.port")
-			.withDescription("The port that the server listens on / the client connects to.");
+			.withDescription("The port that the client connects to.");
 
 	/**
 	 * The time in ms that the client waits for the leader address, e.g., Dispatcher or

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -28,6 +28,8 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @Internal
 public class RestOptions {
 
+	private static final String REST_PORT_KEY = "rest.port";
+
 	/**
 	 * The address that the server binds itself to.
 	 */
@@ -43,7 +45,7 @@ public class RestOptions {
 	public static final ConfigOption<String> BIND_PORT =
 		key("rest.bind-port")
 			.defaultValue("8081")
-			.withDeprecatedKeys("rest.port", WebOptions.PORT.key(), ConfigConstants.JOB_MANAGER_WEB_PORT_KEY)
+			.withDeprecatedKeys(REST_PORT_KEY, WebOptions.PORT.key(), ConfigConstants.JOB_MANAGER_WEB_PORT_KEY)
 			.withDescription("The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges" +
 				" (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid" +
 				" collisions when multiple Rest servers are running on the same machine.");
@@ -62,9 +64,9 @@ public class RestOptions {
 	 * The port that the client connects to.
 	 */
 	public static final ConfigOption<Integer> PORT =
-		key("rest.port")
+		key(REST_PORT_KEY)
 			.defaultValue(8081)
-			.withDeprecatedKeys("web.port")
+			.withDeprecatedKeys(WebOptions.PORT.key())
 			.withDescription("The port that the client connects to.");
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -80,7 +80,7 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 	private final String restAddress;
 	private final String restBindAddress;
-	private final String restBindPort;
+	private final String restBindPortRange;
 	@Nullable
 	private final SSLHandlerFactory sslHandlerFactory;
 	private final int maxContentLength;
@@ -102,7 +102,7 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 		this.restAddress = configuration.getRestAddress();
 		this.restBindAddress = configuration.getRestBindAddress();
-		this.restBindPort = configuration.getRestBindPort();
+		this.restBindPortRange = configuration.getRestBindPortRange();
 		this.sslHandlerFactory = configuration.getSslHandlerFactory();
 
 		this.uploadDir = configuration.getUploadDir();
@@ -190,11 +190,11 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 			// parse port range definition and create port iterator
 			Iterator<Integer> portsIterator;
 			try {
-				portsIterator = NetUtils.getPortRangeFromString(restBindPort);
+				portsIterator = NetUtils.getPortRangeFromString(restBindPortRange);
 			} catch (IllegalConfigurationException e) {
 				throw e;
 			} catch (Exception e) {
-				throw new IllegalArgumentException("Invalid port range definition: " + restBindPort);
+				throw new IllegalArgumentException("Invalid port range definition: " + restBindPortRange);
 			}
 
 			int chosenPort = 0;
@@ -219,8 +219,8 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 			if (serverChannel == null) {
 				// if we come here, we have exhausted the port range
-				throw new BindException("Could not start task manager on any port in port range "
-					+ restBindPort);
+				throw new BindException("Could not start rest server endpoint on any port in port range "
+					+ restBindPortRange);
 			}
 
 			log.debug("Binding rest endpoint to {}:{}.", restBindAddress, chosenPort);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.net.RedirectingSslHandler;
@@ -190,6 +191,8 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 			Iterator<Integer> portsIterator;
 			try {
 				portsIterator = NetUtils.getPortRangeFromString(restBindPort);
+			} catch (IllegalConfigurationException e) {
+				throw e;
 			} catch (Exception e) {
 				throw new IllegalArgumentException("Invalid port range definition: " + restBindPort);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -206,10 +206,9 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
 					serverChannel = channel.syncUninterruptibly().channel();
 					break;
 				} catch (Exception e) {
-					// we can continue to try if this contains a netty channel exception
-					Throwable cause = e.getCause();
-					if (!(cause instanceof org.jboss.netty.channel.ChannelException ||
-						cause instanceof java.net.BindException)) {
+					// we can continue the loop to try follow-up ports if this contains a netty channel exception
+					if (!(e instanceof org.jboss.netty.channel.ChannelException ||
+						e instanceof java.net.BindException)) {
 						throw e;
 					} // else fall through the loop and try the next port
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -48,7 +48,7 @@ public final class RestServerEndpointConfiguration {
 	@Nullable
 	private final String restBindAddress;
 
-	private final String restBindPort;
+	private final String restBindPortRange;
 
 	@Nullable
 	private final SSLHandlerFactory sslHandlerFactory;
@@ -62,7 +62,7 @@ public final class RestServerEndpointConfiguration {
 	private RestServerEndpointConfiguration(
 			final String restAddress,
 			@Nullable String restBindAddress,
-			String restBindPort,
+			String restBindPortRange,
 			@Nullable SSLHandlerFactory sslHandlerFactory,
 			final Path uploadDir,
 			final int maxContentLength,
@@ -72,7 +72,7 @@ public final class RestServerEndpointConfiguration {
 
 		this.restAddress = requireNonNull(restAddress);
 		this.restBindAddress = restBindAddress;
-		this.restBindPort = requireNonNull(restBindPort);
+		this.restBindPortRange = requireNonNull(restBindPortRange);
 		this.sslHandlerFactory = sslHandlerFactory;
 		this.uploadDir = requireNonNull(uploadDir);
 		this.maxContentLength = maxContentLength;
@@ -100,8 +100,8 @@ public final class RestServerEndpointConfiguration {
 	 *
 	 * @return port range that the REST server endpoint should listen on
 	 */
-	public String getRestBindPort() {
-		return restBindPort;
+	public String getRestBindPortRange() {
+		return restBindPortRange;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -48,7 +48,7 @@ public final class RestServerEndpointConfiguration {
 	@Nullable
 	private final String restBindAddress;
 
-	private final int restBindPort;
+	private final String restBindPort;
 
 	@Nullable
 	private final SSLHandlerFactory sslHandlerFactory;
@@ -62,18 +62,17 @@ public final class RestServerEndpointConfiguration {
 	private RestServerEndpointConfiguration(
 			final String restAddress,
 			@Nullable String restBindAddress,
-			int restBindPort,
+			String restBindPort,
 			@Nullable SSLHandlerFactory sslHandlerFactory,
 			final Path uploadDir,
 			final int maxContentLength,
 			final Map<String, String> responseHeaders) {
 
-		Preconditions.checkArgument(0 <= restBindPort && restBindPort < 65536, "The bing rest port " + restBindPort + " is out of range (0, 65536[");
 		Preconditions.checkArgument(maxContentLength > 0, "maxContentLength must be positive, was: %d", maxContentLength);
 
 		this.restAddress = requireNonNull(restAddress);
 		this.restBindAddress = restBindAddress;
-		this.restBindPort = restBindPort;
+		this.restBindPort = requireNonNull(restBindPort);
 		this.sslHandlerFactory = sslHandlerFactory;
 		this.uploadDir = requireNonNull(uploadDir);
 		this.maxContentLength = maxContentLength;
@@ -97,11 +96,11 @@ public final class RestServerEndpointConfiguration {
 	}
 
 	/**
-	 * Returns the port that the REST server endpoint should listen on.
+	 * Returns the port range that the REST server endpoint should listen on.
 	 *
-	 * @return port that the REST server endpoint should listen on
+	 * @return port range that the REST server endpoint should listen on
 	 */
-	public int getRestBindPort() {
+	public String getRestBindPort() {
 		return restBindPort;
 	}
 
@@ -153,7 +152,7 @@ public final class RestServerEndpointConfiguration {
 			RestOptions.ADDRESS.key());
 
 		final String restBindAddress = config.getString(RestOptions.BIND_ADDRESS);
-		final int port = config.getInteger(RestOptions.PORT);
+		final String portRangeDefinition = config.getString(RestOptions.BIND_PORT);
 
 		final SSLHandlerFactory sslHandlerFactory;
 		if (SSLUtils.isRestSSLEnabled(config)) {
@@ -179,7 +178,7 @@ public final class RestServerEndpointConfiguration {
 		return new RestServerEndpointConfiguration(
 			restAddress,
 			restBindAddress,
-			port,
+			portRangeDefinition,
 			sslHandlerFactory,
 			uploadDir,
 			maxContentLength,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -571,7 +571,7 @@ public class MiniClusterITCase extends TestLogger {
 
 	private Configuration getDefaultConfiguration() {
 		final Configuration configuration = new Configuration();
-		configuration.setInteger(RestOptions.PORT, 0);
+		configuration.setString(RestOptions.BIND_PORT, "0");
 
 		return configuration;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -97,7 +97,7 @@ public class MultipartUploadResource extends ExternalResource {
 	public void before() throws Exception {
 		temporaryFolder.create();
 		Configuration config = new Configuration();
-		config.setInteger(RestOptions.PORT, 0);
+		config.setString(RestOptions.BIND_PORT, "0");
 		config.setString(RestOptions.ADDRESS, "localhost");
 		// set this to a lower value on purpose to test that files larger than the content limit are still accepted
 		config.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, 1024 * 1024);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
@@ -18,42 +18,18 @@
 
 package org.apache.flink.runtime.rest;
 
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
-import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
-import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
-import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
-import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
-import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.webmonitor.RestfulGateway;
-import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
-import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ConfigurationException;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
-
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import javax.net.ssl.SSLHandshakeException;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link RestServerEndpointConfiguration}.
@@ -64,7 +40,6 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 	private static final String BIND_ADDRESS = "023.023.023.023";
 	private static final String BIND_PORT = "7282";
 	private static final int CONTENT_LENGTH = 1234;
-	private static final Time timeout = Time.seconds(10L);
 
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -81,221 +56,10 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 		final RestServerEndpointConfiguration result = RestServerEndpointConfiguration.fromConfiguration(originalConfig);
 		Assert.assertEquals(ADDRESS, result.getRestAddress());
 		Assert.assertEquals(BIND_ADDRESS, result.getRestBindAddress());
-		Assert.assertEquals(BIND_PORT, result.getRestBindPort());
+		Assert.assertEquals(BIND_PORT, result.getRestBindPortRange());
 		Assert.assertEquals(CONTENT_LENGTH, result.getMaxContentLength());
 		Assert.assertThat(
 			result.getUploadDir().toAbsolutePath().toString(),
 			containsString(temporaryFolder.getRoot().getAbsolutePath()));
 	}
-
-	@Test
-	public void testDefaultRestServerBindPort() throws Exception {
-		testRestServerBindPort(null, "8081");
-	}
-
-	@Test
-	public void testRestServerSpecificBindPort() throws Exception {
-		testRestServerBindPort("12345", "12345");
-	}
-
-	@Test
-	public void testRestServerSpecificBindPortRange() throws Exception {
-		testRestServerBindPort("12345,12346", "12345");
-	}
-
-	@Test
-	public void testRestServerBindPortRange() throws Exception {
-		testRestServerBindPort("12345-12350", "12345");
-	}
-
-	@Test
-	public void testRestServerBindPortAndConnectionPortSuccess() throws Exception {
-		testRestServerBindPortAndConnectionPort("12345,12346", 12345);
-	}
-
-	@Test
-	public void testRestServerBindPortAndConnectionPortFailed() throws Exception {
-		try {
-			testRestServerBindPortAndConnectionPort("12345-12346", 12347);
-		} catch (Exception e) {
-			assertTrue(e.getMessage().contains("Connection refused")
-				&& e.getMessage().contains("12347"));
-		}
-	}
-
-	@Test
-	public void testRestServerBindPortConflict() throws Exception {
-		RestServerEndpoint serverEndpoint1 = null;
-		RestServerEndpoint serverEndpoint2 = null;
-		RestClient restClient = null;
-
-		try {
-			final Configuration config = new Configuration();
-			config.setString(RestOptions.ADDRESS, "localhost");
-			config.setString(RestOptions.BIND_PORT, "12345,12346");
-
-			RestServerEndpointITCase.TestHandler testHandler;
-
-			RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
-			RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
-
-			final String restAddress = "http://localhost:1234";
-			RestfulGateway mockRestfulGateway = TestingRestfulGateway.newBuilder()
-				.setAddress("http://localhost:1234")
-				.build();
-
-			final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
-				CompletableFuture.completedFuture(mockRestfulGateway);
-
-			testHandler = new RestServerEndpointITCase.TestHandler(
-				CompletableFuture.completedFuture(restAddress),
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT);
-
-			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT);
-
-			final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
-				Tuple2.of(new RestServerEndpointITCase.TestHeaders(), testHandler),
-				Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler));
-
-			serverEndpoint1 = new RestServerEndpointITCase.TestRestServerEndpoint(serverConfig, handlers);
-			serverEndpoint2 = new RestServerEndpointITCase.TestRestServerEndpoint(serverConfig, handlers);
-			restClient = new RestServerEndpointITCase.TestRestClient(clientConfig);
-
-			//start two rest server instances, the first one pick port : 12345
-			//the second one pick port : 12345 firstly, but will conflict with the first instance,
-			//then the expected behavior is that it should choose port : 12346
-			serverEndpoint1.start();
-			serverEndpoint2.start();
-
-			CompletableFuture<EmptyResponseBody> response = restClient.sendRequest(
-				config.getString(RestOptions.ADDRESS),
-				12346,		//connect to the second port
-				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
-				EmptyMessageParameters.getInstance(),
-				EmptyRequestBody.getInstance(),
-				Collections.emptyList()
-			);
-
-			response.get(5, TimeUnit.SECONDS);
-		} catch (Exception e) {
-			throw e;
-		} finally {
-			if (restClient != null) {
-				restClient.shutdown(timeout);
-			}
-
-			if (serverEndpoint1 != null) {
-				serverEndpoint1.closeAsync().get(timeout.getSize(), timeout.getUnit());
-			}
-
-			if (serverEndpoint2 != null) {
-				serverEndpoint2.closeAsync().get(timeout.getSize(), timeout.getUnit());
-			}
-		}
-	}
-
-	private void testRestServerBindPortAndConnectionPort(String bindPort, int connectPort) throws Exception {
-		RestServerEndpoint serverEndpoint = null;
-		RestClient restClient = null;
-
-		try {
-			final Configuration config = new Configuration();
-			config.setString(RestOptions.ADDRESS, "localhost");
-			config.setString(RestOptions.BIND_PORT, bindPort);
-
-			RestServerEndpointITCase.TestHandler testHandler;
-
-			RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
-			RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
-
-			final String restAddress = "http://localhost:1234";
-			RestfulGateway mockRestfulGateway = TestingRestfulGateway.newBuilder()
-				.setAddress("http://localhost:1234")
-				.build();
-
-			final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
-				CompletableFuture.completedFuture(mockRestfulGateway);
-
-			testHandler = new RestServerEndpointITCase.TestHandler(
-				CompletableFuture.completedFuture(restAddress),
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT);
-
-			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT);
-
-			final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
-				Tuple2.of(new RestServerEndpointITCase.TestHeaders(), testHandler),
-				Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler));
-
-			serverEndpoint = new RestServerEndpointITCase.TestRestServerEndpoint(serverConfig, handlers);
-			restClient = new RestServerEndpointITCase.TestRestClient(clientConfig);
-
-			serverEndpoint.start();
-
-			CompletableFuture<EmptyResponseBody> response = restClient.sendRequest(
-				config.getString(RestOptions.ADDRESS),
-				connectPort,
-				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
-				EmptyMessageParameters.getInstance(),
-				EmptyRequestBody.getInstance(),
-				Collections.emptyList()
-			);
-
-			response.get(5, TimeUnit.SECONDS);
-		} catch (Exception e) {
-			throw e;
-		} finally {
-			if (restClient != null) {
-				restClient.shutdown(timeout);
-			}
-
-			if (serverEndpoint != null) {
-				serverEndpoint.closeAsync().get(timeout.getSize(), timeout.getUnit());
-			}
-		}
-	}
-
-	private void testRestServerBindPort(String restBindPort, String expectedBindPort) throws Exception {
-		RestServerEndpoint serverEndpoint = null;
-
-		try {
-			final Configuration baseConfig = new Configuration();
-			baseConfig.setString(RestOptions.ADDRESS, "localhost");
-
-			if (restBindPort != null) {
-				baseConfig.setString(RestOptions.BIND_PORT, restBindPort);
-			}
-
-			Configuration serverConfig = new Configuration(baseConfig);
-
-			RestServerEndpointConfiguration restServerConfig = RestServerEndpointConfiguration.fromConfiguration(serverConfig);
-
-			RestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
-				.setAddress("http://localhost:1234")
-				.build();
-			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-				() -> CompletableFuture.completedFuture(restfulGateway),
-				RpcUtils.INF_TIMEOUT);
-
-			serverEndpoint = new RestServerEndpointITCase.TestRestServerEndpoint(
-				restServerConfig,
-				Arrays.asList(Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler)));
-			serverEndpoint.start();
-
-			assertEquals("http://localhost:" + expectedBindPort, serverEndpoint.getRestBaseUrl());
-		} catch (ExecutionException exception) {
-			// that is what we want
-			assertTrue(ExceptionUtils.findThrowable(exception, SSLHandshakeException.class).isPresent());
-		} finally {
-			if (serverEndpoint != null) {
-				serverEndpoint.close();
-			}
-		}
-	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
@@ -18,18 +18,45 @@
 
 package org.apache.flink.runtime.rest;
 
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.net.ssl.SSLHandshakeException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link RestServerEndpointConfiguration}.
@@ -38,8 +65,9 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 
 	private static final String ADDRESS = "123.123.123.123";
 	private static final String BIND_ADDRESS = "023.023.023.023";
-	private static final int PORT = 7282;
+	private static final String BIND_PORT = "7282";
 	private static final int CONTENT_LENGTH = 1234;
+	private static final Time timeout = Time.seconds(10L);
 
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -49,17 +77,154 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 		Configuration originalConfig = new Configuration();
 		originalConfig.setString(RestOptions.ADDRESS, ADDRESS);
 		originalConfig.setString(RestOptions.BIND_ADDRESS, BIND_ADDRESS);
-		originalConfig.setInteger(RestOptions.PORT, PORT);
+		originalConfig.setString(RestOptions.BIND_PORT, BIND_PORT);
 		originalConfig.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, CONTENT_LENGTH);
 		originalConfig.setString(WebOptions.TMP_DIR, temporaryFolder.getRoot().getAbsolutePath());
 
 		final RestServerEndpointConfiguration result = RestServerEndpointConfiguration.fromConfiguration(originalConfig);
 		Assert.assertEquals(ADDRESS, result.getRestAddress());
 		Assert.assertEquals(BIND_ADDRESS, result.getRestBindAddress());
-		Assert.assertEquals(PORT, result.getRestBindPort());
+		Assert.assertEquals(BIND_PORT, result.getRestBindPort());
 		Assert.assertEquals(CONTENT_LENGTH, result.getMaxContentLength());
 		Assert.assertThat(
 			result.getUploadDir().toAbsolutePath().toString(),
 			containsString(temporaryFolder.getRoot().getAbsolutePath()));
 	}
+
+	@Test
+	public void testDefaultRestServerBindPort() throws Exception {
+		testRestServerBindPort(null, "8081");
+	}
+
+	@Test
+	public void testRestServerSpecificBindPort() throws Exception {
+		testRestServerBindPort("12345", "12345");
+	}
+
+	@Test
+	public void testRestServerSpecificBindPortRange() throws Exception {
+		testRestServerBindPort("12345,12346", "12345");
+	}
+
+	@Test
+	public void testRestServerBindPortRange() throws Exception {
+		testRestServerBindPort("12345-12350", "12345");
+	}
+
+	@Test
+	public void testRestServerBindPortAndConnectionPortSuccess() throws Exception {
+		testRestServerBindPortAndConnectionPort("12345,12346", 12345);
+	}
+
+	@Test
+	public void testRestServerBindPortAndConnectionPortFailed() throws Exception {
+		try {
+			testRestServerBindPortAndConnectionPort("12345-12346", 12347);
+		} catch (Exception e) {
+			assertTrue(e.getMessage().contains("Connection refused")
+				&& e.getMessage().contains("12347"));
+		}
+	}
+
+	private void testRestServerBindPortAndConnectionPort(String bindPort, int connectPort) throws Exception {
+		RestServerEndpoint serverEndpoint = null;
+		RestClient restClient = null;
+
+		try {
+			final Configuration config = new Configuration();
+			config.setString(RestOptions.ADDRESS, "localhost");
+			config.setString(RestOptions.BIND_PORT, bindPort);
+			config.setInteger(RestOptions.PORT, connectPort);
+
+			RestServerEndpointITCase.TestHandler testHandler;
+
+			RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
+			RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
+
+			final String restAddress = "http://localhost:1234";
+			RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
+			when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(restAddress));
+
+			final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
+				CompletableFuture.completedFuture(mockRestfulGateway);
+
+			testHandler = new RestServerEndpointITCase.TestHandler(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT);
+
+			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT);
+
+			final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
+				Tuple2.of(new RestServerEndpointITCase.TestHeaders(), testHandler),
+				Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler));
+
+			serverEndpoint = new RestServerEndpointITCase.TestRestServerEndpoint(serverConfig, handlers);
+			restClient = new RestServerEndpointITCase.TestRestClient(clientConfig);
+
+			serverEndpoint.start();
+
+			CompletableFuture<EmptyResponseBody> response = restClient.sendRequest(
+				config.getString(RestOptions.ADDRESS),
+				config.getInteger(RestOptions.PORT),
+				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
+				EmptyMessageParameters.getInstance(),
+				EmptyRequestBody.getInstance(),
+				Collections.emptyList()
+			);
+
+			response.get(5, TimeUnit.SECONDS);
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			if (restClient != null) {
+				restClient.shutdown(timeout);
+			}
+
+			if (serverEndpoint != null) {
+				serverEndpoint.closeAsync().get(timeout.getSize(), timeout.getUnit());
+			}
+		}
+	}
+
+	private void testRestServerBindPort(String restBindPort, String expectedBindPort) throws Exception {
+		RestServerEndpoint serverEndpoint = null;
+
+		try {
+			final Configuration baseConfig = new Configuration();
+			baseConfig.setString(RestOptions.ADDRESS, "localhost");
+
+			if (restBindPort != null) {
+				baseConfig.setString(RestOptions.BIND_PORT, restBindPort);
+			}
+
+			Configuration serverConfig = new Configuration(baseConfig);
+
+			RestServerEndpointConfiguration restServerConfig = RestServerEndpointConfiguration.fromConfiguration(serverConfig);
+
+			RestfulGateway restfulGateway = TestingRestfulGateway.newBuilder().build();
+			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
+				CompletableFuture.completedFuture("http://localhost:1234"),
+				() -> CompletableFuture.completedFuture(restfulGateway),
+				RpcUtils.INF_TIMEOUT);
+
+			serverEndpoint = new RestServerEndpointITCase.TestRestServerEndpoint(
+				restServerConfig,
+				Arrays.asList(Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler)));
+			serverEndpoint.start();
+
+			assertEquals("http://localhost:" + expectedBindPort, serverEndpoint.getRestBaseUrl());
+		} catch (ExecutionException exception) {
+			// that is what we want
+			assertTrue(ExceptionUtils.findThrowable(exception, SSLHandshakeException.class).isPresent());
+		} finally {
+			if (serverEndpoint != null) {
+				serverEndpoint.close();
+			}
+		}
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
@@ -54,9 +54,6 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link RestServerEndpointConfiguration}.
@@ -143,8 +140,9 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 			RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
 
 			final String restAddress = "http://localhost:1234";
-			RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
-			when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(restAddress));
+			RestfulGateway mockRestfulGateway = TestingRestfulGateway.newBuilder()
+				.setAddress("http://localhost:1234")
+				.build();
 
 			final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
 				CompletableFuture.completedFuture(mockRestfulGateway);
@@ -155,7 +153,6 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 				RpcUtils.INF_TIMEOUT);
 
 			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-				CompletableFuture.completedFuture(restAddress),
 				mockGatewayRetriever,
 				RpcUtils.INF_TIMEOUT);
 
@@ -215,8 +212,9 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 			RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
 
 			final String restAddress = "http://localhost:1234";
-			RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
-			when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(restAddress));
+			RestfulGateway mockRestfulGateway = TestingRestfulGateway.newBuilder()
+				.setAddress("http://localhost:1234")
+				.build();
 
 			final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
 				CompletableFuture.completedFuture(mockRestfulGateway);
@@ -227,7 +225,6 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 				RpcUtils.INF_TIMEOUT);
 
 			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-				CompletableFuture.completedFuture(restAddress),
 				mockGatewayRetriever,
 				RpcUtils.INF_TIMEOUT);
 
@@ -278,9 +275,10 @@ public class RestServerEndpointConfigurationTest extends TestLogger {
 
 			RestServerEndpointConfiguration restServerConfig = RestServerEndpointConfiguration.fromConfiguration(serverConfig);
 
-			RestfulGateway restfulGateway = TestingRestfulGateway.newBuilder().build();
+			RestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+				.setAddress("http://localhost:1234")
+				.build();
 			RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-				CompletableFuture.completedFuture("http://localhost:1234"),
 				() -> CompletableFuture.completedFuture(restfulGateway),
 				RpcUtils.INF_TIMEOUT);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -169,7 +169,7 @@ public class RestServerEndpointITCase extends TestLogger {
 
 	private static Configuration getBaseConfig() {
 		final Configuration config = new Configuration();
-		config.setInteger(RestOptions.PORT, 0);
+		config.setString(RestOptions.BIND_PORT, "0");
 		config.setString(RestOptions.ADDRESS, "localhost");
 		config.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
 		config.setInteger(RestOptions.CLIENT_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
@@ -601,7 +601,10 @@ public class RestServerEndpointITCase extends TestLogger {
 		protected void startInternal() {}
 	}
 
-	private static class TestHandler extends AbstractRestHandler<RestfulGateway, TestRequest, TestResponse, TestParameters> {
+	/**
+	 * Test handler.
+	 */
+	public static class TestHandler extends AbstractRestHandler<RestfulGateway, TestRequest, TestResponse, TestParameters> {
 
 		private CompletableFuture<Void> closeFuture = CompletableFuture.completedFuture(null);
 
@@ -749,7 +752,10 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 	}
 
-	private static class TestHeaders implements MessageHeaders<TestRequest, TestResponse, TestParameters> {
+	/**
+	 * Test headers.
+	 */
+	public static class TestHeaders implements MessageHeaders<TestRequest, TestResponse, TestParameters> {
 
 		@Override
 		public HttpMethodWrapper getHttpMethod() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
-import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
@@ -74,7 +73,6 @@ import org.junit.runners.Parameterized;
 import javax.annotation.Nonnull;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocketFactory;
 
 import java.io.File;
@@ -103,9 +101,12 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -564,113 +565,28 @@ public class RestServerEndpointITCase extends TestLogger {
 	}
 
 	@Test
-	public void testDefaultRestServerBindPort() throws Exception {
-		final Configuration baseConfig = new Configuration();
-		baseConfig.setString(RestOptions.ADDRESS, "localhost");
-
-		Configuration serverConfig = new Configuration(baseConfig);
-
-		RestServerEndpointConfiguration restServerConfig = RestServerEndpointConfiguration.fromConfiguration(serverConfig);
-
-		RestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
-			.setAddress("http://localhost:1234")
-			.build();
-		RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-			() -> CompletableFuture.completedFuture(restfulGateway),
-			RpcUtils.INF_TIMEOUT);
-
-		try (RestServerEndpoint serverEndpoint = new RestServerEndpointITCase.TestRestServerEndpoint(
-			restServerConfig,
-			Arrays.asList(Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler)));) {
-			serverEndpoint.start();
-
-			assertEquals("http://localhost:" + 8081, serverEndpoint.getRestBaseUrl());
-		} catch (ExecutionException exception) {
-			// that is what we want
-			assertTrue(ExceptionUtils.findThrowable(exception, SSLHandshakeException.class).isPresent());
-		}
-	}
-
-	@Test
 	public void testRestServerBindPort() throws Exception {
-		RestClient restClient = null;
-
+		final int portRangeStart = 52300;
+		final int portRangeEnd = 52400;
 		final Configuration config = new Configuration();
 		config.setString(RestOptions.ADDRESS, "localhost");
-		config.setString(RestOptions.BIND_PORT, "52345,52346");
+		config.setString(RestOptions.BIND_PORT, portRangeStart + "-" + portRangeEnd);
 
-		RestServerEndpointITCase.TestHandler testHandler;
+		final RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
 
-		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
-		RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
-
-		final String restAddress = "http://localhost:1234";
-		RestfulGateway mockRestfulGateway = TestingRestfulGateway.newBuilder()
-			.setAddress("http://localhost:1234")
-			.build();
-
-		final GatewayRetriever<RestfulGateway> mockGatewayRetriever = () ->
-			CompletableFuture.completedFuture(mockRestfulGateway);
-
-		testHandler = new RestServerEndpointITCase.TestHandler(
-			CompletableFuture.completedFuture(restAddress),
-			mockGatewayRetriever,
-			RpcUtils.INF_TIMEOUT);
-
-		RestServerEndpointITCase.TestVersionHandler testVersionHandler = new RestServerEndpointITCase.TestVersionHandler(
-			mockGatewayRetriever,
-			RpcUtils.INF_TIMEOUT);
-
-		final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
-			Tuple2.of(new RestServerEndpointITCase.TestHeaders(), testHandler),
-			Tuple2.of(testVersionHandler.getMessageHeaders(), testVersionHandler));
-
-		try (RestServerEndpoint serverEndpoint1 = new RestServerEndpointITCase.TestRestServerEndpoint(serverConfig, handlers);
-			RestServerEndpoint serverEndpoint2 = new RestServerEndpointITCase.TestRestServerEndpoint(serverConfig, handlers)) {
-
-			restClient = new RestServerEndpointITCase.TestRestClient(clientConfig);
+		try (RestServerEndpoint serverEndpoint1 = new TestRestServerEndpoint(serverConfig, Collections.emptyList());
+			RestServerEndpoint serverEndpoint2 = new TestRestServerEndpoint(serverConfig, Collections.emptyList())) {
 
 			serverEndpoint1.start();
 			serverEndpoint2.start();
 
-			CompletableFuture<EmptyResponseBody> responseFromServer1 = restClient.sendRequest(
-				config.getString(RestOptions.ADDRESS),
-				52345,		//connect to the first port
-				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
-				EmptyMessageParameters.getInstance(),
-				EmptyRequestBody.getInstance(),
-				Collections.emptyList()
-			);
-			CompletableFuture<EmptyResponseBody> responseFromServer2 = restClient.sendRequest(
-				config.getString(RestOptions.ADDRESS),
-				52346,		//connect to the second port
-				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
-				EmptyMessageParameters.getInstance(),
-				EmptyRequestBody.getInstance(),
-				Collections.emptyList()
-			);
+			assertNotEquals(serverEndpoint1.getServerAddress().getPort(), serverEndpoint2.getServerAddress().getPort());
 
-			responseFromServer1.get(5, TimeUnit.SECONDS);
-			responseFromServer2.get(5, TimeUnit.SECONDS);
+			assertThat(serverEndpoint1.getServerAddress().getPort(), is(greaterThanOrEqualTo(portRangeStart)));
+			assertThat(serverEndpoint1.getServerAddress().getPort(), is(lessThanOrEqualTo(portRangeEnd)));
 
-			//test connect port failed
-			CompletableFuture<EmptyResponseBody> failedResponse = restClient.sendRequest(
-				config.getString(RestOptions.ADDRESS),
-				52347,		//connect to an error port
-				RestServerEndpointITCase.TestVersionHeaders.INSTANCE,
-				EmptyMessageParameters.getInstance(),
-				EmptyRequestBody.getInstance(),
-				Collections.emptyList()
-			);
-			failedResponse.get(5, TimeUnit.SECONDS);
-			fail("Expected an connection refused exception.");
-		} catch (Exception e) {
-			assertTrue(e.getMessage().contains("Connection refused")
-				&& e.getMessage().contains("52347"));
-		} finally {
-			if (restClient != null) {
-				restClient.shutdown(timeout);
-			}
+			assertThat(serverEndpoint2.getServerAddress().getPort(), is(greaterThanOrEqualTo(portRangeStart)));
+			assertThat(serverEndpoint2.getServerAddress().getPort(), is(lessThanOrEqualTo(portRangeEnd)));
 		}
 	}
 
@@ -714,10 +630,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		protected void startInternal() {}
 	}
 
-	/**
-	 * Test handler.
-	 */
-	public static class TestHandler extends AbstractRestHandler<RestfulGateway, TestRequest, TestResponse, TestParameters> {
+	private static class TestHandler extends AbstractRestHandler<RestfulGateway, TestRequest, TestResponse, TestParameters> {
 
 		private CompletableFuture<Void> closeFuture = CompletableFuture.completedFuture(null);
 
@@ -865,10 +778,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 	}
 
-	/**
-	 * Test headers.
-	 */
-	public static class TestHeaders implements MessageHeaders<TestRequest, TestResponse, TestParameters> {
+	private static class TestHeaders implements MessageHeaders<TestRequest, TestResponse, TestParameters> {
 
 		@Override
 		public HttpMethodWrapper getHttpMethod() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -66,7 +66,7 @@ public class RestServerSSLAuthITCase extends TestLogger {
 
 		try {
 			final Configuration baseConfig = new Configuration();
-			baseConfig.setInteger(RestOptions.PORT, 0);
+			baseConfig.setString(RestOptions.BIND_PORT, "0");
 			baseConfig.setString(RestOptions.ADDRESS, "localhost");
 			baseConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
 			baseConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/DispatcherProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/DispatcherProcess.java
@@ -120,7 +120,7 @@ public class DispatcherProcess extends TestJvmProcess {
 				LOG.info("Configuration: {}.", config);
 
 				config.setInteger(JobManagerOptions.PORT, 0);
-				config.setInteger(RestOptions.PORT, 0);
+				config.setString(RestOptions.BIND_PORT, "0");
 
 				final StandaloneSessionClusterEntrypoint clusterEntrypoint = new StandaloneSessionClusterEntrypoint(config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -127,7 +127,7 @@ public class MiniClusterResource extends ExternalResource {
 
 		// set rest and rpc port to 0 to avoid clashes with concurrent MiniClusters
 		configuration.setInteger(JobManagerOptions.PORT, 0);
-		configuration.setInteger(RestOptions.PORT, 0);
+		configuration.setString(RestOptions.BIND_PORT, "0");
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -99,8 +99,8 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		// add (and override) the settings with what the user defined
 		configuration.addAll(this.configuration);
 
-		if (!configuration.contains(RestOptions.PORT)) {
-			configuration.setInteger(RestOptions.PORT, 0);
+		if (!configuration.contains(RestOptions.BIND_PORT)) {
+			configuration.setString(RestOptions.BIND_PORT, "0");
 		}
 
 		int numSlotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, jobGraph.getMaximumParallelism());

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		Configuration config = new Configuration();
 		config.setString(AkkaOptions.ASK_TIMEOUT, "100 s");
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
-		config.setInteger(RestOptions.PORT, 0);
+		config.setString(RestOptions.BIND_PORT, "0");
 		config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 500L);
 		config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 10000L);
 		config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
@@ -97,7 +97,7 @@ public class SchedulingITCase extends TestLogger {
 	}
 
 	private void executeSchedulingTest(Configuration configuration) throws Exception {
-		configuration.setInteger(RestOptions.PORT, 0);
+		configuration.setString(RestOptions.BIND_PORT, "0");
 
 		final long slotIdleTimeout = 50L;
 		configuration.setLong(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -98,9 +98,9 @@ public class YarnEntrypointUtils {
 			configuration.setInteger(WebOptions.PORT, 0);
 		}
 
-		if (configuration.getInteger(RestOptions.PORT) >= 0) {
+		if (!configuration.getString(RestOptions.BIND_PORT).equals("0")) {
 			// set the REST port to 0 to select it randomly
-			configuration.setInteger(RestOptions.PORT, 0);
+			configuration.setString(RestOptions.BIND_PORT, "0");
 		}
 
 		// if the user has set the deprecated YARN-specific config keys, we add the

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -98,10 +98,8 @@ public class YarnEntrypointUtils {
 			configuration.setInteger(WebOptions.PORT, 0);
 		}
 
-		if (!configuration.getString(RestOptions.BIND_PORT).equals("0")) {
-			// set the REST port to 0 to select it randomly
-			configuration.setString(RestOptions.BIND_PORT, "0");
-		}
+		// set the REST port to 0 to select it randomly
+		configuration.setString(RestOptions.BIND_PORT, "0");
 
 		// if the user has set the deprecated YARN-specific config keys, we add the
 		// corresponding generic config keys instead. that way, later code needs not


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports binding port range for REST server*

## Brief change log

  - *Support binding port range for REST server*


## Verifying this change

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - *testDefaultRestServerBindPort*
  - *testRestServerSpecificBindPort*
  - *testRestServerSpecificBindPort*
  - *testRestServerBindPortRange*
  - *testRestServerBindPortAndConnectionPortSuccess*
  - *testRestServerBindPortAndConnectionPortFailed*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
