### PR TITLE
[FLINK-11180][tests] Fix ProcessFailureCancelingITCase.testCancelingOnProcessFailure error by specifying a free port

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -67,9 +67,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.StringWriter;
-import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -119,9 +117,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 100);
-
-		int defaultPort = config.getInteger(RestOptions.PORT);
-		config.setString("rest.port", String.valueOf(findFreePort(defaultPort, 100)));
+		config.setInteger(RestOptions.PORT, 0);
 
 		final RpcService rpcService = AkkaRpcServiceUtils.createRpcService("localhost", 0, config);
 		final int jobManagerPort = rpcService.getPort();
@@ -336,18 +332,5 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 		System.out.println("-----------------------------------------");
 		System.out.println("		END SPAWNED PROCESS LOG");
 		System.out.println("-----------------------------------------");
-	}
-
-	private int findFreePort(int startPort, int range) {
-		for (int p = startPort; p < startPort + range; ++p) {
-			try {
-				new ServerSocket(p).close();
-				System.out.println("Find free port: " + p);
-				return p;
-			} catch (IOException e) {
-				continue;
-			}
-		}
-		throw new RuntimeException("No free port found!");
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix ProcessFailureCancelingITCase.testCancelingOnProcessFailure error by specifying a free port


## Brief change log

  - Fix ProcessFailureCancelingITCase.testCancelingOnProcessFailure error by specifying a free port


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
