### PR TITLE
[FLINK-11194][hbase] Use type instead of classifier

### DIFF
--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -49,19 +49,6 @@ under the License.
 					<forkCount>1</forkCount>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<!-- Disable inherited shade-flink because of a problem in the shade plugin -->
-						<!-- When enabled you'll run into an infinite loop creating the dependency-reduced-pom.xml -->
-						<!-- Seems similar to https://issues.apache.org/jira/browse/MSHADE-148 -->
-						<id>shade-flink</id>
-						<phase>none</phase>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 
@@ -255,7 +242,7 @@ under the License.
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-server</artifactId>
 			<version>${hbase.version}</version>
-			<classifier>tests</classifier>
+			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

The hbase-connector module has been disabling the shade-plugin due to an infinite loop that occurs when creating the dependency-reduced pom. As a result the released pom contained unresolved properties for the scala version, which breaks the connector when using scala 2.12.

The loop is caused by having multiple instances for the same dependency with different classifiers. Classifiers are suffixes that added to jars; most notable "tests" for the test-jar.
The plugin however _can_ handle multiple instances with different _types_, like `test-jar`.

Since we refer to the same artifact regardless we can just use the `types` parameter to select the test-jar, preventing the loop.

## Brief change log

* use `<type>` instead of  `<classifier>`
* remove custom shade-plugin configuration

## Verifying this change

Compile the module and ensure that the dependency-reduced-pom.xml is created and does not contain unresolved properties.
