### PR TITLE
[FLINK-11123][docs] fix the import of the class is missing in ml quic…

### DIFF
--- a/docs/dev/libs/ml/quickstart.md
+++ b/docs/dev/libs/ml/quickstart.md
@@ -153,6 +153,8 @@ A conversion can be done using a simple normalizer mapping function:
  
 {% highlight scala %}
 
+import org.apache.flink.ml.math.Vector
+
 def normalizer : LabeledVector => LabeledVector = { 
     lv => LabeledVector(if (lv.label > 0.0) 1.0 else -1.0, lv.vector)
 }


### PR DESCRIPTION
## What is the purpose of the change

*This PR fix the import of the class is missing in ml quick start document.*


## Brief change log
  - *Add `import org.apache.flink.ml.math.Vector` in ml quick start doc.*

## Verifying this change
This change is a documentation improvement without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
