### PR TITLE
[FLINK-11196] Extend S3 EntropyInjector to use key replacement (instead of key removal) when creating checkpoint metadata files.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
@@ -43,6 +43,12 @@ public interface EntropyInjectingFileSystem {
 	String getEntropyInjectionKey();
 
 	/**
+	 * Gets the replacement string for the entropy key when creating files that do not require
+	 * entropy injection (e.g. checkpoint metadata files).
+	 */
+	String getEntropyKeyReplacement();
+
+	/**
 	 * Creates a string with random entropy to be injected into a path.
 	 */
 	String generateEntropy();

--- a/flink-core/src/test/java/org/apache/flink/testutils/EntropyInjectingTestFileSystem.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/EntropyInjectingTestFileSystem.java
@@ -34,11 +34,18 @@ public class EntropyInjectingTestFileSystem extends LocalFileSystem implements E
 
 	public static final String ENTROPY_INJECTION_KEY = "_entropy_";
 
+	public static final String ENTROPY_KEY_REPLACEMENT = "";
+
 	public static final String ENTROPY = "_resolved_";
 
 	@Override
 	public String getEntropyInjectionKey() {
 		return ENTROPY_INJECTION_KEY;
+	}
+
+	@Override
+	public String getEntropyKeyReplacement() {
+		return ENTROPY_KEY_REPLACEMENT;
 	}
 
 	@Override

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -67,7 +67,18 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 			.withDescription(
 					"This option can be used to improve performance due to sharding issues on Amazon S3. " +
 					"For file creations with entropy injection, this key will be replaced by random " +
-					"alphanumeric characters. For other file creations, the key will be filtered out.");
+					"alphanumeric characters. For other file creations, the key will be replaced.");
+
+	/**
+	 * The replacement string to replace the entropy key with, when creating files that do not require
+	 * entropy while entropy injection is configured.
+	 */
+	public static final ConfigOption<String> ENTROPY_INJECT_KEY_REPLACEMENT_OPTION = ConfigOptions
+			.key("s3.entropy.replacement")
+			.defaultValue("")
+			.withDescription(
+					"When '" + ENTROPY_INJECT_KEY_OPTION.key() + "' is set, this option defines the replacement " +
+					"string for entropy key when creating files that do not require entropy injection.");
 
 	/**
 	 * The number of entropy characters, in case entropy injection is configured.
@@ -125,6 +136,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 
 			// load the entropy injection settings
 			String entropyInjectionKey = flinkConfig.getString(ENTROPY_INJECT_KEY_OPTION);
+			String entropyKeyReplacement = flinkConfig.getString(ENTROPY_INJECT_KEY_REPLACEMENT_OPTION);
 			int numEntropyChars = -1;
 			if (entropyInjectionKey != null) {
 				if (entropyInjectionKey.matches(INVALID_ENTROPY_KEY_CHARS)) {
@@ -147,6 +159,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
 					fs,
 					localTmpDirectory,
 					entropyInjectionKey,
+					entropyKeyReplacement,
 					numEntropyChars,
 					s3AccessHelper,
 					s3minPartSize,

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/FlinkS3FileSystem.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/FlinkS3FileSystem.java
@@ -48,6 +48,8 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 	@Nullable
 	private final String entropyInjectionKey;
 
+	private final String entropyKeyReplacement;
+
 	private final int entropyLength;
 
 	// ------------------- Recoverable Writer Parameters -------------------
@@ -75,13 +77,15 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 	 * <p>This constructor additionally configures the entropy injection for the file system.
 	 *
 	 * @param hadoopS3FileSystem The Hadoop FileSystem that will be used under the hood.
-	 * @param entropyInjectionKey The substring that will be replaced by entropy or removed.
+	 * @param entropyInjectionKey The substring that will be replaced by entropy or by the key replacement.
+	 * @param entropyKeyReplacement The string that will be replace the entropy for files that do not require entropy.
 	 * @param entropyLength The number of random alphanumeric characters to inject as entropy.
 	 */
 	public FlinkS3FileSystem(
 			org.apache.hadoop.fs.FileSystem hadoopS3FileSystem,
 			String localTmpDirectory,
 			@Nullable String entropyInjectionKey,
+			String entropyKeyReplacement,
 			int entropyLength,
 			@Nullable S3AccessHelper s3UploadHelper,
 			long s3uploadPartSize,
@@ -94,6 +98,7 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 		}
 
 		this.entropyInjectionKey = entropyInjectionKey;
+		this.entropyKeyReplacement = entropyKeyReplacement;
 		this.entropyLength = entropyLength;
 
 		// recoverable writer parameter configuration initialization
@@ -113,6 +118,11 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 	@Override
 	public String getEntropyInjectionKey() {
 		return entropyInjectionKey;
+	}
+
+	@Override
+	public String getEntropyKeyReplacement() {
+		return entropyKeyReplacement;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -69,7 +69,7 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 		this.reference = checkNotNull(reference);
 
 		// the metadata file should not have entropy in its path
-		Path metadataDir = EntropyInjector.removeEntropyMarkerIfPresent(fileSystem, checkpointDir);
+		Path metadataDir = EntropyInjector.replaceEntropyMarkerIfPresent(fileSystem, checkpointDir);
 
 		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
 		this.fileStateSizeThreshold = fileStateSizeThreshold;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertThat;
 public class FsStateBackendEntropyTest {
 
 	static final String ENTROPY_MARKER = "__ENTROPY__";
+	static final String ENTROPY_REPLACEMENT = "+REPLACEMENT+";
 	static final String RESOLVED_MARKER = "+RESOLVED+";
 
 	@Rule
@@ -113,6 +114,11 @@ public class FsStateBackendEntropyTest {
 		@Override
 		public String getEntropyInjectionKey() {
 			return ENTROPY_MARKER;
+		}
+
+		@Override
+		public String getEntropyKeyReplacement() {
+			return ENTROPY_REPLACEMENT;
 		}
 
 		@Override


### PR DESCRIPTION
[FLINK-11196] Extend S3 EntropyInjector to use key replacement (instead of key removal) when creating checkpoint metadata files.

## What is the purpose of the change
Extend S3 entropy injection feature to optionally replace the entropy marker in the path (instead of just removing the marker) when writing checkpoint metadata files.

It introduces a new configuration `s3.entropy.replacement` which specifies the string that will be use to replace the entropy marker with (only when writing checkpoint metadata files). Checkpoint state files entropy injection behavior does not change.

If `s3.entropy.replacement` is not configured, then the behavior will be the same as it is today. Entropy marker will be removed from checkpoint metadata file path and entropy will be injected for checkpoint state file paths. This PR is an optional extension to the current feature. Only if `s3.entropy.replacement` is set to a non-empty string, it will use the value to replace the entropy marker when writing checkpoint metadata files.

## Verifying this change
- Unit tests
- Integration tests with entropy injection enabled (manually verified)

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: yes

## Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? new configuration
