### PR TITLE
[FLINK-11175][docs][table] Fix the sample code describing the Processing tim…

### DIFF
--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -117,8 +117,8 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedProctime
 
 	@Override
 	public TypeInformation<Row> getReturnType() {
-		String[] names = new String[] {"Username" , "Data"};
-		TypeInformation[] types = new TypeInformation[] {Types.STRING(), Types.STRING()};
+		String[] names = new String[] {"Username" , "Data", "UserActionTime"};
+		TypeInformation[] types = new TypeInformation[] {Types.STRING(), Types.STRING(), Types.LONG()};
 		return Types.ROW(names, types);
 	}
 
@@ -150,8 +150,8 @@ WindowedTable windowedTable = tEnv
 class UserActionSource extends StreamTableSource[Row] with DefinedProctimeAttribute {
 
 	override def getReturnType = {
-		val names = Array[String]("Username" , "Data")
-		val types = Array[TypeInformation[_]](Types.STRING, Types.STRING)
+		val names = Array[String]("Username" , "Data", "UserActionTime")
+		val types = Array[TypeInformation[_]](Types.STRING, Types.STRING, Types.LONG)
 		Types.ROW(names, types)
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request corrects the sample code in Time Attributes docs.


## Brief change log
Explicitly specify the field name and type of the processing time attribute in the sample code describing the Processing time used in TableSource in Time Attributes docs.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector:  no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not documented
