### PR TITLE
[FLINK-11168] Fix LargePlanTest timeout on Travis

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/planning/LargePlanTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/planning/LargePlanTest.java
@@ -34,9 +34,9 @@ import org.junit.Test;
  */
 public class LargePlanTest {
 
-	@Test(expected = OptimizerPlanEnvironment.ProgramAbortException.class, timeout = 15_000)
+	@Test(expected = OptimizerPlanEnvironment.ProgramAbortException.class, timeout = 30_000)
 	public void testPlanningOfLargePlan() throws Exception {
-		runProgram(new PreviewPlanEnvironment(), 10, 50);
+		runProgram(new PreviewPlanEnvironment(), 10, 20);
 	}
 
 	private static void runProgram(ExecutionEnvironment env, int depth, int width) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix a flaky test on Travis. The test completes in 500ms on my machine. On Travis the resources are much more limited and it fails occasionally.

## Brief change log

- Increase test timeout to 30 seconds
- Reduce complexity of tests by decreasing branching factor

## Verifying this change

The test still takes forever to run without the fix in #7276.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no

