### PR TITLE
[FLINK-11094] [rocksdb] Make non-accessed restored state in RocksDBStateBackend snapshottable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
-import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -106,22 +105,9 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	private final boolean asynchronousSnapshots;
 
 	/**
-	 * Map of state names to their corresponding restored state meta info.
-	 *
-	 * <p>TODO this map can be removed when eager-state registration is in place.
-	 * TODO we currently need this cached to check state migration strategies when new serializers are registered.
-	 */
-	private final Map<String, StateMetaInfoSnapshot> restoredOperatorStateMetaInfos;
-
-	/**
-	 * Map of state names to their corresponding restored broadcast state meta info.
-	 */
-	private final Map<String, StateMetaInfoSnapshot> restoredBroadcastStateMetaInfos;
-
-	/**
 	 * Cache of already accessed states.
 	 *
-	 * <p>In contrast to {@link #registeredOperatorStates} and {@link #restoredOperatorStateMetaInfos} which may be repopulated
+	 * <p>In contrast to {@link #registeredOperatorStates} which may be repopulated
 	 * with restored state, this map is always empty at the beginning.
 	 *
 	 * <p>TODO this map should be moved to a base class once we have proper hierarchy for the operator state backends.
@@ -148,8 +134,6 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		this.asynchronousSnapshots = asynchronousSnapshots;
 		this.accessedStatesByName = new HashMap<>();
 		this.accessedBroadcastStatesByName = new HashMap<>();
-		this.restoredOperatorStateMetaInfos = new HashMap<>();
-		this.restoredBroadcastStateMetaInfos = new HashMap<>();
 		this.snapshotStrategy = new DefaultOperatorStateBackendSnapshotStrategy();
 	}
 
@@ -226,34 +210,22 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					broadcastState.getStateMetaInfo().getAssignmentMode(),
 					OperatorStateHandle.Mode.BROADCAST);
 
-			final StateMetaInfoSnapshot metaInfoSnapshot = restoredBroadcastStateMetaInfos.get(name);
+			RegisteredBroadcastStateBackendMetaInfo<K, V> restoredBroadcastStateMetaInfo = broadcastState.getStateMetaInfo();
 
 			// check whether new serializers are incompatible
-			TypeSerializerSnapshot<K> keySerializerSnapshot = Preconditions.checkNotNull(
-				(TypeSerializerSnapshot<K>) metaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER));
-
 			TypeSerializerSchemaCompatibility<K> keyCompatibility =
-				keySerializerSnapshot.resolveSchemaCompatibility(broadcastStateKeySerializer);
+				restoredBroadcastStateMetaInfo.updateKeySerializer(broadcastStateKeySerializer);
 			if (keyCompatibility.isIncompatible()) {
 				throw new StateMigrationException("The new key serializer for broadcast state must not be incompatible.");
 			}
 
-			TypeSerializerSnapshot<V> valueSerializerSnapshot = Preconditions.checkNotNull(
-				(TypeSerializerSnapshot<V>) metaInfoSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
-
 			TypeSerializerSchemaCompatibility<V> valueCompatibility =
-				valueSerializerSnapshot.resolveSchemaCompatibility(broadcastStateValueSerializer);
+				restoredBroadcastStateMetaInfo.updateValueSerializer(broadcastStateValueSerializer);
 			if (valueCompatibility.isIncompatible()) {
 				throw new StateMigrationException("The new value serializer for broadcast state must not be incompatible.");
 			}
 
-			// new serializer is compatible; use it to replace the old serializer
-			broadcastState.setStateMetaInfo(
-					new RegisteredBroadcastStateBackendMetaInfo<>(
-							name,
-							OperatorStateHandle.Mode.BROADCAST,
-							broadcastStateKeySerializer,
-							broadcastStateValueSerializer));
+			broadcastState.setStateMetaInfo(restoredBroadcastStateMetaInfo);
 		}
 
 		accessedBroadcastStatesByName.put(name, broadcastState);
@@ -345,8 +317,6 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 							" not be loaded. This is a temporary restriction that will be fixed in future versions.");
 					}
 
-					restoredOperatorStateMetaInfos.put(restoredSnapshot.getName(), restoredSnapshot);
-
 					PartitionableListState<?> listState = registeredOperatorStates.get(restoredSnapshot.getName());
 
 					if (null == listState) {
@@ -380,8 +350,6 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 								" have been removed from the classpath, or their implementations have changed and could" +
 								" not be loaded. This is a temporary restriction that will be fixed in future versions.");
 					}
-
-					restoredBroadcastStateMetaInfos.put(restoredSnapshot.getName(), restoredSnapshot);
 
 					BackendWritableBroadcastState<? ,?> broadcastState = registeredBroadcastStates.get(restoredSnapshot.getName());
 
@@ -590,25 +558,19 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					partitionableListState.getStateMetaInfo().getAssignmentMode(),
 					mode);
 
-			StateMetaInfoSnapshot restoredSnapshot = restoredOperatorStateMetaInfos.get(name);
-			RegisteredOperatorStateBackendMetaInfo<S> metaInfo =
-				new RegisteredOperatorStateBackendMetaInfo<>(restoredSnapshot);
+			RegisteredOperatorStateBackendMetaInfo<S> restoredPartitionableListStateMetaInfo =
+				partitionableListState.getStateMetaInfo();
 
-			// check compatibility to determine if state migration is required
+			// check compatibility to determine if new serializers are incompatible
 			TypeSerializer<S> newPartitionStateSerializer = partitionStateSerializer.duplicate();
 
-			@SuppressWarnings("unchecked")
-			TypeSerializerSnapshot<S> stateSerializerSnapshot = Preconditions.checkNotNull(
-				(TypeSerializerSnapshot<S>) restoredSnapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER));
-
 			TypeSerializerSchemaCompatibility<S> stateCompatibility =
-				stateSerializerSnapshot.resolveSchemaCompatibility(newPartitionStateSerializer);
+				restoredPartitionableListStateMetaInfo.updatePartitionStateSerializer(newPartitionStateSerializer);
 			if (stateCompatibility.isIncompatible()) {
 				throw new StateMigrationException("The new state serializer for operator state must not be incompatible.");
 			}
 
-			partitionableListState.setStateMetaInfo(
-				new RegisteredOperatorStateBackendMetaInfo<>(name, newPartitionStateSerializer, mode));
+			partitionableListState.setStateMetaInfo(restoredPartitionableListStateMetaInfo);
 		}
 
 		accessedStatesByName.put(name, partitionableListState);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
@@ -19,11 +19,13 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,11 +40,11 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 
 	/** The type serializer for the keys in the map state. */
 	@Nonnull
-	private final TypeSerializer<K> keySerializer;
+	private final StateSerializerProvider<K> keySerializerProvider;
 
 	/** The type serializer for the values in the map state. */
 	@Nonnull
-	private final TypeSerializer<V> valueSerializer;
+	private final StateSerializerProvider<V> valueSerializerProvider;
 
 	public RegisteredBroadcastStateBackendMetaInfo(
 			@Nonnull final String name,
@@ -50,19 +52,19 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 			@Nonnull final TypeSerializer<K> keySerializer,
 			@Nonnull final TypeSerializer<V> valueSerializer) {
 
-		super(name);
-		Preconditions.checkArgument(assignmentMode == OperatorStateHandle.Mode.BROADCAST);
-		this.assignmentMode = assignmentMode;
-		this.keySerializer = keySerializer;
-		this.valueSerializer = valueSerializer;
+		this(
+			name,
+			assignmentMode,
+			StateSerializerProvider.fromNewState(keySerializer),
+			StateSerializerProvider.fromNewState(valueSerializer));
 	}
 
 	public RegisteredBroadcastStateBackendMetaInfo(@Nonnull RegisteredBroadcastStateBackendMetaInfo<K, V> copy) {
 		this(
 			Preconditions.checkNotNull(copy).name,
 			copy.assignmentMode,
-			copy.keySerializer.duplicate(),
-			copy.valueSerializer.duplicate());
+			copy.getKeySerializer().duplicate(),
+			copy.getValueSerializer().duplicate());
 	}
 
 	@SuppressWarnings("unchecked")
@@ -71,10 +73,13 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 			snapshot.getName(),
 			OperatorStateHandle.Mode.valueOf(
 				snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE)),
-			(TypeSerializer<K>) Preconditions.checkNotNull(
-				snapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER)),
-			(TypeSerializer<V>) Preconditions.checkNotNull(
-				snapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER)));
+			StateSerializerProvider.fromRestoredState(
+				(TypeSerializerSnapshot<K>) Preconditions.checkNotNull(
+					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER))),
+			StateSerializerProvider.fromRestoredState(
+				(TypeSerializerSnapshot<V>) Preconditions.checkNotNull(
+					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))));
+
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.BROADCAST == snapshot.getBackendStateType());
 	}
 
@@ -86,6 +91,19 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 		return new RegisteredBroadcastStateBackendMetaInfo<>(this);
 	}
 
+	private RegisteredBroadcastStateBackendMetaInfo(
+		@Nonnull final String name,
+		@Nonnull final OperatorStateHandle.Mode assignmentMode,
+		@Nonnull final StateSerializerProvider<K> keySerializerProvider,
+		@Nonnull final StateSerializerProvider<V> valueSerializerProvider) {
+
+		super(name);
+		Preconditions.checkArgument(assignmentMode == OperatorStateHandle.Mode.BROADCAST);
+		this.assignmentMode = assignmentMode;
+		this.keySerializerProvider = keySerializerProvider;
+		this.valueSerializerProvider = valueSerializerProvider;
+	}
+
 	@Nonnull
 	@Override
 	public StateMetaInfoSnapshot snapshot() {
@@ -94,12 +112,32 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 
 	@Nonnull
 	public TypeSerializer<K> getKeySerializer() {
-		return keySerializer;
+		return keySerializerProvider.currentSchemaSerializer();
+	}
+
+	@Nonnull
+	public TypeSerializerSchemaCompatibility<K> updateKeySerializer(TypeSerializer<K> newKeySerializer) {
+		return keySerializerProvider.registerNewSerializerForRestoredState(newKeySerializer);
+	}
+
+	@Nullable
+	public TypeSerializer<K> getPreviousKeySerializer() {
+		return keySerializerProvider.previousSchemaSerializer();
 	}
 
 	@Nonnull
 	public TypeSerializer<V> getValueSerializer() {
-		return valueSerializer;
+		return valueSerializerProvider.currentSchemaSerializer();
+	}
+
+	@Nonnull
+	public TypeSerializerSchemaCompatibility<V> updateValueSerializer(TypeSerializer<V> newValueSerializer) {
+		return valueSerializerProvider.registerNewSerializerForRestoredState(newValueSerializer);
+	}
+
+	@Nullable
+	public TypeSerializer<V> getPreviousValueSerializer() {
+		return valueSerializerProvider.previousSchemaSerializer();
 	}
 
 	@Nonnull
@@ -122,16 +160,16 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 
 		return Objects.equals(name, other.getName())
 				&& Objects.equals(assignmentMode, other.getAssignmentMode())
-				&& Objects.equals(keySerializer, other.getKeySerializer())
-				&& Objects.equals(valueSerializer, other.getValueSerializer());
+				&& Objects.equals(getKeySerializer(), other.getKeySerializer())
+				&& Objects.equals(getValueSerializer(), other.getValueSerializer());
 	}
 
 	@Override
 	public int hashCode() {
 		int result = name.hashCode();
 		result = 31 * result + assignmentMode.hashCode();
-		result = 31 * result + keySerializer.hashCode();
-		result = 31 * result + valueSerializer.hashCode();
+		result = 31 * result + getKeySerializer().hashCode();
+		result = 31 * result + getValueSerializer().hashCode();
 		return result;
 	}
 
@@ -139,8 +177,8 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 	public String toString() {
 		return "RegisteredBroadcastBackendStateMetaInfo{" +
 				"name='" + name + '\'' +
-				", keySerializer=" + keySerializer +
-				", valueSerializer=" + valueSerializer +
+				", keySerializer=" + getKeySerializer() +
+				", valueSerializer=" + getValueSerializer() +
 				", assignmentMode=" + assignmentMode +
 				'}';
 	}
@@ -154,8 +192,12 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 		Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap = new HashMap<>(2);
 		String keySerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER.toString();
 		String valueSerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString();
+
+		TypeSerializer<K> keySerializer = getKeySerializer();
 		serializerMap.put(keySerializerKey, keySerializer.duplicate());
 		serializerConfigSnapshotsMap.put(keySerializerKey, keySerializer.snapshotConfiguration());
+
+		TypeSerializer<V> valueSerializer = getValueSerializer();
 		serializerMap.put(valueSerializerKey, valueSerializer.duplicate());
 		serializerConfigSnapshotsMap.put(valueSerializerKey, valueSerializer.snapshotConfiguration());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
@@ -75,10 +75,10 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
 				snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE)),
 			StateSerializerProvider.fromRestoredState(
 				(TypeSerializerSnapshot<K>) Preconditions.checkNotNull(
-					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER))),
+					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER))),
 			StateSerializerProvider.fromRestoredState(
 				(TypeSerializerSnapshot<V>) Preconditions.checkNotNull(
-					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))));
+					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))));
 
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.BROADCAST == snapshot.getBackendStateType());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
@@ -44,18 +45,24 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	@Nonnull
 	private final StateDescriptor.Type stateType;
 	@Nonnull
-	private final TypeSerializer<N> namespaceSerializer;
+	private final StateSerializerProvider<N> namespaceSerializerProvider;
 	@Nonnull
-	private final TypeSerializer<S> stateSerializer;
+	private final StateSerializerProvider<S> stateSerializerProvider;
 	@Nullable
-	private final StateSnapshotTransformer<S> snapshotTransformer;
+	private StateSnapshotTransformer<S> snapshotTransformer;
 
 	public RegisteredKeyValueStateBackendMetaInfo(
 		@Nonnull StateDescriptor.Type stateType,
 		@Nonnull String name,
 		@Nonnull TypeSerializer<N> namespaceSerializer,
 		@Nonnull TypeSerializer<S> stateSerializer) {
-		this(stateType, name, namespaceSerializer, stateSerializer, null);
+
+		this(
+			stateType,
+			name,
+			StateSerializerProvider.fromNewState(namespaceSerializer),
+			StateSerializerProvider.fromNewState(stateSerializer),
+			null);
 	}
 
 	public RegisteredKeyValueStateBackendMetaInfo(
@@ -65,11 +72,12 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		@Nonnull TypeSerializer<S> stateSerializer,
 		@Nullable StateSnapshotTransformer<S> snapshotTransformer) {
 
-		super(name);
-		this.stateType = stateType;
-		this.namespaceSerializer = namespaceSerializer;
-		this.stateSerializer = stateSerializer;
-		this.snapshotTransformer = snapshotTransformer;
+		this(
+			stateType,
+			name,
+			StateSerializerProvider.fromNewState(namespaceSerializer),
+			StateSerializerProvider.fromNewState(stateSerializer),
+			snapshotTransformer);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -77,11 +85,29 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		this(
 			StateDescriptor.Type.valueOf(snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE)),
 			snapshot.getName(),
-			(TypeSerializer<N>) Preconditions.checkNotNull(
-				snapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER)),
-			(TypeSerializer<S>) Preconditions.checkNotNull(
-				snapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER)), null);
+			StateSerializerProvider.fromRestoredState(
+				(TypeSerializerSnapshot<N>) Preconditions.checkNotNull(
+					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER))),
+			StateSerializerProvider.fromRestoredState(
+				(TypeSerializerSnapshot<S>) Preconditions.checkNotNull(
+					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
+			null);
+
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.KEY_VALUE == snapshot.getBackendStateType());
+	}
+
+	private RegisteredKeyValueStateBackendMetaInfo(
+		@Nonnull StateDescriptor.Type stateType,
+		@Nonnull String name,
+		@Nonnull StateSerializerProvider<N> namespaceSerializerProvider,
+		@Nonnull StateSerializerProvider<S> stateSerializerProvider,
+		@Nullable StateSnapshotTransformer<S> snapshotTransformer) {
+
+		super(name);
+		this.stateType = stateType;
+		this.namespaceSerializerProvider = namespaceSerializerProvider;
+		this.stateSerializerProvider = stateSerializerProvider;
+		this.snapshotTransformer = snapshotTransformer;
 	}
 
 	@Nonnull
@@ -91,17 +117,41 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 
 	@Nonnull
 	public TypeSerializer<N> getNamespaceSerializer() {
-		return namespaceSerializer;
+		return namespaceSerializerProvider.currentSchemaSerializer();
+	}
+
+	@Nonnull
+	public TypeSerializerSchemaCompatibility<N> updateNamespaceSerializer(TypeSerializer<N> newNamespaceSerializer) {
+		return namespaceSerializerProvider.registerNewSerializerForRestoredState(newNamespaceSerializer);
+	}
+
+	@Nullable
+	public TypeSerializer<N> getPreviousNamespaceSerializer() {
+		return namespaceSerializerProvider.previousSchemaSerializer();
 	}
 
 	@Nonnull
 	public TypeSerializer<S> getStateSerializer() {
-		return stateSerializer;
+		return stateSerializerProvider.currentSchemaSerializer();
+	}
+
+	@Nonnull
+	public TypeSerializerSchemaCompatibility<S> updateStateSerializer(TypeSerializer<S> newStateSerializer) {
+		return stateSerializerProvider.registerNewSerializerForRestoredState(newStateSerializer);
+	}
+
+	@Nullable
+	public TypeSerializer<S> getPreviousStateSerializer() {
+		return stateSerializerProvider.previousSchemaSerializer();
 	}
 
 	@Nullable
 	public StateSnapshotTransformer<S> getSnapshotTransformer() {
 		return snapshotTransformer;
+	}
+
+	public void updateSnapshotTransformer(StateSnapshotTransformer<S> snapshotTransformer) {
+		this.snapshotTransformer = snapshotTransformer;
 	}
 
 	@Override
@@ -133,8 +183,8 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		return "RegisteredKeyedBackendStateMetaInfo{" +
 				"stateType=" + stateType +
 				", name='" + name + '\'' +
-				", namespaceSerializer=" + namespaceSerializer +
-				", stateSerializer=" + stateSerializer +
+				", namespaceSerializer=" + getNamespaceSerializer() +
+				", stateSerializer=" + getStateSerializer() +
 				'}';
 	}
 
@@ -153,34 +203,19 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		return computeSnapshot();
 	}
 
-	public static void checkStateMetaInfo(StateMetaInfoSnapshot stateMetaInfoSnapshot, StateDescriptor<?, ?> stateDesc) {
-		Preconditions.checkState(
-			stateMetaInfoSnapshot != null,
-			"Requested to check compatibility of a restored RegisteredKeyedBackendStateMetaInfo," +
-				" but its corresponding restored snapshot cannot be found.");
-
-		Preconditions.checkState(stateMetaInfoSnapshot.getBackendStateType()
-				== StateMetaInfoSnapshot.BackendStateType.KEY_VALUE,
-			"Incompatible state types. " +
-				"Was [" + stateMetaInfoSnapshot.getBackendStateType() + "], " +
-				"registered as [" + StateMetaInfoSnapshot.BackendStateType.KEY_VALUE + "].");
+	public void checkStateMetaInfo(StateDescriptor<?, ?> stateDesc) {
 
 		Preconditions.checkState(
-			Objects.equals(stateDesc.getName(), stateMetaInfoSnapshot.getName()),
+			Objects.equals(stateDesc.getName(), getName()),
 			"Incompatible state names. " +
-				"Was [" + stateMetaInfoSnapshot.getName() + "], " +
+				"Was [" + getName() + "], " +
 				"registered with [" + stateDesc.getName() + "].");
 
-		final StateDescriptor.Type restoredType =
-			StateDescriptor.Type.valueOf(
-				stateMetaInfoSnapshot.getOption(
-					StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE));
-
-		if (stateDesc.getType() != StateDescriptor.Type.UNKNOWN && restoredType != StateDescriptor.Type.UNKNOWN) {
+		if (stateDesc.getType() != StateDescriptor.Type.UNKNOWN && getStateType() != StateDescriptor.Type.UNKNOWN) {
 			Preconditions.checkState(
-				stateDesc.getType() == restoredType,
+				stateDesc.getType() == getStateType(),
 				"Incompatible key/value state types. " +
-					"Was [" + restoredType + "], " +
+					"Was [" + getStateType() + "], " +
 					"registered with [" + stateDesc.getType() + "].");
 		}
 	}
@@ -194,8 +229,12 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap = new HashMap<>(2);
 		String namespaceSerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER.toString();
 		String valueSerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString();
+
+		TypeSerializer<N> namespaceSerializer = getNamespaceSerializer();
 		serializerMap.put(namespaceSerializerKey, namespaceSerializer.duplicate());
 		serializerConfigSnapshotsMap.put(namespaceSerializerKey, namespaceSerializer.snapshotConfiguration());
+
+		TypeSerializer<S> stateSerializer = getStateSerializer();
 		serializerMap.put(valueSerializerKey, stateSerializer.duplicate());
 		serializerConfigSnapshotsMap.put(valueSerializerKey, stateSerializer.snapshotConfiguration());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -87,10 +87,10 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 			snapshot.getName(),
 			StateSerializerProvider.fromRestoredState(
 				(TypeSerializerSnapshot<N>) Preconditions.checkNotNull(
-					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER))),
+					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER))),
 			StateSerializerProvider.fromRestoredState(
 				(TypeSerializerSnapshot<S>) Preconditions.checkNotNull(
-					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
+					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
 			null);
 
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.KEY_VALUE == snapshot.getBackendStateType());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
@@ -73,7 +73,7 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 			snapshot.getName(),
 			StateSerializerProvider.fromRestoredState(
 				(TypeSerializerSnapshot<S>) Preconditions.checkNotNull(
-					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
+					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
 			OperatorStateHandle.Mode.valueOf(
 				snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE)));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorStateBackendMetaInfo.java
@@ -19,11 +19,13 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -46,21 +48,22 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 	 * The type serializer for the elements in the state list
 	 */
 	@Nonnull
-	private final TypeSerializer<S> partitionStateSerializer;
+	private final StateSerializerProvider<S> partitionStateSerializerProvider;
 
 	public RegisteredOperatorStateBackendMetaInfo(
 			@Nonnull String name,
 			@Nonnull TypeSerializer<S> partitionStateSerializer,
 			@Nonnull OperatorStateHandle.Mode assignmentMode) {
-		super(name);
-		this.partitionStateSerializer = partitionStateSerializer;
-		this.assignmentMode = assignmentMode;
+		this(
+			name,
+			StateSerializerProvider.fromNewState(partitionStateSerializer),
+			assignmentMode);
 	}
 
 	private RegisteredOperatorStateBackendMetaInfo(@Nonnull RegisteredOperatorStateBackendMetaInfo<S> copy) {
 		this(
 			Preconditions.checkNotNull(copy).name,
-			copy.partitionStateSerializer.duplicate(),
+			copy.getPartitionStateSerializer().duplicate(),
 			copy.assignmentMode);
 	}
 
@@ -68,11 +71,22 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 	public RegisteredOperatorStateBackendMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
 		this(
 			snapshot.getName(),
-			(TypeSerializer<S>) Preconditions.checkNotNull(
-				snapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER)),
+			StateSerializerProvider.fromRestoredState(
+				(TypeSerializerSnapshot<S>) Preconditions.checkNotNull(
+					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
 			OperatorStateHandle.Mode.valueOf(
 				snapshot.getOption(StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE)));
+
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.OPERATOR == snapshot.getBackendStateType());
+	}
+
+	private RegisteredOperatorStateBackendMetaInfo(
+			@Nonnull String name,
+			@Nonnull StateSerializerProvider<S> partitionStateSerializerProvider,
+			@Nonnull OperatorStateHandle.Mode assignmentMode) {
+		super(name);
+		this.partitionStateSerializerProvider = partitionStateSerializerProvider;
+		this.assignmentMode = assignmentMode;
 	}
 
 	/**
@@ -96,7 +110,17 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 
 	@Nonnull
 	public TypeSerializer<S> getPartitionStateSerializer() {
-		return partitionStateSerializer;
+		return partitionStateSerializerProvider.currentSchemaSerializer();
+	}
+
+	@Nonnull
+	public TypeSerializerSchemaCompatibility<S> updatePartitionStateSerializer(TypeSerializer<S> newPartitionStateSerializer) {
+		return partitionStateSerializerProvider.registerNewSerializerForRestoredState(newPartitionStateSerializer);
+	}
+
+	@Nullable
+	public TypeSerializer<S> getPreviousPartitionStateSerializer() {
+		return partitionStateSerializerProvider.previousSchemaSerializer();
 	}
 
 	@Override
@@ -112,7 +136,7 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 		return (obj instanceof RegisteredOperatorStateBackendMetaInfo)
 			&& name.equals(((RegisteredOperatorStateBackendMetaInfo) obj).getName())
 			&& assignmentMode.equals(((RegisteredOperatorStateBackendMetaInfo) obj).getAssignmentMode())
-			&& partitionStateSerializer.equals(((RegisteredOperatorStateBackendMetaInfo) obj).getPartitionStateSerializer());
+			&& getPartitionStateSerializer().equals(((RegisteredOperatorStateBackendMetaInfo) obj).getPartitionStateSerializer());
 	}
 
 	@Override
@@ -128,7 +152,7 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 		return "RegisteredOperatorBackendStateMetaInfo{" +
 			"name='" + name + "\'" +
 			", assignmentMode=" + assignmentMode +
-			", partitionStateSerializer=" + partitionStateSerializer +
+			", partitionStateSerializer=" + getPartitionStateSerializer() +
 			'}';
 	}
 
@@ -138,6 +162,8 @@ public class RegisteredOperatorStateBackendMetaInfo<S> extends RegisteredStateMe
 			StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE.toString(),
 			assignmentMode.toString());
 		String valueSerializerKey = StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString();
+
+		TypeSerializer<S> partitionStateSerializer = getPartitionStateSerializer();
 		Map<String, TypeSerializer<?>> serializerMap =
 			Collections.singletonMap(valueSerializerKey, partitionStateSerializer.duplicate());
 		Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
@@ -51,7 +51,7 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 			snapshot.getName(),
 			StateSerializerProvider.fromRestoredState(
 				(TypeSerializerSnapshot<T>) Preconditions.checkNotNull(
-					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))));
+					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))));
 
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE == snapshot.getBackendStateType());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredPriorityQueueStateBackendMetaInfo.java
@@ -19,11 +19,13 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -34,22 +36,32 @@ import java.util.Map;
 public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredStateMetaInfoBase {
 
 	@Nonnull
-	private final TypeSerializer<T> elementSerializer;
+	private final StateSerializerProvider<T> elementSerializerProvider;
 
 	public RegisteredPriorityQueueStateBackendMetaInfo(
 		@Nonnull String name,
 		@Nonnull TypeSerializer<T> elementSerializer) {
 
-		super(name);
-		this.elementSerializer = elementSerializer;
+		this(name, StateSerializerProvider.fromNewState(elementSerializer));
 	}
 
 	@SuppressWarnings("unchecked")
 	public RegisteredPriorityQueueStateBackendMetaInfo(StateMetaInfoSnapshot snapshot) {
-		this(snapshot.getName(),
-			(TypeSerializer<T>) Preconditions.checkNotNull(
-				snapshot.restoreTypeSerializer(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER)));
+		this(
+			snapshot.getName(),
+			StateSerializerProvider.fromRestoredState(
+				(TypeSerializerSnapshot<T>) Preconditions.checkNotNull(
+					snapshot.getTypeSerializerConfigSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))));
+
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE == snapshot.getBackendStateType());
+	}
+
+	private RegisteredPriorityQueueStateBackendMetaInfo(
+		@Nonnull String name,
+		@Nonnull StateSerializerProvider<T> elementSerializerProvider) {
+
+		super(name);
+		this.elementSerializerProvider = elementSerializerProvider;
 	}
 
 	@Nonnull
@@ -60,10 +72,21 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 
 	@Nonnull
 	public TypeSerializer<T> getElementSerializer() {
-		return elementSerializer;
+		return elementSerializerProvider.currentSchemaSerializer();
+	}
+
+	@Nonnull
+	public TypeSerializerSchemaCompatibility<T> updateElementSerializer(TypeSerializer<T> newElementSerializer) {
+		return elementSerializerProvider.registerNewSerializerForRestoredState(newElementSerializer);
+	}
+
+	@Nullable
+	public TypeSerializer<T> getPreviousElementSerializer() {
+		return elementSerializerProvider.previousSchemaSerializer();
 	}
 
 	private StateMetaInfoSnapshot computeSnapshot() {
+		TypeSerializer<T> elementSerializer = getElementSerializer();
 		Map<String, TypeSerializer<?>> serializerMap =
 			Collections.singletonMap(
 				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString(),
@@ -82,6 +105,6 @@ public class RegisteredPriorityQueueStateBackendMetaInfo<T> extends RegisteredSt
 	}
 
 	public RegisteredPriorityQueueStateBackendMetaInfo deepCopy() {
-		return new RegisteredPriorityQueueStateBackendMetaInfo<>(name, elementSerializer.duplicate());
+		return new RegisteredPriorityQueueStateBackendMetaInfo<>(name, getElementSerializer().duplicate());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
@@ -42,4 +42,21 @@ public abstract class RegisteredStateMetaInfoBase {
 
 	@Nonnull
 	public abstract StateMetaInfoSnapshot snapshot();
+
+	public static RegisteredStateMetaInfoBase fromMetaInfoSnapshot(@Nonnull StateMetaInfoSnapshot snapshot) {
+
+		final StateMetaInfoSnapshot.BackendStateType backendStateType = snapshot.getBackendStateType();
+		switch (backendStateType) {
+			case KEY_VALUE:
+				return new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
+			case OPERATOR:
+				return new RegisteredOperatorStateBackendMetaInfo<>(snapshot);
+			case BROADCAST:
+				return new RegisteredBroadcastStateBackendMetaInfo<>(snapshot);
+			case PRIORITY_QUEUE:
+				return new RegisteredPriorityQueueStateBackendMetaInfo<>(snapshot);
+			default:
+				throw new IllegalArgumentException("Unknown backend state type: " + backendStateType);
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSerializerProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSerializerProvider.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link StateSerializerProvider} wraps logic on how to obtain serializers for registered state,
+ * either with the previous schema of state in checkpoints or the current schema of state.
+ *
+ * @param <T> the type of the state.
+ */
+@Internal
+public abstract class StateSerializerProvider<T> {
+
+	/**
+	 * The registered serializer for the state.
+	 *
+	 * <p>In the case that this provider was created from a restored serializer snapshot via
+	 * {@link #fromRestoredState(TypeSerializerSnapshot)}, but a new serializer was never registered
+	 * for the state (i.e., this is the case if a restored state was never accessed), this would be {@code null}.
+	 */
+	@Nullable
+	TypeSerializer<T> registeredSerializer;
+
+	/**
+	 * Creates a {@link StateSerializerProvider} for restored state from the previous serializer's snapshot.
+	 *
+	 * <p>Once a new serializer is registered for the state, it should be provided via
+	 * the {@link #registerNewSerializerForRestoredState(TypeSerializer)} method.
+	 *
+	 * @param stateSerializerSnapshot the previous serializer's snapshot.
+	 * @param <T> the type of the state.
+	 *
+	 * @return a new {@link StateSerializerProvider} for restored state.
+	 */
+	public static <T> StateSerializerProvider<T> fromRestoredState(TypeSerializerSnapshot<T> stateSerializerSnapshot) {
+		return new RestoredStateSerializerProvider<>(stateSerializerSnapshot);
+	}
+
+	/**
+	 * Creates a {@link StateSerializerProvider} for new state from the registered state serializer.
+	 *
+	 * @param registeredStateSerializer the new state's registered serializer.
+	 * @param <T> the type of the state.
+	 *
+	 * @return a new {@link StateSerializerProvider} for new state.
+	 */
+	public static <T> StateSerializerProvider<T> fromNewState(TypeSerializer<T> registeredStateSerializer) {
+		return new NewStateSerializerProvider<>(registeredStateSerializer);
+	}
+
+	private StateSerializerProvider(@Nullable TypeSerializer<T> stateSerializer) {
+		this.registeredSerializer = stateSerializer;
+	}
+
+	/**
+	 * Gets the serializer that recognizes the current serialization schema of the state.
+	 * This is the serializer that should be used for regular state serialization and
+	 * deserialization after state has been restored.
+	 *
+	 * <p>If this provider was created from a restored state's serializer snapshot, while a
+	 * new serializer (with a new schema) was not registered for the state (i.e., because
+	 * the state was never accessed after it was restored), then the schema of state remains
+	 * identical. Therefore, in this case, it is guaranteed that the serializer returned by
+	 * this method is the same as the one returned by {@link #previousSchemaSerializer()}.
+	 *
+	 * <p>If this provider was created from new state, then this always returns the
+	 * serializer that the new state was registered with.
+	 *
+	 * @return a serializer that reads and writes in the current schema of the state.
+	 */
+	@Nonnull
+	public abstract TypeSerializer<T> currentSchemaSerializer();
+
+	/**
+	 * Gets the serializer that recognizes the previous serialization schema of the state.
+	 * This is the serializer that should be used for restoring the state, i.e. when the state
+	 * is still in the previous serialization schema.
+	 *
+	 * <p>This method can only be used if this provider was created from a restored state's serializer
+	 * snapshot. If this provider was created from new state, then this method is
+	 * irrelevant, since there doesn't exist any previous version of the state schema.
+	 *
+	 * @return a serializer that reads and writes in the previous schema of the state.
+	 */
+	@Nonnull
+	public abstract TypeSerializer<T> previousSchemaSerializer();
+
+	/**
+	 * For restored state, register a new serializer that potentially has a new serialization schema.
+	 *
+	 * <p>Users are allowed to register serializers for state only once. Therefore, this method
+	 * is irrelevant if this provider was created from new state, since a state serializer had
+	 * been registered already.
+	 *
+	 * <p>For the case where this provider was created from restored state, then this method should
+	 * be called at most once. The new serializer will be checked for its schema compatibility with the
+	 * previous serializer's schema, and returned to the caller. The caller is responsible for
+	 * checking the result and react appropriately to it, as follows:
+	 * <ul>
+	 *     <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAsIs()}: nothing needs to be done.
+	 *     {@link #currentSchemaSerializer()} now returns the newly registered serializer.</li>
+	 *     <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAfterMigration()} ()}: state needs to be
+	 *     migrated before the serializer returned by {@link #currentSchemaSerializer()} can be used.
+	 *     The migration should be performed by reading the state with {@link #previousSchemaSerializer()},
+	 *     and then writing it again with {@link #currentSchemaSerializer()}.</li>
+	 *     <li>{@link TypeSerializerSchemaCompatibility#isIncompatible()}: the registered serializer is
+	 *     incompatible. {@link #currentSchemaSerializer()} can no longer return a serializer for
+	 *     the state, and therefore this provider shouldn't be used anymore.</li>
+	 * </ul>
+	 *
+	 * @return the schema compatibility of the new registered serializer, with respect to the previous serializer.
+	 */
+	@Nonnull
+	public abstract TypeSerializerSchemaCompatibility<T> registerNewSerializerForRestoredState(TypeSerializer<T> newSerializer);
+
+	/**
+	 * Implementation of the {@link StateSerializerProvider} for the restored state case.
+	 */
+	private static class RestoredStateSerializerProvider<T> extends StateSerializerProvider<T> {
+
+		/**
+		 * The snapshot of the previous serializer of the state.
+		 */
+		@Nonnull
+		private final TypeSerializerSnapshot<T> previousSerializerSnapshot;
+
+		private boolean isRegisteredWithIncompatibleSerializer = false;
+
+		RestoredStateSerializerProvider(TypeSerializerSnapshot<T> previousSerializerSnapshot) {
+			super(null);
+			this.previousSerializerSnapshot = Preconditions.checkNotNull(previousSerializerSnapshot);
+		}
+
+		/**
+		 * The restore serializer, lazily created only when the restore serializer is accessed.
+		 *
+		 * <p>NOTE: It is important to only create this lazily, so that off-heap
+		 * state do not fail eagerly when restoring state that has a
+		 * {@link UnloadableDummyTypeSerializer} as the previous serializer. This should
+		 * be relevant only for restores from Flink versions prior to 1.7.x.
+		 */
+		@Nullable
+		private TypeSerializer<T> cachedRestoredSerializer;
+
+		@Override
+		@Nonnull
+		public TypeSerializer<T> currentSchemaSerializer() {
+			if (registeredSerializer != null) {
+				checkState(
+					!isRegisteredWithIncompatibleSerializer,
+					"Unable to provide a serializer with the current schema, because the restored state was " +
+						"registered with a new serializer that has incompatible schema.");
+
+					return registeredSerializer;
+			}
+
+			// if we are not yet registered with a new serializer,
+			// we can just use the restore serializer to read / write the state.
+			return previousSchemaSerializer();
+		}
+
+		@Nonnull
+		public TypeSerializerSchemaCompatibility<T> registerNewSerializerForRestoredState(TypeSerializer<T> newSerializer) {
+			checkNotNull(newSerializer);
+			if (registeredSerializer != null) {
+				throw new UnsupportedOperationException("A serializer has already been registered for the state; re-registration is not allowed.");
+			}
+
+			TypeSerializerSchemaCompatibility<T> result = previousSerializerSnapshot.resolveSchemaCompatibility(newSerializer);
+			if (result.isIncompatible()) {
+				this.isRegisteredWithIncompatibleSerializer = true;
+			}
+			this.registeredSerializer = newSerializer;
+			return result;
+		}
+
+		@Nonnull
+		public final TypeSerializer<T> previousSchemaSerializer() {
+			if (cachedRestoredSerializer != null) {
+				return cachedRestoredSerializer;
+			}
+
+			this.cachedRestoredSerializer = previousSerializerSnapshot.restoreSerializer();
+			return cachedRestoredSerializer;
+		}
+	}
+
+	/**
+	 * Implementation of the {@link StateSerializerProvider} for the new state case.
+	 */
+	private static class NewStateSerializerProvider<T> extends StateSerializerProvider<T> {
+
+		NewStateSerializerProvider(TypeSerializer<T> registeredStateSerializer) {
+			super(Preconditions.checkNotNull(registeredStateSerializer));
+		}
+
+		@Override
+		@Nonnull
+		@SuppressWarnings("ConstantConditions")
+		public TypeSerializer<T> currentSchemaSerializer() {
+			return registeredSerializer;
+		}
+
+		@Override
+		@Nonnull
+		public TypeSerializerSchemaCompatibility<T> registerNewSerializerForRestoredState(TypeSerializer<T> newSerializer) {
+			throw new UnsupportedOperationException("A serializer has already been registered for the state; re-registration is not allowed.");
+		}
+
+		@Override
+		@Nonnull
+		public TypeSerializer<T> previousSchemaSerializer() {
+			throw new UnsupportedOperationException("This is a NewStateSerializerProvider; you cannot get a restore serializer because there was no restored state.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -283,8 +283,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			TypeSerializerSchemaCompatibility<N> namespaceCompatibility =
 				namespaceSerializerSnapshot.resolveSchemaCompatibility(namespaceSerializer);
-			if (namespaceCompatibility.isIncompatible()) {
-				throw new StateMigrationException("For heap backends, the new namespace serializer must not be incompatible.");
+			if (!namespaceCompatibility.isCompatibleAsIs()) {
+				throw new StateMigrationException("For heap backends, the new namespace serializer must be compatible.");
 			}
 
 			@SuppressWarnings("unchecked")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -30,7 +30,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
-import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -79,6 +78,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -126,14 +126,6 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private final Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates;
 
 	/**
-	 * Map of state names to their corresponding restored state meta info.
-	 *
-	 * <p>TODO this map can be removed when eager-state registration is in place.
-	 * TODO we currently need this cached to check state migration strategies when new serializers are registered.
-	 */
-	private final Map<StateUID, StateMetaInfoSnapshot> restoredStateMetaInfo;
-
-	/**
 	 * The configuration for local recovery.
 	 */
 	private final LocalRecoveryConfig localRecoveryConfig;
@@ -173,7 +165,6 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		this.snapshotStrategy = new HeapSnapshotStrategy(synchronicityTrait);
 		LOG.info("Initializing heap keyed state backend with stream factory.");
-		this.restoredStateMetaInfo = new HashMap<>();
 		this.priorityQueueSetFactory = priorityQueueSetFactory;
 	}
 
@@ -194,23 +185,9 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			// TODO we implement the simple way of supporting the current functionality, mimicking keyed state
 			// because this should be reworked in FLINK-9376 and then we should have a common algorithm over
 			// StateMetaInfoSnapshot that avoids this code duplication.
-			StateMetaInfoSnapshot restoredMetaInfoSnapshot =
-				restoredStateMetaInfo.get(StateUID.of(stateName, StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE));
-
-			Preconditions.checkState(
-				restoredMetaInfoSnapshot != null,
-				"Requested to check compatibility of a restored RegisteredKeyedBackendStateMetaInfo," +
-					" but its corresponding restored snapshot cannot be found.");
-
-			StateMetaInfoSnapshot.CommonSerializerKeys serializerKey =
-				StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER;
-
-			@SuppressWarnings("unchecked")
-			TypeSerializerSnapshot<T> serializerSnapshot = Preconditions.checkNotNull(
-				(TypeSerializerSnapshot<T>) restoredMetaInfoSnapshot.getTypeSerializerConfigSnapshot(serializerKey));
 
 			TypeSerializerSchemaCompatibility<T> compatibilityResult =
-				serializerSnapshot.resolveSchemaCompatibility(byteOrderedElementSerializer);
+				existingState.getMetaInfo().updateElementSerializer(byteOrderedElementSerializer);
 
 			if (compatibilityResult.isIncompatible()) {
 				throw new FlinkRuntimeException(new StateMigrationException("For heap backends, the new priority queue serializer must not be incompatible."));
@@ -252,57 +229,42 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private <N, V> StateTable<K, N, V> tryRegisterStateTable(
 			TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<?, V> stateDesc,
-			StateSnapshotTransformer<V> snapshotTransformer) throws StateMigrationException {
+			@Nullable StateSnapshotTransformer<V> snapshotTransformer) throws StateMigrationException {
 
 		@SuppressWarnings("unchecked")
 		StateTable<K, N, V> stateTable = (StateTable<K, N, V>) registeredKVStates.get(stateDesc.getName());
 
 		TypeSerializer<V> newStateSerializer = stateDesc.getSerializer();
-		RegisteredKeyValueStateBackendMetaInfo<N, V> newMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(
-			stateDesc.getType(),
-			stateDesc.getName(),
-			namespaceSerializer,
-			newStateSerializer,
-			snapshotTransformer);
 
 		if (stateTable != null) {
-			@SuppressWarnings("unchecked")
-			StateMetaInfoSnapshot restoredMetaInfoSnapshot =
-				restoredStateMetaInfo.get(
-					StateUID.of(stateDesc.getName(), StateMetaInfoSnapshot.BackendStateType.KEY_VALUE));
+			RegisteredKeyValueStateBackendMetaInfo<N, V> restoredKvMetaInfo = stateTable.getMetaInfo();
 
-			Preconditions.checkState(
-				restoredMetaInfoSnapshot != null,
-				"Requested to check compatibility of a restored RegisteredKeyedBackendStateMetaInfo," +
-					" but its corresponding restored snapshot cannot be found.");
-
-			@SuppressWarnings("unchecked")
-			TypeSerializerSnapshot<N> namespaceSerializerSnapshot = Preconditions.checkNotNull(
-				(TypeSerializerSnapshot<N>) restoredMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
-					StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER.toString()));
+			restoredKvMetaInfo.updateSnapshotTransformer(snapshotTransformer);
 
 			TypeSerializerSchemaCompatibility<N> namespaceCompatibility =
-				namespaceSerializerSnapshot.resolveSchemaCompatibility(namespaceSerializer);
+				restoredKvMetaInfo.updateNamespaceSerializer(namespaceSerializer);
 			if (!namespaceCompatibility.isCompatibleAsIs()) {
 				throw new StateMigrationException("For heap backends, the new namespace serializer must be compatible.");
 			}
 
-			@SuppressWarnings("unchecked")
-			TypeSerializerSnapshot<V> stateSerializerSnapshot = Preconditions.checkNotNull(
-				(TypeSerializerSnapshot<V>) restoredMetaInfoSnapshot.getTypeSerializerConfigSnapshot(
-					StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString()));
-
-			RegisteredKeyValueStateBackendMetaInfo.checkStateMetaInfo(restoredMetaInfoSnapshot, stateDesc);
+			restoredKvMetaInfo.checkStateMetaInfo(stateDesc);
 
 			TypeSerializerSchemaCompatibility<V> stateCompatibility =
-				stateSerializerSnapshot.resolveSchemaCompatibility(newStateSerializer);
+				restoredKvMetaInfo.updateStateSerializer(newStateSerializer);
 
 			if (stateCompatibility.isIncompatible()) {
 				throw new StateMigrationException("For heap backends, the new state serializer must not be incompatible.");
 			}
 
-			stateTable.setMetaInfo(newMetaInfo);
+			stateTable.setMetaInfo(restoredKvMetaInfo);
 		} else {
+			RegisteredKeyValueStateBackendMetaInfo<N, V> newMetaInfo = new RegisteredKeyValueStateBackendMetaInfo<>(
+				stateDesc.getType(),
+				stateDesc.getName(),
+				namespaceSerializer,
+				newStateSerializer,
+				snapshotTransformer);
+
 			stateTable = snapshotStrategy.newStateTable(newMetaInfo);
 			registeredKVStates.put(stateDesc.getName(), stateTable);
 		}
@@ -536,10 +498,6 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		Map<Integer, StateMetaInfoSnapshot> kvStatesById) {
 
 		for (StateMetaInfoSnapshot metaInfoSnapshot : restoredMetaInfo) {
-			restoredStateMetaInfo.put(
-				StateUID.of(metaInfoSnapshot.getName(), metaInfoSnapshot.getBackendStateType()),
-				metaInfoSnapshot);
-
 			final StateSnapshotRestore registeredState;
 
 			switch (metaInfoSnapshot.getBackendStateType()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
@@ -150,17 +150,6 @@ public class StateMetaInfoSnapshot {
 		return name;
 	}
 
-	@Nullable
-	public TypeSerializer<?> restoreTypeSerializer(@Nonnull String key) {
-		TypeSerializerSnapshot<?> configSnapshot = getTypeSerializerConfigSnapshot(key);
-		return (configSnapshot != null) ? configSnapshot.restoreSerializer() : null;
-	}
-
-	@Nullable
-	public TypeSerializer<?> restoreTypeSerializer(@Nonnull CommonSerializerKeys key) {
-		return restoreTypeSerializer(key.toString());
-	}
-
 	@Nonnull
 	public Map<String, TypeSerializerSnapshot<?>> getSerializerConfigSnapshotsImmutable() {
 		return Collections.unmodifiableMap(serializerConfigSnapshots);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
@@ -81,7 +81,7 @@ public class StateMetaInfoSnapshot {
 
 	/** The configurations of all the type serializers used with the state. */
 	@Nonnull
-	private final Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshots;
+	private final Map<String, TypeSerializerSnapshot<?>> serializerSnapshots;
 
 	// TODO this will go away once all serializers have the restoreSerializer() factory method properly implemented.
 	/** The serializers used by the state. */
@@ -92,8 +92,8 @@ public class StateMetaInfoSnapshot {
 		@Nonnull String name,
 		@Nonnull BackendStateType backendStateType,
 		@Nonnull Map<String, String> options,
-		@Nonnull Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshots) {
-		this(name, backendStateType, options, serializerConfigSnapshots, new HashMap<>());
+		@Nonnull Map<String, TypeSerializerSnapshot<?>> serializerSnapshots) {
+		this(name, backendStateType, options, serializerSnapshots, new HashMap<>());
 	}
 
 	/**
@@ -106,12 +106,12 @@ public class StateMetaInfoSnapshot {
 		@Nonnull String name,
 		@Nonnull BackendStateType backendStateType,
 		@Nonnull Map<String, String> options,
-		@Nonnull Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshots,
+		@Nonnull Map<String, TypeSerializerSnapshot<?>> serializerSnapshots,
 		@Nonnull Map<String, TypeSerializer<?>> serializers) {
 		this.name = name;
 		this.backendStateType = backendStateType;
 		this.options = options;
-		this.serializerConfigSnapshots = serializerConfigSnapshots;
+		this.serializerSnapshots = serializerSnapshots;
 		this.serializers = serializers;
 	}
 
@@ -121,13 +121,13 @@ public class StateMetaInfoSnapshot {
 	}
 
 	@Nullable
-	public TypeSerializerSnapshot<?> getTypeSerializerConfigSnapshot(@Nonnull String key) {
-		return serializerConfigSnapshots.get(key);
+	public TypeSerializerSnapshot<?> getTypeSerializerSnapshot(@Nonnull String key) {
+		return serializerSnapshots.get(key);
 	}
 
 	@Nullable
-	public TypeSerializerSnapshot<?> getTypeSerializerConfigSnapshot(@Nonnull CommonSerializerKeys key) {
-		return getTypeSerializerConfigSnapshot(key.toString());
+	public TypeSerializerSnapshot<?> getTypeSerializerSnapshot(@Nonnull CommonSerializerKeys key) {
+		return getTypeSerializerSnapshot(key.toString());
 	}
 
 	@Nullable
@@ -151,8 +151,8 @@ public class StateMetaInfoSnapshot {
 	}
 
 	@Nonnull
-	public Map<String, TypeSerializerSnapshot<?>> getSerializerConfigSnapshotsImmutable() {
-		return Collections.unmodifiableMap(serializerConfigSnapshots);
+	public Map<String, TypeSerializerSnapshot<?>> getSerializerSnapshotsImmutable() {
+		return Collections.unmodifiableMap(serializerSnapshots);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotReadersWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotReadersWriters.java
@@ -165,7 +165,7 @@ public class StateMetaInfoSnapshotReadersWriters {
 			@Nonnull DataOutputView outputView) throws IOException {
 			final Map<String, String> optionsMap = snapshot.getOptionsImmutable();
 			final Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap =
-				snapshot.getSerializerConfigSnapshotsImmutable();
+				snapshot.getSerializerSnapshotsImmutable();
 
 			outputView.writeUTF(snapshot.getName());
 			outputView.writeInt(snapshot.getBackendStateType().ordinal());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -251,7 +251,7 @@ public class SerializationProxiesTest {
 		Assert.assertEquals(expected.getBackendStateType(), actual.getBackendStateType());
 		Assert.assertEquals(expected.getOptionsImmutable(), actual.getOptionsImmutable());
 		Assert.assertEquals(
-			expected.getSerializerConfigSnapshotsImmutable(),
-			actual.getSerializerConfigSnapshotsImmutable());
+			expected.getSerializerSnapshotsImmutable(),
+			actual.getSerializerSnapshotsImmutable());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -34,21 +34,20 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.testutils.statemigration.TestType;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.StateMigrationException;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.RunnableFuture;
 
 /**
@@ -69,17 +68,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 	// lazily initialized stream storage
 	private CheckpointStorageLocation checkpointStorageLocation;
 
-	/**
-	 * The compatibility behaviour of {@link TestSerializer}.
-	 * This controls what format the serializer writes in, as well as
-	 * the result of the compatibility check against the prior serializer snapshot.
-	 */
-	public enum SerializerCompatibilityType {
-		COMPATIBLE_AS_IS,
-		REQUIRES_MIGRATION,
-		INCOMPATIBLE
-	}
-
 	// -------------------------------------------------------------------------------
 	//  Keyed state backend migration tests
 	// -------------------------------------------------------------------------------
@@ -95,7 +83,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ValueStateDescriptor<TestType> kvId = new ValueStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ValueState<TestType> valueState = backend
 				.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -113,10 +101,10 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot);
 
-			// the new serializer is REQUIRES_MIGRATION, and has a completely new serialization schema.
+			// the new serializer is V2, and has a completely new serialization schema.
 			kvId = new ValueStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestType.V2TestTypeSerializer());
 			valueState = backend
 				.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -151,7 +139,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ListStateDescriptor<TestType> kvId = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ListState<TestType> listState = backend
 				.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -174,10 +162,10 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot);
 
-			// the new serializer is REQUIRES_MIGRATION, and has a completely new serialization schema.
+			// the new serializer is V2, and has a completely new serialization schema.
 			kvId = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestType.V2TestTypeSerializer());
 			listState = backend
 				.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -221,7 +209,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ValueStateDescriptor<TestType> kvId = new ValueStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ValueState<TestType> valueState = backend
 				.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -241,7 +229,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			kvId = new ValueStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
+				new TestType.IncompatibleTestTypeSerializer());
 
 			// the new serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
@@ -265,7 +253,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ListStateDescriptor<TestType> kvId = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ListState<TestType> listState = backend
 				.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -290,7 +278,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			kvId = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
+				new TestType.IncompatibleTestTypeSerializer());
 
 			// the new serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
@@ -312,7 +300,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 		try {
 			InternalPriorityQueue<TestType> internalPriorityQueue = backend.create(
-				"testPriorityQueue", new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				"testPriorityQueue", new TestType.V1TestTypeSerializer());
 
 			internalPriorityQueue.add(new TestType("key-1", 123));
 			internalPriorityQueue.add(new TestType("key-2", 346));
@@ -325,7 +313,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot);
 			backend.create(
-				"testPriorityQueue", new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
+				"testPriorityQueue", new TestType.IncompatibleTestTypeSerializer());
 
 			Assert.fail("should have failed");
 		} catch (Exception e) {
@@ -341,7 +329,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 
 		AbstractKeyedStateBackend<TestType> backend = createKeyedBackend(
-			new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+			new TestType.V1TestTypeSerializer());
 
 		final String stateName = "test-name";
 		try {
@@ -361,7 +349,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			try {
 				// the new key serializer is incompatible; this should fail the restore
-				restoreKeyedBackend(new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE), snapshot);
+				restoreKeyedBackend(new TestType.IncompatibleTestTypeSerializer(), snapshot);
 
 				Assert.fail("should have failed");
 			} catch (Exception e) {
@@ -370,7 +358,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			try {
 				// the new key serializer requires migration; this should fail the restore
-				restoreKeyedBackend(new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION), snapshot);
+				restoreKeyedBackend(new TestType.V2TestTypeSerializer(), snapshot);
 
 				Assert.fail("should have failed");
 			} catch (Exception e) {
@@ -394,7 +382,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			ValueState<Integer> valueState = backend
 				.getPartitionedState(
 					new TestType("namespace", 123),
-					new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS),
+					new TestType.V1TestTypeSerializer(),
 					kvId);
 
 			backend.setCurrentKey(1);
@@ -413,7 +401,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 				// the new namespace serializer is incompatible; this should fail the restore
 				backend.getPartitionedState(
 					new TestType("namespace", 123),
-					new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE),
+					new TestType.IncompatibleTestTypeSerializer(),
 					kvId);
 
 				Assert.fail("should have failed");
@@ -428,7 +416,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 				// the new namespace serializer requires migration; this should fail the restore
 				backend.getPartitionedState(
 					new TestType("namespace", 123),
-					new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION),
+					new TestType.V2TestTypeSerializer(),
 					kvId);
 
 				Assert.fail("should have failed");
@@ -454,7 +442,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ListStateDescriptor<TestType> descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ListState<TestType> state = backend.getListState(descriptor);
 
 			state.add(new TestType("foo", 13));
@@ -468,7 +456,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestType.V2TestTypeSerializer());
 			state = backend.getListState(descriptor);
 
 			// the state backend should have decided whether or not it needs to perform state migration;
@@ -493,7 +481,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ListStateDescriptor<TestType> descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ListState<TestType> state = backend.getUnionListState(descriptor);
 
 			state.add(new TestType("foo", 13));
@@ -507,7 +495,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestType.V2TestTypeSerializer());
 			state = backend.getUnionListState(descriptor);
 
 			// the state backend should have decided whether or not it needs to perform state migration;
@@ -533,7 +521,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			MapStateDescriptor<Integer, TestType> descriptor = new MapStateDescriptor<>(
 				stateName,
 				IntSerializer.INSTANCE,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			BroadcastState<Integer, TestType> state = backend.getBroadcastState(descriptor);
 
 			state.put(3, new TestType("foo", 13));
@@ -548,7 +536,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			descriptor = new MapStateDescriptor<>(
 				stateName,
 				IntSerializer.INSTANCE,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestType.V2TestTypeSerializer());
 			state = backend.getBroadcastState(descriptor);
 
 			// the state backend should have decided whether or not it needs to perform state migration;
@@ -571,7 +559,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			MapStateDescriptor<TestType, Integer> descriptor = new MapStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS),
+				new TestType.V1TestTypeSerializer(),
 				IntSerializer.INSTANCE);
 			BroadcastState<TestType, Integer> state = backend.getBroadcastState(descriptor);
 
@@ -586,7 +574,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			descriptor = new MapStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION),
+				new TestType.V2TestTypeSerializer(),
 				IntSerializer.INSTANCE);
 			state = backend.getBroadcastState(descriptor);
 
@@ -610,7 +598,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ListStateDescriptor<TestType> descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ListState<TestType> state = backend.getListState(descriptor);
 
 			state.add(new TestType("foo", 13));
@@ -624,7 +612,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
+				new TestType.IncompatibleTestTypeSerializer());
 
 			// the new serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getListState(descriptor);
@@ -647,7 +635,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			ListStateDescriptor<TestType> descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			ListState<TestType> state = backend.getUnionListState(descriptor);
 
 			state.add(new TestType("foo", 13));
@@ -661,7 +649,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			descriptor = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
+				new TestType.IncompatibleTestTypeSerializer());
 
 			// the new serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getUnionListState(descriptor);
@@ -685,7 +673,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			MapStateDescriptor<Integer, TestType> descriptor = new MapStateDescriptor<>(
 				stateName,
 				IntSerializer.INSTANCE,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS));
+				new TestType.V1TestTypeSerializer());
 			BroadcastState<Integer, TestType> state = backend.getBroadcastState(descriptor);
 
 			state.put(3, new TestType("foo", 13));
@@ -700,7 +688,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			descriptor = new MapStateDescriptor<>(
 				stateName,
 				IntSerializer.INSTANCE,
-				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
+				new TestType.IncompatibleTestTypeSerializer());
 
 			// the new value serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getBroadcastState(descriptor);
@@ -723,7 +711,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		try {
 			MapStateDescriptor<TestType, Integer> descriptor = new MapStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS),
+				new TestType.V1TestTypeSerializer(),
 				IntSerializer.INSTANCE);
 			BroadcastState<TestType, Integer> state = backend.getBroadcastState(descriptor);
 
@@ -738,7 +726,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			descriptor = new MapStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE),
+				new TestType.IncompatibleTestTypeSerializer(),
 				IntSerializer.INSTANCE);
 
 			// the new key serializer is INCOMPATIBLE, so registering the state should fail
@@ -755,223 +743,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 	// -------------------------------------------------------------------------------
 	//  Test types, serializers, and serializer snapshots
 	// -------------------------------------------------------------------------------
-
-	/**
-	 * The type used as state under tests.
-	 *
-	 * <p>This is implemented so that the type can also be used as keyed priority queue state.
-	 */
-	private static class TestType implements HeapPriorityQueueElement, PriorityComparable<TestType>, Keyed<String> {
-
-		private int index;
-
-		private final int value;
-		private final String key;
-
-		public TestType(String key, int value) {
-			this.key = key;
-			this.value = value;
-		}
-
-		@Override
-		public String getKey() {
-			return key;
-		}
-
-		@Override
-		public int comparePriorityTo(@Nonnull TestType other) {
-			return Integer.compare(value, other.value);
-		}
-
-		@Override
-		public int getInternalIndex() {
-			return index;
-		}
-
-		@Override
-		public void setInternalIndex(int newIndex) {
-			this.index = newIndex;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (obj == null || !(obj instanceof StateBackendMigrationTestBase.TestType)) {
-				return false;
-			}
-
-			if (obj == this) {
-				return true;
-			}
-
-			TestType other = (TestType) obj;
-			return Objects.equals(key, other.key) && value == other.value;
-		}
-
-		@Override
-		public int hashCode() {
-			return 31 * key.hashCode() + value;
-		}
-	}
-
-	private static class TestSerializer extends TypeSerializer<TestType> {
-
-		private static final String MIGRATION_PAYLOAD = "random-migration-payload";
-
-		private final SerializerCompatibilityType compatibilityType;
-
-		TestSerializer(SerializerCompatibilityType compatibilityType) {
-			this.compatibilityType = compatibilityType;
-		}
-
-		// --------------------------------------------------------------------------------
-		//  State serialization relevant methods
-		// --------------------------------------------------------------------------------
-
-		@Override
-		public void serialize(TestType record, DataOutputView target) throws IOException {
-			switch (compatibilityType) {
-				case COMPATIBLE_AS_IS:
-					target.writeUTF(record.getKey());
-					target.writeInt(record.value);
-					break;
-
-				case REQUIRES_MIGRATION:
-					target.writeUTF(record.getKey());
-					target.writeUTF(MIGRATION_PAYLOAD);
-					target.writeInt(record.value);
-					target.writeBoolean(true);
-					break;
-
-				case INCOMPATIBLE:
-					// the serializer shouldn't be used in this case
-					throw new UnsupportedOperationException();
-			}
-		}
-
-		@Override
-		public TestType deserialize(DataInputView source) throws IOException {
-			String key;
-			int value;
-
-			switch (compatibilityType) {
-				case COMPATIBLE_AS_IS:
-					key = source.readUTF();
-					value = source.readInt();
-					break;
-
-				case REQUIRES_MIGRATION:
-					key = source.readUTF();
-					Assert.assertEquals(MIGRATION_PAYLOAD, source.readUTF());
-					value = source.readInt();
-					Assert.assertTrue(source.readBoolean());
-					break;
-
-				default:
-				case INCOMPATIBLE:
-					// the serializer shouldn't be used in this case
-					throw new UnsupportedOperationException();
-			}
-
-			return new TestType(key, value);
-		}
-
-		@Override
-		public TestType copy(TestType from) {
-			return new TestType(from.key, from.value);
-		}
-
-		@Override
-		public TypeSerializerSnapshot<TestType> snapshotConfiguration() {
-			return new TestSerializerSnapshot();
-		}
-
-		// --------------------------------------------------------------------------------
-		//  Miscellaneous serializer methods
-		// --------------------------------------------------------------------------------
-
-		@Override
-		public void copy(DataInputView source, DataOutputView target) throws IOException {
-			serialize(deserialize(source), target);
-		}
-
-		@Override
-		public TestType deserialize(TestType reuse, DataInputView source) throws IOException {
-			return deserialize(source);
-		}
-
-		@Override
-		public TestType copy(TestType from, TestType reuse) {
-			return copy(from);
-		}
-
-		@Override
-		public TestType createInstance() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public TypeSerializer<TestType> duplicate() {
-			return this;
-		}
-
-		@Override
-		public boolean isImmutableType() {
-			return false;
-		}
-
-		@Override
-		public int getLength() {
-			return -1;
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return getClass().equals(obj.getClass());
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj == this;
-		}
-	}
-
-	public static class TestSerializerSnapshot implements TypeSerializerSnapshot<TestType> {
-
-		@Override
-		public int getCurrentVersion() {
-			return 1;
-		}
-
-		@Override
-		public TypeSerializer<TestType> restoreSerializer() {
-			return new TestSerializer(SerializerCompatibilityType.COMPATIBLE_AS_IS);
-		}
-
-		@Override
-		public TypeSerializerSchemaCompatibility<TestType> resolveSchemaCompatibility(TypeSerializer<TestType> newSerializer) {
-			switch (((TestSerializer) newSerializer).compatibilityType) {
-				case COMPATIBLE_AS_IS:
-					return TypeSerializerSchemaCompatibility.compatibleAsIs();
-				case REQUIRES_MIGRATION:
-					return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
-				case INCOMPATIBLE:
-					return TypeSerializerSchemaCompatibility.incompatible();
-				default:
-					throw new UnsupportedOperationException();
-			}
-		}
-
-		@Override
-		public void writeSnapshot(DataOutputView out) throws IOException {}
-
-		@Override
-		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {}
-	}
 
 	public static class CustomVoidNamespaceSerializer extends TypeSerializer<VoidNamespace> {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -245,6 +245,8 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			// the new serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
+
+			Assert.fail("should have failed");
 		} catch (Exception e) {
 			Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 		}finally {
@@ -288,10 +290,12 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			kvId = new ListStateDescriptor<>(
 				stateName,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
 
 			// the new serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getPartitionedState(VoidNamespace.INSTANCE, CustomVoidNamespaceSerializer.INSTANCE, kvId);
+
+			Assert.fail("should have failed");
 		} catch (Exception e) {
 			Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 		} finally {
@@ -358,6 +362,8 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			try {
 				// the new key serializer is incompatible; this should fail the restore
 				restoreKeyedBackend(new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE), snapshot);
+
+				Assert.fail("should have failed");
 			} catch (Exception e) {
 				Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 			}
@@ -365,6 +371,8 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			try {
 				// the new key serializer requires migration; this should fail the restore
 				restoreKeyedBackend(new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION), snapshot);
+
+				Assert.fail("should have failed");
 			} catch (Exception e) {
 				Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 			}
@@ -397,26 +405,33 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			KeyedStateHandle snapshot = runSnapshot(
 				backend.snapshot(1L, 2L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
 				sharedStateRegistry);
+
+			// test incompatible namespace serializer; start with a freshly restored backend
 			backend.dispose();
-
 			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot);
-
 			try {
 				// the new namespace serializer is incompatible; this should fail the restore
 				backend.getPartitionedState(
 					new TestType("namespace", 123),
 					new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE),
 					kvId);
+
+				Assert.fail("should have failed");
 			} catch (Exception e) {
 				Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 			}
 
+			// test namespace serializer that requires migration; start with a freshly restored backend
+			backend.dispose();
+			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot);
 			try {
 				// the new namespace serializer requires migration; this should fail the restore
 				backend.getPartitionedState(
 					new TestType("namespace", 123),
 					new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION),
 					kvId);
+
+				Assert.fail("should have failed");
 			} catch (Exception e) {
 				Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 			}
@@ -685,10 +700,12 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			descriptor = new MapStateDescriptor<>(
 				stateName,
 				IntSerializer.INSTANCE,
-				new TestSerializer(SerializerCompatibilityType.REQUIRES_MIGRATION));
+				new TestSerializer(SerializerCompatibilityType.INCOMPATIBLE));
 
 			// the new value serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getBroadcastState(descriptor);
+
+			Assert.fail("should have failed.");
 		} catch (Exception e) {
 			Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 		} finally {
@@ -726,6 +743,8 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 			// the new key serializer is INCOMPATIBLE, so registering the state should fail
 			backend.getBroadcastState(descriptor);
+
+			Assert.fail("should have failed.");
 		} catch (Exception e) {
 			Assert.assertTrue(ExceptionUtils.findThrowable(e, StateMigrationException.class).isPresent());
 		} finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -149,14 +149,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 	@Rule
 	public final ExpectedException expectedException = ExpectedException.none();
 
-	/**
-	 * The serialization timeliness behaviour of the state backend under test.
-	 */
-	public enum BackendSerializationTimeliness {
-		ON_ACCESS,
-		ON_CHECKPOINTS
-	}
-
 	// lazily initialized stream storage
 	private CheckpointStorageLocation checkpointStorageLocation;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSerializerProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSerializerProviderTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.testutils.statemigration.TestType;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test suit for {@link StateSerializerProvider}.
+ */
+public class StateSerializerProviderTest {
+
+	// --------------------------------------------------------------------------------
+	//  Tests for #currentSchemaSerializer()
+	// --------------------------------------------------------------------------------
+
+	@Test
+	public void testCurrentSchemaSerializerForNewStateSerializerProvider() {
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromNewState(new TestType.V1TestTypeSerializer());
+		assertTrue(testProvider.currentSchemaSerializer() instanceof TestType.V1TestTypeSerializer);
+	}
+
+	@Test
+	public void testCurrentSchemaSerializerForRestoredStateSerializerProvider() {
+		TestType.V1TestTypeSerializer serializer = new TestType.V1TestTypeSerializer();
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromRestoredState(serializer.snapshotConfiguration());
+		assertTrue(testProvider.currentSchemaSerializer() instanceof TestType.V1TestTypeSerializer);
+	}
+
+	// --------------------------------------------------------------------------------
+	//  Tests for #previousSchemaSerializer()
+	// --------------------------------------------------------------------------------
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testPreviousSchemaSerializerForNewStateSerializerProvider() {
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromNewState(new TestType.V1TestTypeSerializer());
+
+		// this should fail with an exception
+		testProvider.previousSchemaSerializer();
+	}
+
+	@Test
+	public void testPreviousSchemaSerializerForRestoredStateSerializerProvider() {
+		TestType.V1TestTypeSerializer serializer = new TestType.V1TestTypeSerializer();
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromRestoredState(serializer.snapshotConfiguration());
+		assertTrue(testProvider.previousSchemaSerializer() instanceof TestType.V1TestTypeSerializer);
+	}
+
+	@Test
+	public void testLazyInstantiationOfPreviousSchemaSerializer() {
+		// create the provider with an exception throwing snapshot;
+		// this would throw an exception if the restore serializer was eagerly accessed
+		StateSerializerProvider<String> testProvider =
+			StateSerializerProvider.fromRestoredState(new ExceptionThrowingSerializerSnapshot());
+
+		try {
+			// if we fail here, that means the restore serializer was indeed lazily accessed
+			testProvider.previousSchemaSerializer();
+			fail("expected to fail when accessing the restore serializer.");
+		} catch (Exception expected) {
+			// success
+		}
+	}
+
+	// --------------------------------------------------------------------------------
+	//  Tests for #registerNewSerializerForRestoredState(TypeSerializer)
+	// --------------------------------------------------------------------------------
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testRegisterNewSerializerWithNewStateSerializerProviderShouldFail() {
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromNewState(new TestType.V1TestTypeSerializer());
+		testProvider.registerNewSerializerForRestoredState(new TestType.V2TestTypeSerializer());
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testRegisterNewSerializerTwiceWithNewStateSerializerProviderShouldFail() {
+		TestType.V1TestTypeSerializer serializer = new TestType.V1TestTypeSerializer();
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromRestoredState(serializer.snapshotConfiguration());
+
+		testProvider.registerNewSerializerForRestoredState(new TestType.V2TestTypeSerializer());
+
+		// second registration should fail
+		testProvider.registerNewSerializerForRestoredState(new TestType.V2TestTypeSerializer());
+	}
+
+	@Test
+	public void testRegisterNewCompatibleAsIsSerializer() {
+		TestType.V1TestTypeSerializer serializer = new TestType.V1TestTypeSerializer();
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromRestoredState(serializer.snapshotConfiguration());
+
+		// register compatible serializer for state
+		TypeSerializerSchemaCompatibility<TestType> schemaCompatibility =
+			testProvider.registerNewSerializerForRestoredState(new TestType.V1TestTypeSerializer());
+		assertTrue(schemaCompatibility.isCompatibleAsIs());
+
+		assertTrue(testProvider.currentSchemaSerializer() instanceof TestType.V1TestTypeSerializer);
+		assertTrue(testProvider.previousSchemaSerializer() instanceof TestType.V1TestTypeSerializer);
+	}
+
+	@Test
+	public void testRegisterNewCompatibleAfterMigrationSerializer() {
+		TestType.V1TestTypeSerializer serializer = new TestType.V1TestTypeSerializer();
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromRestoredState(serializer.snapshotConfiguration());
+
+		// register serializer that requires migration for state
+		TypeSerializerSchemaCompatibility<TestType> schemaCompatibility =
+			testProvider.registerNewSerializerForRestoredState(new TestType.V2TestTypeSerializer());
+		assertTrue(schemaCompatibility.isCompatibleAfterMigration());
+	}
+
+	@Test
+	public void testRegisterIncompatibleSerializer() {
+		TestType.V1TestTypeSerializer serializer = new TestType.V1TestTypeSerializer();
+		StateSerializerProvider<TestType> testProvider = StateSerializerProvider.fromRestoredState(serializer.snapshotConfiguration());
+
+		// register serializer that requires migration for state
+		TypeSerializerSchemaCompatibility<TestType> schemaCompatibility =
+			testProvider.registerNewSerializerForRestoredState(new TestType.IncompatibleTestTypeSerializer());
+		assertTrue(schemaCompatibility.isIncompatible());
+
+		try {
+			// a serializer for the current schema will no longer be accessible
+			testProvider.currentSchemaSerializer();
+		} catch (Exception excepted) {
+			// success
+		}
+	}
+
+	// --------------------------------------------------------------------------------
+	//  Utilities
+	// --------------------------------------------------------------------------------
+
+	public static class ExceptionThrowingSerializerSnapshot implements TypeSerializerSnapshot<String> {
+
+		@Override
+		public TypeSerializer<String> restoreSerializer() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void writeSnapshot(DataOutputView out) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TypeSerializerSchemaCompatibility<String> resolveSchemaCompatibility(TypeSerializer<String> newSerializer) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int getCurrentVersion() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils.statemigration;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.junit.Assert;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A data type used as state in state migration tests.
+ *
+ * <p>This is implemented so that the type can also be used as keyed priority queue state.
+ */
+public class TestType implements HeapPriorityQueueElement, PriorityComparable<TestType>, Keyed<String> {
+
+    private int index;
+
+    private final int value;
+    private final String key;
+
+    public TestType(String key, int value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+	public int getValue() {
+		return value;
+	}
+
+	@Override
+    public int comparePriorityTo(@Nonnull TestType other) {
+        return Integer.compare(value, other.value);
+    }
+
+    @Override
+    public int getInternalIndex() {
+        return index;
+    }
+
+    @Override
+    public void setInternalIndex(int newIndex) {
+        this.index = newIndex;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof TestType)) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        TestType other = (TestType) obj;
+        return Objects.equals(key, other.key) && value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * key.hashCode() + value;
+    }
+
+	/**
+	 * A serializer that read / writes {@link TestType} in schema version 1.
+	 */
+	public static class V1TestTypeSerializer extends TestTypeSerializerBase {
+		private static final long serialVersionUID = 5053346160938769779L;
+
+		@Override
+		public void serialize(TestType record, DataOutputView target) throws IOException {
+			target.writeUTF(record.getKey());
+			target.writeInt(record.getValue());
+		}
+
+		@Override
+		public TestType deserialize(DataInputView source) throws IOException {
+			return new TestType(source.readUTF(), source.readInt());
+		}
+
+		@Override
+		public TypeSerializerSnapshot<TestType> snapshotConfiguration() {
+			return new V1TestTypeSerializerSnapshot();
+		}
+	}
+
+	/**
+	 * A serializer that read / writes {@link TestType} in schema version 2.
+	 * Migration is required if the state was previously written with {@link V1TestTypeSerializer}.
+	 */
+	public static class V2TestTypeSerializer extends TestTypeSerializerBase {
+
+		private static final long serialVersionUID = 7199590310936186578L;
+
+		private static final String RANDOM_PAYLOAD = "random-payload";
+
+		@Override
+		public void serialize(TestType record, DataOutputView target) throws IOException {
+			target.writeUTF(record.getKey());
+			target.writeUTF(RANDOM_PAYLOAD);
+			target.writeInt(record.getValue());
+			target.writeBoolean(true);
+		}
+
+		@Override
+		public TestType deserialize(DataInputView source) throws IOException {
+			String key = source.readUTF();
+			Assert.assertEquals(RANDOM_PAYLOAD, source.readUTF());
+			int value = source.readInt();
+			Assert.assertTrue(source.readBoolean());
+
+			return new TestType(key, value);
+		}
+
+		@Override
+		public TypeSerializerSnapshot<TestType> snapshotConfiguration() {
+			return new V1TestTypeSerializerSnapshot();
+		}
+	}
+
+	/**
+	 * A serializer that is meant to be incompatible with any of the serializers.
+	 */
+	public static class IncompatibleTestTypeSerializer extends TestTypeSerializerBase {
+
+		private static final long serialVersionUID = -2959080770523247215L;
+
+		@Override
+		public void serialize(TestType record, DataOutputView target) throws IOException {
+			throw new UnsupportedOperationException("This is an incompatible serializer; shouldn't be used.");
+		}
+
+		@Override
+		public TestType deserialize(DataInputView source) throws IOException {
+			throw new UnsupportedOperationException("This is an incompatible serializer; shouldn't be used.");
+		}
+
+		@Override
+		public TypeSerializerSnapshot<TestType> snapshotConfiguration() {
+			throw new UnsupportedOperationException("This is an incompatible serializer; shouldn't be used.");
+		}
+	}
+
+	public static abstract class TestTypeSerializerBase extends TypeSerializer<TestType> {
+
+		private static final long serialVersionUID = 256299937766275871L;
+
+		// --------------------------------------------------------------------------------
+		//  Miscellaneous serializer methods
+		// --------------------------------------------------------------------------------
+
+		@Override
+		public TestType copy(TestType from) {
+			return new TestType(from.getKey(), from.getValue());
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			serialize(deserialize(source), target);
+		}
+
+		@Override
+		public TestType deserialize(TestType reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public TestType copy(TestType from, TestType reuse) {
+			return copy(from);
+		}
+
+		@Override
+		public TestType createInstance() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TypeSerializer<TestType> duplicate() {
+			return this;
+		}
+
+		@Override
+		public boolean isImmutableType() {
+			return false;
+		}
+
+		@Override
+		public int getLength() {
+			return -1;
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return getClass().equals(obj.getClass());
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj == this;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/V1TestTypeSerializerSnapshot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/V1TestTypeSerializerSnapshot.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils.statemigration;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * Snapshot class for {@link TestType.V1TestTypeSerializer}.
+ */
+public class V1TestTypeSerializerSnapshot implements TypeSerializerSnapshot<TestType> {
+
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<TestType> resolveSchemaCompatibility(TypeSerializer<TestType> newSerializer) {
+		if (newSerializer instanceof TestType.V1TestTypeSerializer) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else if (newSerializer instanceof TestType.V2TestTypeSerializer) {
+			return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<TestType> restoreSerializer() {
+		return new TestType.V1TestTypeSerializer();
+	}
+
+	@Override
+    public void writeSnapshot(DataOutputView out) throws IOException {
+	}
+
+    @Override
+    public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/V2TestTypeSerializerSnapshot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/V2TestTypeSerializerSnapshot.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils.statemigration;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * Snapshot class for {@link TestType.V2TestTypeSerializer}.
+ */
+public class V2TestTypeSerializerSnapshot implements TypeSerializerSnapshot<TestType> {
+
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<TestType> resolveSchemaCompatibility(TypeSerializer<TestType> newSerializer) {
+		if (newSerializer instanceof TestType.V2TestTypeSerializer) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<TestType> restoreSerializer() {
+		return new TestType.V2TestTypeSerializer();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) throws IOException {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The ultimate goal of this PR is to fix a bug where NPE is thrown if a non-accessed restored state in `RocksDBKeyedStatebackend` was snapshotted.
This was an overlooked issue caused by changes in [FLINK-10679](https://issues.apache.org/jira/browse/FLINK-10679).

The problem is that in that change, in the `RocksDBKeyedBackend`, `RegisteredStateMetaInfoBase`s were no longer created eagerly for all restored state, but instead only lazily created when the state was accessed again by the user. This causes non-accessed restored state to have empty meta info, and throws NPE when trying to take a snapshot of them.

The rationale behind FLINK-10679 was that, since `RegisteredStateMetaInfoBase` holds already serializer instances for state access, creating them eagerly at restore time with restored serializer snapshots did not make sense (because at that point-in-time, we do not have the new serializers yet for state access; the snapshot is only capable of creating the previous state serializer).

This PR fixes this by letting state meta infos hold a `StateSerializerProvider`, instead of serializer instances. This allows meta infos to be instantiated from snapshots without eagerly accessing the restore serializer.

The API for the `StateSerializerProvider` is as follows:
```
public abstract class StateSerializerProvider<T> {
    TypeSerializer<T> currentSchemaSerializer();
    TypeSerializerSchemaCompatibility<T> registerSerializerForRestoredState(TypeSerializer<T> newRegisteredSerializer);
    TypeSerializer<T> previousSchemaSerializer();

    // factory methods for provider:
    public static <T> StateSerializerProvider<T> fromNewState(TypeSerializer<T> registeredSerializer);
    public static <T> StateSerializerProvider<T> fromRestoredState(TypeSerializerSnapshot<T> snapshot);
}
```

A StateSerializerProvider can be created either from:
1. A restored serializer snapshot when restoring the state.
2. A fresh, new state's serializer, when registering the state for the first time.

For 1), state that has not been accessed yet after the restore will return the same serializer (i.e. the serializer for previous schema) for both `currentSchemaSerializer` and `previousSchemaSerializer`, meaning that since no new serializer has been registered, the schema remains the same anyways.
Once a restored state is re-accessed, then `registerSerializerForRestoredState(TypeSerializer<T> newSerializer)` should be used to update what serializer the provider returns in `currentSchemaSerializer`.

## Brief change log

Main changes are:

- First 3 hotfixes (3c99bf3 to 074e6aa) is some preliminary code cleanup / test hardening for the `StateBackendMigrationTestBase`.
- 32cf5ab: Introduce the new `StateSerializerProvider` abstraction and added tests for it
- 239e942: Eagerly create meta infos from restored snapshots, so that they are created even if the state isn't accessed.
- 5e9d568: Let meta infos use `StateSerializerProvider` instead of serializer instance
- 7cd35c7 to e13e4b3: Remove all `restoredXXStateMetaInfos` maps from all state backends. They can be removed because all restored meta infos are now implicitly part of the eagerly created `RegisteredStateMetaInfoBase`s (which is kept in the `registeredXXXMetaInfo` maps in all state backends).
- dc7fd17: Add test coverage for snapshotting non-accessed restored state

## Verifying this change

This PR adds a new test `StateBackendTestBase.testSnapshotNonAccessedState()` to cover the issue.
The test fails for RocksDB state backend case without the fixes.

Also, unit tests are added for `StateSerializerProvider`, in `StateSerializerProviderTest`.

All existing migration related tests in `StateBackendMigrationTestBase` are also related and should not be failing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)
