### PR TITLE
[FLINK-11235] fix thread lack when elasticsearch transport client init failed

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.util.ElasticsearchUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.elasticsearch.action.bulk.BackoffPolicy;
@@ -72,6 +73,10 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge<T
 
 		// verify that we actually are connected to a cluster
 		if (transportClient.connectedNodes().isEmpty()) {
+
+			// close the transportClient here
+			IOUtils.closeQuietly(transportClient);
+
 			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
 		}
 

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.util.ElasticsearchUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.elasticsearch.action.bulk.BackoffPolicy;
@@ -78,6 +79,10 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 
 		// verify that we actually are connected to a cluster
 		if (transportClient.connectedNodes().isEmpty()) {
+
+			// close the transportClient here
+			IOUtils.closeQuietly(transportClient);
+
 			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

### elasticsearch transport sink init steps
1, create client thread
2, try to check every host:port
3, if each host:port is unreachable, while throw RuntimeException

but, because of throw RuntimeException, the client can not close, so causing thread leak

```
TransportClient transportClient = new PreBuiltTransportClient(settings);
for (TransportAddress transport : ElasticsearchUtils.convertInetSocketAddresses(transportAddresses)){
    transportClient.addTransportAddress(transport); 
}

// verify that we actually are connected to a cluster
if (transportClient.connectedNodes().isEmpty()) {
    throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
}

return transportClient;
```

### thread leak
![image](https://user-images.githubusercontent.com/20113411/50562654-acd9a400-0d50-11e9-925b-86f44a33d012.png)


## Brief change log
   close the client before throw RuntimeException

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
