### PR TITLE
[hotfix][docs] Fix incorrect example in cep doc

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1372,7 +1372,7 @@ Pattern: `a b+` and sequence: `a b1 b2 b3` Then the results will be:
         <td>After found matching <code>a b1</code>, the match process will not discard any result.</td>
     </tr>
     <tr>
-        <td><strong>SKIP_TO_NEXT</strong>[<code>b</code>]</td>
+        <td><strong>SKIP_TO_NEXT</strong></td>
         <td>
             <code>a b1</code><br>
         </td>

--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1324,7 +1324,7 @@ For example, for a given pattern `b+ c` and a data stream `b1 b2 b3 c`, the diff
 </table>
 
 Have a look also at another example to better see the difference between NO_SKIP and SKIP_TO_FIRST:
-Pattern: `(a | c) (b | c) c+.greedy d` and sequence: `a b c1 c2 c3 d` Then the results will be:
+Pattern: `(a | b | c) (b | c) c+.greedy d` and sequence: `a b c1 c2 c3 d` Then the results will be:
 
 
 <table class="table table-bordered">
@@ -1339,12 +1339,11 @@ Pattern: `(a | c) (b | c) c+.greedy d` and sequence: `a b c1 c2 c3 d` Then the r
             <code>a b c1 c2 c3 d</code><br>
             <code>b c1 c2 c3 d</code><br>
             <code>c1 c2 c3 d</code><br>
-            <code>c2 c3 d</code><br>
         </td>
         <td>After found matching <code>a b c1 c2 c3 d</code>, the match process will not discard any result.</td>
     </tr>
     <tr>
-        <td><strong>SKIP_TO_FIRST</strong>[<code>b*</code>]</td>
+        <td><strong>SKIP_TO_FIRST</strong>[<code>c*</code>]</td>
         <td>
             <code>a b c1 c2 c3 d</code><br>
             <code>c1 c2 c3 d</code><br>
@@ -1373,7 +1372,7 @@ Pattern: `a b+` and sequence: `a b1 b2 b3` Then the results will be:
         <td>After found matching <code>a b1</code>, the match process will not discard any result.</td>
     </tr>
     <tr>
-        <td><strong>SKIP_TO_NEXT</strong>[<code>b*</code>]</td>
+        <td><strong>SKIP_TO_NEXT</strong>[<code>b</code>]</td>
         <td>
             <code>a b1</code><br>
         </td>


### PR DESCRIPTION
## What is the purpose of the change

If I understand the Skip Strategy correctly, the example of the comparison between SKIP_TO_FIRST and NO_SKIP is incorrect in CEP doc. This PR try to fix it with minimal modification.

## Brief change log

- Fix incorrect example in cep doc

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts(**all no**):

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? no

cc @dawidwys 