### PR TITLE
[FLINK-11137] [runtime] Fix unexpected RegistrationTimeoutException of TaskExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -272,6 +272,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	public void start() throws Exception {
 		super.start();
 
+		startRegistrationTimeout();
 		// start by connecting to the ResourceManager
 		try {
 			resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
@@ -286,8 +287,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		jobLeaderService.start(getAddress(), getRpcService(), haServices, new JobLeaderListenerImpl());
 
 		fileCache = new FileCache(taskManagerConfiguration.getTmpDirectories(), blobCacheService.getPermanentBlobService());
-
-		startRegistrationTimeout();
 	}
 
 	/**
@@ -1024,11 +1023,13 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 	}
 
-	private void stopRegistrationTimeout() {
+	@VisibleForTesting
+	void stopRegistrationTimeout() {
 		currentRegistrationTimeoutId = null;
 	}
 
-	private void registrationTimeout(@Nonnull UUID registrationTimeoutId) {
+	@VisibleForTesting
+	void registrationTimeout(@Nonnull UUID registrationTimeoutId) {
 		if (registrationTimeoutId.equals(currentRegistrationTimeoutId)) {
 			final Time maxRegistrationDuration = taskManagerConfiguration.getMaxRegistrationDuration();
 
@@ -1478,6 +1479,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	@VisibleForTesting
 	HeartbeatManager<Void, SlotReport> getResourceManagerHeartbeatManager() {
 		return resourceManagerHeartbeatManager;
+	}
+
+	@VisibleForTesting
+	UUID getCurrentRegistrationTimeoutId() {
+		return currentRegistrationTimeoutId;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1944,7 +1944,7 @@ public class TaskExecutorTest extends TestLogger {
 	}
 
 	/**
-	 * A implementation of {@link TaskSlotTable} that can blocking with a future when starting.
+	 * A implementation of {@link TaskSlotTable} that can be blocked with a future when starting.
 	 */
 	private static final class BlockingTaskSlotTable extends TaskSlotTable {
 


### PR DESCRIPTION
## What is the purpose of the change

* Fix bug about unexpected `RegistrationTimeoutException` of `TaskExecutor` due to a race condition of registration to `ResourceManager`

## Brief change log

* Set registration timeout checking before starting leader retriever

## Verifying this change

* This change added unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
