### PR TITLE
[FLINK-10168] [Core/DataStream] Add FileFilter to FileInputFormat and FileModTimeFilter which sets a read start position for files by modification time

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FilePathFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FilePathFilter.java
@@ -17,17 +17,17 @@
 package org.apache.flink.api.common.io;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.io.filters.FileFilter;
+import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.Path;
 
-import java.io.Serializable;
-
 /**
- * The {@link #filterPath(Path)} method is responsible for deciding if a path is eligible for further
+ * A filter that is responsible for deciding if a path is eligible for further
  * processing or not. This can serve to exclude temporary or partial files that
  * are still being written.
  */
 @PublicEvolving
-public abstract class FilePathFilter implements Serializable {
+public abstract class FilePathFilter implements FileFilter {
 
 	private static final long serialVersionUID = 1L;
 
@@ -44,8 +44,14 @@ public abstract class FilePathFilter implements Serializable {
 	 *     return filePath.getName().startsWith(".") || filePath.getName().contains("_COPYING_");
 	 * }
 	 * }</pre>
+	 *
 	 */
 	public abstract boolean filterPath(Path filePath);
+
+	@Override
+	public boolean accept(FileStatus fileStatus) {
+		return !filterPath(fileStatus.getPath());
+	}
 
 	/**
 	 * Returns the default filter, which excludes the following files:

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Preconditions;
 
@@ -135,4 +136,8 @@ public class GlobFilePathFilter extends FilePathFilter {
 		return false;
 	}
 
+	@Override
+	public boolean accept(FileStatus fileStatus) {
+		return !filterPath(fileStatus.getPath());
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/filters/FileFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/filters/FileFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.io.filters;
+
+import org.apache.flink.core.fs.FileStatus;
+
+import java.io.Serializable;
+
+/**
+ * A filter that decides if a file should be processed or not.
+ */
+public interface FileFilter extends Serializable {
+	/**
+	 * Decides if a file should be accepted for processing or not.
+	 *
+	 * @param fileStatus The file
+	 * @return True if the file should be accepted for processing; False, otherwise
+	 */
+	boolean accept(FileStatus fileStatus);
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/filters/FileModTimeFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/filters/FileModTimeFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.io.filters;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A filter that only keeps files whose their modification time is no less than a given timestamp
+ * as consuming time position. It basically sets a read start position in file system for Flink.
+ */
+public class FileModTimeFilter implements FileFilter {
+	/**
+	 * The consuming time position to process files whose their modification time is no less than this timestamp.
+	 */
+	private long consumingTimePosition;
+
+	public FileModTimeFilter(long consumingTimePosition) {
+		Preconditions.checkArgument(consumingTimePosition >= 0);
+
+		this.consumingTimePosition = consumingTimePosition;
+	}
+
+	@Override
+	public boolean accept(FileStatus fileStatus) {
+		// Always accept dir, because it may contain files newer than itself
+		return fileStatus.isDir() || fileStatus.getModificationTime() >= consumingTimePosition;
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/filters/FileModTimeFilterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/filters/FileModTimeFilterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.io.filters;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the FileModTimeFilter.
+ */
+public class FileModTimeFilterTest {
+	private static final long TEST_TIMESTAMP = 10L;
+
+	private static final FileStatus MOCKED_DIR = new MockedDirFileStatus();
+	private static final FileStatus MOCKED_FILE = new MockedFileStatus();
+
+	@Test
+	public void testAlwaysAcceptDir() {
+		assertTrue(new FileModTimeFilter(TEST_TIMESTAMP - 1).accept(MOCKED_DIR));
+		assertTrue(new FileModTimeFilter(TEST_TIMESTAMP).accept(MOCKED_DIR));
+		assertTrue(new FileModTimeFilter(TEST_TIMESTAMP + 1).accept(MOCKED_DIR));
+	}
+
+	@Test
+	public void testFilterFile() {
+		assertTrue(new FileModTimeFilter(TEST_TIMESTAMP - 1).accept(MOCKED_FILE));
+		assertTrue(new FileModTimeFilter(TEST_TIMESTAMP).accept(MOCKED_FILE));
+		assertFalse(new FileModTimeFilter(TEST_TIMESTAMP + 1).accept(MOCKED_FILE));
+	}
+
+	private static class MockedFileStatus implements FileStatus {
+
+		@Override
+		public long getLen() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long getBlockSize() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public short getReplication() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long getModificationTime() {
+			return 10;
+		}
+
+		@Override
+		public long getAccessTime() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isDir() {
+			return false;
+		}
+
+		@Override
+		public Path getPath() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static class MockedDirFileStatus implements FileStatus {
+
+		@Override
+		public long getLen() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long getBlockSize() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public short getReplication() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long getModificationTime() {
+			return 20;
+		}
+
+		@Override
+		public long getAccessTime() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isDir() {
+			return true;
+		}
+
+		@Override
+		public Path getPath() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The motivation is 

1. enabling users to set a read start position for files, so they can process files that are only modified after a given timestamp
2. exposing more file information to users and providing them with a more flexible file filter interface to define their own filtering rules

## Brief change log

- add `FileFilter` interface that users can access all available information of a file and set filtering rules
- allow users to set `FileFilter` to `FileInputFormat`
- add `FileModTimeFilter`, in which users can set a read start position for files so Flink only process files that are modified after the given timestamp

## Verifying this change

This change added tests and can be verified as follows:

  - extended unit tests for FileInputFormat in `FileInputFormatTest`
  - added `FileModTimeFilterTest`

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? - Documentation will be added in another PR in a different jira ticket
