### PR TITLE
[Flink-10742][network] Let Netty use Flink's buffers directly in credit-based mode

### DIFF
--- a/docs/_includes/generated/netty_configuration.html
+++ b/docs/_includes/generated/netty_configuration.html
@@ -23,6 +23,11 @@
             <td>The number of Netty arenas.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.netty.max-order</h5></td>
+            <td style="word-wrap: break-word;">9</td>
+            <td>The power of 2 of the number of pages in each chunk.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/BufferResponseAndNoDataBufferMessageParser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/BufferResponseAndNoDataBufferMessageParser.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+
+/**
+ * The parser for both {@link NettyMessage.BufferResponse} and messages with no data buffer part.
+ */
+public class BufferResponseAndNoDataBufferMessageParser extends NoDataBufferMessageParser {
+	/** The allocator for the flink buffer. */
+	private final NetworkBufferAllocator networkBufferAllocator;
+
+	BufferResponseAndNoDataBufferMessageParser(NetworkBufferAllocator networkBufferAllocator) {
+		this.networkBufferAllocator = networkBufferAllocator;
+	}
+
+	@Override
+	public int getMessageHeaderLength(int lengthWithoutFrameHeader, int msgId) {
+		if (msgId == NettyMessage.BufferResponse.ID) {
+			return NettyMessage.BufferResponse.MESSAGE_HEADER_LENGTH;
+		} else {
+			return super.getMessageHeaderLength(lengthWithoutFrameHeader, msgId);
+		}
+	}
+
+	@Override
+	public MessageHeaderParseResult parseMessageHeader(int msgId, ByteBuf messageHeader) throws Exception {
+		if (msgId == NettyMessage.BufferResponse.ID) {
+			NettyMessage.BufferResponse<Buffer> bufferResponse =
+					NettyMessage.BufferResponse.readFrom(messageHeader, networkBufferAllocator);
+
+			if (bufferResponse.getBuffer() == null) {
+				return MessageHeaderParseResult.discardDataBuffer(bufferResponse, bufferResponse.getBufferSize());
+			} else {
+				return MessageHeaderParseResult.receiveDataBuffer(bufferResponse, bufferResponse.getBufferSize(), bufferResponse.getBuffer());
+			}
+		} else {
+			return super.parseMessageHeader(msgId, messageHeader);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
@@ -52,28 +52,24 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 	private static final boolean PREFER_DIRECT = true;
 
 	/**
-	 * Arenas allocate chunks of pageSize << maxOrder bytes. With these defaults, this results in
-	 * chunks of 16 MB.
-	 *
-	 * @see #MAX_ORDER
-	 */
-	private static final int PAGE_SIZE = 8192;
-
-	/**
-	 * Arenas allocate chunks of pageSize << maxOrder bytes. With these defaults, this results in
-	 * chunks of 16 MB.
-	 *
-	 * @see #PAGE_SIZE
-	 */
-	private static final int MAX_ORDER = 11;
-
-	/**
 	 * Creates Netty's buffer pool with the specified number of direct arenas.
 	 *
 	 * @param numberOfArenas Number of arenas (recommended: 2 * number of task
 	 *                       slots)
 	 */
 	public NettyBufferPool(int numberOfArenas) {
+		this(numberOfArenas, NettyConfig.MAX_ORDER.defaultValue(), NettyConfig.DEFAULT_PAGE_SIZE);
+	}
+
+	/**
+	 * Creates Netty's buffer pool with the specified number of direct arenas.
+	 *
+	 * @param numberOfArenas Number of arenas (recommended: 2 * number of task
+	 *                       slots)
+	 * @param maxOrder Max order for the netty buffer pool, default to 9.
+	 * @param pageSize Page size for the netty buffer bool, default to 8k.
+	 */
+	public NettyBufferPool(int numberOfArenas, int maxOrder, int pageSize) {
 		super(
 			PREFER_DIRECT,
 			// No heap arenas, please.
@@ -85,8 +81,8 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 			// control the memory allocations with low/high watermarks when writing
 			// to the TCP channels. Chunks are allocated lazily.
 			numberOfArenas,
-			PAGE_SIZE,
-			MAX_ORDER);
+			pageSize,
+			maxOrder);
 
 		checkArgument(numberOfArenas >= 1, "Number of arenas");
 		this.numberOfArenas = numberOfArenas;
@@ -94,7 +90,7 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 		// Arenas allocate chunks of pageSize << maxOrder bytes. With these
 		// defaults, this results in chunks of 16 MB.
 
-		this.chunkSize = PAGE_SIZE << MAX_ORDER;
+		this.chunkSize = pageSize << maxOrder;
 
 		Object[] allocDirectArenas = null;
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -38,7 +38,7 @@ public class NettyConnectionManager implements ConnectionManager {
 	public NettyConnectionManager(NettyConfig nettyConfig) {
 		this.server = new NettyServer(nettyConfig);
 		this.client = new NettyClient(nettyConfig);
-		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
+		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas(), nettyConfig.getMaxOrder(), nettyConfig.getPageSize());
 
 		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessageParser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessageParser.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+
+/**
+ * Responsible for offering the message header length and parsing the message header part of the message.
+ */
+public interface NettyMessageParser {
+	/**
+	 * Indicates how to deal with the data buffer part of the current message.
+	 */
+	enum DataBufferAction {
+		/** The current message does not have the data buffer part. */
+		NO_DATA_BUFFER,
+
+		/** The current message has data buffer part and this part needs to be received. */
+		RECEIVE,
+
+		/**
+		 * The current message has data buffer part but it needs to be discarded. For example,
+		 * when the target input channel has been closed.
+		 */
+		DISCARD
+	}
+
+	/**
+	 * Indicates the result of parsing the message header.
+	 */
+	class MessageHeaderParseResult {
+		/** The message object parsed from the buffer. */
+		private NettyMessage parsedMessage;
+
+		/** The target action of how to process the data buffer part. */
+		private DataBufferAction dataBufferAction;
+
+		/** The size of the data buffer part. */
+		private int dataBufferSize;
+
+		/** The target data buffer for receiving the data. */
+		private Buffer targetDataBuffer;
+
+		private MessageHeaderParseResult(
+				NettyMessage parsedMessage,
+				DataBufferAction dataBufferAction,
+				int dataBufferSize,
+				Buffer targetDataBuffer) {
+			this.parsedMessage = parsedMessage;
+			this.dataBufferAction = dataBufferAction;
+			this.dataBufferSize = dataBufferSize;
+			this.targetDataBuffer = targetDataBuffer;
+		}
+
+		static MessageHeaderParseResult noDataBuffer(NettyMessage message) {
+			return new MessageHeaderParseResult(message, DataBufferAction.NO_DATA_BUFFER, 0, null);
+		}
+
+		static MessageHeaderParseResult receiveDataBuffer(NettyMessage message, int dataBufferSize, Buffer targetDataBuffer) {
+			return new MessageHeaderParseResult(message, DataBufferAction.RECEIVE, dataBufferSize, targetDataBuffer);
+		}
+
+		static MessageHeaderParseResult discardDataBuffer(NettyMessage message, int dataBufferSize) {
+			return new MessageHeaderParseResult(message, DataBufferAction.DISCARD, dataBufferSize, null);
+		}
+
+		NettyMessage getParsedMessage() {
+			return parsedMessage;
+		}
+
+		DataBufferAction getDataBufferAction() {
+			return dataBufferAction;
+		}
+
+		int getDataBufferSize() {
+			return dataBufferSize;
+		}
+
+		Buffer getTargetDataBuffer() {
+			return targetDataBuffer;
+		}
+	}
+
+	/**
+	 * Get the length of the message header part.
+	 *
+	 * @param lengthWithoutFrameHeader the message length not counting the frame header part.
+	 * @param msgId the id of the current message.
+	 * @return the length of the message header part.
+	 */
+	int getMessageHeaderLength(int lengthWithoutFrameHeader, int msgId);
+
+	/**
+	 * Parse the message header.
+	 *
+	 * @param msgId  the id of the current message.
+	 * @param messageHeader the buffer containing the serialized message header.
+	 * @return the parsed result.
+	 */
+	MessageHeaderParseResult parseMessageHeader(int msgId, ByteBuf messageHeader) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NetworkBufferAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NetworkBufferAllocator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An allocator used for requesting buffers in the receiver side of netty handlers.
+ */
+public class NetworkBufferAllocator {
+	private final CreditBasedPartitionRequestClientHandler partitionRequestClientHandler;
+
+	NetworkBufferAllocator(CreditBasedPartitionRequestClientHandler partitionRequestClientHandler) {
+		this.partitionRequestClientHandler = checkNotNull(partitionRequestClientHandler);
+	}
+
+	/**
+	 * Allocates a pooled network buffer for the specific input channel.
+	 *
+	 * @param receiverId The input channel id to request pooled buffer with.
+	 * @param size The requested buffer size.
+	 * @return The pooled network buffer.
+	 */
+	public Buffer allocatePooledNetworkBuffer(InputChannelID receiverId, int size) {
+		Buffer buffer = null;
+
+		RemoteInputChannel inputChannel = partitionRequestClientHandler.getInputChannel(receiverId);
+		if (inputChannel != null) {
+			buffer = inputChannel.requestBuffer();
+		}
+
+		return buffer;
+	}
+
+	/**
+	 * Allocates an un-pooled network buffer with the specific size.
+	 *
+	 * @param size The requested buffer size.
+	 * @return The un-pooled network buffer.
+	 */
+	public Buffer allocateUnPooledNetworkBuffer(int size) {
+		byte[] byteArray = new byte[size];
+		MemorySegment memSeg = MemorySegmentFactory.wrap(byteArray);
+
+		return new NetworkBuffer(memSeg, FreeingBufferRecycler.INSTANCE, false);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NoDataBufferMessageParser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NoDataBufferMessageParser.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+
+import java.net.ProtocolException;
+
+/**
+ * The parser for messages with no data buffer part.
+ */
+public class NoDataBufferMessageParser implements NettyMessageParser {
+
+	@Override
+	public int getMessageHeaderLength(int lengthWithoutFrameHeader, int msgId) {
+		return lengthWithoutFrameHeader;
+	}
+
+	@Override
+	public MessageHeaderParseResult parseMessageHeader(int msgId, ByteBuf messageHeader) throws Exception {
+		NettyMessage decodedMsg;
+
+		switch (msgId) {
+			case NettyMessage.PartitionRequest.ID:
+				decodedMsg = NettyMessage.PartitionRequest.readFrom(messageHeader);
+				break;
+			case NettyMessage.TaskEventRequest.ID:
+				decodedMsg = NettyMessage.TaskEventRequest.readFrom(messageHeader, getClass().getClassLoader());
+				break;
+			case NettyMessage.ErrorResponse.ID:
+				decodedMsg = NettyMessage.ErrorResponse.readFrom(messageHeader);
+				break;
+			case NettyMessage.CancelPartitionRequest.ID:
+				decodedMsg = NettyMessage.CancelPartitionRequest.readFrom(messageHeader);
+				break;
+			case NettyMessage.CloseRequest.ID:
+				decodedMsg = NettyMessage.CloseRequest.readFrom(messageHeader);
+				break;
+			case NettyMessage.AddCredit.ID:
+				decodedMsg = NettyMessage.AddCredit.readFrom(messageHeader);
+				break;
+			default:
+				throw new ProtocolException("Received unknown message from producer: " + messageHeader);
+		}
+
+		return MessageHeaderParseResult.noDataBuffer(decodedMsg);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -241,8 +241,9 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 						registerAvailableReader(reader);
 					}
 
-					BufferResponse msg = new BufferResponse(
-						next.buffer(),
+					BufferResponse msg = new BufferResponse<>(
+						new NettyMessage.FlinkBufferHolder(next.buffer()),
+						next.buffer().isBuffer(),
 						reader.getSequenceNumber(),
 						reader.getReceiverId(),
 						next.buffersInBacklog());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/ZeroCopyNettyMessageDecoder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/ZeroCopyNettyMessageDecoder.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.FRAME_HEADER_LENGTH;
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.MAGIC_NUMBER;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Decodes messages from the fragmentary netty buffers. This decoder assumes the
+ * messages have the following format:
+ * +-----------------------------------+--------------------------------+
+ * | FRAME HEADER ||  MESSAGE HEADER   |     DATA BUFFER (Optional)     |
+ * +-----------------------------------+--------------------------------+
+ * and it decodes each part in order.
+ *
+ * This decoder tries best to eliminate copying. For the frame header and message header,
+ * it only cumulates data when they span multiple input buffers. For the buffer part, it
+ * copies directly to the input channels to avoid future copying.
+ *
+ * The format of the frame header is
+ * +------------------+------------------+--------++----------------+
+ * | FRAME LENGTH (4) | MAGIC NUMBER (4) | ID (1) || CUSTOM MESSAGE |
+ * +------------------+------------------+--------++----------------+
+ */
+public class ZeroCopyNettyMessageDecoder extends ChannelInboundHandlerAdapter {
+
+	private static final int INITIAL_MESSAGE_HEADER_BUFFER_LENGTH = 128;
+
+	/** The parser to parse the message header. */
+	private final NettyMessageParser messageParser;
+
+	/** The buffer used to cumulate the frame header part. */
+	private ByteBuf frameHeaderBuffer;
+
+	/** The buffer used to receive the message header part. */
+	private ByteBuf messageHeaderBuffer;
+
+	/** Which part of the current message is being decoded. */
+	private DecodeStep decodeStep;
+
+	/** How many bytes have been decoded in current step. */
+	private int decodedBytesOfCurrentStep;
+
+	/** The intermediate state when decoding the current message. */
+	private final MessageDecodeIntermediateState intermediateState;
+
+	ZeroCopyNettyMessageDecoder(NettyMessageParser messageParser) {
+		this.messageParser = messageParser;
+		this.intermediateState = new MessageDecodeIntermediateState();
+	}
+
+	@Override
+	public void channelActive(ChannelHandlerContext ctx) throws Exception {
+		super.channelActive(ctx);
+
+		frameHeaderBuffer = ctx.alloc().directBuffer(NettyMessage.FRAME_HEADER_LENGTH);
+		messageHeaderBuffer = ctx.alloc().directBuffer(INITIAL_MESSAGE_HEADER_BUFFER_LENGTH);
+
+		decodeStep = DecodeStep.DECODING_FRAME;
+	}
+
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		super.channelInactive(ctx);
+
+		if (intermediateState.messageHeaderParseResult != null) {
+			Buffer buffer = intermediateState.messageHeaderParseResult.getTargetDataBuffer();
+
+			if (buffer != null) {
+				buffer.recycleBuffer();
+			}
+		}
+
+		clearState();
+
+		frameHeaderBuffer.release();
+		messageHeaderBuffer.release();
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		if (!(msg instanceof ByteBuf)) {
+			ctx.fireChannelRead(msg);
+			return;
+		}
+
+		ByteBuf data = (ByteBuf) msg;
+
+		try {
+			while (data.readableBytes() > 0) {
+				if (decodeStep == DecodeStep.DECODING_FRAME) {
+					ByteBuf toDecode = cumulateBufferIfNeeded(frameHeaderBuffer, data, FRAME_HEADER_LENGTH);
+
+					if (toDecode != null) {
+						decodeFrameHeader(toDecode);
+
+						decodedBytesOfCurrentStep = 0;
+						decodeStep = DecodeStep.DECODING_MESSAGE_HEADER;
+					}
+				}
+
+				if (decodeStep == DecodeStep.DECODING_MESSAGE_HEADER) {
+					ByteBuf toDecoder = cumulateBufferIfNeeded(messageHeaderBuffer, data, intermediateState.messageHeaderLength);
+
+					if (toDecoder != null) {
+						intermediateState.messageHeaderParseResult = messageParser.parseMessageHeader(intermediateState.msgId, toDecoder);
+
+						if (intermediateState.messageHeaderParseResult.getDataBufferAction() == NettyMessageParser.DataBufferAction.NO_DATA_BUFFER) {
+							ctx.fireChannelRead(intermediateState.messageHeaderParseResult.getParsedMessage());
+							clearState();
+						} else {
+							decodedBytesOfCurrentStep = 0;
+							decodeStep = DecodeStep.DECODING_BUFFER;
+						}
+					}
+				}
+
+				if (decodeStep == DecodeStep.DECODING_BUFFER) {
+					readOrDiscardBufferResponse(data);
+
+					if (decodedBytesOfCurrentStep == intermediateState.messageHeaderParseResult.getDataBufferSize()) {
+						ctx.fireChannelRead(intermediateState.messageHeaderParseResult.getParsedMessage());
+						clearState();
+					}
+				}
+			}
+
+			checkState(!data.isReadable(), "Not all data of the received buffer consumed.");
+		} finally {
+			data.release();
+		}
+	}
+
+	private void decodeFrameHeader(ByteBuf frameHeaderBuffer) {
+		int messageLength = frameHeaderBuffer.readInt();
+		checkState(messageLength >= 0, "The length field of current message must be non-negative");
+
+		int magicNumber = frameHeaderBuffer.readInt();
+		checkState(magicNumber == MAGIC_NUMBER, "Network stream corrupted: received incorrect magic number.");
+
+		intermediateState.msgId = frameHeaderBuffer.readByte();
+		intermediateState.messageHeaderLength = messageParser.getMessageHeaderLength(
+				messageLength - FRAME_HEADER_LENGTH,
+				intermediateState.msgId);
+	}
+
+	private void readOrDiscardBufferResponse(ByteBuf data) {
+		int dataBufferSize = intermediateState.messageHeaderParseResult.getDataBufferSize();
+
+		// If current buffer is empty, then there is no more data to receive.
+		if (dataBufferSize == 0) {
+			return;
+		}
+
+		NettyMessageParser.DataBufferAction dataBufferAction = intermediateState.messageHeaderParseResult.getDataBufferAction();
+		int remainingBufferSize = dataBufferSize - decodedBytesOfCurrentStep;
+
+		switch (dataBufferAction) {
+			case RECEIVE:
+				Buffer dataBuffer = intermediateState.messageHeaderParseResult.getTargetDataBuffer();
+				decodedBytesOfCurrentStep += copyToTargetBuffer(dataBuffer.asByteBuf(), data, remainingBufferSize);
+				break;
+			case DISCARD:
+				int actualBytesToDiscard = Math.min(data.readableBytes(), remainingBufferSize);
+				data.readerIndex(data.readerIndex() + actualBytesToDiscard);
+				decodedBytesOfCurrentStep += actualBytesToDiscard;
+				break;
+		}
+	}
+
+	private ByteBuf cumulateBufferIfNeeded(ByteBuf cumulatedBuffer, ByteBuf src, int size) {
+		int cumulatedSize = cumulatedBuffer.readableBytes();
+
+		if (cumulatedSize == 0) {
+			if (src.readableBytes() >= size) {
+				return src;
+			} else {
+				// The capacity will stop increasing after reaching the maximum value.
+				if (cumulatedBuffer.capacity() < size) {
+					cumulatedBuffer.capacity(size);
+				}
+			}
+		}
+
+		copyToTargetBuffer(cumulatedBuffer, src, size - cumulatedBuffer.readableBytes());
+
+		if (cumulatedBuffer.readableBytes() == size) {
+			return cumulatedBuffer;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Clears all the intermediate state for reading the next message.
+	 */
+	private void clearState() {
+		frameHeaderBuffer.clear();
+		messageHeaderBuffer.clear();
+
+		intermediateState.resetState();
+
+		decodedBytesOfCurrentStep = 0;
+		decodeStep = DecodeStep.DECODING_FRAME;
+	}
+
+	/**
+	 * Copies bytes from the src to dest, but do not exceed the capacity of the dest buffer.
+	 *
+	 * @param dest The ByteBuf to copy bytes to.
+	 * @param src The ByteBuf to copy bytes from.
+	 * @param maxCopySize Maximum size of bytes to copy.
+	 * @return The length of actually copied bytes.
+	 */
+	private int copyToTargetBuffer(ByteBuf dest, ByteBuf src, int maxCopySize) {
+		int copyLength = Math.min(src.readableBytes(), maxCopySize);
+		checkState(dest.writableBytes() >= copyLength,
+			"There is not enough space to copy " + copyLength + " bytes, writable = " + dest.writableBytes());
+
+		dest.writeBytes(src, copyLength);
+
+		return copyLength;
+	}
+
+	/**
+	 * Indicates which part of the current message is being decoded.
+	 */
+	private enum DecodeStep {
+		/** The frame header is under decoding. */
+		DECODING_FRAME,
+
+		/** The message header is under decoding. */
+		DECODING_MESSAGE_HEADER,
+
+		/** The data buffer part is under decoding. */
+		DECODING_BUFFER;
+	}
+
+	/**
+	 * The intermediate state produced when decoding the current message.
+	 */
+	private static class MessageDecodeIntermediateState {
+		/** The message id of current message. */
+		byte msgId = -1;
+
+		/** The length of message header part of current message */
+		int messageHeaderLength = -1;
+
+		/** The parse result of the message header part */
+		NettyMessageParser.MessageHeaderParseResult messageHeaderParseResult;
+
+		void resetState() {
+			msgId = -1;
+			messageHeaderLength = -1;
+			messageHeaderParseResult = null;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -18,32 +18,13 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
-import org.apache.flink.core.memory.MemorySegmentFactory;
-import org.apache.flink.runtime.event.task.IntegerTaskEvent;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
-import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
-import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
-import org.junit.Test;
-
-import java.util.Random;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 /**
- * Tests for the serialization and deserialization of the various {@link NettyMessage} sub-classes.
+ * Tests for the serialization and deserialization of the various {@link NettyMessage} sub-classes
+ * with the non-zero-copy netty handlers.
  */
-public class NettyMessageSerializationTest {
+public class NettyMessageSerializationTest extends NettyMessageSerializationTestBase {
 
 	public static final boolean RESTORE_OLD_NETTY_BEHAVIOUR = false;
 
@@ -51,140 +32,15 @@ public class NettyMessageSerializationTest {
 			new NettyMessage.NettyMessageEncoder(), // outbound messages
 			new NettyMessage.NettyMessageDecoder(RESTORE_OLD_NETTY_BEHAVIOUR)); // inbound messages
 
-	private final Random random = new Random();
-
-	@Test
-	public void testEncodeDecode() {
-		testEncodeDecodeBuffer(false);
-		testEncodeDecodeBuffer(true);
-
-		{
-			{
-				IllegalStateException expectedError = new IllegalStateException();
-				InputChannelID receiverId = new InputChannelID();
-
-				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError, receiverId);
-				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
-
-				assertEquals(expected.cause.getClass(), actual.cause.getClass());
-				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
-				assertEquals(receiverId, actual.receiverId);
-			}
-
-			{
-				IllegalStateException expectedError = new IllegalStateException("Illegal illegal illegal");
-				InputChannelID receiverId = new InputChannelID();
-
-				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError, receiverId);
-				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
-
-				assertEquals(expected.cause.getClass(), actual.cause.getClass());
-				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
-				assertEquals(receiverId, actual.receiverId);
-			}
-
-			{
-				IllegalStateException expectedError = new IllegalStateException("Illegal illegal illegal");
-
-				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError);
-				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
-
-				assertEquals(expected.cause.getClass(), actual.cause.getClass());
-				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
-				assertNull(actual.receiverId);
-				assertTrue(actual.isFatalError());
-			}
-		}
-
-		{
-			NettyMessage.PartitionRequest expected = new NettyMessage.PartitionRequest(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(), new InputChannelID(), random.nextInt());
-			NettyMessage.PartitionRequest actual = encodeAndDecode(expected);
-
-			assertEquals(expected.partitionId, actual.partitionId);
-			assertEquals(expected.queueIndex, actual.queueIndex);
-			assertEquals(expected.receiverId, actual.receiverId);
-			assertEquals(expected.credit, actual.credit);
-		}
-
-		{
-			NettyMessage.TaskEventRequest expected = new NettyMessage.TaskEventRequest(new IntegerTaskEvent(random.nextInt()), new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), new InputChannelID());
-			NettyMessage.TaskEventRequest actual = encodeAndDecode(expected);
-
-			assertEquals(expected.event, actual.event);
-			assertEquals(expected.partitionId, actual.partitionId);
-			assertEquals(expected.receiverId, actual.receiverId);
-		}
-
-		{
-			NettyMessage.CancelPartitionRequest expected = new NettyMessage.CancelPartitionRequest(new InputChannelID());
-			NettyMessage.CancelPartitionRequest actual = encodeAndDecode(expected);
-
-			assertEquals(expected.receiverId, actual.receiverId);
-		}
-
-		{
-			NettyMessage.CloseRequest expected = new NettyMessage.CloseRequest();
-			NettyMessage.CloseRequest actual = encodeAndDecode(expected);
-
-			assertEquals(expected.getClass(), actual.getClass());
-		}
-
-		{
-			NettyMessage.AddCredit expected = new NettyMessage.AddCredit(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(Integer.MAX_VALUE) + 1, new InputChannelID());
-			NettyMessage.AddCredit actual = encodeAndDecode(expected);
-
-			assertEquals(expected.partitionId, actual.partitionId);
-			assertEquals(expected.credit, actual.credit);
-			assertEquals(expected.receiverId, actual.receiverId);
-		}
+	@Override
+	public EmbeddedChannel getChannel() {
+		return channel;
 	}
 
-	private void testEncodeDecodeBuffer(boolean testReadOnlyBuffer) {
-		NetworkBuffer buffer = new NetworkBuffer(MemorySegmentFactory.allocateUnpooledSegment(1024), FreeingBufferRecycler.INSTANCE);
-
-		for (int i = 0; i < 1024; i += 4) {
-			buffer.writeInt(i);
-		}
-
-		Buffer testBuffer = testReadOnlyBuffer ? buffer.readOnlySlice() : buffer;
-
-		NettyMessage.BufferResponse expected = new NettyMessage.BufferResponse(
-			testBuffer, random.nextInt(), new InputChannelID(), random.nextInt());
-		NettyMessage.BufferResponse actual = encodeAndDecode(expected);
-
+	@Override
+	public boolean bufferIsReleasedOnDecoding() {
 		// Netty 4.1 is not copying the messages, but retaining slices of them. BufferResponse actual is in this case
 		// holding a reference to the buffer. Buffer will be recycled only once "actual" will be released.
-		assertFalse(buffer.isRecycled());
-		assertFalse(testBuffer.isRecycled());
-
-		final ByteBuf retainedSlice = actual.getNettyBuffer();
-
-		// Ensure not recycled and same size as original buffer
-		assertEquals(1, retainedSlice.refCnt());
-		assertEquals(1024, retainedSlice.readableBytes());
-
-		for (int i = 0; i < 1024; i += 4) {
-			assertEquals(i, retainedSlice.readInt());
-		}
-
-		// Release the retained slice
-		actual.releaseBuffer();
-		assertEquals(0, retainedSlice.refCnt());
-		assertTrue(buffer.isRecycled());
-		assertTrue(testBuffer.isRecycled());
-
-		assertEquals(expected.sequenceNumber, actual.sequenceNumber);
-		assertEquals(expected.receiverId, actual.receiverId);
-		assertEquals(expected.backlog, actual.backlog);
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T extends NettyMessage> T encodeAndDecode(T msg) {
-		channel.writeOutbound(msg);
-		ByteBuf encoded = (ByteBuf) channel.readOutbound();
-
-		assertTrue(channel.writeInbound(encoded));
-
-		return (T) channel.readInbound();
+		return false;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTestBase.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.event.task.IntegerTaskEvent;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the serialization and deserialization of the various {@link NettyMessage} sub-classes.
+ */
+public abstract class NettyMessageSerializationTestBase {
+	private final Random random = new Random();
+
+	public abstract EmbeddedChannel getChannel();
+
+	public abstract boolean bufferIsReleasedOnDecoding();
+
+	@Test
+	public void testEncodeDecode() {
+		testEncodeDecodeBuffer(false);
+		testEncodeDecodeBuffer(true);
+
+		{
+			{
+				IllegalStateException expectedError = new IllegalStateException();
+				InputChannelID receiverId = new InputChannelID();
+
+				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError, receiverId);
+				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
+
+				assertEquals(expected.cause.getClass(), actual.cause.getClass());
+				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
+				assertEquals(receiverId, actual.receiverId);
+			}
+
+			{
+				IllegalStateException expectedError = new IllegalStateException("Illegal illegal illegal");
+				InputChannelID receiverId = new InputChannelID();
+
+				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError, receiverId);
+				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
+
+				assertEquals(expected.cause.getClass(), actual.cause.getClass());
+				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
+				assertEquals(receiverId, actual.receiverId);
+			}
+
+			{
+				IllegalStateException expectedError = new IllegalStateException("Illegal illegal illegal");
+
+				NettyMessage.ErrorResponse expected = new NettyMessage.ErrorResponse(expectedError);
+				NettyMessage.ErrorResponse actual = encodeAndDecode(expected);
+
+				assertEquals(expected.cause.getClass(), actual.cause.getClass());
+				assertEquals(expected.cause.getMessage(), actual.cause.getMessage());
+				assertNull(actual.receiverId);
+				assertTrue(actual.isFatalError());
+			}
+		}
+
+		{
+			NettyMessage.PartitionRequest expected = new NettyMessage.PartitionRequest(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(), new InputChannelID(), random.nextInt());
+			NettyMessage.PartitionRequest actual = encodeAndDecode(expected);
+
+			assertEquals(expected.partitionId, actual.partitionId);
+			assertEquals(expected.queueIndex, actual.queueIndex);
+			assertEquals(expected.receiverId, actual.receiverId);
+			assertEquals(expected.credit, actual.credit);
+		}
+
+		{
+			NettyMessage.TaskEventRequest expected = new NettyMessage.TaskEventRequest(new IntegerTaskEvent(random.nextInt()), new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), new InputChannelID());
+			NettyMessage.TaskEventRequest actual = encodeAndDecode(expected);
+
+			assertEquals(expected.event, actual.event);
+			assertEquals(expected.partitionId, actual.partitionId);
+			assertEquals(expected.receiverId, actual.receiverId);
+		}
+
+		{
+			NettyMessage.CancelPartitionRequest expected = new NettyMessage.CancelPartitionRequest(new InputChannelID());
+			NettyMessage.CancelPartitionRequest actual = encodeAndDecode(expected);
+
+			assertEquals(expected.receiverId, actual.receiverId);
+		}
+
+		{
+			NettyMessage.CloseRequest expected = new NettyMessage.CloseRequest();
+			NettyMessage.CloseRequest actual = encodeAndDecode(expected);
+
+			assertEquals(expected.getClass(), actual.getClass());
+		}
+
+		{
+			NettyMessage.AddCredit expected = new NettyMessage.AddCredit(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(Integer.MAX_VALUE) + 1, new InputChannelID());
+			NettyMessage.AddCredit actual = encodeAndDecode(expected);
+
+			assertEquals(expected.partitionId, actual.partitionId);
+			assertEquals(expected.credit, actual.credit);
+			assertEquals(expected.receiverId, actual.receiverId);
+		}
+	}
+
+	private void testEncodeDecodeBuffer(boolean testReadOnlyBuffer) {
+		NetworkBuffer buffer = new NetworkBuffer(MemorySegmentFactory.allocateUnpooledSegment(1024), FreeingBufferRecycler.INSTANCE);
+
+		for (int i = 0; i < 1024; i += 4) {
+			buffer.writeInt(i);
+		}
+
+		Buffer testBuffer = testReadOnlyBuffer ? buffer.readOnlySlice() : buffer;
+
+		NettyMessage.BufferResponse expected = new NettyMessage.BufferResponse<>(
+			new NettyMessage.FlinkBufferHolder(testBuffer),
+			testBuffer.isBuffer(),
+			random.nextInt(),
+			new InputChannelID(),
+			random.nextInt());
+		NettyMessage.BufferResponse actual = encodeAndDecode(expected);
+
+		if (!bufferIsReleasedOnDecoding()) {
+			assertFalse(buffer.isRecycled());
+			assertFalse(testBuffer.isRecycled());
+		} else {
+			assertTrue(buffer.isRecycled());
+			assertTrue(testBuffer.isRecycled());
+		}
+
+		final ByteBuf retainedSlice = actual.asByteBuf();
+
+		// Ensure not recycled and same size as original buffer
+		assertEquals(1, retainedSlice.refCnt());
+		assertEquals(1024, retainedSlice.readableBytes());
+
+		for (int i = 0; i < 1024; i += 4) {
+			assertEquals(i, retainedSlice.readInt());
+		}
+
+		// Release the retained slice
+		actual.releaseBuffer();
+		assertEquals(0, retainedSlice.refCnt());
+		assertTrue(buffer.isRecycled());
+		assertTrue(testBuffer.isRecycled());
+
+		assertEquals(expected.sequenceNumber, actual.sequenceNumber);
+		assertEquals(expected.receiverId, actual.receiverId);
+		assertEquals(expected.backlog, actual.backlog);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T extends NettyMessage> T encodeAndDecode(T msg) {
+		EmbeddedChannel channel = getChannel();
+		channel.writeOutbound(msg);
+		ByteBuf encoded = channel.readOutbound();
+		assertTrue(channel.writeInbound(encoded));
+		return (T) channel.readInbound();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -289,7 +289,12 @@ public class PartitionRequestClientHandlerTest {
 			int backlog) throws IOException {
 
 		// Mock buffer to serialize
-		BufferResponse resp = new BufferResponse(buffer, sequenceNumber, receivingChannelId, backlog);
+		BufferResponse resp = new BufferResponse<>(
+				new NettyMessage.FlinkBufferHolder(buffer),
+				buffer.isBuffer(),
+				sequenceNumber,
+				receivingChannelId,
+				backlog);
 
 		ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ZeroCopyNettyMessageDecoderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ZeroCopyNettyMessageDecoderTest.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.util.TestTaskEvent;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.PooledByteBufAllocator;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.flink.runtime.io.network.netty.PartitionRequestClientHandlerTest.createRemoteInputChannel;
+import static org.apache.flink.runtime.io.network.netty.PartitionRequestClientHandlerTest.createSingleInputGate;
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests the zero copy message decoder.
+ */
+public class ZeroCopyNettyMessageDecoderTest {
+	private static final PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator();
+
+	private static final InputChannelID NORMAL_INPUT_CHANNEL_ID = new InputChannelID();
+	private static final InputChannelID RELEASED_INPUT_CHANNEL_ID = new InputChannelID();
+
+	/**
+	 * Verifies that the message decoder works well for the upstream netty handler pipeline.
+	 */
+	@Test
+	public void testUpstreamMessageDecoder() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(new ZeroCopyNettyMessageDecoder(new NoDataBufferMessageParser()));
+		NettyMessage[] messages = new NettyMessage[]{
+			new NettyMessage.PartitionRequest(new ResultPartitionID(), 1, NORMAL_INPUT_CHANNEL_ID, 2),
+			new NettyMessage.TaskEventRequest(new TestTaskEvent(), new ResultPartitionID(), NORMAL_INPUT_CHANNEL_ID),
+			new NettyMessage.CloseRequest(),
+			new NettyMessage.CancelPartitionRequest(NORMAL_INPUT_CHANNEL_ID),
+			new NettyMessage.AddCredit(new ResultPartitionID(), 2, NORMAL_INPUT_CHANNEL_ID),
+		};
+
+        // Segment points:
+        // +--------+--------+--------+-----------+-----------+
+        // |        |        |        |           |           |
+        // +--------+--------+--------+-----------+-----------+
+        // 0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15
+		ByteBuf[] splitBuffers = segmentMessages(messages, 3, new int[] {
+			1, 7, 11, 14
+		});
+		readInputAndVerify(channel, splitBuffers, messages);
+
+		splitBuffers = segmentMessages(messages, 3, new int[] {
+			1, 4, 7, 9, 12, 14
+		});
+		readInputAndVerify(channel, splitBuffers, messages);
+	}
+
+	/**
+	 * Verifies that the message decoder works well for the downstream netty handler pipeline.
+	 */
+	@Test
+	public void testDownstreamMessageDecode() throws Exception {
+		// 8 buffers required for running 2 rounds and 4 buffers each round.
+
+		EmbeddedChannel channel = new EmbeddedChannel(
+				new ZeroCopyNettyMessageDecoder(new BufferResponseAndNoDataBufferMessageParser(
+				        new NetworkBufferAllocator(createPartitionRequestClientHandler(8)))));
+
+		NettyMessage[] messages = new NettyMessage[]{
+		    createBufferResponse(128, true, 0, NORMAL_INPUT_CHANNEL_ID, 4),
+            createBufferResponse(256, true, 1, NORMAL_INPUT_CHANNEL_ID, 3),
+            createBufferResponse(32, false, 2, NORMAL_INPUT_CHANNEL_ID, 4),
+            new NettyMessage.ErrorResponse(new EquableException("test"), NORMAL_INPUT_CHANNEL_ID),
+            createBufferResponse(56, true, 3, NORMAL_INPUT_CHANNEL_ID, 4)
+		};
+
+		// Segment points of the above five messages are
+        // +--------+--------+--------+-----------+-----------+
+        // |        |        |        |           |           |
+        // +--------+--------+--------+-----------+-----------+
+        // 0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15
+		ByteBuf[] splitBuffers = segmentMessages(messages, 3, new int[] {
+			1, 7, 11, 14
+		});
+		readInputAndVerify(channel, splitBuffers, messages);
+
+		splitBuffers = segmentMessages(messages, 3, new int[] {
+			1, 4, 7, 9, 12, 14
+		});
+		readInputAndVerify(channel, splitBuffers, messages);
+	}
+
+	/**
+	 * Verifies that NettyMessageDecoder works well with buffers sent to a released channel.
+	 * For such a channel, no Buffer is available to receive the data buffer in the message,
+	 * and the data buffer part should be discarded before reading the next message.
+	 */
+	@Test
+	public void testDownstreamMessageDecodeWithReleasedInputChannel() throws Exception {
+		// 6 buffers required for running 2 rounds and 3 buffers each round.
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new ZeroCopyNettyMessageDecoder(new BufferResponseAndNoDataBufferMessageParser(
+                        new NetworkBufferAllocator(createPartitionRequestClientHandler(6)))));
+
+		NettyMessage[] messages = new NettyMessage[]{
+                createBufferResponse(128, true, 0, NORMAL_INPUT_CHANNEL_ID, 4),
+                createBufferResponse(256, true, 1, RELEASED_INPUT_CHANNEL_ID, 3),
+                createBufferResponse(32, false, 2, NORMAL_INPUT_CHANNEL_ID, 4),
+                new NettyMessage.ErrorResponse(new EquableException("test"), RELEASED_INPUT_CHANNEL_ID),
+                createBufferResponse(64, false,3, NORMAL_INPUT_CHANNEL_ID, 4),
+		};
+
+        // Segment points of the above five messages are
+        // +--------+--------+--------+-----------+-----------+
+        // |        |        |        |           |           |
+        // +--------+--------+--------+-----------+-----------+
+        // 0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15
+		ByteBuf[] splitBuffers = segmentMessages(messages, 3, new int[]{
+			1, 4, 7, 9, 12, 14
+		});
+		readInputAndVerify(channel, splitBuffers, messages);
+
+		splitBuffers = segmentMessages(messages, 3, new int[]{
+			1, 3, 4, 5, 7, 10, 13
+		});
+		readInputAndVerify(channel, splitBuffers, messages);
+	}
+
+	//------------------------------------------------------------------------------------------------------------------
+
+	private void readInputAndVerify(EmbeddedChannel channel, ByteBuf[] inputBuffers, NettyMessage[] expected) {
+		for (ByteBuf buffer : inputBuffers) {
+			channel.writeInbound(buffer);
+		}
+
+		channel.runPendingTasks();
+
+		List<NettyMessage> decodedMessages = new ArrayList<>();
+		Object input;
+		while ((input = channel.readInbound()) != null) {
+			assertTrue(input instanceof NettyMessage);
+			decodedMessages.add((NettyMessage) input);
+		}
+
+		assertEquals(expected.length, decodedMessages.size());
+		for (int i = 0; i < expected.length; ++i) {
+			assertEquals(expected[i].getClass(), decodedMessages.get(i).getClass());
+
+			if (expected[i] instanceof NettyMessage.AddCredit ||
+                expected[i] instanceof NettyMessage.PartitionRequest ||
+                expected[i] instanceof NettyMessage.TaskEventRequest ||
+                expected[i] instanceof NettyMessage.CancelPartitionRequest ||
+                expected[i] instanceof NettyMessage.CloseRequest ||
+                expected[i] instanceof NettyMessage.ErrorResponse) {
+
+				assertTrue("Received different message, expected is " + expected[i] + ", actual is " + decodedMessages.get(i),
+                        EqualsBuilder.reflectionEquals(expected[i], decodedMessages.get(i)));
+			} else if (expected[i] instanceof NettyMessage.BufferResponse) {
+				assertEquals(((NettyMessage.BufferResponse) expected[i]).backlog, ((NettyMessage.BufferResponse) decodedMessages.get(i)).backlog);
+				assertEquals(((NettyMessage.BufferResponse) expected[i]).sequenceNumber, ((NettyMessage.BufferResponse) decodedMessages.get(i)).sequenceNumber);
+                assertEquals(((NettyMessage.BufferResponse) expected[i]).isBuffer, ((NettyMessage.BufferResponse) decodedMessages.get(i)).isBuffer);
+				assertEquals(((NettyMessage.BufferResponse) expected[i]).bufferSize, ((NettyMessage.BufferResponse) decodedMessages.get(i)).bufferSize);
+				assertEquals(((NettyMessage.BufferResponse) expected[i]).receiverId, ((NettyMessage.BufferResponse) decodedMessages.get(i)).receiverId);
+
+				if (((NettyMessage.BufferResponse) expected[i]).receiverId.equals(RELEASED_INPUT_CHANNEL_ID)) {
+					assertNull(((NettyMessage.BufferResponse) decodedMessages.get(i)).getBuffer());
+				} else {
+					assertEquals(((NettyMessage.BufferResponse) expected[i]).getBuffer(), ((NettyMessage.BufferResponse) decodedMessages.get(i)).getBuffer());
+				}
+			} else {
+				fail("Unsupported message type");
+			}
+		}
+	}
+
+	/**
+	 * Segments the serialized buffer of the messages. This method first segments each message into
+	 * numberOfSegmentsEachMessage parts, and number all the boundary and inner segment points from
+	 * 0. Then the segment points whose index is in the segmentPointIndex are used to segment
+	 * the serialized buffer.
+	 *
+	 * <p>For example, suppose there are 3 messages and numberOfSegmentsEachMessage is 3,
+	 * then all the available segment points are:
+	 *
+	 * <pre>
+	 * +---------------+---------------+-------------------+
+	 * |               |               |                   |
+	 * +---------------+---------------+-------------------+
+	 * 0    1     2    3    4    5     6     7       8     9
+	 * </pre>
+	 *
+	 * @param messages The messages to be serialized and segmented.
+	 * @param numberOfSegmentsEachMessage How much parts each message is segmented into.
+	 * @param segmentPointIndex The chosen segment points.
+	 * @return The segmented ByteBuf.
+	 */
+	private ByteBuf[] segmentMessages(NettyMessage[] messages, int numberOfSegmentsEachMessage, int[] segmentPointIndex) throws Exception {
+		List<Integer> segmentPoints = new ArrayList<>();
+		ByteBuf allData = ALLOCATOR.buffer();
+
+		int startBytesOfCurrentMessage = 0;
+		for (NettyMessage message : messages) {
+			ByteBuf buf = message.write(ALLOCATOR);
+
+			// Records the position of each segments point.
+			int length = buf.readableBytes();
+
+			for (int i = 0; i < numberOfSegmentsEachMessage; ++i) {
+				segmentPoints.add(startBytesOfCurrentMessage + length * i / numberOfSegmentsEachMessage);
+			}
+
+			allData.writeBytes(buf);
+			startBytesOfCurrentMessage += length;
+		}
+
+		// Adds the last segment point.
+		segmentPoints.add(allData.readableBytes());
+
+		// Segments the serialized buffer according to the segment points.
+		List<ByteBuf> segmentedBuffers = new ArrayList<>();
+
+		for (int i = 0; i <= segmentPointIndex.length; ++i) {
+			ByteBuf buf = ALLOCATOR.buffer();
+
+			int startPos = (i == 0 ? 0 : segmentPoints.get(segmentPointIndex[i - 1]));
+			int endPos = (i == segmentPointIndex.length ? segmentPoints.get(segmentPoints.size() - 1) : segmentPoints.get(segmentPointIndex[i]));
+
+			checkState(startPos == allData.readerIndex());
+
+			buf.writeBytes(allData, endPos - startPos);
+			segmentedBuffers.add(buf);
+		}
+
+		checkState(!allData.isReadable());
+		return segmentedBuffers.toArray(new ByteBuf[0]);
+	}
+
+	private NettyMessage.BufferResponse<Buffer> createBufferResponse(
+	        int size,
+            boolean isBuffer,
+            int sequenceNumber,
+            InputChannelID receiverID,
+            int backlog) {
+
+	    MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
+        NetworkBuffer buffer = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
+        for (int i = 0; i < size / 4; ++i) {
+            buffer.writeInt(i);
+        }
+
+        if (!isBuffer) {
+            buffer.tagAsEvent();
+        }
+
+        return new NettyMessage.BufferResponse<>(
+                new NettyMessage.FlinkBufferHolder(buffer),
+                isBuffer,
+                sequenceNumber,
+                receiverID,
+                backlog);
+    }
+
+	private CreditBasedPartitionRequestClientHandler createPartitionRequestClientHandler(int numberOfBuffersInNormalChannel) throws Exception {
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(
+				numberOfBuffersInNormalChannel,
+				32 * 1024);
+
+		final SingleInputGate inputGate = createSingleInputGate();
+
+		final RemoteInputChannel normalInputChannel = spy(createRemoteInputChannel(inputGate));
+		when(normalInputChannel.getInputChannelId()).thenReturn(NORMAL_INPUT_CHANNEL_ID);
+
+		// Assign exclusive segments before add the released input channel so that the
+		// released input channel will return null when requesting buffers. This will
+		// test the process of discarding the data buffer.
+		inputGate.assignExclusiveSegments(networkBufferPool, numberOfBuffersInNormalChannel);
+
+		final RemoteInputChannel releasedInputChannel = spy(createRemoteInputChannel(inputGate));
+		when(releasedInputChannel.getInputChannelId()).thenReturn(RELEASED_INPUT_CHANNEL_ID);
+		when(releasedInputChannel.isReleased()).thenReturn(true);
+
+		CreditBasedPartitionRequestClientHandler handler = new CreditBasedPartitionRequestClientHandler();
+		handler.addInputChannel(normalInputChannel);
+		handler.addInputChannel(releasedInputChannel);
+
+		return handler;
+	}
+
+    /**
+     * A specialized exception who compares two objects by comparing the messages.
+     */
+	private static class EquableException extends RuntimeException {
+        EquableException(String message) {
+            super(message);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof EquableException)) {
+                return false;
+            }
+
+            return getMessage().equals(((EquableException) obj).getMessage());
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ZeroCopyNettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ZeroCopyNettyMessageSerializationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests for the serialization and deserialization of the various {@link NettyMessage} sub-classes with
+ * the zero-copy netty handlers.
+ */
+public class ZeroCopyNettyMessageSerializationTest extends NettyMessageSerializationTestBase {
+	private final EmbeddedChannel channel = new EmbeddedChannel(
+			new NettyMessage.NettyMessageEncoder(), // outbound messages
+			new ZeroCopyNettyMessageDecoder(new BufferResponseAndNoDataBufferMessageParser(
+					new NetworkBufferAllocator(createPartitionRequestClientHandler()))));
+
+	@Override
+	public EmbeddedChannel getChannel() {
+		return channel;
+	}
+
+	@Override
+	public boolean bufferIsReleasedOnDecoding() {
+		// For ZeroCopyMessageDecoder, the input buffer will be copied to the input channels directly and thus the
+		// input channel will be released.
+		return true;
+	}
+
+	private CreditBasedPartitionRequestClientHandler createPartitionRequestClientHandler() {
+		CreditBasedPartitionRequestClientHandler handler = mock(CreditBasedPartitionRequestClientHandler.class);
+
+		RemoteInputChannel inputChannel = mock(RemoteInputChannel.class);
+		when(inputChannel.requestBuffer()).thenAnswer(new Answer<Buffer>() {
+			@Override
+			public Buffer answer(InvocationOnMock invocationOnMock) throws Throwable {
+				return new NetworkBuffer(MemorySegmentFactory.allocateUnpooledSegment(1024), FreeingBufferRecycler.INSTANCE);
+			}
+		});
+		when(handler.getInputChannel(any(InputChannelID.class))).thenReturn(inputChannel);
+
+		return handler;
+	}
+}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This PR aims to add the zero-copy decoder for the receiver side of the network stack. The new decoder copies the buffer part of BufferResponse directly into the Flink Buffer instead of cumulating the message with the Netty ByteBuf first.  This helps to reduce the copy actions caused by cumulating messages and decrease the memory usage of the Netty pipeline.*

## Brief change log

- *Add a new ZeroCopyMessageDecoder for the receiver side*
- *Make the max-order of the NettyBufferPool configurable, and change its default value from 11 to 9, which decrease the chunk size from 16M to 4M*


## Verifying this change

This change added tests and can be verified as follows:
- *Extends the existing NettyMessageSerializationTest to cover the new decoder*
- *Add ZeroCopyNettyMessageDecoderTest to validate that the  new decoder can process different messages rightly with the input buffers segmented in different ways*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
