### PR TITLE
[FLINK-11181][tests] Fix SimpleRecoveryFailureRateStrategyITBase test error

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -33,6 +33,7 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
 	@ClassRule
 	public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE = new MiniClusterWithClientResource(
 		new MiniClusterResourceConfiguration.Builder()
+			.setConfiguration(getConfiguration())
 			.setNumberTaskManagers(2)
 			.setNumberSlotsPerTaskManager(2)
 			.build());

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -110,6 +110,8 @@ public abstract class SimpleRecoveryITCaseBase {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		} finally {
+			FailingMapper1.failuresBeforeSuccess = 1;
 		}
 	}
 
@@ -158,6 +160,8 @@ public abstract class SimpleRecoveryITCaseBase {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		} finally {
+			FailingMapper2.failuresBeforeSuccess = 1;
 		}
 	}
 
@@ -194,6 +198,8 @@ public abstract class SimpleRecoveryITCaseBase {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		} finally {
+			FailingMapper3.failuresBeforeSuccess = 3;
 		}
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix `SimpleRecoveryFailureRateStrategyITBase` test error. 
The configuration has not been passed to the `MiniClusterWithClientResource`.  


## Brief change log

  - Pass configuration to `MiniClusterWithClientResource`.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
