### PR TITLE
[FLINK-11171] Avoid concurrent usage of StateSnapshotTransformer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -151,8 +151,8 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		return stateSnapshotTransformFactory;
 	}
 
-	public void updateSnapshotTransformerFactory(StateSnapshotTransformFactory<S> sStateSnapshotTransformFactory) {
-		this.stateSnapshotTransformFactory = sStateSnapshotTransformFactory;
+	public void updateSnapshotTransformerFactory(StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
+		this.stateSnapshotTransformFactory = stateSnapshotTransformFactory;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -151,7 +151,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		return stateSnapshotTransformFactory;
 	}
 
-	public void updateSnapshotTransformerFactory(StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
+	public void updateSnapshotTransformFactory(StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
 		this.stateSnapshotTransformFactory = stateSnapshotTransformFactory;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
 
@@ -48,8 +49,8 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 	private final StateSerializerProvider<N> namespaceSerializerProvider;
 	@Nonnull
 	private final StateSerializerProvider<S> stateSerializerProvider;
-	@Nullable
-	private StateSnapshotTransformer<S> snapshotTransformer;
+	@Nonnull
+	private StateSnapshotTransformFactory<S> stateSnapshotTransformFactory;
 
 	public RegisteredKeyValueStateBackendMetaInfo(
 		@Nonnull StateDescriptor.Type stateType,
@@ -62,7 +63,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 			name,
 			StateSerializerProvider.fromNewRegisteredSerializer(namespaceSerializer),
 			StateSerializerProvider.fromNewRegisteredSerializer(stateSerializer),
-			null);
+			StateSnapshotTransformFactory.noTransform());
 	}
 
 	public RegisteredKeyValueStateBackendMetaInfo(
@@ -70,14 +71,14 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		@Nonnull String name,
 		@Nonnull TypeSerializer<N> namespaceSerializer,
 		@Nonnull TypeSerializer<S> stateSerializer,
-		@Nullable StateSnapshotTransformer<S> snapshotTransformer) {
+		@Nonnull StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
 
 		this(
 			stateType,
 			name,
 			StateSerializerProvider.fromNewRegisteredSerializer(namespaceSerializer),
 			StateSerializerProvider.fromNewRegisteredSerializer(stateSerializer),
-			snapshotTransformer);
+			stateSnapshotTransformFactory);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -91,7 +92,7 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 			StateSerializerProvider.fromPreviousSerializerSnapshot(
 				(TypeSerializerSnapshot<S>) Preconditions.checkNotNull(
 					snapshot.getTypeSerializerSnapshot(StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER))),
-			null);
+			StateSnapshotTransformFactory.noTransform());
 
 		Preconditions.checkState(StateMetaInfoSnapshot.BackendStateType.KEY_VALUE == snapshot.getBackendStateType());
 	}
@@ -101,13 +102,13 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		@Nonnull String name,
 		@Nonnull StateSerializerProvider<N> namespaceSerializerProvider,
 		@Nonnull StateSerializerProvider<S> stateSerializerProvider,
-		@Nullable StateSnapshotTransformer<S> snapshotTransformer) {
+		@Nonnull StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
 
 		super(name);
 		this.stateType = stateType;
 		this.namespaceSerializerProvider = namespaceSerializerProvider;
 		this.stateSerializerProvider = stateSerializerProvider;
-		this.snapshotTransformer = snapshotTransformer;
+		this.stateSnapshotTransformFactory = stateSnapshotTransformFactory;
 	}
 
 	@Nonnull
@@ -145,13 +146,13 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
 		return stateSerializerProvider.previousSchemaSerializer();
 	}
 
-	@Nullable
-	public StateSnapshotTransformer<S> getSnapshotTransformer() {
-		return snapshotTransformer;
+	@Nonnull
+	public StateSnapshotTransformFactory<S> getStateSnapshotTransformFactory() {
+		return stateSnapshotTransformFactory;
 	}
 
-	public void updateSnapshotTransformer(StateSnapshotTransformer<S> snapshotTransformer) {
-		this.snapshotTransformer = snapshotTransformer;
+	public void updateSnapshotTransformerFactory(StateSnapshotTransformFactory<S> sStateSnapshotTransformFactory) {
+		this.stateSnapshotTransformFactory = sStateSnapshotTransformFactory;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotTransformers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotTransformers.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.state.StateSnapshotTransformer.CollectionStateSnapshotTransformer.TransformStrategy.STOP_ON_FIRST_INCLUDED;
+
+/** Collection of common state snapshot transformers and their factories. */
+public class StateSnapshotTransformers {
+	/**
+	 * General implementation of list state transformer.
+	 *
+	 * <p>This transformer wraps a transformer per-entry
+	 * and transforms the whole list state.
+	 * If the wrapped per entry transformer is {@link CollectionStateSnapshotTransformer},
+	 * it respects its {@link CollectionStateSnapshotTransformer.TransformStrategy}.
+	 */
+	public static class ListStateSnapshotTransformer<T> implements StateSnapshotTransformer<List<T>> {
+		private final StateSnapshotTransformer<T> entryValueTransformer;
+		private final CollectionStateSnapshotTransformer.TransformStrategy transformStrategy;
+
+		public ListStateSnapshotTransformer(StateSnapshotTransformer<T> entryValueTransformer) {
+			this.entryValueTransformer = entryValueTransformer;
+			this.transformStrategy = entryValueTransformer instanceof CollectionStateSnapshotTransformer ?
+				((CollectionStateSnapshotTransformer) entryValueTransformer).getFilterStrategy() :
+				CollectionStateSnapshotTransformer.TransformStrategy.TRANSFORM_ALL;
+		}
+
+		@Override
+		@Nullable
+		public List<T> filterOrTransform(@Nullable List<T> list) {
+			if (list == null) {
+				return null;
+			}
+			List<T> transformedList = new ArrayList<>();
+			boolean anyChange = false;
+			for (int i = 0; i < list.size(); i++) {
+				T entry = list.get(i);
+				T transformedEntry = entryValueTransformer.filterOrTransform(entry);
+				if (transformedEntry != null) {
+					if (transformStrategy == STOP_ON_FIRST_INCLUDED) {
+						transformedList = list.subList(i, list.size());
+						anyChange = i > 0;
+						break;
+					} else {
+						transformedList.add(transformedEntry);
+					}
+				}
+				anyChange |= transformedEntry == null || !Objects.equals(entry, transformedEntry);
+			}
+			transformedList = anyChange ? transformedList : list;
+			return transformedList.isEmpty() ? null : transformedList;
+		}
+	}
+
+	public static class ListStateSnapshotTransformFactory<T> extends StateSnapshotTransformFactoryWrapAdaptor<T, List<T>> {
+		public ListStateSnapshotTransformFactory(StateSnapshotTransformFactory<T> originalSnapshotTransformFactory) {
+			super(originalSnapshotTransformFactory);
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<List<T>>> createForDeserializedState() {
+			return originalSnapshotTransformFactory.createForDeserializedState().map(ListStateSnapshotTransformer::new);
+		}
+	}
+
+	/**
+	 * General implementation of map state transformer.
+	 *
+	 * <p>This transformer wraps a transformer per-entry
+	 * and transforms the whole map state.
+	 */
+	public static class MapStateSnapshotTransformer<K, V> implements StateSnapshotTransformer<Map<K, V>> {
+		private final StateSnapshotTransformer<V> entryValueTransformer;
+
+		public MapStateSnapshotTransformer(StateSnapshotTransformer<V> entryValueTransformer) {
+			this.entryValueTransformer = entryValueTransformer;
+		}
+
+		@Nullable
+		@Override
+		public Map<K, V> filterOrTransform(@Nullable Map<K, V> map) {
+			if (map == null) {
+				return null;
+			}
+			Map<K, V> transformedMap = new HashMap<>();
+			boolean anyChange = false;
+			for (Map.Entry<K, V> entry : map.entrySet()) {
+				V transformedValue = entryValueTransformer.filterOrTransform(entry.getValue());
+				if (transformedValue != null) {
+					transformedMap.put(entry.getKey(), transformedValue);
+				}
+				anyChange |= transformedValue == null || !Objects.equals(entry.getValue(), transformedValue);
+			}
+			return anyChange ? (transformedMap.isEmpty() ? null : transformedMap) : map;
+		}
+	}
+
+	public static class MapStateSnapshotTransformFactory<K, V> extends StateSnapshotTransformFactoryWrapAdaptor<V, Map<K, V>> {
+		public MapStateSnapshotTransformFactory(StateSnapshotTransformFactory<V> originalSnapshotTransformFactory) {
+			super(originalSnapshotTransformFactory);
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<Map<K, V>>> createForDeserializedState() {
+			return originalSnapshotTransformFactory.createForDeserializedState().map(MapStateSnapshotTransformer::new);
+		}
+	}
+
+	public abstract static class StateSnapshotTransformFactoryWrapAdaptor<S, T> implements StateSnapshotTransformFactory<T> {
+		final StateSnapshotTransformFactory<S> originalSnapshotTransformFactory;
+
+		StateSnapshotTransformFactoryWrapAdaptor(StateSnapshotTransformFactory<S> originalSnapshotTransformFactory) {
+			this.originalSnapshotTransformFactory = originalSnapshotTransformFactory;
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<T>> createForDeserializedState() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<byte[]>> createForSerializedState() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotTransformers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotTransformers.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * This class represents the snapshot of a {@link CopyOnWriteStateTable} and has a role in operator state checkpointing. Besides
@@ -147,16 +148,16 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 					localKeySerializer.serialize(element.key, dov);
 					localStateSerializer.serialize(element.state, dov);
 				};
-			StateSnapshotTransformer<S> stateSnapshotTransformer = owningStateTable.metaInfo.
-				getStateSnapshotTransformFactory().createForDeserializedState().orElse(null);
-			StateTableKeyGroupPartitioner<K, N, S> stateTableKeyGroupPartitioner = stateSnapshotTransformer != null ?
+			Optional<StateSnapshotTransformer<S>> stateSnapshotTransformer = owningStateTable.metaInfo.
+				getStateSnapshotTransformFactory().createForDeserializedState();
+			StateTableKeyGroupPartitioner<K, N, S> stateTableKeyGroupPartitioner = stateSnapshotTransformer.isPresent() ?
 				new TransformingStateTableKeyGroupPartitioner<>(
 					snapshotData,
 					numberOfEntriesInSnapshotData,
 					keyGroupRange,
 					numberOfKeyGroups,
 					elementWriterFunction,
-					stateSnapshotTransformer) :
+					stateSnapshotTransformer.get()) :
 				new StateTableKeyGroupPartitioner<>(
 					snapshotData,
 					numberOfEntriesInSnapshotData,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -147,7 +147,8 @@ public class CopyOnWriteStateTableSnapshot<K, N, S>
 					localKeySerializer.serialize(element.key, dov);
 					localStateSerializer.serialize(element.state, dov);
 				};
-			StateSnapshotTransformer<S> stateSnapshotTransformer = owningStateTable.metaInfo.getSnapshotTransformer();
+			StateSnapshotTransformer<S> stateSnapshotTransformer = owningStateTable.metaInfo.
+				getStateSnapshotTransformFactory().createForDeserializedState().orElse(null);
 			StateTableKeyGroupPartitioner<K, N, S> stateTableKeyGroupPartitioner = stateSnapshotTransformer != null ?
 				new TransformingStateTableKeyGroupPartitioner<>(
 					snapshotData,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -237,7 +237,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		if (stateTable != null) {
 			RegisteredKeyValueStateBackendMetaInfo<N, V> restoredKvMetaInfo = stateTable.getMetaInfo();
 
-			restoredKvMetaInfo.updateSnapshotTransformerFactory(snapshotTransformFactory);
+			restoredKvMetaInfo.updateSnapshotTransformFactory(snapshotTransformFactory);
 
 			TypeSerializerSchemaCompatibility<N> namespaceCompatibility =
 				restoredKvMetaInfo.updateNamespaceSerializer(namespaceSerializer);
@@ -299,12 +299,12 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			throw new FlinkRuntimeException(message);
 		}
 		StateTable<K, N, SV> stateTable = tryRegisterStateTable(
-			namespaceSerializer, stateDesc, getStateSnapshotTransformerFactory(stateDesc, snapshotTransformFactory));
+			namespaceSerializer, stateDesc, getStateSnapshotTransformFactory(stateDesc, snapshotTransformFactory));
 		return stateFactory.createState(stateDesc, stateTable, getKeySerializer());
 	}
 
 	@SuppressWarnings("unchecked")
-	private <SV, SEV> StateSnapshotTransformFactory<SV> getStateSnapshotTransformerFactory(
+	private <SV, SEV> StateSnapshotTransformFactory<SV> getStateSnapshotTransformFactory(
 		StateDescriptor<?, SV> stateDesc,
 		StateSnapshotTransformFactory<SEV> snapshotTransformFactory) {
 		if (stateDesc instanceof ListStateDescriptor) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -78,7 +78,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -89,7 +88,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.stream.Collectors;
@@ -229,7 +227,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private <N, V> StateTable<K, N, V> tryRegisterStateTable(
 			TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<?, V> stateDesc,
-			@Nullable StateSnapshotTransformer<V> snapshotTransformer) throws StateMigrationException {
+			@Nonnull StateSnapshotTransformFactory<V> snapshotTransformer) throws StateMigrationException {
 
 		@SuppressWarnings("unchecked")
 		StateTable<K, N, V> stateTable = (StateTable<K, N, V>) registeredKVStates.get(stateDesc.getName());
@@ -239,7 +237,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		if (stateTable != null) {
 			RegisteredKeyValueStateBackendMetaInfo<N, V> restoredKvMetaInfo = stateTable.getMetaInfo();
 
-			restoredKvMetaInfo.updateSnapshotTransformer(snapshotTransformer);
+			restoredKvMetaInfo.updateSnapshotTransformerFactory(snapshotTransformer);
 
 			TypeSerializerSchemaCompatibility<N> namespaceCompatibility =
 				restoredKvMetaInfo.updateNamespaceSerializer(namespaceSerializer);
@@ -301,27 +299,22 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			throw new FlinkRuntimeException(message);
 		}
 		StateTable<K, N, SV> stateTable = tryRegisterStateTable(
-			namespaceSerializer, stateDesc, getStateSnapshotTransformer(stateDesc, snapshotTransformFactory));
+			namespaceSerializer, stateDesc, getStateSnapshotTransformerFactory(stateDesc, snapshotTransformFactory));
 		return stateFactory.createState(stateDesc, stateTable, getKeySerializer());
 	}
 
 	@SuppressWarnings("unchecked")
-	private <SV, SEV> StateSnapshotTransformer<SV> getStateSnapshotTransformer(
+	private <SV, SEV> StateSnapshotTransformFactory<SV> getStateSnapshotTransformerFactory(
 		StateDescriptor<?, SV> stateDesc,
 		StateSnapshotTransformFactory<SEV> snapshotTransformFactory) {
-		Optional<StateSnapshotTransformer<SEV>> original = snapshotTransformFactory.createForDeserializedState();
-		if (original.isPresent()) {
-			if (stateDesc instanceof ListStateDescriptor) {
-				return (StateSnapshotTransformer<SV>) new StateSnapshotTransformer
-					.ListStateSnapshotTransformer<>(original.get());
-			} else if (stateDesc instanceof MapStateDescriptor) {
-				return (StateSnapshotTransformer<SV>) new StateSnapshotTransformer
-					.MapStateSnapshotTransformer<>(original.get());
-			} else {
-				return (StateSnapshotTransformer<SV>) original.get();
-			}
+		if (stateDesc instanceof ListStateDescriptor) {
+			return (StateSnapshotTransformFactory<SV>) new StateSnapshotTransformer
+				.ListStateSnapshotTransformFactory<>(snapshotTransformFactory);
+		} else if (stateDesc instanceof MapStateDescriptor) {
+			return (StateSnapshotTransformFactory<SV>) new StateSnapshotTransformer
+				.MapStateSnapshotTransformFactory<>(snapshotTransformFactory);
 		} else {
-			return null;
+			return (StateSnapshotTransformFactory<SV>) snapshotTransformFactory;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateSnapshotTransformer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateSnapshotTransformer.java
@@ -91,7 +91,7 @@ abstract class TtlStateSnapshotTransformer<T> implements CollectionStateSnapshot
 			try {
 				ts = deserializeTs(value);
 			} catch (IOException e) {
-				throw new FlinkRuntimeException("Unexpected timestamp deserialization failure");
+				throw new FlinkRuntimeException("Unexpected timestamp deserialization failure", e);
 			}
 			return expired(ts) ? null : value;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -70,6 +70,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.KvStateRegistryListener;
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.heap.AbstractHeapState;
 import org.apache.flink.runtime.state.heap.NestedMapsStateTable;
 import org.apache.flink.runtime.state.heap.StateTable;
@@ -85,6 +86,7 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.StateMigrationException;
+import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.base.Joiner;
@@ -98,6 +100,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -108,6 +111,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.PrimitiveIterator;
 import java.util.Random;
 import java.util.Timer;
@@ -3900,6 +3904,84 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		} finally {
 			backend.dispose();
 		}
+	}
+
+	@Test
+	public void testNonConcurrentSnapshotTransformerAccess() throws Exception {
+		Random rnd = new Random();
+		BlockerCheckpointStreamFactory streamFactory = new BlockerCheckpointStreamFactory(1024 * 1024);
+		AbstractKeyedStateBackend<Integer> backend = null;
+		try {
+			backend = createKeyedBackend(IntSerializer.INSTANCE);
+			InternalValueState<Integer, VoidNamespace, String> valueState = backend.createInternalState(
+				VoidNamespaceSerializer.INSTANCE,
+				new ValueStateDescriptor<>("test", StringSerializer.INSTANCE),
+				createSingleThreadAccessCheckingStateSnapshotTransformFactory());
+
+			valueState.setCurrentNamespace(VoidNamespace.INSTANCE);
+
+			for (int i = 0; i < 100; i++) {
+				backend.setCurrentKey(i);
+				valueState.update(StringUtils.getRandomString(rnd,5, 10));
+			}
+
+			CheckpointOptions checkpointOptions = CheckpointOptions.forCheckpointWithDefaultLocation();
+
+			RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot1 =
+				backend.snapshot(1L, 0L, streamFactory, checkpointOptions);
+
+			RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot2 =
+				backend.snapshot(2L, 0L, streamFactory, checkpointOptions);
+
+			Thread runner1 = new Thread(snapshot1, "snapshot1");
+			runner1.start();
+			Thread runner2 = new Thread(snapshot2, "snapshot2");
+			runner2.start();
+
+			runner1.join();
+			runner2.join();
+
+			snapshot1.get();
+			snapshot2.get();
+		} finally {
+			if (backend != null) {
+				IOUtils.closeQuietly(backend);
+				backend.dispose();
+			}
+		}
+	}
+
+	private static <T> StateSnapshotTransformFactory<T>
+	createSingleThreadAccessCheckingStateSnapshotTransformFactory() {
+		return new StateSnapshotTransformFactory<T>() {
+			@Override
+			public Optional<StateSnapshotTransformer<T>> createForDeserializedState() {
+				return createStateSnapshotTransformer();
+			}
+
+			@Override
+			public Optional<StateSnapshotTransformer<byte[]>> createForSerializedState() {
+				return createStateSnapshotTransformer();
+			}
+
+			private <T1> Optional<StateSnapshotTransformer<T1>> createStateSnapshotTransformer() {
+				return Optional.of(new StateSnapshotTransformer<T1>() {
+					private Thread currentThread = null;
+
+					@Nullable
+					@Override
+					public T1 filterOrTransform(@Nullable T1 value) {
+						if (currentThread == null) {
+							currentThread = Thread.currentThread();
+						} else {
+							assertEquals("Concurrent access from another thread",
+								currentThread, Thread.currentThread());
+						}
+						return value;
+					}
+				});
+			}
+		};
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
+import org.apache.flink.util.StringUtils;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.RunnableFuture;
+
+import static org.junit.Assert.assertEquals;
+
+class StateSnapshotTransformerTest {
+	private final AbstractKeyedStateBackend<Integer> backend;
+	private final BlockerCheckpointStreamFactory streamFactory;
+	private final StateSnapshotTransformFactory<?> snapshotTransformFactory;
+
+	StateSnapshotTransformerTest(
+		AbstractKeyedStateBackend<Integer> backend,
+		BlockerCheckpointStreamFactory streamFactory) {
+
+		this.backend = backend;
+		this.streamFactory = streamFactory;
+		this.snapshotTransformFactory = SingleThreadAccessCheckingsnapshotTransformFactory.create();
+	}
+
+	void testNonConcurrentSnapshotTransformerAccess() throws Exception {
+		List<TestState> testStates = Arrays.asList(
+			new TestValueState(),
+			new TestListState(),
+			new TestMapState()
+		);
+
+		for (TestState state : testStates) {
+			for (int i = 0; i < 100; i++) {
+				backend.setCurrentKey(i);
+				state.setToRandomValue();
+			}
+
+			CheckpointOptions checkpointOptions = CheckpointOptions.forCheckpointWithDefaultLocation();
+
+			RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot1 =
+				backend.snapshot(1L, 0L, streamFactory, checkpointOptions);
+
+			RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot2 =
+				backend.snapshot(2L, 0L, streamFactory, checkpointOptions);
+
+			Thread runner1 = new Thread(snapshot1, "snapshot1");
+			runner1.start();
+			Thread runner2 = new Thread(snapshot2, "snapshot2");
+			runner2.start();
+
+			runner1.join();
+			runner2.join();
+
+			snapshot1.get();
+			snapshot2.get();
+		}
+	}
+
+	private abstract class TestState {
+		final Random rnd;
+
+		private TestState() {
+			this.rnd = new Random();
+		}
+
+		abstract void setToRandomValue() throws Exception;
+
+		String getRandomString() {
+			return StringUtils.getRandomString(rnd, 5, 10);
+		}
+	}
+
+	private class TestValueState extends TestState {
+		private final InternalValueState<Integer, VoidNamespace, String> state;
+
+		private TestValueState() throws Exception {
+			this.state = backend.createInternalState(
+				VoidNamespaceSerializer.INSTANCE,
+				new ValueStateDescriptor<>("TestValueState", StringSerializer.INSTANCE),
+				snapshotTransformFactory);
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+		}
+
+		@Override
+		void setToRandomValue() throws Exception {
+			state.update(getRandomString());
+		}
+	}
+
+	private class TestListState extends TestState {
+		private final InternalListState<Integer, VoidNamespace, String> state;
+
+		private TestListState() throws Exception {
+			this.state = backend.createInternalState(
+				VoidNamespaceSerializer.INSTANCE,
+				new ListStateDescriptor<>("TestListState", StringSerializer.INSTANCE),
+				snapshotTransformFactory);
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+		}
+
+		@Override
+		void setToRandomValue() throws Exception {
+			int length = rnd.nextInt(10);
+			for (int i = 0; i < length; i++) {
+				state.add(getRandomString());
+			}
+		}
+	}
+
+	private class TestMapState extends TestState {
+		private final InternalMapState<Integer, VoidNamespace, String, String> state;
+
+		private TestMapState() throws Exception {
+			this.state = backend.createInternalState(
+				VoidNamespaceSerializer.INSTANCE,
+				new MapStateDescriptor<>("TestMapState", StringSerializer.INSTANCE, StringSerializer.INSTANCE),
+				snapshotTransformFactory);
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+		}
+
+		@Override
+		void setToRandomValue() throws Exception {
+			int length = rnd.nextInt(10);
+			for (int i = 0; i < length; i++) {
+				state.put(getRandomString(), getRandomString());
+			}
+		}
+	}
+
+	private static class SingleThreadAccessCheckingsnapshotTransformFactory<T>
+		implements StateSnapshotTransformFactory<T> {
+
+		static <T> StateSnapshotTransformFactory<T> create() {
+			return new SingleThreadAccessCheckingsnapshotTransformFactory<>();
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<T>> createForDeserializedState() {
+			return createStateSnapshotTransformer();
+		}
+
+		@Override
+		public Optional<StateSnapshotTransformer<byte[]>> createForSerializedState() {
+			return createStateSnapshotTransformer();
+		}
+
+		private <T1> Optional<StateSnapshotTransformer<T1>> createStateSnapshotTransformer() {
+			return Optional.of(new StateSnapshotTransformer<T1>() {
+				private Thread currentThread = null;
+
+				@Nullable
+				@Override
+				public T1 filterOrTransform(@Nullable T1 value) {
+					if (currentThread == null) {
+						currentThread = Thread.currentThread();
+					} else {
+						assertEquals("Concurrent access from another thread",
+							currentThread, Thread.currentThread());
+					}
+					return value;
+				}
+			});
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+import org.apache.flink.runtime.state.StateSnapshotTransformers;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
 import org.apache.flink.runtime.state.ttl.TtlStateFactory;
@@ -131,11 +132,9 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		Optional<StateSnapshotTransformer<SEV>> original = snapshotTransformFactory.createForDeserializedState();
 		if (original.isPresent()) {
 			if (stateDesc instanceof ListStateDescriptor) {
-				return (StateSnapshotTransformer<SV>) new StateSnapshotTransformer
-					.ListStateSnapshotTransformer<>(original.get());
+				return (StateSnapshotTransformer<SV>) new StateSnapshotTransformers.ListStateSnapshotTransformer<>(original.get());
 			} else if (stateDesc instanceof MapStateDescriptor) {
-				return (StateSnapshotTransformer<SV>) new StateSnapshotTransformer
-					.MapStateSnapshotTransformer<>(original.get());
+				return (StateSnapshotTransformer<SV>) new StateSnapshotTransformers.MapStateSnapshotTransformer<>(original.get());
 			} else {
 				return (StateSnapshotTransformer<SV>) original.get();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -27,10 +27,12 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -65,7 +67,28 @@ public class MockStateBackend extends AbstractStateBackend {
 
 			@Override
 			public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {
-				return null;
+				return new CheckpointStorageLocation() {
+
+					@Override
+					public CheckpointStateOutputStream createCheckpointStateOutputStream(CheckpointedStateScope scope) {
+						return null;
+					}
+
+					@Override
+					public CheckpointMetadataOutputStream createMetadataOutputStream() {
+						return null;
+					}
+
+					@Override
+					public void disposeOnFailure() {
+
+					}
+
+					@Override
+					public CheckpointStorageLocationReference getLocationReference() {
+						return null;
+					}
+				};
 			}
 
 			@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -124,8 +124,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.apache.flink.contrib.streaming.state.RocksDbStateDataTransfer.transferAllStateDataToDirectory;
 import static org.apache.flink.contrib.streaming.state.RocksDBSnapshotTransformFactoryAdaptor.wrapStateSnapshotTransformerFactory;
+import static org.apache.flink.contrib.streaming.state.RocksDbStateDataTransfer.transferAllStateDataToDirectory;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.SST_FILE_SUFFIX;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.clearMetaDataFollowsFlag;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -124,7 +124,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.apache.flink.contrib.streaming.state.RocksDBSnapshotTransformFactoryAdaptor.wrapStateSnapshotTransformerFactory;
+import static org.apache.flink.contrib.streaming.state.RocksDBSnapshotTransformFactoryAdaptor.wrapStateSnapshotTransformFactory;
 import static org.apache.flink.contrib.streaming.state.RocksDbStateDataTransfer.transferAllStateDataToDirectory;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.SST_FILE_SUFFIX;
@@ -1382,7 +1382,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		@SuppressWarnings("unchecked")
 		RegisteredKeyValueStateBackendMetaInfo<N, SV> restoredKvStateMetaInfo = oldStateInfo.f1;
 
-		restoredKvStateMetaInfo.updateSnapshotTransformerFactory(snapshotTransformFactory);
+		restoredKvStateMetaInfo.updateSnapshotTransformFactory(snapshotTransformFactory);
 
 		TypeSerializerSchemaCompatibility<N> s = restoredKvStateMetaInfo.updateNamespaceSerializer(namespaceSerializer);
 		if (s.isCompatibleAfterMigration() || s.isIncompatible()) {
@@ -1500,7 +1500,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			throw new FlinkRuntimeException(message);
 		}
 		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult = tryRegisterKvStateInformation(
-			stateDesc, namespaceSerializer, wrapStateSnapshotTransformerFactory(stateDesc, snapshotTransformFactory));
+			stateDesc, namespaceSerializer, wrapStateSnapshotTransformFactory(stateDesc, snapshotTransformFactory));
 		return stateFactory.createState(stateDesc, registerResult, RocksDBKeyedStateBackend.this);
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSnapshotTransformFactoryAdaptor.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSnapshotTransformFactoryAdaptor.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+
+import java.util.Optional;
+
+abstract class RocksDBSnapshotTransformFactoryAdaptor<S> implements StateSnapshotTransformFactory<S> {
+	@Override
+	public Optional<StateSnapshotTransformer<S>> createForDeserializedState() {
+		throw new UnsupportedOperationException("Only serialized state filtering is supported in RocksDB backend");
+	}
+
+	@SuppressWarnings("unchecked")
+	static <SV, SEV> StateSnapshotTransformFactory<SV> wrapStateSnapshotTransformerFactory(
+		StateDescriptor<?, SV> stateDesc,
+		StateSnapshotTransformFactory<SEV> snapshotTransformFactory) {
+		if (stateDesc instanceof ListStateDescriptor) {
+			Optional<StateSnapshotTransformer<SEV>> original = snapshotTransformFactory.createForDeserializedState();
+			return new RocksDBSnapshotTransformFactoryAdaptor<SV>() {
+				@Override
+				public Optional<StateSnapshotTransformer<byte[]>> createForSerializedState() {
+					return original.map(est -> (StateSnapshotTransformer<byte[]>) createRocksDBListStateTransformer(stateDesc, est));
+				}
+			};
+		} else if (stateDesc instanceof MapStateDescriptor) {
+			Optional<StateSnapshotTransformer<byte[]>> original = snapshotTransformFactory.createForSerializedState();
+			return new RocksDBSnapshotTransformFactoryAdaptor<SV>() {
+				@Override
+				public Optional<StateSnapshotTransformer<byte[]>> createForSerializedState() {
+					return original.map(RocksDBMapState.StateSnapshotTransformerWrapper::new);
+				}
+			};
+		} else {
+			return new RocksDBSnapshotTransformFactoryAdaptor<SV>() {
+				@Override
+				public Optional<StateSnapshotTransformer<byte[]>> createForSerializedState() {
+					return snapshotTransformFactory.createForSerializedState();
+				}
+			};
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <SV, SEV> StateSnapshotTransformer<SV> createRocksDBListStateTransformer(
+		StateDescriptor<?, SV> stateDesc,
+		StateSnapshotTransformer<SEV> elementTransformer) {
+		return (StateSnapshotTransformer<SV>) new RocksDBListState.StateSnapshotTransformerWrapper<>(
+			elementTransformer, ((ListStateDescriptor<SEV>) stateDesc).getElementSerializer());
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
@@ -410,8 +410,8 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 		ReadOptions readOptions) {
 		StateSnapshotTransformer<byte[]> stateSnapshotTransformer = null;
 		if (metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo) {
-			stateSnapshotTransformer = (StateSnapshotTransformer<byte[]>)
-				((RegisteredKeyValueStateBackendMetaInfo<?, ?>) metaInfo).getSnapshotTransformer();
+			stateSnapshotTransformer = ((RegisteredKeyValueStateBackendMetaInfo<?, ?>) metaInfo).
+				getStateSnapshotTransformFactory().createForSerializedState().orElse(null);
 		}
 		RocksIterator rocksIterator = db.newIterator(columnFamilyHandle, readOptions);
 		return stateSnapshotTransformer == null ?

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
@@ -192,7 +192,7 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 		private List<StateMetaInfoSnapshot> stateMetaInfoSnapshots;
 
 		@Nonnull
-		private List<Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase>> metaDataCopy;
+		private List<MetaData> metaData;
 
 		@Nonnull
 		private final String logPathString;
@@ -209,7 +209,7 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 			this.dbLease = dbLease;
 			this.snapshot = snapshot;
 			this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
-			this.metaDataCopy = metaDataCopy;
+			this.metaData = fillMetaData(metaDataCopy);
 			this.logPathString = logPathString;
 		}
 
@@ -248,7 +248,7 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 			@Nonnull KeyGroupRangeOffsets keyGroupRangeOffsets) throws IOException, InterruptedException {
 
 			final List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators =
-				new ArrayList<>(metaDataCopy.size());
+				new ArrayList<>(metaData.size());
 			final DataOutputView outputView =
 				new DataOutputViewStreamWrapper(checkpointStreamWithResultProvider.getCheckpointOutputStream());
 			final ReadOptions readOptions = new ReadOptions();
@@ -273,10 +273,10 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 
 			int kvStateId = 0;
 
-			for (Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> tuple2 : metaDataCopy) {
+			for (MetaData metaDataEntry : metaData) {
 
-				RocksIteratorWrapper rocksIteratorWrapper =
-					getRocksIterator(db, tuple2.f0, tuple2.f1, readOptions);
+				RocksIteratorWrapper rocksIteratorWrapper = getRocksIterator(
+					db, metaDataEntry.columnFamilyHandle, metaDataEntry.stateSnapshotTransformer, readOptions);
 
 				kvStateIterators.add(Tuple2.of(rocksIteratorWrapper, kvStateId));
 				++kvStateId;
@@ -402,20 +402,45 @@ public class RocksFullSnapshotStrategy<K> extends RocksDBSnapshotStrategyBase<K>
 		}
 	}
 
+	private static List<MetaData> fillMetaData(
+		List<Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase>> metaDataCopy) {
+		List<MetaData> metaData = new ArrayList<>(metaDataCopy.size());
+		for (Tuple2<ColumnFamilyHandle, RegisteredStateMetaInfoBase> metaInfo : metaDataCopy) {
+			StateSnapshotTransformer<byte[]> stateSnapshotTransformer = null;
+			if (metaInfo.f1 instanceof RegisteredKeyValueStateBackendMetaInfo) {
+				stateSnapshotTransformer = ((RegisteredKeyValueStateBackendMetaInfo<?, ?>) metaInfo.f1).
+					getStateSnapshotTransformFactory().createForSerializedState().orElse(null);
+			}
+			metaData.add(new MetaData(metaInfo.f0, metaInfo.f1, stateSnapshotTransformer));
+		}
+		return metaData;
+	}
+
 	@SuppressWarnings("unchecked")
 	private static RocksIteratorWrapper getRocksIterator(
 		RocksDB db,
 		ColumnFamilyHandle columnFamilyHandle,
-		RegisteredStateMetaInfoBase metaInfo,
+		StateSnapshotTransformer<byte[]> stateSnapshotTransformer,
 		ReadOptions readOptions) {
-		StateSnapshotTransformer<byte[]> stateSnapshotTransformer = null;
-		if (metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo) {
-			stateSnapshotTransformer = ((RegisteredKeyValueStateBackendMetaInfo<?, ?>) metaInfo).
-				getStateSnapshotTransformFactory().createForSerializedState().orElse(null);
-		}
 		RocksIterator rocksIterator = db.newIterator(columnFamilyHandle, readOptions);
 		return stateSnapshotTransformer == null ?
 			new RocksIteratorWrapper(rocksIterator) :
 			new RocksTransformingIteratorWrapper(rocksIterator, stateSnapshotTransformer);
+	}
+
+	private static class MetaData {
+		final ColumnFamilyHandle columnFamilyHandle;
+		final RegisteredStateMetaInfoBase registeredStateMetaInfoBase;
+		final StateSnapshotTransformer<byte[]> stateSnapshotTransformer;
+
+		private MetaData(
+			ColumnFamilyHandle columnFamilyHandle,
+			RegisteredStateMetaInfoBase registeredStateMetaInfoBase,
+			StateSnapshotTransformer<byte[]> stateSnapshotTransformer) {
+
+			this.columnFamilyHandle = columnFamilyHandle;
+			this.registeredStateMetaInfoBase = registeredStateMetaInfoBase;
+			this.stateSnapshotTransformer = stateSnapshotTransformer;
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

StateSnapshotTransformer objects are now created when state is initialised. Afterwards, they are called in asynchronous part of checkpoint. However, they can be non-thread safe if accessed from multiple checkpoint operations.

This PR changes backends to keep transformer factory after state init and create transformer right before iterating the state entries in the same thread.

## Brief change log

Change backends to keep transformer factory and create thread-confined transformer.

## Verifying this change

Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
