### PR TITLE
[FLINK-9702] Improvement in (de)serialization of keys and values for RocksDB state

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -86,16 +87,21 @@ public final class GenericArraySerializer<C> extends TypeSerializer<C[]> {
 
 	@Override
 	public C[] copy(C[] from) {
-		C[] copy = create(from.length);
 
-		for (int i = 0; i < copy.length; i++) {
-			C val = from[i];
-			if (val != null) {
-				copy[i] = this.componentSerializer.copy(val);
+		final TypeSerializer<C> serializer = this.componentSerializer;
+
+		if (serializer.isImmutableType()) {
+			return Arrays.copyOf(from, from.length);
+		} else {
+			C[] copy = create(from.length);
+			for (int i = 0; i < copy.length; i++) {
+				C val = from[i];
+				if (val != null) {
+					copy[i] = serializer.copy(val);
+				}
 			}
+			return copy;
 		}
-
-		return copy;
 	}
 	
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 
@@ -112,7 +111,7 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
 	}
 
 	@Override
-	public void close() throws IOException {
+	public void close() {
 	}
 
 	public byte[] getBuf() {

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputSerializer.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.core.memory;
 
+import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -348,6 +350,11 @@ public class DataOutputSerializer implements DataOutputView {
 
 		source.readFully(this.buffer, this.position, numBytes);
 		this.position += numBytes;
+	}
+
+	public void setPosition(int position) {
+		Preconditions.checkArgument(position >= 0 && position <= this.position, "Position out of bounds.");
+		this.position = position;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.contrib.streaming.state;
 
-import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -28,8 +27,8 @@ import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
 
-abstract class AbstractRocksDBAppendingState <K, N, IN, SV, OUT, S extends State>
-	extends AbstractRocksDBState<K, N, SV, S>
+abstract class AbstractRocksDBAppendingState <K, N, IN, SV, OUT>
+	extends AbstractRocksDBState<K, N, SV>
 	implements InternalAppendingState<K, N, IN, SV, OUT> {
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -44,9 +44,8 @@ import java.io.IOException;
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
  * @param <V> The type of values kept internally in state.
- * @param <S> The type of {@link State}.
  */
-public abstract class AbstractRocksDBState<K, N, V, S extends State> implements InternalKvState<K, N, V>, State {
+public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K, N, V>, State {
 
 	/** Serializer for the namespace. */
 	final TypeSerializer<N> namespaceSerializer;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -34,6 +34,7 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Base class for {@link State} implementations that store state in a RocksDB database.
@@ -70,7 +71,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 
 	protected final DataInputDeserializer dataInputView;
 
-	private final boolean ambiguousKeyPossible;
+	private final RocksDBSerializedCompositeKeyBuilder<K> sharedKeyNamespaceSerializer;
 
 	/**
 	 * Creates a new RocksDB backed state.
@@ -99,8 +100,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 
 		this.dataOutputView = new DataOutputSerializer(128);
 		this.dataInputView = new DataInputDeserializer();
-		this.ambiguousKeyPossible =
-			RocksDBKeySerializationUtils.isAmbiguousKeyPossible(backend.getKeySerializer(), namespaceSerializer);
+		this.sharedKeyNamespaceSerializer = backend.getSharedRocksKeyBuilder();
 	}
 
 	// ------------------------------------------------------------------------
@@ -108,17 +108,15 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 	@Override
 	public void clear() {
 		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = dataOutputView.getCopyOfBuffer();
-			backend.db.delete(columnFamily, writeOptions, key);
-		} catch (IOException | RocksDBException e) {
+			backend.db.delete(columnFamily, writeOptions, serializeCurrentKeyWithGroupAndNamespace());
+		} catch (RocksDBException e) {
 			throw new FlinkRuntimeException("Error while removing entry from RocksDB", e);
 		}
 	}
 
 	@Override
 	public void setCurrentNamespace(N namespace) {
-		this.currentNamespace = Preconditions.checkNotNull(namespace, "Namespace");
+		this.currentNamespace = namespace;
 	}
 
 	@Override
@@ -128,30 +126,78 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 			final TypeSerializer<N> safeNamespaceSerializer,
 			final TypeSerializer<V> safeValueSerializer) throws Exception {
 
-		Preconditions.checkNotNull(serializedKeyAndNamespace);
-		Preconditions.checkNotNull(safeKeySerializer);
-		Preconditions.checkNotNull(safeNamespaceSerializer);
-		Preconditions.checkNotNull(safeValueSerializer);
-
 		//TODO make KvStateSerializer key-group aware to save this round trip and key-group computation
 		Tuple2<K, N> keyAndNamespace = KvStateSerializer.deserializeKeyAndNamespace(
 				serializedKeyAndNamespace, safeKeySerializer, safeNamespaceSerializer);
 
 		int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(keyAndNamespace.f0, backend.getNumberOfKeyGroups());
 
-		// we cannot reuse the keySerializationStream member since this method
-		// is called concurrently to the other ones and it may thus contain garbage
-		DataOutputSerializer tmpKeySerializationView = new DataOutputSerializer(128);
+		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
+						new RocksDBSerializedCompositeKeyBuilder<>(
+							safeKeySerializer,
+							backend.getKeyGroupPrefixBytes(),
+							32
+						);
+		keyBuilder.setKeyAndKeyGroup(keyAndNamespace.f0, keyGroup);
+		byte[] key = keyBuilder.buildCompositeKeyNamespace(keyAndNamespace.f1, namespaceSerializer);
+		return backend.db.get(columnFamily, key);
+	}
 
-		writeKeyWithGroupAndNamespace(
-				keyGroup,
-				keyAndNamespace.f0,
-				safeKeySerializer,
-				keyAndNamespace.f1,
-				safeNamespaceSerializer,
-				tmpKeySerializationView);
+	<UK> byte[] serializeCurrentKeyWithGroupAndNamespacePlusUserKey(
+		UK userKey,
+		TypeSerializer<UK> userKeySerializer) throws IOException {
+		return sharedKeyNamespaceSerializer.buildCompositeKeyNamesSpaceUserKey(
+			currentNamespace,
+			namespaceSerializer,
+			userKey,
+			userKeySerializer
+		);
+	}
 
-		return backend.db.get(columnFamily, tmpKeySerializationView.getCopyOfBuffer());
+	private <T> byte[] serializeValueInternal(T value, TypeSerializer<T> serializer) throws IOException {
+		serializer.serialize(value, dataOutputView);
+		return dataOutputView.getCopyOfBuffer();
+	}
+
+	byte[] serializeCurrentKeyWithGroupAndNamespace() {
+		return sharedKeyNamespaceSerializer.buildCompositeKeyNamespace(currentNamespace, namespaceSerializer);
+	}
+
+	byte[] serializeValue(V value) throws IOException {
+		return serializeValue(value, valueSerializer);
+	}
+
+	<T> byte[] serializeValueNullSensitive(T value, TypeSerializer<T> serializer) throws IOException {
+		dataOutputView.clear();
+		dataOutputView.writeBoolean(value == null);
+		return serializeValueInternal(value, serializer);
+	}
+
+	<T> byte[] serializeValue(T value, TypeSerializer<T> serializer) throws IOException {
+		dataOutputView.clear();
+		return serializeValueInternal(value, serializer);
+	}
+
+	<T> byte[] serializeValueList(
+		List<T> valueList,
+		TypeSerializer<T> elementSerializer,
+		byte delimiter) throws IOException {
+
+		dataOutputView.clear();
+		boolean first = true;
+
+		for (T value : valueList) {
+			Preconditions.checkNotNull(value, "You cannot add null to a value list.");
+
+			if (first) {
+				first = false;
+			} else {
+				dataOutputView.write(delimiter);
+			}
+			elementSerializer.serialize(value, dataOutputView);
+		}
+
+		return dataOutputView.getCopyOfBuffer();
 	}
 
 	public void migrateSerializedValue(
@@ -169,12 +215,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 	}
 
 	byte[] getKeyBytes() {
-		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			return dataOutputView.getCopyOfBuffer();
-		} catch (IOException e) {
-			throw new FlinkRuntimeException("Error while serializing key", e);
-		}
+		return serializeCurrentKeyWithGroupAndNamespace();
 	}
 
 	byte[] getValueBytes(V value) {
@@ -185,45 +226,6 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 		} catch (IOException e) {
 			throw new FlinkRuntimeException("Error while serializing value", e);
 		}
-	}
-
-	protected void writeCurrentKeyWithGroupAndNamespace() throws IOException {
-		writeKeyWithGroupAndNamespace(
-			backend.getCurrentKeyGroupIndex(),
-			backend.getCurrentKey(),
-			currentNamespace,
-			dataOutputView);
-	}
-
-	protected void writeKeyWithGroupAndNamespace(
-			int keyGroup, K key, N namespace,
-			DataOutputSerializer keySerializationDataOutputView) throws IOException {
-
-		writeKeyWithGroupAndNamespace(
-				keyGroup,
-				key,
-				backend.getKeySerializer(),
-				namespace,
-				namespaceSerializer,
-				keySerializationDataOutputView);
-	}
-
-	protected void writeKeyWithGroupAndNamespace(
-			final int keyGroup,
-			final K key,
-			final TypeSerializer<K> keySerializer,
-			final N namespace,
-			final TypeSerializer<N> namespaceSerializer,
-			final DataOutputSerializer keySerializationDataOutputView) throws IOException {
-
-		Preconditions.checkNotNull(key, "No key set. This method should not be called outside of a keyed context.");
-		Preconditions.checkNotNull(keySerializer);
-		Preconditions.checkNotNull(namespaceSerializer);
-
-		keySerializationDataOutputView.clear();
-		RocksDBKeySerializationUtils.writeKeyGroup(keyGroup, backend.getKeyGroupPrefixBytes(), keySerializationDataOutputView);
-		RocksDBKeySerializationUtils.writeKey(key, keySerializer, keySerializationDataOutputView, ambiguousKeyPossible);
-		RocksDBKeySerializationUtils.writeNameSpace(namespace, namespaceSerializer, keySerializationDataOutputView, ambiguousKeyPossible);
 	}
 
 	protected V getDefaultValue() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -43,7 +43,7 @@ import java.util.Collection;
  * @param <R> The type of the value returned from the state
  */
 class RocksDBAggregatingState<K, N, T, ACC, R>
-	extends AbstractRocksDBAppendingState<K, N, T, ACC, R, AggregatingState<T, R>>
+	extends AbstractRocksDBAppendingState<K, N, T, ACC, R>
 	implements InternalAggregatingState<K, N, T, ACC, R> {
 
 	/** User-specified aggregation function. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -42,7 +42,7 @@ import org.rocksdb.ColumnFamilyHandle;
  */
 @Deprecated
 class RocksDBFoldingState<K, N, T, ACC>
-	extends AbstractRocksDBAppendingState<K, N, T, ACC, ACC, FoldingState<T, ACC>>
+	extends AbstractRocksDBAppendingState<K, N, T, ACC, ACC>
 	implements InternalFoldingState<K, N, T, ACC> {
 
 	/** User-specified fold function. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
@@ -23,6 +23,8 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 
 /**
@@ -80,8 +82,12 @@ public class RocksDBKeySerializationUtils {
 		}
 	}
 
+	public static boolean isSerializerTypeVariableSized(@Nonnull TypeSerializer<?> serializer) {
+		return serializer.getLength() < 0;
+	}
+
 	public static boolean isAmbiguousKeyPossible(TypeSerializer keySerializer, TypeSerializer namespaceSerializer) {
-		return (keySerializer.getLength() < 0) && (namespaceSerializer.getLength() < 0);
+		return (isSerializerTypeVariableSized(keySerializer) && isSerializerTypeVariableSized(namespaceSerializer));
 	}
 
 	public static void writeKeyGroup(
@@ -108,7 +114,7 @@ public class RocksDBKeySerializationUtils {
 		}
 	}
 
-	private static void readVariableIntBytes(DataInputView inputView, int value) throws IOException {
+	public static void readVariableIntBytes(DataInputView inputView, int value) throws IOException {
 		do {
 			inputView.readByte();
 			value >>>= 8;
@@ -122,7 +128,7 @@ public class RocksDBKeySerializationUtils {
 		writeVariableIntBytes(length, keySerializationDateDataOutputView);
 	}
 
-	private static void writeVariableIntBytes(
+	public static void writeVariableIntBytes(
 		int value,
 		DataOutputView keySerializationDateDataOutputView)
 		throws IOException {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -249,6 +249,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	/** The native metrics monitor. */
 	private RocksDBNativeMetricMonitor nativeMetricMonitor;
 
+	/** Helper to build the byte arrays of composite keys to address data in RocksDB. Shared across all states.*/
+	private final RocksDBSerializedCompositeKeyBuilder<K> sharedRocksKeyBuilder;
+
 	public RocksDBKeyedStateBackend(
 		String operatorIdentifier,
 		ClassLoader userCodeClassLoader,
@@ -300,6 +303,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.restoredKvStateMetaInfos = new HashMap<>();
 
 		this.writeOptions = new WriteOptions().setDisableWAL(true);
+		this.sharedRocksKeyBuilder = new RocksDBSerializedCompositeKeyBuilder<>(keySerializer, keyGroupPrefixBytes, 32);
 
 		this.metricOptions = metricOptions;
 		this.metricGroup = metricGroup;
@@ -377,6 +381,12 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		if (nativeMetricMonitor != null) {
 			nativeMetricMonitor.registerColumnFamily(columnFamilyName, registeredColumn.f0);
 		}
+	}
+
+	@Override
+	public void setCurrentKey(K newKey) {
+		super.setCurrentKey(newKey);
+		sharedRocksKeyBuilder.setKeyAndKeyGroup(getCurrentKey(), getCurrentKeyGroupIndex());
 	}
 
 	/**
@@ -461,6 +471,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	public WriteOptions getWriteOptions() {
 		return writeOptions;
+	}
+
+	RocksDBSerializedCompositeKeyBuilder<K> getSharedRocksKeyBuilder() {
+		return sharedRocksKeyBuilder;
 	}
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1479,7 +1479,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		@SuppressWarnings("unchecked")
-		AbstractRocksDBState<?, ?, SV, S> rocksDBState = (AbstractRocksDBState<?, ?, SV, S>) state;
+		AbstractRocksDBState<?, ?, SV> rocksDBState = (AbstractRocksDBState<?, ?, SV>) state;
 
 		Snapshot rocksDBSnapshot = db.getSnapshot();
 		try (

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -59,7 +59,7 @@ import static org.apache.flink.runtime.state.StateSnapshotTransformer.Collection
  * @param <V> The type of the values in the list state.
  */
 class RocksDBListState<K, N, V>
-	extends AbstractRocksDBState<K, N, List<V>, ListState<V>>
+	extends AbstractRocksDBState<K, N, List<V>>
 	implements InternalListState<K, N, V> {
 
 	/** Serializer for the values. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -64,7 +64,7 @@ import java.util.Map;
  * @param <UV> The type of the values in the map state.
  */
 class RocksDBMapState<K, N, UK, UV>
-	extends AbstractRocksDBState<K, N, Map<UK, UV>, MapState<UK, UV>>
+	extends AbstractRocksDBState<K, N, Map<UK, UV>>
 	implements InternalMapState<K, N, UK, UV> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBMapState.class);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -41,7 +41,7 @@ import java.util.Collection;
  * @param <V> The type of value that the state state stores.
  */
 class RocksDBReducingState<K, N, V>
-	extends AbstractRocksDBAppendingState<K, N, V, V, V, ReducingState<V>>
+	extends AbstractRocksDBAppendingState<K, N, V, V, V>
 	implements InternalReducingState<K, N, V> {
 
 	/** User-specified reduce function. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -102,20 +102,14 @@ class RocksDBReducingState<K, N, V>
 			return;
 		}
 
-		// cache key and namespace
-		final K key = backend.getCurrentKey();
-		final int keyGroup = backend.getCurrentKeyGroupIndex();
-
 		try {
 			V current = null;
 
 			// merge the sources to the target
 			for (N source : sources) {
 				if (source != null) {
-
-					writeKeyWithGroupAndNamespace(keyGroup, key, source, dataOutputView);
-
-					final byte[] sourceKey = dataOutputView.getCopyOfBuffer();
+					setCurrentNamespace(source);
+					final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
 					final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 					backend.db.delete(columnFamily, writeOptions, sourceKey);
 
@@ -136,9 +130,8 @@ class RocksDBReducingState<K, N, V>
 			// if something came out of merging the sources, merge it or write it to the target
 			if (current != null) {
 				// create the target full-binary-key
-				writeKeyWithGroupAndNamespace(keyGroup, key, target, dataOutputView);
-
-				final byte[] targetKey = dataOutputView.getCopyOfBuffer();
+				setCurrentNamespace(target);
+				final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
 				final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
 				if (targetValueBytes != null) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -35,6 +36,7 @@ import java.io.IOException;
  * @param <K> type of the key.
  */
 @NotThreadSafe
+@Internal
 class RocksDBSerializedCompositeKeyBuilder<K> {
 
 	/** The serializer for the key. */
@@ -56,7 +58,7 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 	@Nonnegative
 	private int afterKeyMark;
 
-	RocksDBSerializedCompositeKeyBuilder(
+	public RocksDBSerializedCompositeKeyBuilder(
 		@Nonnull TypeSerializer<K> keySerializer,
 		@Nonnegative int keyGroupPrefixBytes,
 		@Nonnegative int initialSize) {
@@ -82,7 +84,14 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 		this.afterKeyMark = afterKeyMark;
 	}
 
-	void setKeyAndKeyGroup(@Nonnull K key, @Nonnegative int keyGroupId) {
+	/**
+	 * Sets the key and key-group as prefix. This will serialize them into the buffer and the will be used to create
+	 * composite keys with provided namespaces.
+	 *
+	 * @param key        the key.
+	 * @param keyGroupId the key-group id for the key.
+	 */
+	public void setKeyAndKeyGroup(@Nonnull K key, @Nonnegative int keyGroupId) {
 		try {
 			serializeKeyGroupAndKey(key, keyGroupId);
 		} catch (IOException shouldNeverHappen) {
@@ -90,7 +99,17 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 		}
 	}
 
-	<N> byte[] buildCompositeKeyNamespace(@Nonnull N namespace, @Nonnull TypeSerializer<N> namespaceSerializer) {
+	/**
+	 * Returns a serialized composite key, from the key and key-group provided in a previous call to
+	 * {@link #setKeyAndKeyGroup(Object, int)} and the given namespace.
+	 *
+	 * @param namespace           the namespace to concatenate for the serialized composite key bytes.
+	 * @param namespaceSerializer the serializer to obtain the serialized form of the namespace.
+	 * @param <N>                 the type of the namespace.
+	 * @return the bytes for the serialized composite key of key-group, key, namespace.
+	 */
+	@Nonnull
+	public <N> byte[] buildCompositeKeyNamespace(@Nonnull N namespace, @Nonnull TypeSerializer<N> namespaceSerializer) {
 		try {
 			serializeNamespace(namespace, namespaceSerializer);
 			final byte[] result = keyOutView.getCopyOfBuffer();
@@ -101,7 +120,20 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 		}
 	}
 
-	<N, UK> byte[] buildCompositeKeyNamesSpaceUserKey(
+	/**
+	 * Returns a serialized composite key, from the key and key-group provided in a previous call to
+	 * {@link #setKeyAndKeyGroup(Object, int)} and the given namespace, folloed by the given user-key.
+	 *
+	 * @param namespace           the namespace to concatenate for the serialized composite key bytes.
+	 * @param namespaceSerializer the serializer to obtain the serialized form of the namespace.
+	 * @param userKey             the user-key to concatenate for the serialized composite key, after the namespace.
+	 * @param userKeySerializer   the serializer to obtain the serialized form of the user-key.
+	 * @param <N>                 the type of the namespace.
+	 * @param <UK>                the type of the user-key.
+	 * @return the bytes for the serialized composite key of key-group, key, namespace.
+	 */
+	@Nonnull
+	public <N, UK> byte[] buildCompositeKeyNamesSpaceUserKey(
 		@Nonnull N namespace,
 		@Nonnull TypeSerializer<N> namespaceSerializer,
 		@Nonnull UK userKey,
@@ -114,7 +146,10 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 	}
 
 	private void serializeKeyGroupAndKey(K key, int keyGroupId) throws IOException {
+
+		// clear buffer and mark
 		resetFully();
+
 		// write key-group
 		RocksDBKeySerializationUtils.writeKeyGroup(
 			keyGroupId,
@@ -128,11 +163,12 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 	private <N> void serializeNamespace(
 		@Nonnull N namespace,
 		@Nonnull TypeSerializer<N> namespaceSerializer) throws IOException {
+
+		// this should only be called when there is already a key written so that we build the composite.
 		assert isKeyWritten();
-		final boolean ambiguousKeyPossible =
-			keySerializerTypeVariableSized &
-				RocksDBKeySerializationUtils.isSerializerTypeVariableSized(namespaceSerializer);
-		if (ambiguousKeyPossible) {
+
+		final boolean ambiguousCompositeKeyPossible = isAmbiguousCompositeKeyPossible(namespaceSerializer);
+		if (ambiguousCompositeKeyPossible) {
 			RocksDBKeySerializationUtils.writeVariableIntBytes(
 				afterKeyMark - keyGroupPrefixBytes,
 				keyOutView);
@@ -141,7 +177,7 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 			namespace,
 			namespaceSerializer,
 			keyOutView,
-			ambiguousKeyPossible);
+			ambiguousCompositeKeyPossible);
 	}
 
 	private void resetFully() {
@@ -150,10 +186,21 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 	}
 
 	private void resetToKey() {
-		this.keyOutView.setPosition(afterKeyMark);
+		keyOutView.setPosition(afterKeyMark);
 	}
 
 	private boolean isKeyWritten() {
 		return afterKeyMark > 0;
+	}
+
+	@VisibleForTesting
+	boolean isAmbiguousCompositeKeyPossible(TypeSerializer<?> namespaceSerializer) {
+		return keySerializerTypeVariableSized &
+			RocksDBKeySerializationUtils.isSerializerTypeVariableSized(namespaceSerializer);
+	}
+
+	@VisibleForTesting
+	boolean isKeySerializerTypeVariableSized() {
+		return keySerializerTypeVariableSized;
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+
+/**
+ * Responsible for serialization of currentKey, currentGroup and namespace.
+ * Will reuse the previous serialized currentKeyed if possible.
+ * @param <K> type of the key.
+ */
+@NotThreadSafe
+class RocksDBSerializedCompositeKeyBuilder<K> {
+
+	/** The serializer for the key. */
+	@Nonnull
+	private final TypeSerializer<K> keySerializer;
+
+	/** The output to write the key into. */
+	@Nonnull
+	private final DataOutputSerializer keyOutView;
+
+	/** The number of Key-group-prefix bytes for the key. */
+	@Nonnegative
+	private final int keyGroupPrefixBytes;
+
+	/** This flag indicates whether the key type has a variable byte size in serialization. */
+	private final boolean keySerializerTypeVariableSized;
+
+	/** Mark for the position after the serialized key. */
+	@Nonnegative
+	private int afterKeyMark;
+
+	RocksDBSerializedCompositeKeyBuilder(
+		@Nonnull TypeSerializer<K> keySerializer,
+		@Nonnegative int keyGroupPrefixBytes,
+		@Nonnegative int initialSize) {
+		this(
+			keySerializer,
+			new DataOutputSerializer(initialSize),
+			keyGroupPrefixBytes,
+			RocksDBKeySerializationUtils.isSerializerTypeVariableSized(keySerializer),
+			0);
+	}
+
+	@VisibleForTesting
+	RocksDBSerializedCompositeKeyBuilder(
+		@Nonnull TypeSerializer<K> keySerializer,
+		@Nonnull DataOutputSerializer keyOutView,
+		@Nonnegative int keyGroupPrefixBytes,
+		boolean keySerializerTypeVariableSized,
+		@Nonnegative int afterKeyMark) {
+		this.keySerializer = keySerializer;
+		this.keyOutView = keyOutView;
+		this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+		this.keySerializerTypeVariableSized = keySerializerTypeVariableSized;
+		this.afterKeyMark = afterKeyMark;
+	}
+
+	void setKeyAndKeyGroup(@Nonnull K key, @Nonnegative int keyGroupId) {
+		try {
+			serializeKeyGroupAndKey(key, keyGroupId);
+		} catch (IOException shouldNeverHappen) {
+			throw new FlinkRuntimeException(shouldNeverHappen);
+		}
+	}
+
+	<N> byte[] buildCompositeKeyNamespace(@Nonnull N namespace, @Nonnull TypeSerializer<N> namespaceSerializer) {
+		try {
+			serializeNamespace(namespace, namespaceSerializer);
+			final byte[] result = keyOutView.getCopyOfBuffer();
+			resetToKey();
+			return result;
+		} catch (IOException shouldNeverHappen) {
+			throw new FlinkRuntimeException(shouldNeverHappen);
+		}
+	}
+
+	<N, UK> byte[] buildCompositeKeyNamesSpaceUserKey(
+		@Nonnull N namespace,
+		@Nonnull TypeSerializer<N> namespaceSerializer,
+		@Nonnull UK userKey,
+		@Nonnull TypeSerializer<UK> userKeySerializer) throws IOException {
+		serializeNamespace(namespace, namespaceSerializer);
+		userKeySerializer.serialize(userKey, keyOutView);
+		byte[] result = keyOutView.getCopyOfBuffer();
+		resetToKey();
+		return result;
+	}
+
+	private void serializeKeyGroupAndKey(K key, int keyGroupId) throws IOException {
+		resetFully();
+		// write key-group
+		RocksDBKeySerializationUtils.writeKeyGroup(
+			keyGroupId,
+			keyGroupPrefixBytes,
+			keyOutView);
+		// write key
+		keySerializer.serialize(key, keyOutView);
+		afterKeyMark = keyOutView.length();
+	}
+
+	private <N> void serializeNamespace(
+		@Nonnull N namespace,
+		@Nonnull TypeSerializer<N> namespaceSerializer) throws IOException {
+		assert isKeyWritten();
+		final boolean ambiguousKeyPossible =
+			keySerializerTypeVariableSized &
+				RocksDBKeySerializationUtils.isSerializerTypeVariableSized(namespaceSerializer);
+		if (ambiguousKeyPossible) {
+			RocksDBKeySerializationUtils.writeVariableIntBytes(
+				afterKeyMark - keyGroupPrefixBytes,
+				keyOutView);
+		}
+		RocksDBKeySerializationUtils.writeNameSpace(
+			namespace,
+			namespaceSerializer,
+			keyOutView,
+			ambiguousKeyPossible);
+	}
+
+	private void resetFully() {
+		afterKeyMark = 0;
+		keyOutView.clear();
+	}
+
+	private void resetToKey() {
+		this.keyOutView.setPosition(afterKeyMark);
+	}
+
+	private boolean isKeyWritten() {
+		return afterKeyMark > 0;
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  * @param <V> The type of value that the state state stores.
  */
 class RocksDBValueState<K, N, V>
-	extends AbstractRocksDBState<K, N, V, ValueState<V>>
+	extends AbstractRocksDBState<K, N, V>
 	implements InternalValueState<K, N, V> {
 
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -80,9 +80,9 @@ class RocksDBValueState<K, N, V>
 	@Override
 	public V value() {
 		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = dataOutputView.getCopyOfBuffer();
-			byte[] valueBytes = backend.db.get(columnFamily, key);
+			byte[] valueBytes = backend.db.get(columnFamily,
+				serializeCurrentKeyWithGroupAndNamespace());
+
 			if (valueBytes == null) {
 				return getDefaultValue();
 			}
@@ -101,11 +101,9 @@ class RocksDBValueState<K, N, V>
 		}
 
 		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = dataOutputView.getCopyOfBuffer();
-			dataOutputView.clear();
-			valueSerializer.serialize(value, dataOutputView);
-			backend.db.put(columnFamily, writeOptions, key, dataOutputView.getCopyOfBuffer());
+			backend.db.put(columnFamily, writeOptions,
+				serializeCurrentKeyWithGroupAndNamespace(),
+				serializeValue(value));
 		} catch (Exception e) {
 			throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
 		}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilderTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test for @{@link RocksDBSerializedCompositeKeyBuilder}.
+ */
+public class RocksDBSerializedCompositeKeyBuilderTest {
+
+	private final DataOutputSerializer dataOutputSerializer = new DataOutputSerializer(128);
+
+	private static final int[] TEST_PARALLELISMS = new int[]{64, 4096};
+	private static final Collection<Integer> TEST_INTS = Arrays.asList(42, 4711);
+	private static final Collection<String> TEST_STRINGS = Arrays.asList("test123", "abc");
+
+	@Before
+	public void before() {
+		dataOutputSerializer.clear();
+	}
+
+	@Test
+	public void testSetKey() throws IOException {
+		for (int parallelism : TEST_PARALLELISMS) {
+			testSetKeyInternal(IntSerializer.INSTANCE, TEST_INTS, parallelism);
+			testSetKeyInternal(StringSerializer.INSTANCE, TEST_STRINGS, parallelism);
+		}
+	}
+
+	@Test
+	public void testSetKeyNamespace() throws IOException {
+		for (int parallelism : TEST_PARALLELISMS) {
+			testSetKeyNamespaceInternal(IntSerializer.INSTANCE, IntSerializer.INSTANCE, TEST_INTS, TEST_INTS, parallelism);
+			testSetKeyNamespaceInternal(IntSerializer.INSTANCE, StringSerializer.INSTANCE, TEST_INTS, TEST_STRINGS, parallelism);
+			testSetKeyNamespaceInternal(StringSerializer.INSTANCE, IntSerializer.INSTANCE, TEST_STRINGS, TEST_INTS, parallelism);
+			testSetKeyNamespaceInternal(StringSerializer.INSTANCE, StringSerializer.INSTANCE, TEST_STRINGS, TEST_STRINGS, parallelism);
+		}
+	}
+
+	@Test
+	public void testSetKeyNamespaceUserKey() throws IOException {
+		for (int parallelism : TEST_PARALLELISMS) {
+			testSetKeyNamespaceUserKeyInternal(IntSerializer.INSTANCE, IntSerializer.INSTANCE, IntSerializer.INSTANCE, TEST_INTS, TEST_INTS, TEST_INTS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(IntSerializer.INSTANCE, StringSerializer.INSTANCE, IntSerializer.INSTANCE, TEST_INTS, TEST_STRINGS, TEST_INTS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(StringSerializer.INSTANCE, IntSerializer.INSTANCE, IntSerializer.INSTANCE, TEST_STRINGS, TEST_INTS, TEST_INTS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(StringSerializer.INSTANCE, StringSerializer.INSTANCE, IntSerializer.INSTANCE, TEST_STRINGS, TEST_STRINGS, TEST_INTS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(IntSerializer.INSTANCE, IntSerializer.INSTANCE, StringSerializer.INSTANCE, TEST_INTS, TEST_INTS, TEST_STRINGS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(IntSerializer.INSTANCE, StringSerializer.INSTANCE, StringSerializer.INSTANCE, TEST_INTS, TEST_STRINGS, TEST_STRINGS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(StringSerializer.INSTANCE, IntSerializer.INSTANCE, StringSerializer.INSTANCE, TEST_STRINGS, TEST_INTS, TEST_STRINGS, parallelism);
+			testSetKeyNamespaceUserKeyInternal(StringSerializer.INSTANCE, StringSerializer.INSTANCE, StringSerializer.INSTANCE, TEST_STRINGS, TEST_STRINGS, TEST_STRINGS, parallelism);
+		}
+	}
+
+	private <K> void testSetKeyInternal(TypeSerializer<K> serializer, Collection<K> testKeys, int maxParallelism) throws IOException {
+		final int prefixBytes = maxParallelism > Byte.MAX_VALUE ? 2 : 1;
+		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
+			createRocksDBSerializedCompositeKeyBuilder(serializer, prefixBytes);
+
+		final DataInputDeserializer deserializer = new DataInputDeserializer();
+		for (K testKey : testKeys) {
+			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, maxParallelism);
+			byte[] result = dataOutputSerializer.getCopyOfBuffer();
+			deserializer.setBuffer(result);
+			assertKeyKeyGroupBytes(testKey, keyGroup, prefixBytes, serializer, deserializer, false);
+			Assert.assertEquals(0, deserializer.available());
+		}
+	}
+
+	private <K, N> void testSetKeyNamespaceInternal(
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer,
+		Collection<K> testKeys,
+		Collection<N> testNamespaces,
+		int maxParallelism) throws IOException {
+		final int prefixBytes = maxParallelism > Byte.MAX_VALUE ? 2 : 1;
+
+		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
+			createRocksDBSerializedCompositeKeyBuilder(keySerializer, prefixBytes);
+
+		final DataInputDeserializer deserializer = new DataInputDeserializer();
+
+		final boolean ambiguousPossible = keyBuilder.isAmbiguousCompositeKeyPossible(namespaceSerializer);
+
+		for (K testKey : testKeys) {
+			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, maxParallelism);
+			for (N testNamespace : testNamespaces) {
+				byte[] compositeBytes = keyBuilder.buildCompositeKeyNamespace(testNamespace, namespaceSerializer);
+				deserializer.setBuffer(compositeBytes);
+				assertKeyGroupKeyNamespaceBytes(
+					testKey,
+					keyGroup,
+					prefixBytes,
+					keySerializer,
+					testNamespace,
+					namespaceSerializer,
+					deserializer,
+					ambiguousPossible);
+				Assert.assertEquals(0, deserializer.available());
+			}
+		}
+	}
+
+	private <K, N, U> void testSetKeyNamespaceUserKeyInternal(
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer,
+		TypeSerializer<U> userKeySerializer,
+		Collection<K> testKeys,
+		Collection<N> testNamespaces,
+		Collection<U> testUserKeys,
+		int maxParallelism) throws IOException {
+		final int prefixBytes = maxParallelism > Byte.MAX_VALUE ? 2 : 1;
+
+		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
+			createRocksDBSerializedCompositeKeyBuilder(keySerializer, prefixBytes);
+
+		final DataInputDeserializer deserializer = new DataInputDeserializer();
+
+		final boolean ambiguousPossible = keyBuilder.isAmbiguousCompositeKeyPossible(namespaceSerializer);
+
+		for (K testKey : testKeys) {
+			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, maxParallelism);
+			for (N testNamespace : testNamespaces) {
+				for (U testUserKey : testUserKeys) {
+					byte[] compositeBytes = keyBuilder.buildCompositeKeyNamesSpaceUserKey(
+						testNamespace,
+						namespaceSerializer,
+						testUserKey,
+						userKeySerializer);
+
+					deserializer.setBuffer(compositeBytes);
+					assertKeyGroupKeyNamespaceUserKeyBytes(
+						testKey,
+						keyGroup,
+						prefixBytes,
+						keySerializer,
+						testNamespace,
+						namespaceSerializer,
+						testUserKey,
+						userKeySerializer,
+						deserializer,
+						ambiguousPossible);
+
+					Assert.assertEquals(0, deserializer.available());
+				}
+			}
+		}
+	}
+
+	private <K> RocksDBSerializedCompositeKeyBuilder<K> createRocksDBSerializedCompositeKeyBuilder(
+		TypeSerializer<K> serializer,
+		int prefixBytes) {
+		final boolean variableSize = RocksDBKeySerializationUtils.isSerializerTypeVariableSized(serializer);
+		return new RocksDBSerializedCompositeKeyBuilder<>(
+			serializer,
+			dataOutputSerializer,
+			prefixBytes,
+			variableSize,
+			0);
+	}
+
+	private <K> int setKeyAndReturnKeyGroup(
+		RocksDBSerializedCompositeKeyBuilder<K> compositeKeyBuilder,
+		K key,
+		int maxParallelism) {
+
+		int keyGroup = KeyGroupRangeAssignment.assignKeyToParallelOperator(key, maxParallelism, maxParallelism);
+		compositeKeyBuilder.setKeyAndKeyGroup(key, keyGroup);
+		return keyGroup;
+	}
+
+	private <K> void assertKeyKeyGroupBytes(
+		K key,
+		int keyGroup,
+		int prefixBytes,
+		TypeSerializer<K> typeSerializer,
+		DataInputDeserializer deserializer,
+		boolean ambiguousCompositeKeyPossible) throws IOException {
+
+		Assert.assertEquals(keyGroup, RocksDBKeySerializationUtils.readKeyGroup(prefixBytes, deserializer));
+		Assert.assertEquals(key, RocksDBKeySerializationUtils.readKey(typeSerializer, deserializer, ambiguousCompositeKeyPossible));
+	}
+
+	private <K, N> void assertKeyGroupKeyNamespaceBytes(
+		K key,
+		int keyGroup,
+		int prefixBytes,
+		TypeSerializer<K> keySerializer,
+		N namespace,
+		TypeSerializer<N> namespaceSerializer,
+		DataInputDeserializer deserializer,
+		boolean ambiguousCompositeKeyPossible) throws IOException {
+		assertKeyKeyGroupBytes(key, keyGroup, prefixBytes, keySerializer, deserializer, ambiguousCompositeKeyPossible);
+		N readNamespace =
+			RocksDBKeySerializationUtils.readNamespace(namespaceSerializer, deserializer, ambiguousCompositeKeyPossible);
+		Assert.assertEquals(namespace, readNamespace);
+	}
+
+	private <K, N, U> void assertKeyGroupKeyNamespaceUserKeyBytes(
+		K key,
+		int keyGroup,
+		int prefixBytes,
+		TypeSerializer<K> keySerializer,
+		N namespace,
+		TypeSerializer<N> namespaceSerializer,
+		U userKey,
+		TypeSerializer<U> userKeySerializer,
+		DataInputDeserializer deserializer,
+		boolean ambiguousCompositeKeyPossible) throws IOException {
+		assertKeyGroupKeyNamespaceBytes(
+			key,
+			keyGroup,
+			prefixBytes,
+			keySerializer,
+			namespace,
+			namespaceSerializer,
+			deserializer,
+			ambiguousCompositeKeyPossible);
+		Assert.assertEquals(userKey, userKeySerializer.deserialize(deserializer));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

When Flink interacts with state in RocksDB, object (de)serialization often contributes significantly to performance overhead. In particular, currently every state has to serialize the backen's current key before each state access. This PR wants to  reduce this effort by sharing serialized key bytes across all state interactions. 

## Verifying this change

This change is already covered by existing tests. Additional unit tests for `RocksDBSerializedCompositeKeyBuilder`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)