### PR TITLE
[FLINK-10359] Scala example in DataSet docs is broken

### DIFF
--- a/docs/dev/batch/dataset_transformations.md
+++ b/docs/dev/batch/dataset_transformations.md
@@ -712,7 +712,7 @@ class MyCombinableGroupReducer
     out: Collector[String]): Unit =
   {
     val r: (String, Int) =
-      in.asScala.reduce( (a,b) => (a._1, a._2 + b._2) )
+      in.iterator.asScala.reduce( (a,b) => (a._1, a._2 + b._2) )
     // concat key and sum and emit
     out.collect (r._1 + "-" + r._2)
   }
@@ -722,7 +722,7 @@ class MyCombinableGroupReducer
     out: Collector[(String, Int)]): Unit =
   {
     val r: (String, Int) =
-      in.asScala.reduce( (a,b) => (a._1, a._2 + b._2) )
+      in.iterator.asScala.reduce( (a,b) => (a._1, a._2 + b._2) )
     // emit tuple with key and sum
     out.collect(r)
   }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed scala example in DataSet docs is broken*


## Brief change log

  - *Fix Scala example in DataSet docs is broken*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
