### PR TITLE
[FLINK-11101][S3] Ban openjdk.jol dependencies

### DIFF
--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -196,6 +196,29 @@ under the License.
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>ban-openjdk.jol</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<excludes>
+										<!-- Incompatible license -->
+										<exclude>org.openjdk.jol:*</exclude>
+									</excludes>
+								</bannedDependencies>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
@@ -210,9 +233,6 @@ under the License.
 								<includes>
 									<include>*:*</include>
 								</includes>
-								<excludes>
-									<exclude>org.openjdk.jol</exclude>
-								</excludes>
 							</artifactSet>
 							<relocations>
 								<!-- relocate the references to Hadoop to match the pre-shaded hadoop artifact -->


### PR DESCRIPTION
## What is the purpose of the change

This PR removes a redundant exclusion for `openjdk.jol` from the presto-s3-filesystem pom, and adds a safeguard via the `maven-enforcer-plugin` to prevent this dependency from showing up in the dependency tree again. This guarantees that the dependency section properly excludes this dependency.

This is a better approach than relying on the shade-plugin configuration since the dependency could still show up in the dependency tree of the project (if the dependency section does not exclude it correctly), which could ring alarm-bells during release testing for no reason.

## Verifying this change

You can manually verify the effectiveness of the enforcer by removing the `openjdk.jol` exclusion from `presto-hive` and running `mvn validate`.
