### PR TITLE
[FLINK-11122][core] Change signature of WrappingProxyUtil#stripProxy(T)

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetCloseableRegistry.java
@@ -87,7 +87,7 @@ public class SafetyNetCloseableRegistry extends
 
 		assert Thread.holdsLock(getSynchronizationLock());
 
-		Closeable innerCloseable = WrappingProxyUtil.stripProxy(wrappingProxyCloseable.getWrappedDelegate());
+		Closeable innerCloseable = WrappingProxyUtil.stripProxy(wrappingProxyCloseable);
 
 		if (null == innerCloseable) {
 			return;
@@ -108,7 +108,7 @@ public class SafetyNetCloseableRegistry extends
 
 		assert Thread.holdsLock(getSynchronizationLock());
 
-		Closeable innerCloseable = WrappingProxyUtil.stripProxy(closeable.getWrappedDelegate());
+		Closeable innerCloseable = WrappingProxyUtil.stripProxy(closeable);
 
 		return null != innerCloseable && closeableMap.remove(innerCloseable) != null;
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/WrappingProxyUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/WrappingProxyUtil.java
@@ -20,6 +20,8 @@ package org.apache.flink.util;
 
 import org.apache.flink.annotation.Internal;
 
+import javax.annotation.Nullable;
+
 /**
  * Utilits for working with {@link WrappingProxy}.
  */
@@ -31,15 +33,19 @@ public final class WrappingProxyUtil {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T> T stripProxy(T object) {
-
-		T previous = null;
-
-		while (object instanceof WrappingProxy && previous != object) {
-			previous = object;
-			object = ((WrappingProxy<T>) object).getWrappedDelegate();
+	public static <T> T stripProxy(@Nullable final WrappingProxy<T> wrappingProxy) {
+		if (wrappingProxy == null) {
+			return null;
 		}
 
-		return object;
+		WrappingProxy<T> previous = null;
+		Object delegate = wrappingProxy.getWrappedDelegate();
+
+		while (delegate instanceof WrappingProxy && previous != delegate) {
+			previous = (WrappingProxy<T>) delegate;
+			delegate = ((WrappingProxy<T>) delegate).getWrappedDelegate();
+		}
+
+		return (T) delegate;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/WrappingProxyUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/WrappingProxyUtil.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 import static java.lang.String.format;
 
 /**
- * Utilits for working with {@link WrappingProxy}.
+ * Utilities for working with {@link WrappingProxy}.
  */
 @Internal
 public final class WrappingProxyUtil {

--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
@@ -253,7 +253,7 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 
 		@Override
 		public void close() throws IOException {
-			closed.set(true);
+			assertTrue("TestCloseable was already closed", closed.compareAndSet(false, true));
 		}
 
 		public boolean isClosed() {

--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.core.fs;
 
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.util.AbstractCloseableRegistry;
 
 import org.junit.Assert;
@@ -26,22 +25,27 @@ import org.junit.Test;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link AbstractCloseableRegistry}.
  */
 public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 
+	private static final int TEST_TIMEOUT_SECONDS = 10;
+
 	protected ProducerThread[] streamOpenThreads;
 	protected AbstractCloseableRegistry<C, T> closeableRegistry;
 	protected AtomicInteger unclosedCounter;
 
-	protected abstract C createCloseable();
+	protected abstract void registerCloseable(Closeable closeable) throws IOException;
 
 	protected abstract AbstractCloseableRegistry<C, T> createRegistry();
 
@@ -74,7 +78,6 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 
 	@Test
 	public void testClose() throws Exception {
-
 		setup(Integer.MAX_VALUE);
 		startThreads();
 
@@ -87,45 +90,29 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 
 		joinThreads();
 
-		Assert.assertEquals(0, unclosedCounter.get());
-		Assert.assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
+		assertEquals(0, unclosedCounter.get());
+		assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
 
-		final C testCloseable = spy(createCloseable());
+		final TestCloseable testCloseable = new TestCloseable();
 
 		try {
+			registerCloseable(testCloseable);
+			fail("Closed registry should not accept closeables!");
+		} catch (IOException expected) {}
 
-			closeableRegistry.registerCloseable(testCloseable);
-
-			Assert.fail("Closed registry should not accept closeables!");
-
-		} catch (IOException expected) {
-			//expected
-		}
-
-		Assert.assertEquals(0, unclosedCounter.get());
-		Assert.assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
-		verify(testCloseable).close();
+		assertTrue(testCloseable.isClosed());
+		assertEquals(0, unclosedCounter.get());
+		assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
 	}
 
 	@Test
 	public void testNonBlockingClose() throws Exception {
 		setup(Integer.MAX_VALUE);
 
-		final OneShotLatch waitRegistryClosedLatch = new OneShotLatch();
-		final OneShotLatch blockCloseLatch = new OneShotLatch();
+		final BlockingTestCloseable blockingCloseable = new BlockingTestCloseable();
+		registerCloseable(blockingCloseable);
 
-		final C spyCloseable = spy(createCloseable());
-
-		doAnswer(invocationOnMock -> {
-			invocationOnMock.callRealMethod();
-			waitRegistryClosedLatch.trigger();
-			blockCloseLatch.await();
-			return null;
-		}).when(spyCloseable).close();
-
-		closeableRegistry.registerCloseable(spyCloseable);
-
-		Assert.assertEquals(1, closeableRegistry.getNumberOfRegisteredCloseables());
+		assertEquals(1, closeableRegistry.getNumberOfRegisteredCloseables());
 
 		Thread closer = new Thread(() -> {
 			try {
@@ -134,23 +121,20 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 
 			}
 		});
-
 		closer.start();
-		waitRegistryClosedLatch.await();
+		blockingCloseable.awaitClose(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-		final C testCloseable = spy(createCloseable());
-
+		final TestCloseable testCloseable = new TestCloseable();
 		try {
-			closeableRegistry.registerCloseable(testCloseable);
-			Assert.fail("Closed registry should not accept closeables!");
+			registerCloseable(testCloseable);
+			fail("Closed registry should not accept closeables!");
 		} catch (IOException ignored) {}
 
-		blockCloseLatch.trigger();
+		blockingCloseable.unblockClose();
 		closer.join();
 
-		verify(spyCloseable).close();
-		verify(testCloseable).close();
-		Assert.assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
+		assertTrue(testCloseable.isClosed());
+		assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
 	}
 
 	/**
@@ -223,6 +207,57 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 		@Override
 		public synchronized void close() throws IOException {
 			refCount.decrementAndGet();
+		}
+	}
+
+	/**
+	 * A noop {@link Closeable} implementation that blocks inside {@link #close()}.
+	 */
+	private static class BlockingTestCloseable implements Closeable {
+
+		private final CountDownLatch closeCalledLatch = new CountDownLatch(1);
+
+		private final CountDownLatch blockCloseLatch = new CountDownLatch(1);
+
+		@Override
+		public void close() throws IOException {
+			closeCalledLatch.countDown();
+			try {
+				blockCloseLatch.await();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		/**
+		 * Unblocks {@link #close()}.
+		 */
+		public void unblockClose() {
+			blockCloseLatch.countDown();
+		}
+
+		/**
+		 * Causes the current thread to wait until {@link #close()} is called.
+		 */
+		public void awaitClose(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
+			closeCalledLatch.await(timeout, timeUnit);
+		}
+	}
+
+	/**
+	 * A noop {@link Closeable} implementation that tracks whether it was closed.
+	 */
+	private static class TestCloseable implements Closeable {
+
+		private final AtomicBoolean closed = new AtomicBoolean();
+
+		@Override
+		public void close() throws IOException {
+			closed.set(true);
+		}
+
+		public boolean isClosed() {
+			return closed.get();
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/fs/CloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/CloseableRegistryTest.java
@@ -30,13 +30,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CloseableRegistryTest extends AbstractCloseableRegistryTest<Closeable, Object> {
 
 	@Override
-	protected Closeable createCloseable() {
-		return new Closeable() {
-			@Override
-			public void close() throws IOException {
-
-			}
-		};
+	protected void registerCloseable(final Closeable closeable) throws IOException {
+		closeableRegistry.registerCloseable(closeable);
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/core/fs/SafetyNetCloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/SafetyNetCloseableRegistryTest.java
@@ -43,17 +43,20 @@ public class SafetyNetCloseableRegistryTest
 	public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	@Override
-	protected WrappingProxyCloseable<? extends Closeable> createCloseable() {
-		return new WrappingProxyCloseable<Closeable>() {
+	protected void registerCloseable(final Closeable closeable) throws IOException {
+		final WrappingProxyCloseable<Closeable> wrappingProxyCloseable = new WrappingProxyCloseable<Closeable>() {
 
 			@Override
-			public void close() throws IOException {}
+			public void close() throws IOException {
+				closeable.close();
+			}
 
 			@Override
 			public Closeable getWrappedDelegate() {
-				return this;
+				return closeable;
 			}
 		};
+		closeableRegistry.registerCloseable(wrappingProxyCloseable);
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/util/WrappingProxyUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/WrappingProxyUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link WrappingProxyUtil}.
+ */
+public class WrappingProxyUtilTest {
+
+	@Test
+	public void testThrowsExceptionIfTooManyProxies() {
+		try {
+			WrappingProxyUtil.stripProxy(new SelfWrappingProxy(WrappingProxyUtil.SAFETY_NET_MAX_ITERATIONS));
+			fail("Expected exception not thrown");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("Are there loops in the object graph?"));
+		}
+	}
+
+	@Test
+	public void testStripsAllProxies() {
+		final SelfWrappingProxy wrappingProxy = new SelfWrappingProxy(WrappingProxyUtil.SAFETY_NET_MAX_ITERATIONS - 1);
+		assertThat(WrappingProxyUtil.stripProxy(wrappingProxy), is(not(instanceOf(SelfWrappingProxy.class))));
+	}
+
+	private static class Wrapped {
+	}
+
+	/**
+	 * Wraps around {@link Wrapped} a specified number of times.
+	 */
+	private static class SelfWrappingProxy extends Wrapped implements WrappingProxy<Wrapped> {
+
+		private int levels;
+
+		private SelfWrappingProxy(final int levels) {
+			this.levels = levels;
+		}
+
+		@Override
+		public Wrapped getWrappedDelegate() {
+			if (levels-- == 0) {
+				return new Wrapped();
+			} else {
+				return this;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*This fixes a type inference ambiguity by the Java 9 compiler.*

cc: @StefanRRichter 

## Brief change log

  - *Change signature of WrappingProxyUtil#stripProxy(T)*

## Verifying this change

This change is already covered by existing tests, such as *SafetyNetCloseableRegistryTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
