### PR TITLE
[hotfix][docs] add Back to top button

### DIFF
--- a/docs/dev/connectors/index.md
+++ b/docs/dev/connectors/index.md
@@ -82,3 +82,5 @@ If the data involved has many fewer reads than writes, a better approach can be
 for an external application to pull from Flink the data it needs.
 The [Queryable State]({{ site.baseurl }}/dev/stream/state/queryable_state.html) interface
 enables this by allowing the state being managed by Flink to be queried on demand.
+
+{% top %}


### PR DESCRIPTION
## What is the purpose of the change

Add back to top button for connectors overview docs.


## Brief change log

Add back to top button for connectors overview docs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
