### PR TITLE
[FLINK-11144][tests] Make Tests runnable on Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -765,6 +765,23 @@ under the License.
 					</dependency>
 				</dependencies>
 			</dependencyManagement>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>1.9</source>
+							<target>1.9</target>
+							<compilerArgs combine.children="append">
+								<arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
+								<arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
+							</compilerArgs>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 
 		<profile>
@@ -1346,31 +1363,15 @@ under the License.
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<!-- just define the Java version to be used for compiling and plugins -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version><!--$NO-MVN-MAN-VER$-->
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-					<!-- The semantics of this option are reversed, see MCOMPILER-209. -->
-					<useIncrementalCompilation>false</useIncrementalCompilation>
-					<compilerArgs>
-						<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
-						to be able to get more warnings -->
-						<arg>-Xlint:all</arg>
-						<!-- Prevents recompilation due to missing package-info.class, see MCOMPILER-205 -->
-						<arg>-Xpkginfo:always</arg>
-					</compilerArgs>
-				</configuration>
 			</plugin>
 
 			<!--surefire for unit tests and integration tests-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<!-- Do NOT use a version >=2.19.X, as test cases may get stuck before execution. See SUREFIRE-1255 -->
-				<version>2.18.1</version>
+				<version>2.22.1</version>
 				<configuration>
 					<forkCount>${flink.forkCount}</forkCount>
 					<reuseForks>${flink.reuseForks}</reuseForks>
@@ -1546,10 +1547,23 @@ under the License.
 			</plugin>
 		</plugins>
 
-		<!-- Plugin configurations for plugins activated in sub-projects -->
-
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+					<configuration>
+						<source>${java.version}</source>
+						<target>${java.version}</target>
+						<!-- The semantics of this option are reversed, see MCOMPILER-209. -->
+						<useIncrementalCompilation>false</useIncrementalCompilation>
+						<compilerArgs>
+							<!-- Prevents recompilation due to missing package-info.class, see MCOMPILER-205 -->
+							<arg>-Xpkginfo:always</arg>
+						</compilerArgs>
+					</configuration>
+				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -1602,7 +1616,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.1.1</version>
 				</plugin>
 
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -767,6 +767,16 @@ under the License.
 			</dependencyManagement>
 
 			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-shade-plugin</artifactId>
+							<version>3.1.1</version>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -1616,7 +1626,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.0.0</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
## What is the purpose of the change

*Make tests run on Java 9 by upgrading plugins to minimum supported version for Java 9: https://cwiki.apache.org/confluence/display/MAVEN/Java+9+-+Jigsaw*

cc: @zentol 


## Brief change log

  - *Upgrade surefire plugin.*
  - *Upgrade shade plugin.*
  - *Upgrade compiler plugin.*


## Verifying this change

This change is already covered by existing tests, such as *all tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
