### PR TITLE
[FLINK-11156] [tests] Reconcile ZooKeeperCompletedCheckpointStoreMockitoTest with JDK 9

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -140,7 +140,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 		// Ensure that the checkpoints path exists
 		client.newNamespaceAwareEnsurePath(checkpointsPath)
-			.ensure(client.getZookeeperClient());
+				.ensure(client.getZookeeperClient());
 
 		// All operations will have the path as root
 		this.client = client.usingNamespace(client.getNamespace() + checkpointsPath);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
@@ -158,13 +158,11 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 		});
 
 		final String checkpointsPath = "foobar";
-		final RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
 			client,
 			checkpointsPath,
-			stateStorage,
 			Executors.directExecutor(),
 			zooKeeperStateHandleStoreMock);
 
@@ -224,13 +222,11 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 
 		final int numCheckpointsToRetain = 1;
 		final String checkpointsPath = "foobar";
-		final RetrievableStateStorageHelper<CompletedCheckpoint> stateSotrage = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
 			client,
 			checkpointsPath,
-			stateSotrage,
 			Executors.directExecutor(),
 			zookeeperStateHandleStoreMock);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
@@ -34,12 +34,9 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.ErrorListenerPathable;
 import org.apache.curator.utils.EnsurePath;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,21 +52,18 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
-import static org.powermock.api.mockito.PowerMockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 /**
  * Mockito based tests for the {@link ZooKeeperStateHandleStore}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ZooKeeperCompletedCheckpointStore.class)
 public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 
 	/**
@@ -125,7 +119,6 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock));
-		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
 		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllAndLock();
 
 		final int numCheckpointsToRetain = 1;
@@ -172,7 +165,8 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 			client,
 			checkpointsPath,
 			stateStorage,
-			Executors.directExecutor());
+			Executors.directExecutor(),
+			zooKeeperStateHandleStoreMock);
 
 		zooKeeperCompletedCheckpointStore.recover();
 
@@ -213,7 +207,6 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zookeeperStateHandleStoreMock =
 			spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock));
-		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zookeeperStateHandleStoreMock);
 
 		doAnswer(new Answer<RetrievableStateHandle<CompletedCheckpoint>>() {
 			@Override
@@ -238,7 +231,8 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 			client,
 			checkpointsPath,
 			stateSotrage,
-			Executors.directExecutor());
+			Executors.directExecutor(),
+			zookeeperStateHandleStoreMock);
 
 		for (long i = 0; i <= numCheckpointsToRetain; ++i) {
 			CompletedCheckpoint checkpointToAdd = mock(CompletedCheckpoint.class);


### PR DESCRIPTION
## What is the purpose of the change

The issue occurs because powermock hasn't fully supported JDK 9+ yet. Specifically, when we `@PrepareForTest` on a class(`ZooKeeperCompletedCheckpointStore`) has a static final field initialized by `Comparator#comparing`, it causes `IncompatibleClassChangeError`. We can fallback to use the previous syntax as a workaround.

Given https://github.com/powermock/powermock/issues/901 the author of powermock said "Right now the project is in frozen state because I do not have enough time.", we'd better fix the issue different from waiting to bump version.

Here we have to use powermock for hijacking the constructor of `ZooKeeperStateHandleStore`. An alternative for resolving this issue is get rid of powermock. I have tried it but ended with adding a testing constructor of `ZooKeeperStateHandleStore`, which looks quite hack for me.

It may be better to introduce builders for classes depending on `powemock#whennew` so we can get rid of it.

## Brief change log

- fallback the implementation to previous style as a workaround

## Verifying this change

This pull request itself is the test. Run `mvn test -Pjava9 -DfailIfNoTests=false -Dcheckstyle.skip=true -Dtest=org.apache.flink.runtime.checkpoint.ZooKeeperCompletedCheckpointStoreMockitoTest` for testing locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)

cc @GJL 