### PR TITLE
[FLINK-11240] [table] External Catalog Factory and Descriptor

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -166,7 +166,7 @@ public class ExecutionContext<T> {
 
 	public EnvironmentInstance createEnvironmentInstance() {
 		try {
-			return new EnvironmentInstance();
+			return wrapClassLoader(EnvironmentInstance::new);
 		} catch (Throwable t) {
 			// catch everything such that a wrong environment does not affect invocations
 			throw new SqlExecutionException("Could not create environment instance.", t);

--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptor.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptor.java
@@ -68,7 +68,7 @@ public abstract class ConnectorDescriptor extends DescriptorBase implements Desc
 
 	/**
 	 * Converts this descriptor into a set of connector properties. Usually prefixed with
-	 * {@link FormatDescriptorValidator#FORMAT}.
+	 * {@link ConnectorDescriptorValidator#CONNECTOR}.
 	 */
 	protected abstract Map<String, String> toConnectorProperties();
 }

--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
@@ -27,6 +27,11 @@ import org.apache.flink.annotation.Internal;
 public abstract class ConnectorDescriptorValidator implements DescriptorValidator {
 
 	/**
+	 * Prefix for connector-related properties.
+	 */
+	public static final String CONNECTOR = "connector";
+
+	/**
 	 * Key for describing the type of the connector. Usually used for factory discovery.
 	 */
 	public static final String CONNECTOR_TYPE = "connector.type";

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptor.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Map;
+
+import static  org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static  org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_TYPE;
+
+/**
+ * Describes a external catalog of tables, views, and functions.
+ */
+@PublicEvolving
+public abstract class ExternalCatalogDescriptor extends DescriptorBase implements Descriptor {
+
+	private final String type;
+
+	private final int version;
+
+	/**
+	 * Constructs a {@link ExternalCatalogDescriptor}.
+	 *
+	 * @param type string that identifies this catalog
+	 * @param version property version for backwards compatibility
+	 */
+	public ExternalCatalogDescriptor(String type, int version) {
+		this.type = type;
+		this.version = version;
+	}
+
+	@Override
+	public final Map<String, String> toProperties() {
+		final DescriptorProperties properties = new DescriptorProperties();
+		properties.putString(CATALOG_TYPE, type);
+		properties.putLong(CATALOG_PROPERTY_VERSION, version);
+		properties.putProperties(toCatalogProperties());
+		return properties.asMap();
+	}
+
+	/**
+	 * Converts this descriptor into a set of catalog properties.
+	 */
+	protected abstract Map<String, String> toCatalogProperties();
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorValidator.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Validator for {@link ExternalCatalogDescriptor}.
+ */
+@Internal
+public abstract class ExternalCatalogDescriptorValidator implements DescriptorValidator {
+
+	/**
+	 * Key for describing the type of the catalog. Usually used for factory discovery.
+	 */
+	public static final String CATALOG_TYPE = "type";
+
+	/**
+	 * Key for describing the property version. This property can be used for backwards
+	 * compatibility in case the property format changes.
+	 */
+	public static final String CATALOG_PROPERTY_VERSION = "property-version";
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		properties.validateString(CATALOG_TYPE, false, 1);
+		properties.validateInt(CATALOG_PROPERTY_VERSION, true, 0);
+	}
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -270,8 +270,8 @@ class ExternalCatalogTableBuilder(private val connectorDescriptor: ConnectorDesc
     * Explicitly declares this external table for supporting only batch environments.
     */
   def supportsBatch(): ExternalCatalogTableBuilder = {
-    isBatch = false
-    isStreaming = true
+    isBatch = true
+    isStreaming = false
     this
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/BatchTableSinkFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/BatchTableSinkFactory.scala
@@ -23,7 +23,7 @@ import java.util
 import org.apache.flink.table.sinks.BatchTableSink
 
 /**
-  * A factory to create configured table sink instances in a streaming environment based on
+  * A factory to create configured table sink instances in a batch environment based on
   * string-based properties. See also [[TableFactory]] for more information.
   *
   * @tparam T type of records that the factory consumes

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/ExternalCatalogFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/ExternalCatalogFactory.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories
+
+import java.util
+
+import org.apache.flink.table.catalog.ExternalCatalog
+
+/**
+  * A factory to create configured external catalog instances based on string-based properties. See
+  * also [[TableFactory]] for more information.
+  */
+trait ExternalCatalogFactory extends TableFactory {
+
+  /**
+    * Creates and configures an [[org.apache.flink.table.catalog.ExternalCatalog]]
+    * using the given properties.
+    *
+    * @param properties normalized properties describing an external catalog.
+    * @return the configured external catalog.
+    */
+  def createExternalCatalog(properties: util.Map[String, String]): ExternalCatalog
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryService.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryService.scala
@@ -22,6 +22,7 @@ import java.util.{ServiceConfigurationError, ServiceLoader, Map => JMap}
 
 import org.apache.flink.table.api._
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator._
+import org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator._
 import org.apache.flink.table.descriptors.FormatDescriptorValidator._
 import org.apache.flink.table.descriptors.MetadataValidator._
 import org.apache.flink.table.descriptors.StatisticsValidator._
@@ -205,6 +206,7 @@ object TableFactoryService extends Logging {
       plainContext.remove(FORMAT_PROPERTY_VERSION)
       plainContext.remove(METADATA_PROPERTY_VERSION)
       plainContext.remove(STATISTICS_PROPERTY_VERSION)
+      plainContext.remove(CATALOG_PROPERTY_VERSION)
 
       // check if required context is met
       plainContext.forall(e => properties.contains(e._1) && properties(e._1) == e._2)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryUtil.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.factories
 
 import org.apache.flink.table.api.{BatchTableEnvironment, StreamTableEnvironment, TableEnvironment, TableException}
+import org.apache.flink.table.catalog.ExternalCatalog
 import org.apache.flink.table.descriptors.Descriptor
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.sources.TableSource
@@ -27,6 +28,21 @@ import org.apache.flink.table.sources.TableSource
   * Utility for dealing with [[TableFactory]] using the [[TableFactoryService]].
   */
 object TableFactoryUtil {
+
+  /**
+    * Returns an external catalog for a table environment.
+    */
+  def findAndCreateExternalCatalog(
+      tableEnvironment: TableEnvironment,
+      descriptor: Descriptor)
+    : ExternalCatalog = {
+
+    val javaMap = descriptor.toProperties
+
+    TableFactoryService
+      .find(classOf[ExternalCatalogFactory], javaMap)
+      .createExternalCatalog(javaMap)
+  }
 
   /**
     * Returns a table source for a table environment.

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorTest.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.table.api.ValidationException;
+
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_TYPE;
+
+/**
+ * Tests for the {@link ExternalCatalogDescriptor} descriptor and {@link ExternalCatalogDescriptorValidator} validator.
+ */
+public class ExternalCatalogDescriptorTest extends DescriptorTestBase {
+
+	private static final String CATALOG_TYPE_VALUE = "ExternalCatalogDescriptorTest";
+	private static final int CATALOG_PROPERTY_VERSION_VALUE = 1;
+	private static final String CATALOG_FOO = "foo";
+	private static final String CATALOG_FOO_VALUE = "foo-1";
+
+	@Test(expected = ValidationException.class)
+	public void testMissingCatalogType() {
+		removePropertyAndVerify(descriptors().get(0), CATALOG_TYPE);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testMissingFoo() {
+		removePropertyAndVerify(descriptors().get(0), CATALOG_FOO);
+	}
+
+	@Override
+	protected List<Descriptor> descriptors() {
+		final Descriptor minimumDesc = new TestExternalCatalogDescriptor(CATALOG_FOO_VALUE);
+		return Collections.singletonList(minimumDesc);
+	}
+
+	@Override
+	protected List<Map<String, String>> properties() {
+		final Map<String, String> minimumProps = new HashMap<>();
+		minimumProps.put(CATALOG_TYPE, CATALOG_TYPE_VALUE);
+		minimumProps.put(CATALOG_PROPERTY_VERSION, "" + CATALOG_PROPERTY_VERSION_VALUE);
+		minimumProps.put(CATALOG_FOO, CATALOG_FOO_VALUE);
+		return Collections.singletonList(minimumProps);
+	}
+
+	@Override
+	protected DescriptorValidator validator() {
+		return new TestExternalCatalogDescriptorValidator();
+	}
+
+	class TestExternalCatalogDescriptor extends ExternalCatalogDescriptor {
+		private String foo;
+
+		public TestExternalCatalogDescriptor(@Nullable String foo) {
+			super(CATALOG_TYPE_VALUE, CATALOG_PROPERTY_VERSION_VALUE);
+			this.foo = foo;
+		}
+
+		@Override
+		protected Map<String, String> toCatalogProperties() {
+			DescriptorProperties properties = new DescriptorProperties();
+			if (foo != null) {
+				properties.putString(CATALOG_FOO, foo);
+			}
+			return properties.asMap();
+		}
+	}
+
+	class TestExternalCatalogDescriptorValidator extends ExternalCatalogDescriptorValidator {
+		@Override
+		public void validate(DescriptorProperties properties) {
+			super.validate(properties);
+			properties.validateString(CATALOG_FOO, false, 1);
+		}
+	}
+}

--- a/flink-libraries/flink-table/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-libraries/flink-table/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -19,3 +19,4 @@ org.apache.flink.table.factories.utils.TestTableSinkFactory
 org.apache.flink.table.factories.utils.TestTableSourceFactory
 org.apache.flink.table.factories.utils.TestTableFormatFactory
 org.apache.flink.table.factories.utils.TestAmbiguousTableFormatFactory
+org.apache.flink.table.factories.utils.TestExternalCatalogFactory

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/ExternalCatalogFactoryServiceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/ExternalCatalogFactoryServiceTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories
+
+import java.util.{HashMap => JHashMap, Map => JMap}
+
+import org.apache.flink.table.api.NoMatchingTableFactoryException
+import org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.{CATALOG_PROPERTY_VERSION, CATALOG_TYPE}
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory.CATALOG_TYPE_VALUE_TEST
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+  * Tests for testing external catalog discovery using [[TableFactoryService]]. The tests assume the
+  * external catalog factory [[TestExternalCatalogFactory]] is registered.
+  */
+class ExternalCatalogFactoryServiceTest {
+
+  @Test
+  def testValidProperties(): Unit = {
+    val props = properties()
+    assertTrue(TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+      .isInstanceOf[TestExternalCatalogFactory])
+  }
+
+  @Test(expected = classOf[NoMatchingTableFactoryException])
+  def testInvalidContext(): Unit = {
+    val props = properties()
+    props.put(CATALOG_TYPE, "unknown-catalog-type")
+    TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+  }
+
+  @Test
+  def testDifferentContextVersion(): Unit = {
+    val props = properties()
+    props.put(CATALOG_PROPERTY_VERSION, "2")
+    // the external catalog should still be found
+    assertTrue(TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+      .isInstanceOf[TestExternalCatalogFactory])
+  }
+
+  @Test(expected = classOf[NoMatchingTableFactoryException])
+  def testUnsupportedProperty(): Unit = {
+    val props = properties()
+    props.put("unknown-property", "/new/path")
+    TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+  }
+
+  private def properties(): JMap[String, String] = {
+    val properties = new JHashMap[String, String]()
+    properties.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_TEST)
+    properties.put(CATALOG_PROPERTY_VERSION, "1")
+    properties
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/utils/TestExternalCatalogFactory.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/utils/TestExternalCatalogFactory.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories.utils
+
+import java.util
+import java.util.Collections
+
+import org.apache.flink.table.catalog.ExternalCatalog
+import org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.{CATALOG_PROPERTY_VERSION, CATALOG_TYPE}
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory._
+import org.apache.flink.table.factories.ExternalCatalogFactory
+import org.apache.flink.table.runtime.utils.CommonTestData
+
+/**
+  * External catalog factory for testing.
+  *
+  * This factory provides the in-memory catalog from [[CommonTestData.getInMemoryTestCatalog()]] as catalog type "test".
+  * Note that the provided catalog tables support only streaming environments.
+  */
+class TestExternalCatalogFactory extends ExternalCatalogFactory {
+
+  override def requiredContext: util.Map[String, String] = {
+    val context = new util.HashMap[String, String]
+    context.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_TEST)
+    context.put(CATALOG_PROPERTY_VERSION, "1")
+    context
+  }
+
+  override def supportedProperties: util.List[String] = Collections.emptyList()
+
+  override def createExternalCatalog(properties: util.Map[String, String]): ExternalCatalog = {
+    CommonTestData.getInMemoryTestCatalog(isStreaming = true)
+  }
+}
+
+object TestExternalCatalogFactory {
+  val CATALOG_TYPE_VALUE_TEST = "test"
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
@@ -85,7 +85,9 @@ object CommonTestData {
       .withSchema(schemaDesc1)
 
     if (isStreaming) {
-      externalTableBuilder1.inAppendMode()
+      externalTableBuilder1.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder1.supportsBatch()
     }
 
     val csvRecord2 = Seq(
@@ -126,7 +128,9 @@ object CommonTestData {
       .withSchema(schemaDesc2)
 
     if (isStreaming) {
-      externalTableBuilder2.inAppendMode()
+      externalTableBuilder2.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder2.supportsBatch()
     }
 
     val tempFilePath3 = writeToTempFile("", "csv-test3", "tmp")
@@ -145,7 +149,9 @@ object CommonTestData {
       .withSchema(schemaDesc3)
 
     if (isStreaming) {
-      externalTableBuilder3.inAppendMode()
+      externalTableBuilder3.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder3.supportsBatch()
     }
 
     val catalog = new InMemoryExternalCatalog("test")


### PR DESCRIPTION
## What is the purpose of the change

_Based on PR #7389;  please see commits that are prefixed with FLINK-11240._

Implements the descriptor and factory infrastructure for external catalogs.

I found it counterproductive to involve `ConnectorDescriptor` for external catalogs.  That type was designed to support a mix-and-match between connector and format.   See FLINK-11241 for more.

On the topic of the transition to `flink-table-common`, I found it convenient to keep the new types in `flink-table` until `ExternalCatalog` moves (FLINK-10755).   Java was used whenever possible.

Closes FLINK-11240.

## Brief change log

- Add `ExternalCatalogDescriptor`
- Add `ExternalCatalogDescriptorValidator`
- Add `ExternalCatalogFactory`
- Add `TableFactoryUtil::findAndCreateExternalCatalog`

## Verifying this change

This change added tests and can be verified as follows:
- Added unit test `ExternalCatalogDescriptorTest` for descriptors
- Added unit test `ExternalCatalogFactoryServiceTest` for factory discovery
- Added a sample factory `TestExternalCatalogFactory` for test purposes which serves the catalog provided by the existing `CommonTestData::getInMemoryTestCatalog`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
