### PR TITLE
[FLINK-11142][docs] Point out fields can be projected out for Position-based Mapping

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -800,7 +800,7 @@ The mapping of a data type to a table schema can happen in two ways: **based on 
 
 **Position-based Mapping**
 
-Position-based mapping can be used to give fields a more meaningful name while keeping the field order. This mapping is available for composite data types *with a defined field order* as well as atomic types. Composite data types such as tuples, rows, and case classes have such a field order. However, fields of a POJO must be mapped based on the field names (see next section).
+Position-based mapping can be used to give fields a more meaningful name while keeping the field order. This mapping is available for composite data types *with a defined field order* as well as atomic types. Composite data types such as tuples, rows, and case classes have such a field order. However, fields of a POJO must be mapped based on the field names (see next section). Fields can be projected out but can't be renamed using an alias `as`.
 
 When defining a position-based mapping, the specified names must not exist in the input data type, otherwise the API will assume that the mapping should happen based on the field names. If no field names are specified, the default field names and field order of the composite type are used or `f0` for atomic types. 
 
@@ -814,6 +814,9 @@ DataStream<Tuple2<Long, Integer>> stream = ...
 
 // convert DataStream into Table with default field names "f0" and "f1"
 Table table = tableEnv.fromDataStream(stream);
+
+// convert DataStream into Table with field "myLong" only
+Table table = tableEnv.fromDataStream(stream, "myLong");
 
 // convert DataStream into Table with field names "myLong" and "myInt"
 Table table = tableEnv.fromDataStream(stream, "myLong, myInt");
@@ -830,8 +833,11 @@ val stream: DataStream[(Long, Int)] = ...
 // convert DataStream into Table with default field names "_1" and "_2"
 val table: Table = tableEnv.fromDataStream(stream)
 
+// convert DataStream into Table with field "myLong" only
+val table: Table = tableEnv.fromDataStream(stream, 'myLong)
+
 // convert DataStream into Table with field names "myLong" and "myInt"
-val table: Table = tableEnv.fromDataStream(stream, 'myLong 'myInt)
+val table: Table = tableEnv.fromDataStream(stream, 'myLong, 'myInt)
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION

## What is the purpose of the change

This pull request improves the document for DataStream/DataSet to Table conversion. It points out fields can be projected out for Position-based Mapping.


## Brief change log

  - Point out fields can be projected out for Position-based Mapping
  - Point out fields can't be renamed using an alias `as` for Position-based Mapping


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
