### PR TITLE
[FLINK-11237] [table] Enhance LocalExecutor to wrap TableEnvironment w/ classloader

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -166,7 +166,7 @@ public class ExecutionContext<T> {
 
 	public EnvironmentInstance createEnvironmentInstance() {
 		try {
-			return new EnvironmentInstance();
+			return wrapClassLoader(EnvironmentInstance::new);
 		} catch (Throwable t) {
 			// catch everything such that a wrong environment does not affect invocations
 			throw new SqlExecutionException("Could not create environment instance.", t);

--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptor.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptor.java
@@ -68,7 +68,7 @@ public abstract class ConnectorDescriptor extends DescriptorBase implements Desc
 
 	/**
 	 * Converts this descriptor into a set of connector properties. Usually prefixed with
-	 * {@link FormatDescriptorValidator#FORMAT}.
+	 * {@link ConnectorDescriptorValidator#CONNECTOR}.
 	 */
 	protected abstract Map<String, String> toConnectorProperties();
 }

--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
@@ -27,6 +27,11 @@ import org.apache.flink.annotation.Internal;
 public abstract class ConnectorDescriptorValidator implements DescriptorValidator {
 
 	/**
+	 * Prefix for connector-related properties.
+	 */
+	public static final String CONNECTOR = "connector";
+
+	/**
 	 * Key for describing the type of the connector. Usually used for factory discovery.
 	 */
 	public static final String CONNECTOR_TYPE = "connector.type";

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -270,8 +270,8 @@ class ExternalCatalogTableBuilder(private val connectorDescriptor: ConnectorDesc
     * Explicitly declares this external table for supporting only batch environments.
     */
   def supportsBatch(): ExternalCatalogTableBuilder = {
-    isBatch = false
-    isStreaming = true
+    isBatch = true
+    isStreaming = false
     this
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/BatchTableSinkFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/BatchTableSinkFactory.scala
@@ -23,7 +23,7 @@ import java.util
 import org.apache.flink.table.sinks.BatchTableSink
 
 /**
-  * A factory to create configured table sink instances in a streaming environment based on
+  * A factory to create configured table sink instances in a batch environment based on
   * string-based properties. See also [[TableFactory]] for more information.
   *
   * @tparam T type of records that the factory consumes

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
@@ -85,7 +85,9 @@ object CommonTestData {
       .withSchema(schemaDesc1)
 
     if (isStreaming) {
-      externalTableBuilder1.inAppendMode()
+      externalTableBuilder1.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder1.supportsBatch()
     }
 
     val csvRecord2 = Seq(
@@ -126,7 +128,9 @@ object CommonTestData {
       .withSchema(schemaDesc2)
 
     if (isStreaming) {
-      externalTableBuilder2.inAppendMode()
+      externalTableBuilder2.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder2.supportsBatch()
     }
 
     val tempFilePath3 = writeToTempFile("", "csv-test3", "tmp")
@@ -145,7 +149,9 @@ object CommonTestData {
       .withSchema(schemaDesc3)
 
     if (isStreaming) {
-      externalTableBuilder3.inAppendMode()
+      externalTableBuilder3.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder3.supportsBatch()
     }
 
     val catalog = new InMemoryExternalCatalog("test")


### PR DESCRIPTION
## What is the purpose of the change

_This issue was discovered in the course of implementing FLINK-9172, which introduces catalogs to the SQL Client environment.   Catalogs are resolved to tables lazily, necessitating this patch._

The `LocalExecutor` calls into the table environment to execute queries, explain statements, and much more. Any call that involves resolving a descriptor to a factory implementation must be wrapped in the context classloader. Some of the calls already are wrapped (for resolving UDFs). With new functionality coming for resolving external catalogs with a descriptor (FLINK-9172), other call sites must be wrapped.

This PR wraps all calls from local executor to table environment, for consistency.   Seems wise to give the table environment maximum flexibility.

## Brief change log

- use the context classloader for all interactions with TableEnvironment

_Note: based on PR #7388; please ignore changes outside of `LocalExecutor` and `ExecutionContext` and focus on 963754098e7ff9388e669ae570cb3f71075e9bcd._


## Verifying this change

This change is already covered by existing tests, such as `DeploymentTest`, which exercises the `LocalExecutor`'s classloading.  Note that a subsequent PR will enhance `DeploymentTest` for more coverage (FLINK-9172).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? N/A
