### PR TITLE
[FLINK-10594][table] Add Subsets for CEP

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
@@ -191,7 +191,8 @@ class DataStreamMatch(
           orderKeys,
           measures,
           inputTypeInfo,
-          patternNames.toSeq)
+          patternNames.toSeq,
+          logicalMatch.subsets)
       patternStream.flatSelect[CRow](patternSelectFunction, outTypeInfo)
     }
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/match/MatchUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/match/MatchUtil.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.`match`
 
 import java.util
 
+import com.google.common.collect.ImmutableMap
 import org.apache.calcite.rel.RelFieldCollation
 import org.apache.calcite.rex.RexNode
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -66,9 +67,10 @@ object MatchUtil {
       orderKeys: util.List[RelFieldCollation],
       measures: util.Map[String, RexNode],
       inputTypeInfo: TypeInformation[_],
-      patternNames: Seq[String])
+      patternNames: Seq[String],
+      subsets: ImmutableMap[String, util.SortedSet[String]])
     : PatternFlatSelectFunction[Row, CRow] = {
-    val generator = new MatchCodeGenerator(config, inputTypeInfo, patternNames)
+    val generator = new MatchCodeGenerator(config, inputTypeInfo, patternNames, subsets = Some(subsets))
 
     val resultExpression = generator.generateOneRowPerMatchExpression(
       partitionKeys,


### PR DESCRIPTION
## What is the purpose of the change

- Add subsets for CEP

## Brief change log

- Add subsets as the parameter of the MatchCodeGenerator
- Merge subset's specified list results


## Verifying this change

- Unit testing(EventTime/ProcessingTime/Multi Subsets)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
