### PR TITLE
[FLINK-11173][table] Fix the exception message of proctime attribute validation in TableSourceUtil#validateTableSource

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
@@ -138,12 +138,12 @@ object TableSourceUtil {
         val proctimeIdx = schema.getFieldNames.indexOf(proctimeAttribute)
         // ensure that field exists
         if (proctimeIdx < 0) {
-          throw new ValidationException(s"Found a RowtimeAttributeDescriptor for field " +
+          throw new ValidationException(s"Found a processing time attribute: field " +
             s"'$proctimeAttribute' but field '$proctimeAttribute' does not exist in table.")
         }
         // ensure that field is of type TIMESTAMP
         if (schema.getFieldTypes()(proctimeIdx) != Types.SQL_TIMESTAMP) {
-          throw new ValidationException(s"Found a RowtimeAttributeDescriptor for field " +
+          throw new ValidationException(s"Found a processing time attribute: field " +
             s"'$proctimeAttribute' but field '$proctimeAttribute' is not of type TIMESTAMP.")
         }
       case _ => // nothing to validate


### PR DESCRIPTION

## What is the purpose of the change

 This pull request makes the exception message of proctime attribute validation in TableSourceUtil#validateTableSource correct.

## Brief change log
The exception message of proctime attribute validation in TableSourceUtil#validateTableSource was changed from "Found a RowtimeAttributeDescriptor for " to "Found a processing time attribute: ".

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no

