### PR TITLE
[hotfix] [docs] Fix typo in documentation

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -36,6 +36,8 @@ Dependencies
 
 The following tables list all available connectors and formats. Their mutual compatibility is tagged in the corresponding sections for [table connectors](connect.html#table-connectors) and [table formats](connect.html#table-formats). The following tables provide dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
 
+{% if site.is_stable %}
+
 ### Connectors
 
 | Name              | Version             | Maven dependency             | SQL Client JAR         |
@@ -56,7 +58,11 @@ The following tables list all available connectors and formats. Their mutual com
 | JSON              | `flink-json`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-json/{{site.version}}/flink-json-{{site.version}}-sql-jar.jar) |
 | Apache Avro       | `flink-avro`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar) |
 
-**Note:** These tables are only suitable for stable releases.
+{% else %}
+
+These tables are only available for stable releases.
+
+{% endif %}
 
 {% top %}
 

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -34,9 +34,7 @@ This page describes how to declare built-in table sources and/or table sinks and
 Dependencies
 ------------
 
-The following table list all available connectors and formats. Their mutual compatibility is tagged in the corresponding sections for [table connectors](connect.html#table-connectors) and [table formats](connect.html#table-formats). The following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-{% if site.is_stable %}
+The following tables list all available connectors and formats. Their mutual compatibility is tagged in the corresponding sections for [table connectors](connect.html#table-connectors) and [table formats](connect.html#table-formats). The following tables provide dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
 
 ### Connectors
 
@@ -58,11 +56,7 @@ The following table list all available connectors and formats. Their mutual comp
 | JSON              | `flink-json`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-json/{{site.version}}/flink-json-{{site.version}}-sql-jar.jar) |
 | Apache Avro       | `flink-avro`                 | [Download](http://central.maven.org/maven2/org/apache/flink/flink-avro/{{site.version}}/flink-avro-{{site.version}}-sql-jar.jar) |
 
-{% else %}
-
-This table is only available for stable releases.
-
-{% endif %}
+**Note:** These tables are only suitable for stable releases.
 
 {% top %}
 

--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -30,7 +30,7 @@ Flink is able to process streaming data based on different notions of *time*.
 
 For more information about time handling in Flink, see the introduction about [Event Time and Watermarks]({{ site.baseurl }}/dev/event_time.html).
 
-This pages explains how time attributes can be defined for time-based operations in Flink's Table API & SQL.
+This page explains how time attributes can be defined for time-based operations in Flink's Table API & SQL.
 
 * This will be replaced by the TOC
 {:toc}


### PR DESCRIPTION
## What is the purpose of the change

This pull request displays the `Connectors` and `Formats` tables in `Connect to External Systems` page. 

For an unstable version, these tables can not be seen in the page but we described them, which is confusing.  Therefore, I removed the Stable checking logic and add a Note to make it more readable. 

What's more, this PR also fixes a typo in `Time Attributes` documentation.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)