### PR TITLE
[FLINK-10593][table, cep] Add support for ALL ROWS PER MATCH

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
@@ -181,20 +181,17 @@ class DataStreamMatch(
 
     val measures = logicalMatch.measures
     val outTypeInfo = CRowTypeInfo(schema.typeInfo)
-    if (logicalMatch.allRows) {
-      throw new TableException("All rows per match mode is not supported yet.")
-    } else {
-      val patternSelectFunction =
-        MatchCodeGenerator.generateOneRowPerMatchExpression(
-          config,
-          schema,
-          partitionKeys,
-          orderKeys,
-          measures,
-          inputTypeInfo,
-          patternNames.toSeq)
-      patternStream.flatSelect[CRow](patternSelectFunction, outTypeInfo)
-    }
+    val patternFlatSelectFunction =
+      MatchCodeGenerator.generatePatternFlatSelectFunction(
+        config,
+        schema,
+        partitionKeys,
+        orderKeys,
+        measures,
+        inputTypeInfo,
+        patternNames.toSeq,
+        logicalMatch.allRows)
+    patternStream.flatSelect[CRow](patternFlatSelectFunction, outTypeInfo)
   }
 
   private def translateOrder(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/MatchRecognizeValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/match/MatchRecognizeValidationTest.scala
@@ -180,29 +180,6 @@ class MatchRecognizeValidationTest extends TableTestBase {
   // ***************************************************************************************
 
   @Test
-  def testAllRowsPerMatch(): Unit = {
-    thrown.expectMessage("All rows per match mode is not supported yet.")
-    thrown.expect(classOf[TableException])
-
-    val sqlQuery =
-      s"""
-         |SELECT *
-         |FROM Ticker
-         |MATCH_RECOGNIZE (
-         |  ORDER BY proctime
-         |  MEASURES
-         |    A.symbol AS aSymbol
-         |  ALL ROWS PER MATCH
-         |  PATTERN (A B)
-         |  DEFINE
-         |    A AS symbol = 'a'
-         |) AS T
-         |""".stripMargin
-
-    streamUtils.tableEnv.sqlQuery(sqlQuery).toAppendStream[Row]
-  }
-
-  @Test
   def testGreedyQuantifierAtTheEndIsNotSupported(): Unit = {
     thrown.expectMessage("Greedy quantifiers are not allowed as the last element of a " +
       "Pattern yet. Finish your pattern with either a simple variable or reluctant quantifier.")


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds support for ALL ROWS PER MATCH*

## Brief change log

  - *Changes to use PatternFlatSelectFunction no matter ONE ROW PER MATCH or ALL ROWS PER MATCH  is used*
  - *Add support of ALL ROWS PER MATCH*
  - *Add the documentation for ALL ROWS PER MATCH*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests MatchRecognizeITCase#testAllRowsPerMatch*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
