### PR TITLE
[FLINK-11116][fs-connector] Removed randomness from HDFS and Local fs writers.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
@@ -56,7 +56,11 @@ class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
 		this.targetFile = checkNotNull(targetFile);
 		this.tempFile = checkNotNull(tempFile);
 
-		this.fileChannel = FileChannel.open(tempFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+		this.fileChannel = FileChannel.open(
+				tempFile.toPath(),
+				StandardOpenOption.CREATE,
+				StandardOpenOption.TRUNCATE_EXISTING,
+				StandardOpenOption.WRITE);
 		this.fos = Channels.newOutputStream(fileChannel);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.core.fs.local;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream.Committer;
@@ -28,7 +27,6 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -114,8 +112,7 @@ public class LocalRecoverableWriter implements RecoverableWriter {
 		return true;
 	}
 
-	@VisibleForTesting
-	static File generateStagingTempFilePath(File targetFile) {
+	private static File generateStagingTempFilePath(File targetFile) {
 		checkArgument(targetFile.isAbsolute(), "targetFile must be absolute");
 		checkArgument(!targetFile.isDirectory(), "targetFile must not be a directory");
 
@@ -124,11 +121,6 @@ public class LocalRecoverableWriter implements RecoverableWriter {
 
 		checkArgument(parent != null, "targetFile must not be the root directory");
 
-		while (true) {
-			File candidate = new File(parent, "." + name + ".inprogress." + UUID.randomUUID().toString());
-			if (!candidate.exists()) {
-				return candidate;
-			}
-		}
+		return new File(parent, "." + name + ".inprogress");
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
@@ -46,6 +46,14 @@ public class LocalRecoverableWriter implements RecoverableWriter {
 	@Override
 	public RecoverableFsDataOutputStream open(Path filePath) throws IOException {
 		final File targetFile = fs.pathToFile(filePath);
+
+		// the finalized part must not exist already
+		if (targetFile.exists()) {
+			throw new IOException("File \"" + filePath + "\" already exists." +
+					" This can be either because another job is writing at the bucket or an accidental \"split-brain\" scenario." +
+					" In any case, please investigate or report as this can have implications on the correctness of your data.");
+		}
+
 		final File tempFile = generateStagingTempFilePath(targetFile);
 
 		// try to create the parent

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream.Committer;
@@ -28,7 +27,6 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.util.HadoopUtils;
 
 import java.io.IOException;
-import java.util.UUID;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -62,7 +60,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 	@Override
 	public RecoverableFsDataOutputStream open(Path filePath) throws IOException {
 		final org.apache.hadoop.fs.Path targetFile = HadoopFileSystem.toHadoopPath(filePath);
-		final org.apache.hadoop.fs.Path tempFile = generateStagingTempFilePath(fs, targetFile);
+		final org.apache.hadoop.fs.Path tempFile = generateStagingTempFilePath(targetFile);
 		return new HadoopRecoverableFsDataOutputStream(fs, targetFile, tempFile);
 	}
 
@@ -121,11 +119,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 		return true;
 	}
 
-	@VisibleForTesting
-	static org.apache.hadoop.fs.Path generateStagingTempFilePath(
-			org.apache.hadoop.fs.FileSystem fs,
-			org.apache.hadoop.fs.Path targetFile) throws IOException {
-
+	private static org.apache.hadoop.fs.Path generateStagingTempFilePath(org.apache.hadoop.fs.Path targetFile) {
 		checkArgument(targetFile.isAbsolute(), "targetFile must be absolute");
 
 		final org.apache.hadoop.fs.Path parent = targetFile.getParent();
@@ -133,12 +127,6 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 
 		checkArgument(parent != null, "targetFile must not be the root directory");
 
-		while (true) {
-			org.apache.hadoop.fs.Path candidate = new org.apache.hadoop.fs.Path(
-					parent, "." + name + ".inprogress." + UUID.randomUUID().toString());
-			if (!fs.exists(candidate)) {
-				return candidate;
-			}
-		}
+		return new org.apache.hadoop.fs.Path(parent, "." + name + ".inprogress");
 	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -60,6 +60,14 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 	@Override
 	public RecoverableFsDataOutputStream open(Path filePath) throws IOException {
 		final org.apache.hadoop.fs.Path targetFile = HadoopFileSystem.toHadoopPath(filePath);
+
+		// the finalized part must not exist already
+		if (fs.exists(targetFile)) {
+			throw new IOException("File \"" + filePath + "\" already exists." +
+					" This can be either because another job is writing at the bucket or an accidental \"split-brain\" scenario." +
+					" In any case, please investigate or report as this can have implications on the correctness of your data.");
+		}
+
 		final org.apache.hadoop.fs.Path tempFile = generateStagingTempFilePath(targetFile);
 		return new HadoopRecoverableFsDataOutputStream(fs, targetFile, tempFile);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -145,13 +145,13 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 			Assert.assertEquals(2L, fileCounter);
 
 			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 5), 5L));
-			TestUtils.checkLocalFs(outDir, 3, 0); // the previous part-0-1 in progress is simply ignored (random extension)
+			TestUtils.checkLocalFs(outDir, 2, 0); // the previous part-0-1 in progress is overwritten
 
 			testHarness.snapshot(2L, 2L);
 
 			// this will close the new part-0-1
 			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 6), 6L));
-			TestUtils.checkLocalFs(outDir, 3, 0);
+			TestUtils.checkLocalFs(outDir, 2, 0);
 
 			fileCounter = 0;
 			for (Map.Entry<File, String> fileContents : TestUtils.getFileContentByPath(outDir).entrySet()) {
@@ -165,11 +165,11 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 					}
 				}
 			}
-			Assert.assertEquals(3L, fileCounter);
+			Assert.assertEquals(2L, fileCounter);
 
 			// this will publish part-0-0
 			testHarness.notifyOfCompletedCheckpoint(2L);
-			TestUtils.checkLocalFs(outDir, 2, 1);
+			TestUtils.checkLocalFs(outDir, 1, 1);
 
 			fileCounter = 0;
 			for (Map.Entry<File, String> fileContents : TestUtils.getFileContentByPath(outDir).entrySet()) {
@@ -183,7 +183,7 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 					}
 				}
 			}
-			Assert.assertEquals(3L, fileCounter);
+			Assert.assertEquals(2L, fileCounter);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

As described in the related jira, this PR targets the in-progress files left after a failure, that belong to no checkpoint. In this case, we lazily overwrite them as soon as the new tasks arrive to that part-counter.

## Brief change log

Just removes the random suffix from the `LocalRecoverableWriter` and the `HadoopRecoverableWriter` so that the temporary files are overwritten.

## Verifying this change

Added 2 tests in the `AbstractRecoverableWriterTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)


R @aljoscha 