### PR TITLE
[hotfix][docs] Fix the mismatch generic type in hadoop compatibility doc

### DIFF
--- a/docs/dev/batch/hadoop_compatibility.md
+++ b/docs/dev/batch/hadoop_compatibility.md
@@ -194,7 +194,7 @@ The following example shows how to use Hadoop `Mapper` and `Reducer` functions.
 // Obtain data to process somehow.
 DataSet<Tuple2<LongWritable, Text>> text = [...]
 
-DataSet<Tuple2<LongWritable, Text>> result = text
+DataSet<Tuple2<Text, LongWritable>> result = text
   // use Hadoop Mapper (Tokenizer) as MapFunction
   .flatMap(new HadoopMapFunction<LongWritable, Text, Text, LongWritable>(
     new Tokenizer()

--- a/docs/dev/batch/hadoop_compatibility.md
+++ b/docs/dev/batch/hadoop_compatibility.md
@@ -192,9 +192,9 @@ The following example shows how to use Hadoop `Mapper` and `Reducer` functions.
 
 {% highlight java %}
 // Obtain data to process somehow.
-DataSet<Tuple2<Text, LongWritable>> text = [...]
+DataSet<Tuple2<LongWritable, Text>> text = [...]
 
-DataSet<Tuple2<Text, LongWritable>> result = text
+DataSet<Tuple2<LongWritable, Text>> result = text
   // use Hadoop Mapper (Tokenizer) as MapFunction
   .flatMap(new HadoopMapFunction<LongWritable, Text, Text, LongWritable>(
     new Tokenizer()
@@ -238,9 +238,9 @@ DataSet<Tuple2<Text, LongWritable>> result = text
   ));
 
 // Set up the Hadoop TextOutputFormat.
-HadoopOutputFormat<Text, IntWritable> hadoopOF =
-  new HadoopOutputFormat<Text, IntWritable>(
-    new TextOutputFormat<Text, IntWritable>(), job
+HadoopOutputFormat<Text, LongWritable> hadoopOF =
+  new HadoopOutputFormat<Text, LongWritable>(
+    new TextOutputFormat<Text, LongWritable>(), job
   );
 hadoopOF.getConfiguration().set("mapreduce.output.textoutputformat.separator", " ");
 TextOutputFormat.setOutputPath(job, new Path(outputPath));


### PR DESCRIPTION
## What is the purpose of the change

This pr fix the mismatch generic type in hadoop compatibility doc.

## Brief change log

- Fix the mismatch generic type in section **Using Hadoop Mappers and Reducers** according to the context
- Fix the mismatch generic type in section **Complete Hadoop WordCount Example**


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
