### PR TITLE
[FLINK-11100][s3][tests] Add FS type argument to s3_setup

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3.sh
@@ -58,7 +58,7 @@ s3util="java -jar ${END_TO_END_DIR}/flink-e2e-test-utils/target/S3UtilProgram.ja
 #   IT_CASE_S3_ACCESS_KEY
 #   IT_CASE_S3_SECRET_KEY
 # Arguments:
-#   None
+#   $1 - s3 filesystem type (hadoop/presto)
 # Returns:
 #   None
 ###################################
@@ -73,12 +73,10 @@ function s3_setup {
   }
   trap s3_cleanup EXIT
 
-  cp $FLINK_DIR/opt/flink-s3-fs-hadoop-*.jar $FLINK_DIR/lib/
+  cp $FLINK_DIR/opt/flink-s3-fs-$1-*.jar $FLINK_DIR/lib/
   echo "s3.access-key: $IT_CASE_S3_ACCESS_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
   echo "s3.secret-key: $IT_CASE_S3_SECRET_KEY" >> "$FLINK_DIR/conf/flink-conf.yaml"
 }
-
-s3_setup
 
 ###################################
 # List s3 objects by full path prefix.

--- a/flink-end-to-end-tests/test-scripts/test_shaded_hadoop_s3a.sh
+++ b/flink-end-to-end-tests/test-scripts/test_shaded_hadoop_s3a.sh
@@ -22,6 +22,7 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_s3.sh
 
+s3_setup hadoop
 start_cluster
 
 $FLINK_DIR/bin/flink run -p 1 $FLINK_DIR/examples/batch/WordCount.jar --input $S3_TEST_DATA_WORDS_URI --output $TEST_DATA_DIR/out/wc_out

--- a/flink-end-to-end-tests/test-scripts/test_shaded_presto_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/test_shaded_presto_s3.sh
@@ -22,6 +22,7 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_s3.sh
 
+s3_setup presto
 start_cluster
 
 $FLINK_DIR/bin/flink run -p 1 $FLINK_DIR/examples/batch/WordCount.jar --input $S3_TEST_DATA_WORDS_URI --output $TEST_DATA_DIR/out/wc_out

--- a/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_file_sink.sh
@@ -22,6 +22,7 @@ OUT_TYPE="${1:-local}" # other type: s3
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_s3.sh
 
+s3_setup hadoop
 set_conf_ssl "mutual"
 
 OUT=temp/test_streaming_file_sink-$(uuidgen)


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the presto-s3-filesystem E2E test. The test was not using the correct filesystem.


## Brief change log

* parameterize `common_s3#s3_setup` to accept a filesystem type argument
* remove implicit call to `s3_setup` in `common_s3`
* add explicit calls to `s3_setup` to all users of `common_s3`

## Verifying this change

Create a separate branch in the Apache repo and run Travis. The Travis run for this PR is NOT relevant as it skips the tests due to S3 credentials not being available.
