### PR TITLE
FLINK-11215  TaskExecutor register fail at resource manager bugfix.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -272,6 +272,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	public void start() throws Exception {
 		super.start();
 
+		startRegistrationTimeout();
 		// start by connecting to the ResourceManager
 		try {
 			resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
@@ -286,8 +287,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		jobLeaderService.start(getAddress(), getRpcService(), haServices, new JobLeaderListenerImpl());
 
 		fileCache = new FileCache(taskManagerConfiguration.getTmpDirectories(), blobCacheService.getPermanentBlobService());
-
-		startRegistrationTimeout();
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change
Solve the problem that taskExecutor register fail at resource manager sometimes.

## Brief change log
move the function startRegistrationTimeout() before resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener())

## Verifying this change
This change is a bugfix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
