### PR TITLE
[FLINK-11160][Kafka Connector]

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -40,7 +40,22 @@ under the License.
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-schema-registry-client</artifactId>
-			<version>3.3.1</version>
+			<version>4.1.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.avro</groupId>
+					<artifactId>avro</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>4.1.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.avro</groupId>
@@ -62,6 +77,17 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>${scala.version}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroKeyedSerializationSchemaForGenericRecordScalaPair.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroKeyedSerializationSchemaForGenericRecordScalaPair.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.formats.avro.registry.confluent;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroKeyedSerializationSchemaForGenericRecordScalaPair.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroKeyedSerializationSchemaForGenericRecordScalaPair.java
@@ -1,0 +1,120 @@
+package org.apache.flink.formats.avro.registry.confluent;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
+import scala.Tuple2;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serialization schema that serializes instances of key-value Scala pairs of {@link GenericRecord} to Avro binary format using {@link KafkaAvroSerializer} that uses
+ * Confluent Schema Registry.
+ */
+public class ConfluentAvroKeyedSerializationSchemaForGenericRecordScalaPair
+        implements KeyedSerializationSchema<Tuple2<GenericRecord, GenericRecord>> {
+
+
+    private final String topic;
+    private final File valueSchemaFile;
+    private final File keySchemaFile;
+    private final String registryURL;
+    private transient Schema valueSchema;
+    private transient Schema keySchema;
+
+    private transient KafkaAvroSerializer valueSerializer;
+    private transient KafkaAvroSerializer KeySerializer;
+
+    /**
+     * Creates a keyed Avro serialization schema.
+     * The constructor takes files instead of {@link Schema} because {@link Schema} is not serializable.
+     *
+     * @param topic             Kafka topic to write to
+     * @param registryURL       url of schema registry to connect
+     * @param keySchemaFile     file of the Avro writer schema used by the key
+     * @param valueSchemaFile   file of the Avro writer schema used by the value
+     */
+    public ConfluentAvroKeyedSerializationSchemaForGenericRecordScalaPair(String topic, String registryURL, File keySchemaFile, File valueSchemaFile) {
+        this.topic = topic;
+        this.registryURL =registryURL;
+        this.valueSchemaFile = valueSchemaFile;
+        this.keySchemaFile = keySchemaFile;
+    }
+
+    /**
+     * Optional method to determine the target topic for the element.
+     *
+     * @param key_value input Scala pair of key and value
+     * @return null or the target topic
+     */
+    @Override
+    public String getTargetTopic(Tuple2<GenericRecord, GenericRecord> key_value) {
+        return topic;
+    }
+
+    /**
+     * Serializes the key of the input Scala pair of key and value.
+     *
+     * @param key_value input Scala pair of key and value
+     * @return          byte array of the serialized key
+     */
+    @Override
+    public byte[] serializeKey(Tuple2<GenericRecord, GenericRecord> key_value) {
+        if (this.KeySerializer == null) {
+            Schema.Parser parser = new Schema.Parser();
+            try {
+                this.keySchema = parser.parse(keySchemaFile);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot parse key Avro writer schema file: " + keySchemaFile, e);
+            }
+            CachedSchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(registryURL, 100);
+            this.KeySerializer = new KafkaAvroSerializer(schemaRegistry);
+            Map map = new HashMap();
+            map.put("schema.registry.url", registryURL);
+            this.KeySerializer.configure(map, true);
+        }
+        List<Schema.Field> filds = keySchema.getFields();
+        GenericRecord reconstructedRecord = new GenericData.Record(keySchema);
+        for(int i=0; i<filds.size(); i++) {
+            String key = filds.get(i).name();
+            reconstructedRecord.put(key, key_value._1.get(key));
+        }
+        return KeySerializer.serialize(topic, reconstructedRecord);
+    }
+
+    /**
+     * Serializes the value of the input Scala pair of key and value.
+     *
+     * @param key_value input Scala pair of key and value
+     * @return          byte array of the serialized value
+     */
+    @Override
+    public byte[] serializeValue(Tuple2<GenericRecord, GenericRecord> key_value
+    ) {
+        if (this.valueSerializer == null) {
+            Schema.Parser parser = new Schema.Parser();
+            try {
+                this.valueSchema = parser.parse(valueSchemaFile);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot parse value Avro writer schema file: " + valueSchemaFile, e);
+            }
+            CachedSchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(registryURL, 500);
+            this.valueSerializer = new KafkaAvroSerializer(schemaRegistry);
+        }
+        List<Schema.Field> filds = valueSchema.getFields();
+        GenericRecord reconstructedRecord = new GenericData.Record(valueSchema);
+        for(int i=0; i<filds.size(); i++) {
+            String key = filds.get(i).name();
+            reconstructedRecord.put(key, key_value._2.get(key));
+        }
+        return valueSerializer.serialize(topic, reconstructedRecord);
+    }
+
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroSerializationSchemaForGenericRecord.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroSerializationSchemaForGenericRecord.java
@@ -1,0 +1,70 @@
+package org.apache.flink.formats.avro.registry.confluent;
+
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Serialization schema that serializes instances of {@link GenericRecord} to Avro binary format using {@link KafkaAvroSerializer} that uses
+ * Confluent Schema Registry.
+ */
+public class ConfluentAvroSerializationSchemaForGenericRecord
+        implements SerializationSchema<GenericRecord> {
+
+    private final String topic;
+    private final File schemaFile;
+    private final String registryURL;
+    private transient Schema externalSchema;
+    private transient KafkaAvroSerializer encoder;
+
+    /**
+     * Creates a Avro serialization schema.
+     * The constructor takes files instead of {@link Schema} because {@link Schema} is not serializable.
+     *
+     * @param topic             Kafka topic to write to
+     * @param registryURL       url of schema registry to connect
+     * @param schemaFile     file of the Avro writer schema
+     */
+    public ConfluentAvroSerializationSchemaForGenericRecord(String topic, String registryURL, File schemaFile) {
+        this.topic = topic;
+        this.registryURL =registryURL;
+        this.schemaFile = schemaFile;
+    }
+
+    /**
+     * Serializes the input record.
+     *
+     * @param element   input record
+     * @return          byte array of the serialized value
+     */
+    @Override
+    public byte[] serialize(GenericRecord element) {
+        if (this.encoder == null) {
+            Schema.Parser parser = new Schema.Parser();
+            try {
+                this.externalSchema = parser.parse(schemaFile);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot parse external Avro reader schema file: " + schemaFile, e);
+            }
+            CachedSchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(registryURL, 100);
+            this.encoder = new KafkaAvroSerializer(schemaRegistry);
+        }
+        List<Schema.Field> filds = externalSchema.getFields();
+        GenericRecord reconstructedRecord = new GenericData.Record(externalSchema);
+        for(int i=0; i<filds.size(); i++) {
+            String key = filds.get(i).name();
+            reconstructedRecord.put(key, element.get(key));
+        }
+        return encoder.serialize(topic, reconstructedRecord);
+    }
+
+}
+

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroSerializationSchemaForGenericRecord.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentAvroSerializationSchemaForGenericRecord.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.formats.avro.registry.confluent;
 
 


### PR DESCRIPTION
Summary: raised the confluent version to 4.1, added serialization schemas for confluent and added dependencies

Note: when I run `mvn clean verify` locally I get 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project flink-core: ExecutionException: java.lang.RuntimeException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```
and when I try to add Travis CI hook per [documentation](https://flink.apache.org/contribute-code.html#best-practices) I get 
```
Note: GitHub Services are being deprecated. Please contact your integrator for more information on how to migrate or replace a service with webhooks or GitHub Apps. 
```

## What is the purpose of the change

Added serialization schemas to work with the Confluent Avro format and the Confluent Avro schema registry.


## Brief change log

  - Added a serialization schema to work with the Confluent Avro format and the Confluent Avro schema registry, only for GenericRecord
  - Added a keyed serialization schema to work with the Confluent Avro format and the Confluent Avro schema registry, only for Scala Pair of GenericRecord



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( don't know)
  - The runtime per-record code paths (performance sensitive): ( don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( JavaDocs, I think)
