### PR TITLE
[FLINK-11041][test] ReinterpretDataStreamAsKeyedStreamITCase source s…

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
@@ -122,7 +122,9 @@ public class ReinterpretDataStreamAsKeyedStreamITCase {
 		public void run(SourceContext<Tuple2<Integer, Integer>> out) throws Exception {
 			Random random = new Random(42);
 			while (--remainingEvents >= 0) {
-				out.collect(new Tuple2<>(random.nextInt(numKeys), 1));
+				synchronized (out.getCheckpointLock()) {
+					out.collect(new Tuple2<>(random.nextInt(numKeys), 1));
+				}
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

This test fixes the flaky behavior of `ReinterpretDataStreamAsKeyedStreamITCase`. the problem was that the test was changed to also test failover, but the source did not use the checkpointing lock.


## Brief change log

Hold checkpointing lock in the test's source function.
