### PR TITLE
[FLINK-11179][tests] add wait time for every record for testCancelSor…

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/cancelling/JoinCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/cancelling/JoinCancelingITCase.java
@@ -122,9 +122,11 @@ public class JoinCancelingITCase extends CancelingTestBase {
 
 	private static final class SimpleMatcher<IN> implements JoinFunction<Tuple2<IN, IN>, Tuple2<IN, IN>, Tuple2<IN, IN>> {
 		private static final long serialVersionUID = 1L;
+		private static final int WAIT_TIME_PER_RECORD = 300; // 0.3 sec.
 
 		@Override
 		public Tuple2<IN, IN> join(Tuple2<IN, IN> first, Tuple2<IN, IN> second) throws Exception {
+			Thread.sleep(WAIT_TIME_PER_RECORD);
 			return new Tuple2<>(first.f0, second.f0);
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

*(test case bug fix: add wait time for every record for testCancelSortMatchWhileDoingHeavySorting.)*


## Brief change log
  - *add wait time for every record for testCancelSortMatchWhileDoingHeavySorting*

## Verifying this change
This change is a test case bug fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)

