### PR TITLE
[FLINK-11119][docs] Correct Scala example for Table Function in User-…

### DIFF
--- a/docs/dev/table/udfs.md
+++ b/docs/dev/table/udfs.md
@@ -190,7 +190,7 @@ tableEnv.sqlQuery("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(s
 class Split(separator: String) extends TableFunction[(String, Int)] {
   def eval(str: String): Unit = {
     // use collect(...) to emit a row.
-    str.split(separator).foreach(x -> collect((x, x.length))
+    str.split(separator).foreach(x => collect((x, x.length)))
   }
 }
 
@@ -210,7 +210,7 @@ tableEnv.registerFunction("split", new Split("#"))
 // CROSS JOIN a table function (equivalent to "join" in Table API)
 tableEnv.sqlQuery("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)) as T(word, length)")
 // LEFT JOIN a table function (equivalent to "leftOuterJoin" in Table API)
-tableEnv.sqlQuery("SELECT a, word, length FROM MyTable LEFT JOIN TABLE(split(a)) as T(word, length) ON TRUE")
+tableEnv.sqlQuery("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 {% endhighlight %}
 **IMPORTANT:** Do not implement TableFunction as a Scala object. Scala object is a singleton and will cause concurrency issues.
 </div>


### PR DESCRIPTION
## What is the purpose of the change

This pull request corrects Scala example for Table Function in User-defined Functions docs.

## Brief change log

Add "LATERAL" to sqlQuery string in Scala example for Table Function in User-defined Functions docs.
Correct Split#eval in  Scala example for Table Function in User-defined Functions docs.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
