### PR TITLE
[hotfix][typo] fix typo in MLUtils

### DIFF
--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/MLUtils.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/MLUtils.scala
@@ -35,7 +35,7 @@ import org.apache.flink.util.Collector
   *   The file format is specified [http://svmlight.joachims.org/ here].
   *
   * - writeLibSVM:
-  *   Writes a data set of [[LabeledVector]] in libSVM/SVMLight format to disk. THe file format
+  *   Writes a data set of [[LabeledVector]] in libSVM/SVMLight format to disk. The file format
   *   is specified [http://svmlight.joachims.org/ here].
   */
 object MLUtils {


### PR DESCRIPTION
## What is the purpose of the change

fix typo `THe` to `the`



