### PR TITLE
[FLINK-11218][runtime] fix the default restart stragegy delay value

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoOrFixedIfCheckpointingEnabledRestartStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoOrFixedIfCheckpointingEnabledRestartStrategyFactory.java
@@ -23,7 +23,7 @@ package org.apache.flink.runtime.executiongraph.restart;
  * depending if checkpointing was enabled.
  */
 public class NoOrFixedIfCheckpointingEnabledRestartStrategyFactory extends RestartStrategyFactory {
-	private static final long DEFAULT_RESTART_DELAY = 10000L;
+	private static final long DEFAULT_RESTART_DELAY = 1000L;
 
 	private static final long serialVersionUID = -1809462525812787862L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoOrFixedIfCheckpointingEnabledRestartStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/NoOrFixedIfCheckpointingEnabledRestartStrategyFactory.java
@@ -23,7 +23,7 @@ package org.apache.flink.runtime.executiongraph.restart;
  * depending if checkpointing was enabled.
  */
 public class NoOrFixedIfCheckpointingEnabledRestartStrategyFactory extends RestartStrategyFactory {
-	private static final long DEFAULT_RESTART_DELAY = 0;
+	private static final long DEFAULT_RESTART_DELAY = 10000L;
 
 	private static final long serialVersionUID = -1809462525812787862L;
 


### PR DESCRIPTION
## What is the purpose of the change

*fix the default restart stragegy delay value*

## Brief change log

from 1.6.x, the default restart stragegy delay value is 0, this pr modify the value to 10000L.
it will endless loop when a operator always throw error, it exhausts the CPU limit and MEM limit.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)

## reproducible example
```
public static void main(String[] args) throws Exception {
    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
    env.enableCheckpointing(5000);

    DataStreamSource<String> source = env.addSource(new SourceFunction<String>() {
        @Override
        public void run(SourceContext<String> ctx) throws Exception {
            for (int i = 0; i < 100000000; i++) {
                Thread.sleep(100);
                ctx.collect("data " + i);
            }
        }
        @Override
        public void cancel() {

        }
    });

    source.addSink(new RichSinkFunction<String>() {
        @Override
        public void open(Configuration parameters) throws Exception {
            System.out.println(1 / 0);
        }
        @Override
        public void invoke(String value, Context context) throws Exception {

        }
    });

    env.execute();
}
```


