### PR TITLE
[FLINK-11227] [table] The DescriptorProperties contains some bounds checking errors

### DIFF
--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -938,7 +938,7 @@ public class DescriptorProperties {
 		}
 
 		// validate
-		for (int i = 0; i < maxIndex; i++) {
+		for (int i = 0; i <= maxIndex; i++) {
 			for (Map.Entry<String, Consumer<String>> subKey : subKeyValidation.entrySet()) {
 				final String fullKey = key + '.' + i + '.' + subKey.getKey();
 				if (properties.containsKey(fullKey)) {
@@ -1134,7 +1134,7 @@ public class DescriptorProperties {
 		}
 
 		// validate array elements
-		for (int i = 0; i < maxIndex; i++) {
+		for (int i = 0; i <= maxIndex; i++) {
 			final String fullKey = key + '.' + i;
 			if (properties.containsKey(fullKey)) {
 				// run validation logic

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/DescriptorPropertiesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/DescriptorPropertiesTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.descriptors
 
 import java.util
 import java.util.Collections
+import java.util.function.Consumer
 
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.util.JavaScalaConversionUtil.toJava
@@ -32,6 +33,9 @@ import org.junit.Test
 class DescriptorPropertiesTest {
 
   private val ARRAY_KEY = "my-array"
+  private val FIXED_INDEXED_PROPERTY_KEY = "my-fixed-indexed-property"
+  private val PROPERTY_1_KEY = "property-1"
+  private val PROPERTY_2_KEY = "property-2"
 
   @Test
   def testEquals(): Unit = {
@@ -97,8 +101,8 @@ class DescriptorPropertiesTest {
   def testArrayInvalidValues(): Unit = {
     val properties = new DescriptorProperties()
     properties.putString(s"$ARRAY_KEY.0", "12")
-    properties.putString(s"$ARRAY_KEY.1", "INVALID")
-    properties.putString(s"$ARRAY_KEY.2", "66")
+    properties.putString(s"$ARRAY_KEY.1", "66")
+    properties.putString(s"$ARRAY_KEY.2", "INVALID")
 
     testArrayValidation(properties, 1, Integer.MAX_VALUE)
   }
@@ -116,6 +120,19 @@ class DescriptorPropertiesTest {
     val properties = new DescriptorProperties()
 
     testArrayValidation(properties, 1, Integer.MAX_VALUE)
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidFixedIndexedProperty(): Unit = {
+    val property = new DescriptorProperties()
+    val list = new util.ArrayList[util.List[String]]()
+    list.add(util.Arrays.asList("1", "string"))
+    list.add(util.Arrays.asList("INVALID", "string"))
+    property.putIndexedFixedProperties(
+      FIXED_INDEXED_PROPERTY_KEY,
+      util.Arrays.asList(PROPERTY_1_KEY, PROPERTY_2_KEY),
+      list)
+    testFixedFieldsValidation(property)
   }
 
   @Test
@@ -155,7 +172,7 @@ class DescriptorPropertiesTest {
       minLength: Int,
       maxLength: Int)
     : Unit = {
-    val validator: (String) => Unit = (key: String) => {
+    val validator: String => Unit = (key: String) => {
       properties.validateInt(key, false)
     }
 
@@ -164,5 +181,27 @@ class DescriptorPropertiesTest {
       toJava(validator),
       minLength,
       maxLength)
+  }
+
+  private def testFixedFieldsValidation(properties: DescriptorProperties): Unit = {
+
+    val validatorMap = new util.HashMap[String, Consumer[String]]()
+
+    // PROPERTY_1 should be Int
+    val validator1: String => Unit = (key: String) => {
+      properties.validateInt(key, false)
+    }
+    validatorMap.put(PROPERTY_1_KEY, toJava(validator1))
+    // PROPERTY_2 should be String
+    val validator2: String => Unit = (key: String) => {
+      properties.validateString(key, false)
+    }
+    validatorMap.put(PROPERTY_2_KEY, toJava(validator2))
+
+    properties.validateFixedIndexedProperties(
+      FIXED_INDEXED_PROPERTY_KEY,
+      false,
+      validatorMap
+    )
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/DescriptorPropertiesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/DescriptorPropertiesTest.scala
@@ -123,7 +123,7 @@ class DescriptorPropertiesTest {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testInvalidFixedIndexedProperty(): Unit = {
+  def testInvalidFixedIndexedProperties(): Unit = {
     val property = new DescriptorProperties()
     val list = new util.ArrayList[util.List[String]]()
     list.add(util.Arrays.asList("1", "string"))
@@ -132,7 +132,7 @@ class DescriptorPropertiesTest {
       FIXED_INDEXED_PROPERTY_KEY,
       util.Arrays.asList(PROPERTY_1_KEY, PROPERTY_2_KEY),
       list)
-    testFixedFieldsValidation(property)
+    testFixedIndexedPropertiesValidation(property)
   }
 
   @Test
@@ -183,7 +183,7 @@ class DescriptorPropertiesTest {
       maxLength)
   }
 
-  private def testFixedFieldsValidation(properties: DescriptorProperties): Unit = {
+  private def testFixedIndexedPropertiesValidation(properties: DescriptorProperties): Unit = {
 
     val validatorMap = new util.HashMap[String, Consumer[String]]()
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix the bounds checking errors for `validateFixedIndexedProperties()` and `validateArray()` in `DescriptorProperties`.

## Brief change log

Change the upper bounds of the loops from `< maxIndex` to `<= maxIndex`.

## Verifying this change

1. To verify `validateArray()`, made the last element an invalid one.
2. To verify `validateFixedIndexedProperties()`, added a new test case `validateFixedIndexedProperties()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
