### PR TITLE
[hotfix][doc] fix error http port in elasticsearch scala doc

### DIFF
--- a/docs/dev/connectors/elasticsearch.md
+++ b/docs/dev/connectors/elasticsearch.md
@@ -340,8 +340,8 @@ import java.util.List
 val input: DataStream[String] = ...
 
 val httpHosts = new java.util.ArrayList[HttpHost]
-httpHosts.add(new HttpHost("127.0.0.1", 9300, "http"))
-httpHosts.add(new HttpHost("10.2.3.1", 9300, "http"))
+httpHosts.add(new HttpHost("127.0.0.1", 9200, "http"))
+httpHosts.add(new HttpHost("10.2.3.1", 9200, "http"))
 
 val esSinkBuilder = new ElasticsearchSink.Builer[String](
   httpHosts,


### PR DESCRIPTION
## What is the purpose of the change

fix error http port in elasticsearch scala doc. 
http port is 9200, not 9300



