### PR TITLE
 [FLINK-11169][runtime] fix the problem of not being reloaded for jobmanager's…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
@@ -256,13 +256,14 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends RedirectH
 		}
 
 		try {
+			String filePath = file.getPath();
 			long fileLength = raf.length();
 
 			HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
 			setContentTypeHeader(response, file);
 
 			// since the log and out files are rapidly changing, we don't want to browser to cache them
-			if (!(requestPath.contains("log") || requestPath.contains("out"))) {
+			if (!(filePath.endsWith(".log") || filePath.endsWith(".out"))) {
 				setDateAndCacheHeaders(response, file);
 			}
 			if (HttpHeaders.isKeepAlive(request)) {


### PR DESCRIPTION
## What is the purpose of the change

*In the Flink web UI page, we can access the log of jobmanager from the tab under its corresponding page, but we could not reload the log (the content is not up-to-date) since the log file has been cached for 300s in the local client' disk. And this problem occurs because of the incorrect way to check if the file should be cached. *

## Brief change log
  - *Change the way of checking if the current file is a log file or out flie.*

## Verifying this change

  - *git clone https://github.com/AlphaGarden/flink.git*
  - *cd flink*
  - *git checkout hotfix-web-reload-jobmanager-log*
  - *mvn clean package -DskipTests*
  - *run the ./start-cluster.sh script, then the log for jobmanager should be reloaded from backend evertime we click the refresh button in Flink Web  UI*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)