### PR TITLE
[FLINK-11214] [table] Support non mergable aggregates for group windows on batch table

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/Row.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Row.java
@@ -141,6 +141,18 @@ public class Row implements Serializable{
 	}
 
 	/**
+	 * Copies the elements from another row to the reuse row.
+	 * This method does not perform a deep copy.
+	 *
+	 * @param row The row being copied.
+	 * @return The reuse row
+	 */
+	public static Row copy(Row row, Row reuse) {
+		System.arraycopy(row.fields, 0, reuse.fields, 0, row.fields.length);
+		return reuse;
+	}
+
+	/**
 	 * Creates a new Row which copied from another row.
 	 * This method does not perform a deep copy.
 	 *
@@ -149,8 +161,7 @@ public class Row implements Serializable{
 	 */
 	public static Row copy(Row row) {
 		final Row newRow = new Row(row.fields.length);
-		System.arraycopy(row.fields, 0, newRow.fields, 0, row.fields.length);
-		return newRow;
+		return copy(row, newRow);
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/types/RowTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RowTest.java
@@ -63,6 +63,22 @@ public class RowTest {
 	}
 
 	@Test
+	public void testRowCopyWithReuse() {
+		Row row = new Row(5);
+		row.setField(0, 1);
+		row.setField(1, "hello");
+		row.setField(2, null);
+		row.setField(3, new Tuple2<>(2, "hi"));
+		row.setField(4, "hello world");
+
+		Row reuse = new Row(6);
+
+		Row copy = Row.copy(row, reuse);
+		assertEquals(row, Row.project(copy, new int[]{0, 1, 2, 3, 4}));
+		assertTrue(reuse == copy);
+	}
+
+	@Test
 	public void testRowProject() {
 		Row row = new Row(5);
 		row.setField(0, 1);

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggReduceGroupFunction.scala
@@ -128,7 +128,11 @@ class DataSetSessionWindowAggReduceGroupFunction(
         windowStart = record.getField(intermediateRowWindowStartPos).asInstanceOf[Long]
       }
 
-      function.mergeAccumulatorsPair(accumulators, record)
+      if (isInputCombined) {
+        function.mergeAccumulatorsPair(accumulators, record)
+      } else {
+        function.accumulate(accumulators, record)
+      }
 
       windowEnd = if (isInputCombined) {
         // partial aggregate is supported

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceCombineFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceCombineFunction.scala
@@ -54,7 +54,8 @@ class DataSetSlideWindowAggReduceCombineFunction(
     finalRowWindowStartPos,
     finalRowWindowEndPos,
     finalRowWindowRowtimePos,
-    windowSize)
+    windowSize,
+    true)
   with CombineFunction[Row, Row] {
 
   private val intermediateRow: Row = new Row(keysAndAggregatesArity + 1)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceGroupFunction.scala
@@ -46,7 +46,8 @@ class DataSetSlideWindowAggReduceGroupFunction(
     finalRowWindowStartPos: Option[Int],
     finalRowWindowEndPos: Option[Int],
     finalRowWindowRowtimePos: Option[Int],
-    windowSize: Long)
+    windowSize: Long,
+    isInputCombined: Boolean)
   extends RichGroupReduceFunction[Row, Row]
     with Compiler[GeneratedAggregations]
     with Logging {
@@ -86,7 +87,11 @@ class DataSetSlideWindowAggReduceGroupFunction(
     var record: Row = null
     while (iterator.hasNext) {
       record = iterator.next()
-      function.mergeAccumulatorsPair(accumulators, record)
+      if (isInputCombined) {
+        function.mergeAccumulatorsPair(accumulators, record)
+      } else {
+        function.accumulate(accumulators, record)
+      }
     }
 
     // set group keys value to final output

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceCombineFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceCombineFunction.scala
@@ -30,8 +30,8 @@ import org.apache.flink.types.Row
   * [[org.apache.flink.api.java.operators.GroupCombineOperator]].
   * It is used for tumbling time-window on batch.
   *
-  * @param genPreAggregations        Code-generated [[GeneratedAggregations]] for partial aggs.
-  * @param genFinalAggregations        Code-generated [[GeneratedAggregations]] for final aggs.
+  * @param genPreAggregations     Code-generated [[GeneratedAggregations]] for partial aggs.
+  * @param genFinalAggregations   Code-generated [[GeneratedAggregations]] for final aggs.
   * @param windowSize             Tumbling time window size
   * @param windowStartPos         The relative window-start field position to the last field of
   *                               output row
@@ -55,10 +55,12 @@ class DataSetTumbleTimeWindowAggReduceCombineFunction(
     windowStartPos,
     windowEndPos,
     windowRowtimePos,
-    keysAndAggregatesArity)
+    keysAndAggregatesArity,
+    true)
     with CombineFunction[Row, Row] {
 
-  protected var preAggfunction: GeneratedAggregations = _
+  private val aggregateBuffer: Row = new Row(keysAndAggregatesArity + 1)
+  private var preAggfunction: GeneratedAggregations = _
 
   override def open(config: Configuration): Unit = {
     super.open(config)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds support of non mergable aggregates for group windows on batch table*


## Brief change log

  - *Changes to AggregateUtil, DataSet(Session/Slide/Tumble)WindowAggXXXFunction, etc to support non-mergable aggregates for group window on batch table*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests in batch.sql.AggregateITCase, batch.table.GroupWindowITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
