### PR TITLE
[FLINK-11126][YARN][security] Filter out AMRMToken in TaskManager‘s credentials

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.util.OperatingSystem;
 
@@ -43,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -121,7 +121,7 @@ public class YarnApplicationMasterRunnerTest {
 		amCredentials.writeTokenStorageFile(new Path(credentialFile.getAbsolutePath()), yarnConf);
 		Map<String, String> systemEnv = new HashMap<>();
 		systemEnv.put("HADOOP_TOKEN_FILE_LOCATION", credentialFile.getAbsolutePath());
-		setEnv(systemEnv);
+		CommonTestUtils.setEnv(systemEnv);
 
 		ContaineredTaskManagerParameters tmParams = mock(ContaineredTaskManagerParameters.class);
 		Configuration taskManagerConf = new Configuration();
@@ -148,22 +148,5 @@ public class YarnApplicationMasterRunnerTest {
 		}
 		assertTrue(hasHdfsDelegationToken);
 		assertFalse(hasAmRmToken);
-	}
-
-	// A helper method used for setting system env variables for the test.
-	// See https://stackoverflow.com/a/496849/6558955
-	private static void setEnv(Map<String, String> newEnv) throws Exception {
-		Class[] classes = Collections.class.getDeclaredClasses();
-		Map<String, String> env = System.getenv();
-		for (Class cl : classes) {
-			if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
-				Field field = cl.getDeclaredField("m");
-				field.setAccessible(true);
-				Object obj = field.get(env);
-				Map<String, String> map = (Map<String, String>) obj;
-				map.clear();
-				map.putAll(newEnv);
-			}
-		}
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
@@ -133,7 +133,7 @@ public class YarnApplicationMasterRunnerTest {
 		assertEquals("file", ctx.getLocalResources().get("flink.jar").getResource().getScheme());
 
 		Credentials credentials = new Credentials();
-		try(DataInputStream dis = new DataInputStream(new ByteArrayInputStream(ctx.getTokens().array()))) {
+		try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(ctx.getTokens().array()))) {
 			credentials.readTokenStorageStream(dis);
 		}
 		Collection<Token<? extends TokenIdentifier>> tokens = credentials.getAllTokens();
@@ -155,8 +155,8 @@ public class YarnApplicationMasterRunnerTest {
 	private static void setEnv(Map<String, String> newEnv) throws Exception {
 		Class[] classes = Collections.class.getDeclaredClasses();
 		Map<String, String> env = System.getenv();
-		for(Class cl : classes) {
-			if("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+		for (Class cl : classes) {
+			if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
 				Field field = cl.getDeclaredField("m");
 				field.setAccessible(true);
 				Object obj = field.get(env);


### PR DESCRIPTION
## What is the purpose of the change

Currently, Flink JobManager propagates its storage tokens to TaskManager to meet the requirement of YARN log aggregation (see FLINK-6376). But in this way the AMRMToken is also included in the TaskManager credentials, which could be potentially insecure. 

The PR filters out AMRMToken before setting the tokens to TaskManager's container launch context, and adds checks for delegation tokens that JobManager prepares for TaskManagers.

## Brief change log

  - *Filter out AMRMToken before setting the tokens to the TaskManager container context.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Extended YarnApplicationMasterRunnerTest to check delegation tokens in the TaskManager executor context.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?
