### PR TITLE
[FLINK-8739] [table] Optimize DISTINCT aggregates to use the same distinct accumulator if possible

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
@@ -19,17 +19,17 @@ package org.apache.flink.table.codegen
 
 import java.lang.reflect.Modifier
 import java.lang.{Iterable => JIterable}
+import java.util.{List => JList}
 
 import org.apache.calcite.rex.RexLiteral
 import org.apache.flink.api.common.state.{ListStateDescriptor, MapStateDescriptor, State, StateDescriptor}
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractionUtils.{extractTypeArgument, getRawClass}
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.dataview._
 import org.apache.flink.table.codegen.CodeGenUtils.{newName, reflectiveFieldWriteAccess}
 import org.apache.flink.table.codegen.Indenter.toISC
-import org.apache.flink.table.dataview.{MapViewTypeInfo, StateListView, StateMapView}
+import org.apache.flink.table.dataview.{StateListView, StateMapView}
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.functions.aggfunctions.DistinctAccumulator
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
@@ -38,6 +38,7 @@ import org.apache.flink.table.runtime.aggregate.{GeneratedAggregations, SingleEl
 import org.apache.flink.table.utils.EncodingUtils
 import org.apache.flink.types.Row
 
+import scala.collection.JavaConversions._
 import scala.collection.mutable
 
 /**
@@ -77,7 +78,8 @@ class AggregationCodeGenerator(
     * @param aggregates  All aggregate functions
     * @param aggFields   Indexes of the input fields for all aggregate functions
     * @param aggMapping  The mapping of aggregates to output fields
-    * @param isDistinctAggs The flag array indicating whether it is distinct aggregate.
+    * @param distinctAccMapping The mapping of the distinct accumulator index to the
+    *                           corresponding aggregates.
     * @param isStateBackedDataViews a flag to indicate if distinct filter uses state backend.
     * @param partialResults A flag defining whether final or partial results (accumulators) are set
     *                       to the output row.
@@ -98,7 +100,7 @@ class AggregationCodeGenerator(
       aggregates: Array[AggregateFunction[_ <: Any, _ <: Any]],
       aggFields: Array[Array[Int]],
       aggMapping: Array[Int],
-      isDistinctAggs: Array[Boolean],
+      distinctAccMapping: Array[(Integer, JList[Integer])],
       isStateBackedDataViews: Boolean,
       partialResults: Boolean,
       fwdMapping: Array[Int],
@@ -174,30 +176,11 @@ class AggregationCodeGenerator(
     }
 
     // get distinct filter of acc fields for each aggregate functions
-    val distinctAccType = s"${classOf[DistinctAccumulator[_]].getName}"
+    val distinctAccType = s"${classOf[DistinctAccumulator].getName}"
 
-    // preparing MapViewSpecs for distinct value maps
-    val distinctAggs: Array[Seq[DataViewSpec[_]]] = isDistinctAggs.zipWithIndex.map {
-      case (isDistinctAgg, idx) if isDistinctAgg =>
+    val distinctAccCount = distinctAccMapping.count(_._1 >= 0)
 
-        // get types of agg function arguments
-        val argTypes: Array[TypeInformation[_]] = aggFields(idx)
-          .map(physicalInputTypes(_))
-        // create type for MapView
-        val mapViewTypeInfo = new MapViewTypeInfo(
-          new RowTypeInfo(argTypes:_*),
-          BasicTypeInfo.LONG_TYPE_INFO)
-        // create MapViewSpec for distinct value map
-        Seq(
-          MapViewSpec(
-            "distinctAgg" + idx,
-            classOf[DistinctAccumulator[_]].getDeclaredField("distinctValueMap"),
-            mapViewTypeInfo)
-        )
-      case _ => Seq()
-    }
-
-    if (isDistinctAggs.contains(true) && partialResults && isStateBackedDataViews) {
+    if (distinctAccCount > 0 && partialResults && isStateBackedDataViews) {
       // should not happen, but add an error message just in case.
       throw new CodeGenException(
         s"Cannot emit partial results if DISTINCT values are tracked in state-backed maps. " +
@@ -266,31 +249,13 @@ class AggregationCodeGenerator(
       * aggregation functions.
       */
     def addAccumulatorDataViews(): Unit = {
-      if (isStateBackedDataViews) {
-        // create MapStates for distinct value maps
-        val descMapping: Map[String, StateDescriptor[_, _]] = distinctAggs
-          .flatMap(specs => specs.map(s => (s.stateId, s.toStateDescriptor)))
-          .toMap[String, StateDescriptor[_ <: State, _]]
-
-        for (i <- aggs.indices) yield {
-          for (spec <- distinctAggs(i)) {
-            // Check if stat descriptor exists.
-            val desc: StateDescriptor[_, _] = descMapping.getOrElse(spec.stateId,
-              throw new CodeGenException(
-                s"Can not find DataView for distinct filter in accumulator by id: ${spec.stateId}"))
-
-            addReusableDataView(spec, desc, i)
-          }
-        }
-      }
-
       if (accConfig.isDefined) {
         // create state handles for DataView backed accumulator fields.
         val descMapping: Map[String, StateDescriptor[_, _]] = accConfig.get
           .flatMap(specs => specs.map(s => (s.stateId, s.toStateDescriptor)))
           .toMap[String, StateDescriptor[_ <: State, _]]
 
-        for (i <- aggs.indices) yield {
+        for (i <- 0 until aggs.length + distinctAccCount) yield {
           for (spec <- accConfig.get(i)) yield {
             // Check if stat descriptor exists.
             val desc: StateDescriptor[_, _] = descMapping.getOrElse(spec.stateId,
@@ -375,14 +340,6 @@ class AggregationCodeGenerator(
       reusableCleanupStatements.add(cleanup)
     }
 
-    def genDistinctDataViewFieldSetter(str: String, i: Int): String = {
-      if (isStateBackedDataViews && distinctAggs(i).nonEmpty) {
-        genDataViewFieldSetter(distinctAggs(i), str, i)
-      } else {
-        ""
-      }
-    }
-
     def genAccDataViewFieldSetter(str: String, i: Int): String = {
       if (accConfig.isDefined) {
         genDataViewFieldSetter(accConfig.get(i), str, i)
@@ -429,38 +386,55 @@ class AggregationCodeGenerator(
            |    org.apache.flink.types.Row output) throws Exception """.stripMargin
 
       val setAggs: String = {
-        for (i <- aggs.indices) yield
-
+        for ((i, aggIndexes) <- distinctAccMapping) yield {
           if (partialResults) {
-            j"""
-               |    output.setField(
-               |      ${aggMapping(i)},
-               |      (${accTypes(i)}) accs.getField($i));""".stripMargin
-          } else {
-            val setAccOutput =
+            def setAggs(aggIndexes: JList[Integer]) = {
+              for (i <- aggIndexes) yield {
+                j"""
+                   |output.setField(
+                   |  ${aggMapping(i)},
+                   |  (${accTypes(i)}) accs.getField($i));
+                 """.stripMargin
+              }
+            }.mkString("\n")
+
+            if (i >= 0) {
               j"""
-                 |    ${genAccDataViewFieldSetter(s"acc$i", i)}
                  |    output.setField(
                  |      ${aggMapping(i)},
-                 |      baseClass$i.getValue(acc$i));
+                 |      ($distinctAccType) accs.getField($i));
+                 |    ${setAggs(aggIndexes)}
                  """.stripMargin
-            if (isDistinctAggs(i)) {
+            } else {
+              j"""
+                 |    ${setAggs(aggIndexes)}
+                 """.stripMargin
+            }
+          } else {
+            def setAggs(aggIndexes: JList[Integer]) = {
+              for (i <- aggIndexes) yield {
+                val setAccOutput =
+                  j"""
+                     |${genAccDataViewFieldSetter(s"acc$i", i)}
+                     |output.setField(
+                     |  ${aggMapping(i)},
+                     |  baseClass$i.getValue(acc$i));
+                     """.stripMargin
+
                 j"""
-                   |    org.apache.flink.table.functions.AggregateFunction baseClass$i =
-                   |      (org.apache.flink.table.functions.AggregateFunction) ${aggs(i)};
-                   |    $distinctAccType distinctAcc$i = ($distinctAccType) accs.getField($i);
-                   |    ${accTypes(i)} acc$i = (${accTypes(i)}) distinctAcc$i.getRealAcc();
-                   |    $setAccOutput
-                   """.stripMargin
-              } else {
-                j"""
-                   |    org.apache.flink.table.functions.AggregateFunction baseClass$i =
-                   |      (org.apache.flink.table.functions.AggregateFunction) ${aggs(i)};
-                   |    ${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
-                   |    $setAccOutput
+                   |org.apache.flink.table.functions.AggregateFunction baseClass$i =
+                   |  (org.apache.flink.table.functions.AggregateFunction) ${aggs(i)};
+                   |${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
+                   |$setAccOutput
                    """.stripMargin
               }
-            }
+            }.mkString("\n")
+
+            j"""
+               |    ${setAggs(aggIndexes)}
+               """.stripMargin
+          }
+        }
       }.mkString("\n")
 
       j"""
@@ -478,27 +452,30 @@ class AggregationCodeGenerator(
            |    org.apache.flink.types.Row input) throws Exception """.stripMargin
 
       val accumulate: String = {
-        for (i <- aggs.indices) yield {
-          val accumulateAcc =
+        def accumulateAcc(aggIndexes: JList[Integer]) = {
+          for (i <- aggIndexes) yield {
             j"""
-               |      ${genAccDataViewFieldSetter(s"acc$i", i)}
-               |      ${aggs(i)}.accumulate(acc$i
-               |        ${if (!parametersCode(i).isEmpty) "," else ""} ${parametersCode(i)});
+               |${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
+               |${genAccDataViewFieldSetter(s"acc$i", i)}
+               |${aggs(i)}.accumulate(acc$i
+               |  ${if (!parametersCode(i).isEmpty) "," else ""} ${parametersCode(i)});
                """.stripMargin
-          if (isDistinctAggs(i)) {
+          }
+        }.mkString("\n")
+
+        for ((i, aggIndexes) <- distinctAccMapping) yield {
+          if (i >= 0) {
             j"""
                |    $distinctAccType distinctAcc$i = ($distinctAccType) accs.getField($i);
-               |    ${genDistinctDataViewFieldSetter(s"distinctAcc$i", i)}
-               |    if (distinctAcc$i.add(
-               |        ${classOf[Row].getCanonicalName}.of(${parametersCode(i)}))) {
-               |      ${accTypes(i)} acc$i = (${accTypes(i)}) distinctAcc$i.getRealAcc();
-               |      $accumulateAcc
+               |    ${genAccDataViewFieldSetter(s"distinctAcc$i", i)}
+               |    if (distinctAcc$i.add(${classOf[Row].getCanonicalName}.of(
+               |        ${parametersCode(aggIndexes.get(0))}))) {
+               |      ${accumulateAcc(aggIndexes)}
                |    }
                """.stripMargin
           } else {
             j"""
-               |    ${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
-               |    $accumulateAcc
+               |    ${accumulateAcc(aggIndexes)}
                """.stripMargin
           }
         }
@@ -518,27 +495,30 @@ class AggregationCodeGenerator(
            |    org.apache.flink.types.Row input) throws Exception """.stripMargin
 
       val retract: String = {
-        for (i <- aggs.indices) yield {
-          val retractAcc =
+        def retractAcc(aggIndexes: JList[Integer]) = {
+          for (i <- aggIndexes) yield {
             j"""
-               |    ${genAccDataViewFieldSetter(s"acc$i", i)}
-               |    ${aggs(i)}.retract(
-               |      acc$i ${if (!parametersCode(i).isEmpty) "," else ""} ${parametersCode(i)});
+               |${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
+               |${genAccDataViewFieldSetter(s"acc$i", i)}
+               |${aggs(i)}.retract(acc$i
+               |  ${if (!parametersCode(i).isEmpty) "," else ""} ${parametersCode(i)});
                """.stripMargin
-          if (isDistinctAggs(i)) {
+          }
+        }.mkString("\n")
+
+        for ((i, aggIndexes) <- distinctAccMapping) yield {
+          if (i >= 0) {
             j"""
                |    $distinctAccType distinctAcc$i = ($distinctAccType) accs.getField($i);
-               |    ${genDistinctDataViewFieldSetter(s"distinctAcc$i", i)}
-               |    if (distinctAcc$i.remove(
-               |        ${classOf[Row].getCanonicalName}.of(${parametersCode(i)}))) {
-               |      ${accTypes(i)} acc$i = (${accTypes(i)}) distinctAcc$i.getRealAcc();
-               |      $retractAcc
+               |    ${genAccDataViewFieldSetter(s"distinctAcc$i", i)}
+               |    if (distinctAcc$i.remove(${classOf[Row].getCanonicalName}.of(
+               |        ${parametersCode(aggIndexes.get(0))}))) {
+               |      ${retractAcc(aggIndexes)}
                |    }
                """.stripMargin
           } else {
             j"""
-               |    ${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
-               |    $retractAcc
+               |    ${retractAcc(aggIndexes)}
                """.stripMargin
           }
         }
@@ -565,26 +545,34 @@ class AggregationCodeGenerator(
       val init: String =
         j"""
            |      org.apache.flink.types.Row accs =
-           |          new org.apache.flink.types.Row(${aggs.length});"""
+           |          new org.apache.flink.types.Row(${aggs.length + distinctAccCount});"""
         .stripMargin
       val create: String = {
-        for (i <- aggs.indices) yield {
-          if (isDistinctAggs(i)) {
+        def createAcc(aggIndexes: JList[Integer]) = {
+          for (i <- aggIndexes) yield {
             j"""
-               |    ${accTypes(i)} acc$i = (${accTypes(i)}) ${aggs(i)}.createAccumulator();
+               |${accTypes(i)} acc$i = (${accTypes(i)}) ${aggs(i)}.createAccumulator();
+               |accs.setField(
+               |  $i,
+               |  acc$i);
+               """.stripMargin
+          }
+        }.mkString("\n")
+
+        for ((i, aggIndexes) <- distinctAccMapping) yield {
+          if (i >= 0) {
+            j"""
                |    $distinctAccType distinctAcc$i = ($distinctAccType)
-               |      new ${classOf[DistinctAccumulator[_]].getCanonicalName} (acc$i);
+               |      new ${classOf[DistinctAccumulator].getCanonicalName}();
                |    accs.setField(
                |      $i,
-               |      distinctAcc$i);"""
-              .stripMargin
+               |      distinctAcc$i);
+               |    ${createAcc(aggIndexes)}
+               """.stripMargin
           } else {
             j"""
-               |    ${accTypes(i)} acc$i = (${accTypes(i)}) ${aggs(i)}.createAccumulator();
-               |    accs.setField(
-               |      $i,
-               |      acc$i);"""
-              .stripMargin
+               |    ${createAcc(aggIndexes)}
+               """.stripMargin
           }
         }
       }.mkString("\n")
@@ -633,8 +621,7 @@ class AggregationCodeGenerator(
     }
 
     def genMergeAccumulatorsPair: String = {
-
-      val mapping = mergeMapping.getOrElse(aggs.indices.toArray)
+      val mapping = mergeMapping.getOrElse((0 until aggs.length + distinctAccCount).toArray)
 
       val sig: String =
         j"""
@@ -643,14 +630,35 @@ class AggregationCodeGenerator(
            |    org.apache.flink.types.Row b)
            """.stripMargin
       val merge: String = {
-        for (i <- aggs.indices) yield {
-          if (isDistinctAggs(i)) {
+        def accumulateAcc(aggIndexes: JList[Integer]) = {
+          for (i <- aggIndexes) yield {
+            j"""
+               |${accTypes(i)} aAcc$i = (${accTypes(i)}) a.getField($i);
+               |${aggs(i)}.accumulate(aAcc$i, ${parametersCodeForDistinctMerge(i)});
+               |a.setField($i, aAcc$i);
+               """.stripMargin
+          }
+        }.mkString("\n")
+
+        def mergeAcc(aggIndexes: JList[Integer]) = {
+          for (i <- aggIndexes) yield {
+            j"""
+               |${accTypes(i)} aAcc$i = (${accTypes(i)}) a.getField($i);
+               |${accTypes(i)} bAcc$i = (${accTypes(i)}) b.getField(${mapping(i)});
+               |accIt$i.setElement(bAcc$i);
+               |${aggs(i)}.merge(aAcc$i, accIt$i);
+               |a.setField($i, aAcc$i);
+               """.stripMargin
+          }
+        }.mkString("\n")
+
+        for ((i, aggIndexes) <- distinctAccMapping) yield {
+          if (i >= 0) {
             j"""
                |    $distinctAccType aDistinctAcc$i = ($distinctAccType) a.getField($i);
                |    $distinctAccType bDistinctAcc$i = ($distinctAccType) b.getField(${mapping(i)});
                |    java.util.Iterator<java.util.Map.Entry> mergeIt$i =
                |        bDistinctAcc$i.elements().iterator();
-               |    ${accTypes(i)} aAcc$i = (${accTypes(i)}) aDistinctAcc$i.getRealAcc();
                |
                |    while (mergeIt$i.hasNext()) {
                |      java.util.Map.Entry entry = (java.util.Map.Entry) mergeIt$i.next();
@@ -658,18 +666,14 @@ class AggregationCodeGenerator(
                |          (${classOf[Row].getCanonicalName}) entry.getKey();
                |      Long v = (Long) entry.getValue();
                |      if (aDistinctAcc$i.add(k, v)) {
-               |        ${aggs(i)}.accumulate(aAcc$i, ${parametersCodeForDistinctMerge(i)});
+               |        ${accumulateAcc(aggIndexes)}
                |      }
                |    }
                |    a.setField($i, aDistinctAcc$i);
                """.stripMargin
           } else {
             j"""
-               |    ${accTypes(i)} aAcc$i = (${accTypes(i)}) a.getField($i);
-               |    ${accTypes(i)} bAcc$i = (${accTypes(i)}) b.getField(${mapping(i)});
-               |    accIt$i.setElement(bAcc$i);
-               |    ${aggs(i)}.merge(aAcc$i, accIt$i);
-               |    a.setField($i, aAcc$i);
+               |    ${mergeAcc(aggIndexes)}
                """.stripMargin
           }
         }
@@ -716,20 +720,28 @@ class AggregationCodeGenerator(
            |    org.apache.flink.types.Row accs) throws Exception """.stripMargin
 
       val reset: String = {
-        for (i <- aggs.indices) yield {
-          if (isDistinctAggs(i)) {
+        def resetAcc(aggIndexes: JList[Integer]) = {
+          for (i <- aggIndexes) yield {
+            j"""
+               |${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
+               |${genAccDataViewFieldSetter(s"acc$i", i)}
+               |${aggs(i)}.resetAccumulator(acc$i);
+               """.stripMargin
+          }
+        }.mkString("\n")
+
+        for ((i, aggIndexes) <- distinctAccMapping) yield {
+          if (i >= 0) {
             j"""
                |    $distinctAccType distinctAcc$i = ($distinctAccType) accs.getField($i);
-               |    ${genDistinctDataViewFieldSetter(s"distinctAcc$i", i)}
-               |    ${accTypes(i)} acc$i = (${accTypes(i)}) distinctAcc$i.getRealAcc();
-               |    ${genAccDataViewFieldSetter(s"acc$i", i)}
+               |    ${genAccDataViewFieldSetter(s"distinctAcc$i", i)}
                |    distinctAcc$i.reset();
-               |    ${aggs(i)}.resetAccumulator(acc$i);""".stripMargin
+               |    ${resetAcc(aggIndexes)}
+               """.stripMargin
           } else {
             j"""
-               |    ${accTypes(i)} acc$i = (${accTypes(i)}) accs.getField($i);
-               |    ${genAccDataViewFieldSetter(s"acc$i", i)}
-               |    ${aggs(i)}.resetAccumulator(acc$i);""".stripMargin
+               |    ${resetAcc(aggIndexes)}
+               """.stripMargin
           }
         }
       }.mkString("\n")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
@@ -771,7 +771,7 @@ class MatchCodeGenerator(
           callsWithIndices.map(_._2).toArray)
       })
 
-      val distinctAccMap: mutable.Map[util.List[Integer], Integer] = mutable.Map()
+      val distinctAccMap: mutable.Map[util.Set[Integer], Integer] = mutable.Map()
       val aggs = logicalAggregates.zipWithIndex.map {
         case (agg, index) =>
           val result = AggregateUtil.extractAggregateCallMetadata(
@@ -780,6 +780,7 @@ class MatchCodeGenerator(
             distinctAccMap,
             new util.ArrayList[Integer](), // TODO properly set once supported in Calcite
             aggregates.length,
+            input.getArity,
             agg.inputTypes,
             needRetraction = false,
             config,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
@@ -651,7 +651,7 @@ class MatchCodeGenerator(
 
   class AggBuilder(variable: String) {
 
-    private val  aggregates = new mutable.ListBuffer[RexCall]()
+    private val aggregates = new mutable.ListBuffer[RexCall]()
 
     private val variableUID = newName("variable")
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/DistinctAccumulator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/DistinctAccumulator.scala
@@ -28,30 +28,19 @@ import org.apache.flink.types.Row
 /**
   * Wraps an accumulator and adds a map to filter distinct values.
   *
-  * @param realAcc the wrapped accumulator.
   * @param distinctValueMap the [[MapView]] that stores the distinct filter hash map.
-  *
-  * @tparam ACC the accumulator type for the realAcc.
   */
-class DistinctAccumulator[ACC](
-    var realAcc: ACC,
-    var distinctValueMap: MapView[Row, JLong]) {
+class DistinctAccumulator(var distinctValueMap: MapView[Row, JLong]) {
 
   def this() {
-    this(null.asInstanceOf[ACC], new MapView[Row, JLong]())
+    this(new MapView[Row, JLong]())
   }
 
-  def this(realAcc: ACC) {
-    this(realAcc, new MapView[Row, JLong]())
-  }
-
-  def getRealAcc: ACC = realAcc
-
-  def canEqual(a: Any): Boolean = a.isInstanceOf[DistinctAccumulator[ACC]]
+  def canEqual(a: Any): Boolean = a.isInstanceOf[DistinctAccumulator]
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: DistinctAccumulator[ACC] => that.canEqual(this) &&
+      case that: DistinctAccumulator => that.canEqual(this) &&
         this.distinctValueMap == that.distinctValueMap
       case _ => false
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -464,15 +464,15 @@ object UserDefinedFunctionUtils {
     * Remove StateView fields from accumulator type information.
     *
     * @param index index of aggregate function
-    * @param aggFun aggregate function
+    * @param acc accumulator
     * @param accType accumulator type information, only support pojo type
     * @param isStateBackedDataViews is data views use state backend
     * @return mapping of accumulator type information and data view config which contains id,
     *         field name and state descriptor
     */
-  def removeStateViewFieldsFromAccTypeInfo(
+  def removeStateViewFieldsFromAccTypeInfo[ACC](
       index: Int,
-      aggFun: AggregateFunction[_, _],
+      acc: ACC,
       accType: TypeInformation[_],
       isStateBackedDataViews: Boolean)
     : (TypeInformation[_], Option[Seq[DataViewSpec[_]]]) = {
@@ -489,7 +489,6 @@ object UserDefinedFunctionUtils {
       )
     }
 
-    val acc = aggFun.createAccumulator()
     accType match {
       case pojoType: PojoTypeInfo[_] if pojoType.getArity > 0 =>
         val arity = pojoType.getArity

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -1335,7 +1335,7 @@ object AggregateUtil {
     *
     * @param aggregateCalls calcite's aggregate function
     * @param aggregateInputType input type of given aggregates
-    * @param inputFieldsCount number of input fields,
+    * @param inputFieldsCount number of input fields
     * @param needRetraction if the [[TableAggregateFunction]] should produce retractions
     * @param tableConfig tableConfig, required for decimal precision
     * @param isStateBackedDataViews if data should be backed by state backend

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
@@ -349,4 +349,80 @@ public class JavaUserDefinedAggFunctions {
 			isCloseCalled = true;
 		}
 	}
+
+	/**
+	 * Count accumulator.
+	 */
+	public static class MultiArgCountAcc {
+		public long count;
+	}
+
+	/**
+	 * Count aggregate function with multiple arguments.
+	 */
+	public static class MultiArgCount extends AggregateFunction<Long, MultiArgCountAcc> {
+
+		@Override
+		public MultiArgCountAcc createAccumulator() {
+			MultiArgCountAcc acc = new MultiArgCountAcc();
+			acc.count = 0L;
+			return acc;
+		}
+
+		public void accumulate(MultiArgCountAcc acc, Object in1, Object in2) {
+			if (in1 != null && in2 != null) {
+				acc.count += 1;
+			}
+		}
+
+		public void retract(MultiArgCountAcc acc, Object in1, Object in2) {
+			if (in1 != null && in2 != null) {
+				acc.count -= 1;
+			}
+		}
+
+		public void merge(MultiArgCountAcc accumulator, java.lang.Iterable<MultiArgCountAcc> iterable) {
+			for (MultiArgCountAcc otherAcc : iterable) {
+				accumulator.count += otherAcc.count;
+			}
+		}
+
+		@Override
+		public Long getValue(MultiArgCountAcc acc) {
+			return acc.count;
+		}
+	}
+
+	/**
+	 * Sum accumulator.
+	 */
+	public static class MultiArgSumAcc {
+		public long count;
+	}
+
+	/**
+	 * Sum aggregate function with multiple arguments.
+	 */
+	public static class MultiArgSum extends AggregateFunction<Long, MultiArgSumAcc> {
+
+		@Override
+		public MultiArgSumAcc createAccumulator() {
+			MultiArgSumAcc acc = new MultiArgSumAcc();
+			acc.count = 0L;
+			return acc;
+		}
+
+		public void accumulate(MultiArgSumAcc acc, long in1, long in2) {
+			acc.count += in1 + in2;
+		}
+
+		public void retract(MultiArgSumAcc acc, long in1, long in2) {
+			acc.count -= in1 + in2;
+		}
+
+		@Override
+		public Long getValue(MultiArgSumAcc acc) {
+			return acc.count;
+		}
+	}
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
@@ -31,6 +31,7 @@ import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.harness.HarnessTestBase._
 import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{MultiArgCount, MultiArgSum}
 import org.apache.flink.types.Row
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -262,6 +263,104 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
 
     // retract after cleanup
     testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 1: JInt, 1L: JLong)))
+
+    val result = testHarness.getOutput
+
+    verify(expectedOutput, result)
+
+    testHarness.close()
+  }
+
+  @Test
+  def testDistinctAggregateWithDifferentArgumentOrder(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = new mutable.MutableList[(JLong, JLong, JLong)]
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T", t)
+    tEnv.registerFunction("myCount", new MultiArgCount)
+    tEnv.registerFunction("mySum", new MultiArgSum)
+    val sqlQuery = tEnv.sqlQuery(
+      s"""
+         |SELECT
+         |  a, myCount(distinct b, c), mySum(distinct c, b)
+         |FROM (
+         |  SELECT a, b, c
+         |  FROM T
+         |  GROUP BY a, b, c
+         |) GROUP BY a
+         |""".stripMargin)
+
+    val testHarness = createHarnessTester[String, CRow, CRow](
+      sqlQuery.toRetractStream[Row](queryConfig), "groupBy")
+
+    testHarness.setStateBackend(getStateBackend)
+    testHarness.open()
+
+    val operator = getOperator(testHarness)
+    val fields = getGeneratedAggregationFields(
+      operator,
+      "function",
+      classOf[GroupAggProcessFunction])
+
+    // check only one DistinctAccumulator is used
+    assertTrue(fields.count(_.getName.endsWith("distinctValueMap_dataview")) == 1)
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    // register cleanup timer with 3001
+    testHarness.setProcessingTime(1)
+
+    // insert
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1L: JLong, 1L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong, 2L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1L: JLong, 1L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1L: JLong, 2L: JLong)))
+
+    // distinct count retract then accumulate for downstream operators
+    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1L: JLong, 1L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(false, 2L: JLong, 1L: JLong, 2L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1L: JLong, 2L: JLong)))
+
+    // update count for accumulate
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 2L: JLong, 3L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 1L: JLong, 2L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 2L: JLong, 7L: JLong)))
+
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 2L: JLong, 3L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong, 7L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 2L: JLong, 7L: JLong)))
+
+    // update count for retraction
+    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong, 3L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong, 7L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 2L: JLong, 7L: JLong)))
+
+    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong, 3L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong, 7L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong, 2L: JLong)))
+
+    // insert
+    testHarness.processElement(new StreamRecord(CRow(4L: JLong, 3L: JLong, 3L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(4L: JLong, 1L: JLong, 6L: JLong)))
+
+    // retract entirely
+    testHarness.processElement(new StreamRecord(CRow(false, 4L: JLong, 3L: JLong, 3L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(false, 4L: JLong, 1L: JLong, 6L: JLong)))
+
+    // trigger cleanup timer and register cleanup timer with 6002
+    testHarness.setProcessingTime(3002)
+
+    // insert
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1L: JLong, 2L: JLong)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong, 3L: JLong)))
+
+    // trigger cleanup timer and register cleanup timer with 9002
+    testHarness.setProcessingTime(6002)
+
+    // retract after cleanup
+    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 1: JInt, 2L: JLong)))
 
     val result = testHarness.getOutput
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
@@ -22,12 +22,20 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.harness.HarnessTestBase._
 import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
+import org.junit.Assert.assertTrue
 import org.junit.Test
+
+import scala.collection.mutable
 
 class GroupAggregateHarnessTest extends HarnessTestBase {
 
@@ -176,21 +184,37 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
 
   @Test
   def testDistinctAggregateWithRetract(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new GroupAggProcessFunction(
-        genDistinctCountAggFunction,
-        distinctCountAggregationStateType,
-        true,
-        queryConfig))
+    val data = new mutable.MutableList[(JLong, JInt)]
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b)
+    tEnv.registerTable("T", t)
+    val sqlQuery = tEnv.sqlQuery(
+      s"""
+         |SELECT
+         |  a, count(distinct b), sum(distinct b)
+         |FROM (
+         |  SELECT a, b
+         |  FROM T
+         |  GROUP BY a, b
+         |) GROUP BY a
+         |""".stripMargin)
 
-    val testHarness =
-      createHarnessTester(
-        processFunction,
-        new TupleRowKeySelector[String](2),
-        BasicTypeInfo.STRING_TYPE_INFO)
+    val testHarness = createHarnessTester[String, CRow, CRow](
+      sqlQuery.toRetractStream[Row](queryConfig), "groupBy")
 
+    testHarness.setStateBackend(getStateBackend)
     testHarness.open()
+
+    val operator = getOperator(testHarness)
+    val fields = getGeneratedAggregationFields(
+      operator,
+      "function",
+      classOf[GroupAggProcessFunction])
+
+    // check only one DistinctAccumulator is used
+    assertTrue(fields.count(_.getName.endsWith("distinctValueMap_dataview")) == 1)
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
@@ -198,46 +222,46 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
     testHarness.setProcessingTime(1)
 
     // insert
-    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1: JInt, "aaa")))
-    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong)))
-    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1: JInt, "bbb")))
-    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong, 1: JInt)))
+    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1L: JLong, 1: JInt)))
 
     // distinct count retract then accumulate for downstream operators
-    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1: JInt, "bbb")))
-    expectedOutput.add(new StreamRecord(CRow(false, 2L: JLong, 1L: JLong)))
-    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(false, 2L: JLong, 1L: JLong, 1: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1L: JLong, 1: JInt)))
 
     // update count for accumulate
-    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 2: JInt, "aaa")))
-    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 1L: JLong)))
-    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 2L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 2: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 1L: JLong, 1: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 2L: JLong, 3: JInt)))
 
     // update count for retraction
-    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 2: JInt, "aaa")))
-    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong)))
-    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 2: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(false, 1L: JLong, 2L: JLong, 3: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong, 1: JInt)))
 
     // insert
-    testHarness.processElement(new StreamRecord(CRow(4L: JLong, 3: JInt, "ccc")))
-    expectedOutput.add(new StreamRecord(CRow(4L: JLong, 1L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(4L: JLong, 3: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(4L: JLong, 1L: JLong, 3: JInt)))
 
     // retract entirely
-    testHarness.processElement(new StreamRecord(CRow(false, 4L: JLong, 3: JInt, "ccc")))
-    expectedOutput.add(new StreamRecord(CRow(false, 4L: JLong, 1L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(false, 4L: JLong, 3: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(false, 4L: JLong, 1L: JLong, 3: JInt)))
 
     // trigger cleanup timer and register cleanup timer with 6002
     testHarness.setProcessingTime(3002)
 
     // insert
-    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1: JInt, "aaa")))
-    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong)))
+    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1: JInt)))
+    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1L: JLong, 1: JInt)))
 
     // trigger cleanup timer and register cleanup timer with 9002
     testHarness.setProcessingTime(6002)
 
     // retract after cleanup
-    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 1: JInt, "aaa")))
+    testHarness.processElement(new StreamRecord(CRow(false, 1L: JLong, 1: JInt, 1L: JLong)))
 
     val result = testHarness.getOutput
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.{TableEnvironment, Types}
 import org.apache.flink.table.descriptors.{Rowtime, Schema}
 import org.apache.flink.table.expressions.utils.Func15
 import org.apache.flink.table.runtime.stream.sql.SqlITCase.TimestampAndWatermarkWithOffset
+import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.MultiArgCount
 import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
 import org.apache.flink.table.runtime.utils.{JavaUserDefinedTableFunctions, StreamITCase, StreamTestData, StreamingWithStateTestBase}
 import org.apache.flink.table.utils.{InMemoryTableFactory, MemoryTableSourceSinkUtil}
@@ -70,15 +71,19 @@ class SqlITCase extends StreamingWithStateTestBase {
     StreamITCase.clear
     val stream = env
       .fromCollection(sessionWindowTestData)
-      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
+      .assignTimestampsAndWatermarks(
+        new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
 
     val tEnv = TableEnvironment.getTableEnvironment(env)
     val table = stream.toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
     tEnv.registerTable("MyTable", table)
+    tEnv.registerFunction("myCount", new MultiArgCount)
 
     val sqlQuery = "SELECT c, " +
       "  COUNT(DISTINCT b)," +
       "  SUM(DISTINCT b)," +
+      "  myCount(DISTINCT b, 1)," +
+      "  myCount(DISTINCT 1, b)," +
       "  SESSION_END(rowtime, INTERVAL '0.005' SECOND) " +
       "FROM MyTable " +
       "GROUP BY SESSION(rowtime, INTERVAL '0.005' SECOND), c "
@@ -88,9 +93,9 @@ class SqlITCase extends StreamingWithStateTestBase {
     env.execute()
 
     val expected = Seq(
-      "Hello World,1,9,1970-01-01 00:00:00.014", // window starts at [9L] till {14L}
-      "Hello,1,16,1970-01-01 00:00:00.021",       // window starts at [16L] till {21L}, not merged
-      "Hello,3,6,1970-01-01 00:00:00.015"        // window starts at [1L,2L],
+      "Hello World,1,9,1,1,1970-01-01 00:00:00.014", // window starts at [9L] till {14L}
+      "Hello,1,16,1,1,1970-01-01 00:00:00.021",       // window starts at [16L] till {21L}, not merged
+      "Hello,3,6,3,3,1970-01-01 00:00:00.015"        // window starts at [1L,2L],
                                                //   merged with [8L,10L], by [4L], till {15L}
     )
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -94,9 +94,9 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val expected = Seq(
       "Hello World,1,9,1,1,1970-01-01 00:00:00.014", // window starts at [9L] till {14L}
-      "Hello,1,16,1,1,1970-01-01 00:00:00.021",       // window starts at [16L] till {21L}, not merged
-      "Hello,3,6,3,3,1970-01-01 00:00:00.015"        // window starts at [1L,2L],
-                                               //   merged with [8L,10L], by [4L], till {15L}
+      "Hello,1,16,1,1,1970-01-01 00:00:00.021",    // window starts at [16L] till {21L}, not merged
+      "Hello,3,6,3,3,1970-01-01 00:00:00.015"      // window starts at [1L,2L],
+                                                   // merged with [8L,10L], by [4L], till {15L}
     )
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -88,15 +88,30 @@ class AggregateITCase extends StreamingWithStateTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
 
-    val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
-      .groupBy('e)
-      .select('e, 'a.count.distinct, 'a.sum.distinct)
+    val data = new mutable.MutableList[(Int, Int, String)]
+    data.+=((1, 1, "A"))
+    data.+=((2, 2, "B"))
+    data.+=((2, 2, "B"))
+    data.+=((4, 3, "C"))
+    data.+=((5, 3, "C"))
+    data.+=((4, 3, "C"))
+    data.+=((7, 3, "B"))
+    data.+=((1, 4, "A"))
+    data.+=((9, 4, "D"))
+    data.+=((4, 1, "A"))
+    data.+=((3, 2, "B"))
+
+    val testAgg = new WeightedAvg
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+      .groupBy('c)
+      .select('c, 'a.count.distinct, 'a.sum.distinct,
+              testAgg.distinct('a, 'b), testAgg.distinct('b, 'a), testAgg('a, 'b))
 
     val results = t.toRetractStream[Row](queryConfig)
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
     env.execute()
 
-    val expected = mutable.MutableList("1,4,12", "2,4,14", "3,2,8")
+    val expected = mutable.MutableList("A,2,5,1,1,1", "B,3,12,4,2,3", "C,2,9,4,3,4", "D,1,9,9,4,9")
     assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
   }
 
@@ -116,39 +131,6 @@ class AggregateITCase extends StreamingWithStateTestBase {
     env.execute()
 
     val expected = mutable.MutableList("1,4,5", "2,4,7", "3,2,3")
-    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
-  }
-
-  @Test
-  def testDistinctAGGWithDifferentArgumentOrder(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
-    val data = new mutable.MutableList[(Int, Int, String)]
-    data.+=((1, 1, "A"))
-    data.+=((2, 2, "B"))
-    data.+=((2, 2, "B"))
-    data.+=((4, 3, "C"))
-    data.+=((5, 3, "C"))
-    data.+=((4, 3, "C"))
-    data.+=((7, 3, "B"))
-    data.+=((1, 4, "A"))
-    data.+=((9, 4, "D"))
-    data.+=((4, 1, "A"))
-    data.+=((3, 2, "B"))
-
-    val testAgg = new WeightedAvg
-    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
-      .groupBy('c)
-      .select('c, testAgg.distinct('a, 'b), testAgg.distinct('b, 'a), testAgg('a, 'b))
-
-    val results = t.toRetractStream[Row](queryConfig)
-    results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
-    env.execute()
-
-    val expected = mutable.MutableList("A,1,1,1", "B,4,2,3", "C,4,3,4", "D,9,4,9")
     assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -90,13 +90,13 @@ class AggregateITCase extends StreamingWithStateTestBase {
 
     val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e)
-      .select('e, 'a.count.distinct)
+      .select('e, 'a.count.distinct, 'a.sum.distinct)
 
     val results = t.toRetractStream[Row](queryConfig)
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
     env.execute()
 
-    val expected = mutable.MutableList("1,4", "2,4", "3,2")
+    val expected = mutable.MutableList("1,4,12", "2,4,14", "3,2,8")
     assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request optimizes the DISTINCT aggregates such as `SELECT COUNT(DISTINCT(a)), SUM(DISTINCT(a))` to use the same distinct accumulator for performance optimization.*

## Brief change log

  - *Separate DistinctAccumulator and the actual accumulator*
  - *Optimize the AggregateCodeGeneration to reuse the same DistinctAccumulator if possible*

## Verifying this change

  - *Existing tests, such as SqlITCase#testDistinctAggOnRowTimeTumbleWindow, AggregateITCase, OverWindowITCase*
  - *Updated harness test GroupAggregateHarnessTest#testDistinctAggregateWithRetract*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
