### PR TITLE
[FLINK-11079][storm] Skip deployment of storm-examples

### DIFF
--- a/flink-contrib/flink-storm-examples/pom.xml
+++ b/flink-contrib/flink-storm-examples/pom.xml
@@ -111,6 +111,14 @@ under the License.
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+
 			<!-- get default data from flink-example-batch package -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What is the purpose of the change

This PR disables the deployment of `flink-storm-examples`. These examples are not bundled with flink-dist, nor are they documented; it is thus quite likely that no one ever used them.

This way we don't have to deal with licensing of jars. As a bonus we are deploying 100mb less data to maven central. (5 fat jars, 20mb each)