### PR TITLE
[FLINK-11176] [table][tests] Improve the harness tests to use the code-generated operator

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
@@ -21,12 +21,10 @@ import java.lang.{Integer => JInt, Long => JLong}
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import org.apache.flink.api.common.time.Time
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo
-import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
+import org.apache.flink.table.api.scala._
+import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
-import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.harness.HarnessTestBase._
@@ -40,60 +38,67 @@ import scala.collection.mutable
 
 class GroupAggregateHarnessTest extends HarnessTestBase {
 
-  protected var queryConfig =
+  private val queryConfig =
     new TestStreamQueryConfig(Time.seconds(2), Time.seconds(3))
 
   @Test
   def testAggregate(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new GroupAggProcessFunction(
-        genSumAggFunction,
-        sumAggregationStateType,
-        false,
-        queryConfig))
+    val data = Seq[(JInt, String)]()
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b)
+    tEnv.registerTable("T", t)
+    val sqlQuery = tEnv.sqlQuery(
+      s"""
+         |SELECT
+         |  b, sum(a)
+         |FROM T
+         |GROUP BY b
+         |""".stripMargin)
 
-    val testHarness =
-      createHarnessTester(
-        processFunction,
-        new TupleRowKeySelector[String](2),
-        BasicTypeInfo.STRING_TYPE_INFO)
+    val testHarness = createHarnessTester[String, CRow, CRow](
+      toUpsertStream[Row](tEnv, sqlQuery, queryConfig), "groupBy")
 
+    testHarness.setStateBackend(getStateBackend)
     testHarness.open()
+
+    val operator = getOperator(testHarness)
+    assertTrue(operator.getKeyedStateBackend.isInstanceOf[RocksDBKeyedStateBackend[_]])
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
     // register cleanup timer with 3001
     testHarness.setProcessingTime(1)
 
-    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1: JInt), 1))
-    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1: JInt, "bbb"), 1))
-    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(1: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 1: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(1: JInt, "bbb"), 1))
+    expectedOutput.add(new StreamRecord(CRow("bbb", 1: JInt), 1))
     // reuse timer 3001
     testHarness.setProcessingTime(1000)
-    testHarness.processElement(new StreamRecord(CRow(3L: JLong, 2: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(3L: JLong, 3: JInt), 1))
-    testHarness.processElement(new StreamRecord(CRow(4L: JLong, 3: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(4L: JLong, 6: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(2: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 3: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(3: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 6: JInt), 1))
 
     // register cleanup timer with 4002
     testHarness.setProcessingTime(1002)
-    testHarness.processElement(new StreamRecord(CRow(5L: JLong, 4: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(5L: JLong, 10: JInt), 1))
-    testHarness.processElement(new StreamRecord(CRow(6L: JLong, 2: JInt, "bbb"), 1))
-    expectedOutput.add(new StreamRecord(CRow(6L: JLong, 3: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(4: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 10: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(2: JInt, "bbb"), 1))
+    expectedOutput.add(new StreamRecord(CRow("bbb", 3: JInt), 1))
 
     // trigger cleanup timer and register cleanup timer with 7003
     testHarness.setProcessingTime(4003)
-    testHarness.processElement(new StreamRecord(CRow(7L: JLong, 5: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(7L: JLong, 5: JInt), 1))
-    testHarness.processElement(new StreamRecord(CRow(8L: JLong, 6: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(8L: JLong, 11: JInt), 1))
-    testHarness.processElement(new StreamRecord(CRow(9L: JLong, 7: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(9L: JLong, 18: JInt), 1))
-    testHarness.processElement(new StreamRecord(CRow(10L: JLong, 3: JInt, "bbb"), 1))
-    expectedOutput.add(new StreamRecord(CRow(10L: JLong, 3: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(5: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 5: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(6: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 11: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(7: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 18: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(3: JInt, "bbb"), 1))
+    expectedOutput.add(new StreamRecord(CRow("bbb", 3: JInt), 1))
 
     val result = testHarness.getOutput
 
@@ -104,21 +109,32 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
 
   @Test
   def testAggregateWithRetract(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new GroupAggProcessFunction(
-        genSumAggFunction,
-        sumAggregationStateType,
-        true,
-        queryConfig))
+    val data = Seq[(JInt, String)]()
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b)
+    tEnv.registerTable("T", t)
+    val sqlQuery = tEnv.sqlQuery(
+      s"""
+         |SELECT
+         |  b, sum(a)
+         |FROM (
+         |  SELECT a, b
+         |  FROM T
+         |  GROUP BY a, b
+         |)
+         |GROUP BY b
+         |""".stripMargin)
 
-    val testHarness =
-      createHarnessTester(
-        processFunction,
-        new TupleRowKeySelector[String](2),
-        BasicTypeInfo.STRING_TYPE_INFO)
+    val testHarness = createHarnessTester[String, CRow, CRow](
+      tEnv.toRetractStream[Row](sqlQuery, queryConfig), "groupBy")
 
+    testHarness.setStateBackend(getStateBackend)
     testHarness.open()
+
+    val operator = getOperator(testHarness)
+    assertTrue(operator.getKeyedStateBackend.isInstanceOf[RocksDBKeyedStateBackend[_]])
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
@@ -126,55 +142,55 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
     testHarness.setProcessingTime(1)
 
     // accumulate
-    testHarness.processElement(new StreamRecord(CRow(1L: JLong, 1: JInt, "aaa"), 1))
-    expectedOutput.add(new StreamRecord(CRow(1L: JLong, 1: JInt), 1))
+    testHarness.processElement(new StreamRecord(CRow(1: JInt, "aaa"), 1))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 1: JInt), 1))
 
     // accumulate
-    testHarness.processElement(new StreamRecord(CRow(2L: JLong, 1: JInt, "bbb"), 2))
-    expectedOutput.add(new StreamRecord(CRow(2L: JLong, 1: JInt), 2))
+    testHarness.processElement(new StreamRecord(CRow(1: JInt, "bbb"), 2))
+    expectedOutput.add(new StreamRecord(CRow("bbb", 1: JInt), 2))
 
     // retract for insertion
-    testHarness.processElement(new StreamRecord(CRow(3L: JLong, 2: JInt, "aaa"), 3))
-    expectedOutput.add(new StreamRecord(CRow(false, 3L: JLong, 1: JInt), 3))
-    expectedOutput.add(new StreamRecord(CRow(3L: JLong, 3: JInt), 3))
+    testHarness.processElement(new StreamRecord(CRow(2: JInt, "aaa"), 3))
+    expectedOutput.add(new StreamRecord(CRow(false, "aaa", 1: JInt), 3))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 3: JInt), 3))
 
     // retract for deletion
-    testHarness.processElement(new StreamRecord(CRow(false, 3L: JLong, 2: JInt, "aaa"), 3))
-    expectedOutput.add(new StreamRecord(CRow(false, 3L: JLong, 3: JInt), 3))
-    expectedOutput.add(new StreamRecord(CRow(3L: JLong, 1: JInt), 3))
+    testHarness.processElement(new StreamRecord(CRow(false, 2: JInt, "aaa"), 3))
+    expectedOutput.add(new StreamRecord(CRow(false, "aaa", 3: JInt), 3))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 1: JInt), 3))
 
     // accumulate
-    testHarness.processElement(new StreamRecord(CRow(4L: JLong, 3: JInt, "ccc"), 4))
-    expectedOutput.add(new StreamRecord(CRow(4L: JLong, 3: JInt), 4))
+    testHarness.processElement(new StreamRecord(CRow(3: JInt, "ccc"), 4))
+    expectedOutput.add(new StreamRecord(CRow("ccc", 3: JInt), 4))
 
     // trigger cleanup timer and register cleanup timer with 6002
     testHarness.setProcessingTime(3002)
 
     // retract after clean up
-    testHarness.processElement(new StreamRecord(CRow(false, 4L: JLong, 3: JInt, "ccc"), 4))
+    testHarness.processElement(new StreamRecord(CRow(false, 3: JInt, "ccc"), 4))
 
     // accumulate
-    testHarness.processElement(new StreamRecord(CRow(5L: JLong, 4: JInt, "aaa"), 5))
-    expectedOutput.add(new StreamRecord(CRow(5L: JLong, 4: JInt), 5))
-    testHarness.processElement(new StreamRecord(CRow(6L: JLong, 2: JInt, "bbb"), 6))
-    expectedOutput.add(new StreamRecord(CRow(6L: JLong, 2: JInt), 6))
+    testHarness.processElement(new StreamRecord(CRow(4: JInt, "aaa"), 5))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 4: JInt), 5))
+    testHarness.processElement(new StreamRecord(CRow(2: JInt, "bbb"), 6))
+    expectedOutput.add(new StreamRecord(CRow("bbb", 2: JInt), 6))
 
     // retract
-    testHarness.processElement(new StreamRecord(CRow(7L: JLong, 5: JInt, "aaa"), 7))
-    expectedOutput.add(new StreamRecord(CRow(false, 7L: JLong, 4: JInt), 7))
-    expectedOutput.add(new StreamRecord(CRow(7L: JLong, 9: JInt), 7))
+    testHarness.processElement(new StreamRecord(CRow(5: JInt, "aaa"), 7))
+    expectedOutput.add(new StreamRecord(CRow(false, "aaa", 4: JInt), 7))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 9: JInt), 7))
 
     // accumulate
-    testHarness.processElement(new StreamRecord(CRow(8L: JLong, 6: JInt, "eee"), 8))
-    expectedOutput.add(new StreamRecord(CRow(8L: JLong, 6: JInt), 8))
+    testHarness.processElement(new StreamRecord(CRow(6: JInt, "eee"), 8))
+    expectedOutput.add(new StreamRecord(CRow("eee", 6: JInt), 8))
 
     // retract
-    testHarness.processElement(new StreamRecord(CRow(9L: JLong, 7: JInt, "aaa"), 9))
-    expectedOutput.add(new StreamRecord(CRow(false, 9L: JLong, 9: JInt), 9))
-    expectedOutput.add(new StreamRecord(CRow(9L: JLong, 16: JInt), 9))
-    testHarness.processElement(new StreamRecord(CRow(10L: JLong, 3: JInt, "bbb"), 10))
-    expectedOutput.add(new StreamRecord(CRow(false, 10L: JLong, 2: JInt), 10))
-    expectedOutput.add(new StreamRecord(CRow(10L: JLong, 5: JInt), 10))
+    testHarness.processElement(new StreamRecord(CRow(7: JInt, "aaa"), 9))
+    expectedOutput.add(new StreamRecord(CRow(false, "aaa", 9: JInt), 9))
+    expectedOutput.add(new StreamRecord(CRow("aaa", 16: JInt), 9))
+    testHarness.processElement(new StreamRecord(CRow(3: JInt, "bbb"), 10))
+    expectedOutput.add(new StreamRecord(CRow(false, "bbb", 2: JInt), 10))
+    expectedOutput.add(new StreamRecord(CRow("bbb", 5: JInt), 10))
 
     val result = testHarness.getOutput
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
@@ -21,6 +21,7 @@ import java.lang.{Integer => JInt, Long => JLong}
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import org.apache.flink.api.common.time.Time
+import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/TemporalJoinHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/TemporalJoinHarnessTest.scala
@@ -720,10 +720,10 @@ class TemporalJoinHarnessTest extends HarnessTestBase {
   @Test
   def testProcessingTimeJoinCleanupTimerUpdatedFromProbeSide(): Unit = {
     // min=2ms max=4ms
-    val testHarness = createTestHarness[(JLong, String, Timestamp), (String, JLong, Timestamp)](
-      isRowtime = true,
-      ordersRowtimeFields,
-      ratesRowtimeFields)
+    val testHarness = createTestHarness[(JLong, String), (String, JLong)](
+      isRowtime = false,
+      ordersProctimeFields,
+      ratesProctimeFields)
 
     testHarness.open()
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
@@ -760,10 +760,10 @@ class TemporalJoinHarnessTest extends HarnessTestBase {
   @Test
   def testProcessingTimeJoinCleanupTimerUpdatedFromBuildSide(): Unit = {
     // min=2ms max=4ms
-    val testHarness = createTestHarness[(JLong, String, Timestamp), (String, JLong, Timestamp)](
-      isRowtime = true,
-      ordersRowtimeFields,
-      ratesRowtimeFields)
+    val testHarness = createTestHarness[(JLong, String), (String, JLong)](
+      isRowtime = false,
+      ordersProctimeFields,
+      ratesProctimeFields)
 
     testHarness.open()
     val expectedOutput = new ConcurrentLinkedQueue[Object]()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request is a followup of #7253 and improves the harness tests to use the code-generated operator.*


## Brief change log

  - *Updates GroupAggregateHarnessTest, OverWindowHarnessTest, SortProcessFunctionHarnessTest, TemporalJoinHarnessTest*
  - *This PR does not touch JoinHarnessTest mainly for 2 reasons: 1) most test cases in JoinHarnessTest have no corresponding SQL, we have to rewritten the test cases if we want to change it 2) the hard-code join function is very simple and it may be better to leave as it is*

## Verifying this change

This change is a code cleanup of test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
