### PR TITLE
[FLINK-11207][core] update commons-compress to 1.18

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -64,7 +64,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.4
 - org.apache.camel:camel-core:2.17.7
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.19.0-GA
@@ -344,7 +344,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.htrace:htrace-core4:4.0.1-incubating
 - org.apache.httpcomponents:httpclient:4.5.3
 - org.apache.httpcomponents:httpcore:4.4.6
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-math3:3.5
 - commons-beanutils:commons-beanutils:1.8.3
 - commons-cli:commons-cli:1.3.1
@@ -2412,7 +2412,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-net:commons-net:3.1
 - org.apache.avro:avro:1.8.2
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-math3:3.5
 - org.apache.zookeeper:zookeeper:3.4.10
 - org.codehaus.jackson:jackson-core-asl:1.9.13

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.4
 - org.apache.camel:camel-core:2.17.7
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.19.0-GA

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.htrace:htrace-core4:4.0.1-incubating
 - org.apache.httpcomponents:httpclient:4.5.3
 - org.apache.httpcomponents:httpcore:4.4.6
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-math3:3.5
 - commons-beanutils:commons-beanutils:1.8.3
 - commons-cli:commons-cli:1.3.1

--- a/flink-shaded-hadoop/flink-shaded-hadoop2-uber/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2-uber/src/main/resources/META-INF/NOTICE
@@ -19,7 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-net:commons-net:3.1
 - org.apache.avro:avro:1.8.2
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-math3:3.5
 - org.apache.zookeeper:zookeeper:3.4.10
 - org.codehaus.jackson:jackson-core-asl:1.9.13

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.4.1</version>
+				<version>1.18</version>
 			</dependency>
 
 			<!-- Managed dependency required for HBase in flink-hbase -->


### PR DESCRIPTION
## What is the purpose of the change

Our current version of Apache commons-compress (1.4.1) is affected by at least one security vulnerability and should be updated.
This addresses [CVE-2018-11771](https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-32473).

## Brief change log

- update commons-compress dependency to version 1.18

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
