### PR TITLE
[hotfix][web] fix the desc about restart strategy in web

### DIFF
--- a/flink-runtime-web/web-dashboard/app/partials/jobs/job.config.jade
+++ b/flink-runtime-web/web-dashboard/app/partials/jobs/job.config.jade
@@ -27,7 +27,7 @@ table.table.table-properties(ng-if="job['execution-config']")
       td {{ job['execution-config']['execution-mode'] }}
 
     tr
-      td Max. number of execution retries
+      td Restart strategy
       td {{ job['execution-config']['restart-strategy'] }}
 
     tr

--- a/flink-runtime-web/web-dashboard/web/partials/jobs/job.config.html
+++ b/flink-runtime-web/web-dashboard/web/partials/jobs/job.config.html
@@ -29,7 +29,7 @@ limitations under the License.
       <td>{{ job['execution-config']['execution-mode'] }}</td>
     </tr>
     <tr>
-      <td>Max. number of execution retries</td>
+      <td>Restart strategy</td>
       <td>{{ job['execution-config']['restart-strategy'] }}</td>
     </tr>
     <tr>


### PR DESCRIPTION
## What is the purpose of the change

int flink job configuration page, it's better use `Restart strategy`.

