### PR TITLE
[hotfix] add hadoop user name to yarn logs command

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -999,7 +999,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		appMasterEnv.put(YarnConfigKeys.FLINK_YARN_FILES, yarnFilesDir.toUri().toString());
 
 		// https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/YarnApplicationSecurity.md#identity-on-an-insecure-cluster-hadoop_user_name
-		appMasterEnv.put(YarnConfigKeys.ENV_HADOOP_USER_NAME, UserGroupInformation.getCurrentUser().getUserName());
+		final String hadoopUserName = UserGroupInformation.getCurrentUser().getUserName();
+		appMasterEnv.put(YarnConfigKeys.ENV_HADOOP_USER_NAME, hadoopUserName);
 
 		if (remotePathKeytab != null) {
 			appMasterEnv.put(YarnConfigKeys.KEYTAB_PATH, remotePathKeytab.toString());
@@ -1068,7 +1069,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 						+ appState + " during deployment. \n" +
 						"Diagnostics from YARN: " + report.getDiagnostics() + "\n" +
 						"If log aggregation is enabled on your cluster, use this command to further investigate the issue:\n" +
-						"yarn logs -applicationId " + appId);
+						"yarn logs -applicationId " + appId + " -appOwner " + hadoopUserName);
 					//break ..
 				case RUNNING:
 					LOG.info("YARN application has been deployed successfully.");


### PR DESCRIPTION
## What is the purpose of the change

if use yarn proxy user to submit the application to yarn cluser, the real hadoop user name will be the proxy user name, so use `yarn logs -applicationId <appId>`  will return nothing. it's right to use `yarn logs -applicationId <appId> -appOwner <userName>`.

example, before submiting app to yarn cluster, if set the proxy user, when the app finished or killed.
`yarn logs -applicationId <appId>` will return nothing.
`yarn logs -applicationId <appId> -appOwner test` will return log info.

#### proxy user
```
export HADOOP_USER_NAME=flink
export HADOOP_PROXY_USER=test
```




