### PR TITLE
[FLINK-11124][table] Add private[flink] to TemporalTableFunction.create() method

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TemporalTableFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TemporalTableFunction.scala
@@ -65,7 +65,7 @@ class TemporalTableFunction private(
 }
 
 object TemporalTableFunction {
-  def create(
+  private[flink] def create(
       table: Table,
       timeAttribute: Expression,
       primaryKey: String): TemporalTableFunction = {


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds `private[flink]` to `TemporalTableFunction.create()` method. As `TemporalTableFunction` is an user-oriented class. I think it would be better to add `private[flink]` to the `TemporalTableFunction.create()` method in order to make it invisible to users.


## Brief change log

  - Add private[flink] to TemporalTableFunction.create()


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
