### PR TITLE
[FLINK-11151][rest] Create parent directories in FileUploadHandler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -102,6 +102,10 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 						checkState(currentUploadDir == null);
 						currentHttpPostRequestDecoder = new HttpPostRequestDecoder(DATA_FACTORY, httpRequest);
 						currentHttpRequest = ReferenceCountUtil.retain(httpRequest);
+
+						// make sure that we still have a upload dir in case that it got deleted in the meanwhile
+						RestServerEndpoint.createUploadDir(uploadDir, LOG);
+
 						currentUploadDir = Files.createDirectory(uploadDir.resolve(UUID.randomUUID().toString()));
 					} else {
 						ctx.fireChannelRead(ReferenceCountUtil.retain(msg));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.runtime.io.network.netty.NettyLeakDetectionResource;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -121,6 +122,20 @@ public class FileUploadHandlerTest extends TestLogger {
 		String jsonPayload = sw.toString();
 
 		return builder.addFormDataPart(attribute, jsonPayload);
+	}
+
+	@Test
+	public void testUploadDirectoryRegeneration() throws Exception {
+		OkHttpClient client = new OkHttpClient();
+
+		MultipartUploadResource.MultipartFileHandler fileHandler = MULTIPART_UPLOAD_RESOURCE.getFileHandler();
+
+		FileUtils.deleteDirectory(MULTIPART_UPLOAD_RESOURCE.getUploadDirectory().toFile());
+
+		Request fileRequest = buildFileRequest(fileHandler.getMessageHeaders().getTargetRestEndpointURL());
+		try (Response response = client.newCall(fileRequest).execute()) {
+			assertEquals(fileHandler.getMessageHeaders().getResponseStatusCode().code(), response.code());
+		}
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -163,6 +163,10 @@ public class MultipartUploadResource extends ExternalResource {
 		return jsonHandler;
 	}
 
+	public Path getUploadDirectory() {
+		return configuredUploadDir;
+	}
+
 	public void resetState() {
 		mixedHandler.lastReceivedRequest = null;
 		jsonHandler.lastReceivedRequest = null;


### PR DESCRIPTION
## What is the purpose of the change

With this PR the FileUploadHandle checks that the upload directory still exists before accepting a request, and regenerates it if this isn't the case. This behavior is in sync with the handling of deleted upload directories during an upload (see the `msg instanceof HttpContent` branch).

Previously, if the directory has been deleted, the handler would continuously fail in this situation.

## Brief change log

* call to `RestServerEndpoint.createUploadDir` before creating request-scoped directory

## Verifying this change

This change added tests and can be verified as follows:

* `org.apache.flink.runtime.rest.FileUploadHandlerTest#testUploadDirectoryRegeneration`