### PR TITLE
[FLINK-11191][table] Check for ambiguous columns in MATCH_RECOGNIZE

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamMatchRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamMatchRule.scala
@@ -20,10 +20,11 @@ package org.apache.flink.table.plan.rules.datastream
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.convert.ConverterRule
-import org.apache.calcite.rex.{RexCall, RexNode}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.calcite.sql.SqlAggFunction
-import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.plan.logical.MatchRecognize
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.datastream.DataStreamMatch
@@ -33,6 +34,8 @@ import org.apache.flink.table.plan.util.RexDefaultVisitor
 import org.apache.flink.table.util.MatchUtil
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.tools.nsc.interpreter.JList
 
 class DataStreamMatchRule
   extends ConverterRule(
@@ -46,6 +49,7 @@ class DataStreamMatchRule
 
     validateAggregations(logicalMatch.getMeasures.values().asScala)
     validateAggregations(logicalMatch.getPatternDefinitions.values().asScala)
+    validateAmbiguousColumns(logicalMatch)
     true
   }
 
@@ -89,6 +93,47 @@ class DataStreamMatchRule
   private def validateAggregations(expr: Iterable[RexNode]): Unit = {
     val validator = new AggregationsValidator
     expr.foreach(_.accept(validator))
+  }
+
+  private def validateAmbiguousColumns(logicalMatch: FlinkLogicalMatch): Unit = {
+    if (logicalMatch.isAllRows) {
+      throw new TableException("All rows per match mode is not supported yet.")
+    } else {
+      val refNameFinder = new RefNameFinder(logicalMatch.getInput.getRowType)
+      validateAmbiguousColumnsOnRowPerMatch(
+        logicalMatch.getPartitionKeys,
+        logicalMatch.getMeasures.keySet().asScala,
+        logicalMatch.getRowType,
+        refNameFinder)
+    }
+  }
+
+  private def validateAmbiguousColumnsOnRowPerMatch(
+      partitionKeys: JList[RexNode],
+      measuresNames: mutable.Set[String],
+      expectedSchema: RelDataType,
+      refNameFinder: RefNameFinder)
+    : Unit = {
+    val actualSize = partitionKeys.size() + measuresNames.size
+    val expectedSize = expectedSchema.getFieldCount
+    if (actualSize != expectedSize) {
+      //try to find ambiguous column
+
+      val ambigousColumns = partitionKeys.asScala.map(_.accept(refNameFinder))
+        .filter(measuresNames.contains).mkString("{ ", ", ", " }")
+
+      throw new ValidationException(s"Columns ambiguously defined: $ambigousColumns")
+    }
+  }
+
+  class RefNameFinder(inputSchema: RelDataType) extends RexDefaultVisitor[String] {
+
+    override def visitInputRef(inputRef: RexInputRef): String = {
+      inputSchema.getFieldList.get(inputRef.getIndex).getName
+    }
+
+    override def visitNode(rexNode: RexNode): String =
+      throw new TableException(s"PARTITION BY clause accepts only input reference. Found $rexNode")
   }
 
   class AggregationsValidator extends RexDefaultVisitor[Object] {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/MatchRecognizeValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/MatchRecognizeValidationTest.scala
@@ -176,7 +176,7 @@ class MatchRecognizeValidationTest extends TableTestBase {
 
   @Test
   def testValidatingAmbiguousColumns(): Unit = {
-    thrown.expectMessage("Columns ambiguously defined: { symbol, price }")
+    thrown.expectMessage("Columns ambiguously defined: {symbol, price}")
     thrown.expect(classOf[ValidationException])
 
     val sqlQuery =

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/MatchRecognizeValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/MatchRecognizeValidationTest.scala
@@ -174,6 +174,30 @@ class MatchRecognizeValidationTest extends TableTestBase {
     streamUtils.tableEnv.sqlQuery(sqlQuery).toAppendStream[Row]
   }
 
+  @Test
+  def testValidatingAmbiguousColumns(): Unit = {
+    thrown.expectMessage("Columns ambiguously defined: { symbol, price }")
+    thrown.expect(classOf[ValidationException])
+
+    val sqlQuery =
+      s"""
+         |SELECT *
+         |FROM Ticker
+         |MATCH_RECOGNIZE (
+         |  PARTITION BY symbol, price
+         |  ORDER BY proctime
+         |  MEASURES
+         |    A.symbol AS symbol,
+         |    A.price AS price
+         |  PATTERN (A)
+         |  DEFINE
+         |    A AS symbol = 'a'
+         |) AS T
+         |""".stripMargin
+
+    streamUtils.tableEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+  }
+
   // ***************************************************************************************
   // * Those validations are temporary. We should remove those tests once we support those *
   // * features.                                                                           *


### PR DESCRIPTION
## What is the purpose of the change

Added a validation that checks if no ambiguous columns are defined in `MATCH_RECOGNIZE` clause. Without the check there is a cryptic message thrown from code generation stack.

## Verifying this change

- org.apache.flink.table.`match`.MatchRecognizeValidationTest#testValidatingAmbiguousColumns

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
