### PR TITLE
[FLINK-11224][scala-shell] Log is missing in scala-shell

### DIFF
--- a/flink-scala-shell/start-script/start-scala-shell.sh
+++ b/flink-scala-shell/start-script/start-scala-shell.sh
@@ -82,14 +82,25 @@ do
     fi
 done
 
-log_setting=""
-
-if [[ $1 = "yarn" ]]
-then
-FLINK_CLASSPATH=$FLINK_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR
-log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-scala-shell-yarn-$HOSTNAME.log
-log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-yarn-session.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback-yarn.xml"
+if [ "$FLINK_IDENT_STRING" = "" ]; then
+        FLINK_IDENT_STRING="$USER"
 fi
+
+MODE=$1
+LOG=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-scala-shell-$MODE-$HOSTNAME.log
+
+if [[ ($MODE = "local") || ($MODE = "remote") ]]
+then
+    LOG4J_CONFIG=log4j.properties
+    LOGBACK_CONFIG=logback.xml
+elif [[ $1 = "yarn" ]]
+then
+    LOG4J_CONFIG=log4j-yarn-session.properties
+    LOGBACK_CONFIG=logback-yarn.xml
+    FLINK_CLASSPATH=$FLINK_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR
+fi
+
+log_setting="-Dlog.file="$LOG" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/$LOG4J_CONFIG -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/$LOGBACK_CONFIG"
 
 if ${EXTERNAL_LIB_FOUND}
 then


### PR DESCRIPTION
## What is the purpose of the change

Currently log is only displayed in yarn mode, but not local and yarn mode. This is to fix the issue that log is missing in scala-shell due to incorrect configuration. 

## Brief change log

Add right log configuration for local and remote mode.


## Verifying this change

Run scala shell in local and remote mode, and check the log file is generated correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
