### PR TITLE
[FLINK-9172][table][sql-client] - Support external catalogs in SQL-Client

### DIFF
--- a/flink-libraries/flink-sql-client/pom.xml
+++ b/flink-libraries/flink-sql-client/pom.xml
@@ -131,6 +131,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.client.config;
 
 import org.apache.flink.table.client.SqlClientException;
+import org.apache.flink.table.client.config.entries.CatalogEntry;
 import org.apache.flink.table.client.config.entries.DeploymentEntry;
 import org.apache.flink.table.client.config.entries.ExecutionEntry;
 import org.apache.flink.table.client.config.entries.FunctionEntry;
@@ -37,7 +38,7 @@ import java.util.Map;
 
 /**
  * Environment configuration that represents the content of an environment file. Environment files
- * define tables, execution, and deployment behavior. An environment might be defined by default or
+ * define catalogs, tables, execution, and deployment behavior. An environment might be defined by default or
  * as part of a session. Environments can be merged or enriched with properties (e.g. from CLI command).
  *
  * <p>In future versions, we might restrict the merging or enrichment of deployment properties to not
@@ -49,6 +50,8 @@ public class Environment {
 
 	public static final String DEPLOYMENT_ENTRY = "deployment";
 
+	private Map<String, CatalogEntry> catalogs;
+
 	private Map<String, TableEntry> tables;
 
 	private Map<String, FunctionEntry> functions;
@@ -58,10 +61,27 @@ public class Environment {
 	private DeploymentEntry deployment;
 
 	public Environment() {
+		this.catalogs = Collections.emptyMap();
 		this.tables = Collections.emptyMap();
 		this.functions = Collections.emptyMap();
 		this.execution = ExecutionEntry.DEFAULT_INSTANCE;
 		this.deployment = DeploymentEntry.DEFAULT_INSTANCE;
+	}
+
+	public Map<String, CatalogEntry> getCatalogs() {
+		return catalogs;
+	}
+
+	public void setCatalogs(List<Map<String, Object>> catalogs) {
+		this.catalogs = new HashMap<>(catalogs.size());
+		catalogs.forEach(config -> {
+			final CatalogEntry catalog = CatalogEntry.create(config);
+			if (this.catalogs.containsKey(catalog.getName())) {
+				throw new SqlClientException(
+					"Cannot create catalog '" + catalog.getName() + "' because a catalog with this name is already registered.");
+			}
+			this.catalogs.put(catalog.getName(), catalog);
+		});
 	}
 
 	public Map<String, TableEntry> getTables() {
@@ -117,6 +137,11 @@ public class Environment {
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder();
+		sb.append("===================== Catalogs =====================\n");
+		catalogs.forEach((name, catalog) -> {
+			sb.append("- ").append(CatalogEntry.CATALOG_NAME).append(": ").append(name).append("\n");
+			catalog.asMap().forEach((k, v) -> sb.append("  ").append(k).append(": ").append(v).append('\n'));
+		});
 		sb.append("===================== Tables =====================\n");
 		tables.forEach((name, table) -> {
 			sb.append("- ").append(TableEntry.TABLES_NAME).append(": ").append(name).append("\n");
@@ -164,6 +189,11 @@ public class Environment {
 	public static Environment merge(Environment env1, Environment env2) {
 		final Environment mergedEnv = new Environment();
 
+		// merge catalogs
+		final Map<String, CatalogEntry> catalogs = new HashMap<>(env1.getCatalogs());
+		catalogs.putAll(env2.getCatalogs());
+		mergedEnv.catalogs = catalogs;
+
 		// merge tables
 		final Map<String, TableEntry> tables = new LinkedHashMap<>(env1.getTables());
 		tables.putAll(env2.getTables());
@@ -192,12 +222,15 @@ public class Environment {
 			Map<String, ViewEntry> views) {
 		final Environment enrichedEnv = new Environment();
 
+		// merge catalogs
+		enrichedEnv.catalogs = new LinkedHashMap<>(env.getCatalogs());
+
 		// merge tables
 		enrichedEnv.tables = new LinkedHashMap<>(env.getTables());
 		enrichedEnv.tables.putAll(views);
 
 		// merge functions
-		enrichedEnv.functions = new HashMap<>(env.getFunctions());
+		enrichedEnv.functions = new LinkedHashMap<>(env.getFunctions());
 
 		// enrich execution properties
 		enrichedEnv.execution = ExecutionEntry.enrich(env.execution, properties);

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/CatalogEntry.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/CatalogEntry.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.config.entries;
+
+import org.apache.flink.table.client.config.ConfigUtil;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_TYPE;
+
+/**
+ * Describes a catalog-like configuration entry.
+ */
+public class CatalogEntry extends ConfigEntry {
+
+	public static final String CATALOG_NAME = "name";
+
+	private final String name;
+
+	protected CatalogEntry(String name, DescriptorProperties properties) {
+		super(properties);
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	protected void validate(DescriptorProperties properties) {
+		properties.validateString(CATALOG_TYPE, false, 1);
+		properties.validateInt(CATALOG_PROPERTY_VERSION, true, 0);
+
+		// further validation is performed by the discovered factory
+	}
+
+	public static CatalogEntry create(Map<String, Object> config) {
+		return create(ConfigUtil.normalizeYaml(config));
+	}
+
+	private static CatalogEntry create(DescriptorProperties properties) {
+		properties.validateString(CATALOG_NAME, false, 1);
+
+		final String name = properties.getString(CATALOG_NAME);
+
+		final DescriptorProperties cleanedProperties =
+			properties.withoutKeys(Collections.singletonList(CATALOG_NAME));
+
+		return new CatalogEntry(name, cleanedProperties);
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigEntry.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ConfigEntry.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Describes an environment configuration entry (such as table, functions, views). Config entries
+ * Describes an environment configuration entry (such as catalogs, tables, functions, views). Config entries
  * are similar to {@link org.apache.flink.table.descriptors.Descriptor} but apply to SQL Client's
  * environment files only.
  */

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -166,7 +166,7 @@ public class ExecutionContext<T> {
 
 	public EnvironmentInstance createEnvironmentInstance() {
 		try {
-			return new EnvironmentInstance();
+			return wrapClassLoader(EnvironmentInstance::new);
 		} catch (Throwable t) {
 			// catch everything such that a wrong environment does not affect invocations
 			throw new SqlExecutionException("Could not create environment instance.", t);

--- a/flink-libraries/flink-sql-client/src/test/assembly/test-table-factories.xml
+++ b/flink-libraries/flink-sql-client/src/test/assembly/test-table-factories.xml
@@ -24,19 +24,6 @@ under the License.
 		<format>jar</format>
 	</formats>
 	<includeBaseDirectory>false</includeBaseDirectory>
-	<fileSets>
-		<fileSet>
-			<directory>${project.build.testOutputDirectory}</directory>
-			<outputDirectory>/</outputDirectory>
-			<!-- modify/add include to match your package(s) -->
-			<includes>
-				<include>org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.class</include>
-				<include>org/apache/flink/table/client/gateway/utils/TestTableSourceFactory$*.class</include>
-				<include>org/apache/flink/table/client/gateway/utils/TestTableSinkFactory.class</include>
-				<include>org/apache/flink/table/client/gateway/utils/TestTableSinkFactory$*.class</include>
-			</includes>
-		</fileSet>
-	</fileSets>
 	<files>
 		<!-- Create META-INF/services -->
 		<file>

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
@@ -18,13 +18,21 @@
 
 package org.apache.flink.table.client.gateway.local;
 
+import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
+import org.apache.flink.table.client.gateway.utils.UserDefinedFunctions;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -39,13 +47,21 @@ public class EnvironmentTest {
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-client-defaults.yaml";
 	private static final String FACTORY_ENVIRONMENT_FILE = "test-sql-client-factory.yaml";
 
-	@Test
-	public void testMerging() throws Exception {
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private static Map<String, String> defaultVars() {
 		final Map<String, String> replaceVars1 = new HashMap<>();
 		replaceVars1.put("$VAR_EXECUTION_TYPE", "batch");
 		replaceVars1.put("$VAR_RESULT_MODE", "table");
 		replaceVars1.put("$VAR_UPDATE_MODE", "");
 		replaceVars1.put("$VAR_MAX_ROWS", "100");
+		return replaceVars1;
+	}
+
+	@Test
+	public void testMerging() throws Exception {
+		final Map<String, String> replaceVars1 = defaultVars();
 		final Environment env1 = EnvironmentFileUtil.parseModified(
 			DEFAULTS_ENVIRONMENT_FILE,
 			replaceVars1);
@@ -58,6 +74,10 @@ public class EnvironmentTest {
 
 		final Environment merged = Environment.merge(env1, env2);
 
+		final Set<String> catalogs = new HashSet<>();
+		catalogs.add("Catalog1");
+		catalogs.add("Catalog2");
+
 		final Set<String> tables = new HashSet<>();
 		tables.add("TableNumber1");
 		tables.add("TableNumber2");
@@ -66,8 +86,63 @@ public class EnvironmentTest {
 		tables.add("TestView1");
 		tables.add("TestView2");
 
+		assertEquals(catalogs, merged.getCatalogs().keySet());
 		assertEquals(tables, merged.getTables().keySet());
 		assertTrue(merged.getExecution().isStreamingExecution());
 		assertEquals(16, merged.getExecution().getMaxParallelism());
+	}
+
+	@Test
+	public void testToString() throws Exception {
+		final Map<String, String> replaceVars1 = defaultVars();
+		final Environment env = EnvironmentFileUtil.parseModified(
+			DEFAULTS_ENVIRONMENT_FILE,
+			replaceVars1);
+		String toString = env.toString();
+		List<String> expected = Arrays.asList(
+			"Catalog1",
+			"TableNumber1", "TableSourceSink", "TestView1",
+			"scalarUDF", "aggregateUDF", "tableUDF");
+		assertTrue(Arrays.asList(toString.split("\\s")).containsAll(expected));
+	}
+
+	@Test
+	public void testDuplicateCatalog() throws Exception {
+		expectedException.expect(SqlClientException.class);
+		expectedException.expectMessage("Cannot create catalog 'Catalog2' because a catalog with this name is already registered.");
+		Environment env = new Environment();
+		env.setCatalogs(Arrays.asList(
+			ImmutableMap.of("name", "Catalog1", "type",  "test"),
+			ImmutableMap.of("name", "Catalog2", "type",  "test"),
+			ImmutableMap.of("name", "Catalog2", "type",  "test")));
+	}
+
+	@Test
+	public void testDuplicateTable() throws Exception {
+		expectedException.expect(SqlClientException.class);
+		expectedException.expectMessage("Cannot create table 'Table2' because a table with this name is already registered.");
+		Environment env = new Environment();
+		env.setTables(Arrays.asList(
+			ImmutableMap.of("name", "Table1", "type",  "source-table"),
+			ImmutableMap.of("name", "Table2", "type",  "source-table"),
+			ImmutableMap.of("name", "Table2", "type",  "source-table")));
+	}
+
+	@Test
+	public void testDuplicateFunction() throws Exception {
+		expectedException.expect(SqlClientException.class);
+		expectedException.expectMessage("Cannot create function 'Function2' because a function with this name is already registered.");
+		Environment env = new Environment();
+		env.setFunctions(Arrays.asList(scalarUdf("Function1", 5),
+			scalarUdf("Function2", 5),
+			scalarUdf("Function2", 5)));
+	}
+
+	private static Map<String, Object> scalarUdf(String name, Integer offset) {
+		return ImmutableMap.of(
+			"name", name,
+			"from", "class",
+			"class", UserDefinedFunctions.ScalarUDF.class.getCanonicalName(),
+			"constructor", Arrays.asList(offset));
 	}
 }

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -71,6 +71,17 @@ public class ExecutionContextTest {
 	}
 
 	@Test
+	public void testExternalCatalogs() throws Exception {
+		final ExecutionContext<?> context = createDefaultExecutionContext();
+		final TableEnvironment tableEnv = context.createEnvironmentInstance().getTableEnvironment();
+		final String[] expected = new String[]{"Catalog1"};
+		final String[] actual = tableEnv.listExternalCatalogs();
+		Arrays.sort(expected);
+		Arrays.sort(actual);
+		assertArrayEquals(expected, actual);
+	}
+
+	@Test
 	public void testFunctions() throws Exception {
 		final ExecutionContext<?> context = createDefaultExecutionContext();
 		final TableEnvironment tableEnv = context.createEnvironmentInstance().getTableEnvironment();
@@ -170,6 +181,7 @@ public class ExecutionContextTest {
 		replaceVars.put("$VAR_RESULT_MODE", "changelog");
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
 		replaceVars.put("$VAR_MAX_ROWS", "100");
+		replaceVars.put("$VAR_CATALOG_IS_STREAMING", "true");
 		return createExecutionContext(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
 	}
 

--- a/flink-libraries/flink-sql-client/src/test/resources/test-factory-services-file
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-factory-services-file
@@ -17,5 +17,6 @@
 # Test file for org.apache.flink.table.client.gateway.local.DependencyTest.
 #==============================================================================
 
+org.apache.flink.table.client.gateway.local.DependencyTest$TestExternalCatalogFactory
 org.apache.flink.table.client.gateway.local.DependencyTest$TestTableSourceFactory
 org.apache.flink.table.client.gateway.local.DependencyTest$TestTableSinkFactory

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -23,6 +23,11 @@
 
 # this file has variables that can be filled with content by replacing $VAR_XXX
 
+catalogs:
+  - name: Catalog1
+    type: test
+    is-streaming: "$VAR_CATALOG_IS_STREAMING"
+
 tables:
   - name: TableNumber1
     type: source-table

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -23,6 +23,10 @@
 
 # this file has variables that can be filled with content by replacing $VAR_XXX
 
+catalogs:
+  - name: Catalog2
+    type: DependencyTest
+
 tables:
   - name: TableNumber1
     type: source-sink-table

--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptor.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptor.java
@@ -68,7 +68,7 @@ public abstract class ConnectorDescriptor extends DescriptorBase implements Desc
 
 	/**
 	 * Converts this descriptor into a set of connector properties. Usually prefixed with
-	 * {@link FormatDescriptorValidator#FORMAT}.
+	 * {@link ConnectorDescriptorValidator#CONNECTOR}.
 	 */
 	protected abstract Map<String, String> toConnectorProperties();
 }

--- a/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
+++ b/flink-libraries/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
@@ -27,6 +27,11 @@ import org.apache.flink.annotation.Internal;
 public abstract class ConnectorDescriptorValidator implements DescriptorValidator {
 
 	/**
+	 * Prefix for connector-related properties.
+	 */
+	public static final String CONNECTOR = "connector";
+
+	/**
 	 * Key for describing the type of the connector. Usually used for factory discovery.
 	 */
 	public static final String CONNECTOR_TYPE = "connector.type";

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptor.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Map;
+
+import static  org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static  org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_TYPE;
+
+/**
+ * Describes a external catalog of tables, views, and functions.
+ */
+@PublicEvolving
+public abstract class ExternalCatalogDescriptor extends DescriptorBase implements Descriptor {
+
+	private final String type;
+
+	private final int version;
+
+	/**
+	 * Constructs a {@link ExternalCatalogDescriptor}.
+	 *
+	 * @param type string that identifies this catalog
+	 * @param version property version for backwards compatibility
+	 */
+	public ExternalCatalogDescriptor(String type, int version) {
+		this.type = type;
+		this.version = version;
+	}
+
+	@Override
+	public final Map<String, String> toProperties() {
+		final DescriptorProperties properties = new DescriptorProperties();
+		properties.putString(CATALOG_TYPE, type);
+		properties.putLong(CATALOG_PROPERTY_VERSION, version);
+		properties.putProperties(toCatalogProperties());
+		return properties.asMap();
+	}
+
+	/**
+	 * Converts this descriptor into a set of catalog properties.
+	 */
+	protected abstract Map<String, String> toCatalogProperties();
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorValidator.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Validator for {@link ExternalCatalogDescriptor}.
+ */
+@Internal
+public abstract class ExternalCatalogDescriptorValidator implements DescriptorValidator {
+
+	/**
+	 * Key for describing the type of the catalog. Usually used for factory discovery.
+	 */
+	public static final String CATALOG_TYPE = "type";
+
+	/**
+	 * Key for describing the property version. This property can be used for backwards
+	 * compatibility in case the property format changes.
+	 */
+	public static final String CATALOG_PROPERTY_VERSION = "property-version";
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		properties.validateString(CATALOG_TYPE, false, 1);
+		properties.validateInt(CATALOG_PROPERTY_VERSION, true, 0);
+	}
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -404,6 +404,15 @@ abstract class TableEnvironment(val config: TableConfig) {
   }
 
   /**
+    * Gets the names of all external catalogs registered in this environment.
+    *
+    * @return A list of the names of all registered external catalogs.
+    */
+  def listExternalCatalogs(): Array[String] = {
+    this.externalCatalogs.keySet.toArray
+  }
+
+  /**
     * Registers an [[ExternalCatalog]] under a unique name in the TableEnvironment's schema.
     * All tables registered in the [[ExternalCatalog]] can be accessed.
     *

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -49,7 +49,7 @@ import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTabl
 import org.apache.flink.table.calcite.{FlinkPlannerImpl, FlinkRelBuilder, FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.catalog.{ExternalCatalog, ExternalCatalogSchema}
 import org.apache.flink.table.codegen.{ExpressionReducer, FunctionCodeGenerator, GeneratedFunction}
-import org.apache.flink.table.descriptors.{ConnectorDescriptor, TableDescriptor}
+import org.apache.flink.table.descriptors.{ConnectExternalCatalogDescriptor, ConnectorDescriptor, ExternalCatalogDescriptor, TableDescriptor}
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
@@ -654,6 +654,31 @@ abstract class TableEnvironment(val config: TableConfig) {
     * @param connectorDescriptor connector descriptor describing the external system
     */
   def connect(connectorDescriptor: ConnectorDescriptor): TableDescriptor
+
+  /**
+    * Connects to an external catalog from a descriptor.
+    *
+    * Descriptors allow for declaring the communication to external systems in an
+    * implementation-agnostic way. The classpath is scanned for suitable table factories that match
+    * the desired configuration.
+    *
+    * The following example shows how to read from an external catalog and
+    * registering it as "MyCatalog":
+    *
+    * {{{
+    *
+    * tableEnv
+    *   .connect(
+    *     new ExternalCatalogXYZ()
+    *       .version("2.3.0"))
+    *   .registerExternalCatalog("MyCatalog")
+    * }}}
+    *
+    * @param catalogDescriptor connector descriptor describing the external system
+    */
+  def connect(catalogDescriptor: ExternalCatalogDescriptor): ConnectExternalCatalogDescriptor = {
+    new ConnectExternalCatalogDescriptor(this, catalogDescriptor)
+  }
 
   private[flink] def scanInternal(tablePath: Array[String]): Option[Table] = {
     require(tablePath != null && !tablePath.isEmpty, "tablePath must not be null or empty.")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -270,8 +270,8 @@ class ExternalCatalogTableBuilder(private val connectorDescriptor: ConnectorDesc
     * Explicitly declares this external table for supporting only batch environments.
     */
   def supportsBatch(): ExternalCatalogTableBuilder = {
-    isBatch = false
-    isStreaming = true
+    isBatch = true
+    isStreaming = false
     this
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/ConnectExternalCatalogDescriptor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/ConnectExternalCatalogDescriptor.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors
+
+import java.util
+
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.factories.TableFactoryUtil
+
+/**
+  * Common class for external catalogs created
+  * with [[TableEnvironment.connect(ExternalCatalogDescriptor)]].
+  */
+ class ConnectExternalCatalogDescriptor(
+    private val tableEnv: TableEnvironment,
+    private val catalogDescriptor: ExternalCatalogDescriptor)
+  extends DescriptorBase {
+
+  /**
+    * Searches for the specified external, configures it accordingly, and registers it as
+    * a catalog under the given name.
+    *
+    * @param name catalog name to be registered in the table environment
+    */
+  def registerExternalCatalog(name: String): Unit = {
+    val externalCatalog = TableFactoryUtil.findAndCreateExternalCatalog(tableEnv, this)
+    tableEnv.registerExternalCatalog(name, externalCatalog)
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+    * Converts this descriptor into a set of properties.
+    */
+  override def toProperties: util.Map[String, String] = {
+    catalogDescriptor.toProperties
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/BatchTableSinkFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/BatchTableSinkFactory.scala
@@ -23,7 +23,7 @@ import java.util
 import org.apache.flink.table.sinks.BatchTableSink
 
 /**
-  * A factory to create configured table sink instances in a streaming environment based on
+  * A factory to create configured table sink instances in a batch environment based on
   * string-based properties. See also [[TableFactory]] for more information.
   *
   * @tparam T type of records that the factory consumes

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/ExternalCatalogFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/ExternalCatalogFactory.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories
+
+import java.util
+
+import org.apache.flink.table.catalog.ExternalCatalog
+
+/**
+  * A factory to create configured external catalog instances based on string-based properties. See
+  * also [[TableFactory]] for more information.
+  */
+trait ExternalCatalogFactory extends TableFactory {
+
+  /**
+    * Creates and configures an [[org.apache.flink.table.catalog.ExternalCatalog]]
+    * using the given properties.
+    *
+    * @param properties normalized properties describing an external catalog.
+    * @return the configured external catalog.
+    */
+  def createExternalCatalog(properties: util.Map[String, String]): ExternalCatalog
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryService.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryService.scala
@@ -22,6 +22,7 @@ import java.util.{ServiceConfigurationError, ServiceLoader, Map => JMap}
 
 import org.apache.flink.table.api._
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator._
+import org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator._
 import org.apache.flink.table.descriptors.FormatDescriptorValidator._
 import org.apache.flink.table.descriptors.MetadataValidator._
 import org.apache.flink.table.descriptors.StatisticsValidator._
@@ -205,6 +206,7 @@ object TableFactoryService extends Logging {
       plainContext.remove(FORMAT_PROPERTY_VERSION)
       plainContext.remove(METADATA_PROPERTY_VERSION)
       plainContext.remove(STATISTICS_PROPERTY_VERSION)
+      plainContext.remove(CATALOG_PROPERTY_VERSION)
 
       // check if required context is met
       plainContext.forall(e => properties.contains(e._1) && properties(e._1) == e._2)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/factories/TableFactoryUtil.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.factories
 
 import org.apache.flink.table.api.{BatchTableEnvironment, StreamTableEnvironment, TableEnvironment, TableException}
+import org.apache.flink.table.catalog.ExternalCatalog
 import org.apache.flink.table.descriptors.Descriptor
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.sources.TableSource
@@ -27,6 +28,21 @@ import org.apache.flink.table.sources.TableSource
   * Utility for dealing with [[TableFactory]] using the [[TableFactoryService]].
   */
 object TableFactoryUtil {
+
+  /**
+    * Returns an external catalog for a table environment.
+    */
+  def findAndCreateExternalCatalog(
+      tableEnvironment: TableEnvironment,
+      descriptor: Descriptor)
+    : ExternalCatalog = {
+
+    val javaMap = descriptor.toProperties
+
+    TableFactoryService
+      .find(classOf[ExternalCatalogFactory], javaMap)
+      .createExternalCatalog(javaMap)
+  }
 
   /**
     * Returns a table source for a table environment.

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorTest.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/descriptors/ExternalCatalogDescriptorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.table.api.ValidationException;
+
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.CATALOG_TYPE;
+
+/**
+ * Tests for the {@link ExternalCatalogDescriptor} descriptor and {@link ExternalCatalogDescriptorValidator} validator.
+ */
+public class ExternalCatalogDescriptorTest extends DescriptorTestBase {
+
+	private static final String CATALOG_TYPE_VALUE = "ExternalCatalogDescriptorTest";
+	private static final int CATALOG_PROPERTY_VERSION_VALUE = 1;
+	private static final String CATALOG_FOO = "foo";
+	private static final String CATALOG_FOO_VALUE = "foo-1";
+
+	@Test(expected = ValidationException.class)
+	public void testMissingCatalogType() {
+		removePropertyAndVerify(descriptors().get(0), CATALOG_TYPE);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testMissingFoo() {
+		removePropertyAndVerify(descriptors().get(0), CATALOG_FOO);
+	}
+
+	@Override
+	protected List<Descriptor> descriptors() {
+		final Descriptor minimumDesc = new TestExternalCatalogDescriptor(CATALOG_FOO_VALUE);
+		return Collections.singletonList(minimumDesc);
+	}
+
+	@Override
+	protected List<Map<String, String>> properties() {
+		final Map<String, String> minimumProps = new HashMap<>();
+		minimumProps.put(CATALOG_TYPE, CATALOG_TYPE_VALUE);
+		minimumProps.put(CATALOG_PROPERTY_VERSION, "" + CATALOG_PROPERTY_VERSION_VALUE);
+		minimumProps.put(CATALOG_FOO, CATALOG_FOO_VALUE);
+		return Collections.singletonList(minimumProps);
+	}
+
+	@Override
+	protected DescriptorValidator validator() {
+		return new TestExternalCatalogDescriptorValidator();
+	}
+
+	class TestExternalCatalogDescriptor extends ExternalCatalogDescriptor {
+		private String foo;
+
+		public TestExternalCatalogDescriptor(@Nullable String foo) {
+			super(CATALOG_TYPE_VALUE, CATALOG_PROPERTY_VERSION_VALUE);
+			this.foo = foo;
+		}
+
+		@Override
+		protected Map<String, String> toCatalogProperties() {
+			DescriptorProperties properties = new DescriptorProperties();
+			if (foo != null) {
+				properties.putString(CATALOG_FOO, foo);
+			}
+			return properties.asMap();
+		}
+	}
+
+	class TestExternalCatalogDescriptorValidator extends ExternalCatalogDescriptorValidator {
+		@Override
+		public void validate(DescriptorProperties properties) {
+			super.validate(properties);
+			properties.validateString(CATALOG_FOO, false, 1);
+		}
+	}
+}

--- a/flink-libraries/flink-table/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-libraries/flink-table/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -19,3 +19,4 @@ org.apache.flink.table.factories.utils.TestTableSinkFactory
 org.apache.flink.table.factories.utils.TestTableSourceFactory
 org.apache.flink.table.factories.utils.TestTableFormatFactory
 org.apache.flink.table.factories.utils.TestAmbiguousTableFormatFactory
+org.apache.flink.table.factories.utils.TestExternalCatalogFactory

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/ConnectExternalCatalogDescriptorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/ConnectExternalCatalogDescriptorTest.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors
+
+import java.util
+
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory.CATALOG_TYPE_VALUE_TEST
+import org.apache.flink.table.utils.TableTestBase
+import org.hamcrest.CoreMatchers.{is, notNullValue}
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+/**
+  * Tests for [[ConnectExternalCatalogDescriptor]].
+  */
+class ConnectExternalCatalogDescriptorTest extends TableTestBase {
+
+  import ConnectExternalCatalogDescriptorTest._
+
+  @Test
+  def testStreamConnectExternalCatalogDescriptor(): Unit = {
+    testConnectExternalCatalogDescriptor(true)
+  }
+
+  @Test
+  def testBatchConnectExternalCatalogDescriptor(): Unit = {
+    testConnectExternalCatalogDescriptor(false)
+  }
+
+  private def testConnectExternalCatalogDescriptor(isStreaming: Boolean): Unit = {
+
+    val tableEnv = if (isStreaming) {
+      streamTestUtil().tableEnv
+    } else {
+      batchTestUtil().tableEnv
+    }
+
+    val catalog = testExternalCatalog(isStreaming)
+    val descriptor: ConnectExternalCatalogDescriptor = tableEnv.connect(catalog)
+
+    // tests the catalog factory discovery and thus validates the result automatically
+    descriptor.registerExternalCatalog("test")
+    assertThat(tableEnv.listExternalCatalogs(), is(Array("test")))
+
+    val tb1 = tableEnv.scan("test", "db1", "tb1")
+    assertThat(tb1, is(notNullValue()))
+  }
+}
+
+object ConnectExternalCatalogDescriptorTest {
+
+  /**
+    * Gets a descriptor for the external catalog produced by [[TestExternalCatalogFactory]].
+    */
+  private def testExternalCatalog(isStreaming: Boolean) = new ExternalCatalogDescriptor(CATALOG_TYPE_VALUE_TEST, 1) {
+    override protected def toCatalogProperties: util.Map[String, String] =
+      java.util.Collections.singletonMap(TestExternalCatalogFactory.CATALOG_IS_STREAMING, isStreaming.toString)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/ConnectExternalCatalogDescriptorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/ConnectExternalCatalogDescriptorTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.descriptors
 import java.util
 
 import org.apache.flink.table.factories.utils.TestExternalCatalogFactory
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory.CATALOG_IS_STREAMING
 import org.apache.flink.table.factories.utils.TestExternalCatalogFactory.CATALOG_TYPE_VALUE_TEST
 import org.apache.flink.table.utils.TableTestBase
 import org.hamcrest.CoreMatchers.{is, notNullValue}
@@ -69,8 +70,10 @@ object ConnectExternalCatalogDescriptorTest {
   /**
     * Gets a descriptor for the external catalog produced by [[TestExternalCatalogFactory]].
     */
-  private def testExternalCatalog(isStreaming: Boolean) = new ExternalCatalogDescriptor(CATALOG_TYPE_VALUE_TEST, 1) {
-    override protected def toCatalogProperties: util.Map[String, String] =
-      java.util.Collections.singletonMap(TestExternalCatalogFactory.CATALOG_IS_STREAMING, isStreaming.toString)
+  private def testExternalCatalog(isStreaming: Boolean) = {
+    new ExternalCatalogDescriptor(CATALOG_TYPE_VALUE_TEST, 1) {
+      override protected def toCatalogProperties: util.Map[String, String] =
+        java.util.Collections.singletonMap(CATALOG_IS_STREAMING, isStreaming.toString)
+    }
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/ExternalCatalogFactoryServiceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/ExternalCatalogFactoryServiceTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories
+
+import java.util.{HashMap => JHashMap, Map => JMap}
+
+import org.apache.flink.table.api.NoMatchingTableFactoryException
+import org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.{CATALOG_PROPERTY_VERSION, CATALOG_TYPE}
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory.CATALOG_TYPE_VALUE_TEST
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+  * Tests for testing external catalog discovery using [[TableFactoryService]]. The tests assume the
+  * external catalog factory [[TestExternalCatalogFactory]] is registered.
+  */
+class ExternalCatalogFactoryServiceTest {
+
+  @Test
+  def testValidProperties(): Unit = {
+    val props = properties()
+    assertTrue(TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+      .isInstanceOf[TestExternalCatalogFactory])
+  }
+
+  @Test(expected = classOf[NoMatchingTableFactoryException])
+  def testInvalidContext(): Unit = {
+    val props = properties()
+    props.put(CATALOG_TYPE, "unknown-catalog-type")
+    TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+  }
+
+  @Test
+  def testDifferentContextVersion(): Unit = {
+    val props = properties()
+    props.put(CATALOG_PROPERTY_VERSION, "2")
+    // the external catalog should still be found
+    assertTrue(TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+      .isInstanceOf[TestExternalCatalogFactory])
+  }
+
+  @Test(expected = classOf[NoMatchingTableFactoryException])
+  def testUnsupportedProperty(): Unit = {
+    val props = properties()
+    props.put("unknown-property", "/new/path")
+    TableFactoryService.find(classOf[ExternalCatalogFactory], props)
+  }
+
+  private def properties(): JMap[String, String] = {
+    val properties = new JHashMap[String, String]()
+    properties.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_TEST)
+    properties.put(CATALOG_PROPERTY_VERSION, "1")
+    properties
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/utils/TestExternalCatalogFactory.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/factories/utils/TestExternalCatalogFactory.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories.utils
+
+import java.util
+import java.util.Collections
+
+import org.apache.flink.table.catalog.ExternalCatalog
+import org.apache.flink.table.descriptors.ExternalCatalogDescriptorValidator.{CATALOG_PROPERTY_VERSION, CATALOG_TYPE}
+import org.apache.flink.table.factories.utils.TestExternalCatalogFactory._
+import org.apache.flink.table.factories.ExternalCatalogFactory
+import org.apache.flink.table.runtime.utils.CommonTestData
+
+/**
+  * External catalog factory for testing.
+  *
+  * This factory provides the in-memory catalog from [[CommonTestData.getInMemoryTestCatalog()]] as catalog type "test".
+  * Note that the provided catalog tables support only streaming environments.
+  */
+class TestExternalCatalogFactory extends ExternalCatalogFactory {
+
+  override def requiredContext: util.Map[String, String] = {
+    val context = new util.HashMap[String, String]
+    context.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_TEST)
+    context.put(CATALOG_PROPERTY_VERSION, "1")
+    context
+  }
+
+  override def supportedProperties: util.List[String] = Collections.emptyList()
+
+  override def createExternalCatalog(properties: util.Map[String, String]): ExternalCatalog = {
+    CommonTestData.getInMemoryTestCatalog(isStreaming = true)
+  }
+}
+
+object TestExternalCatalogFactory {
+  val CATALOG_TYPE_VALUE_TEST = "test"
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
@@ -85,7 +85,9 @@ object CommonTestData {
       .withSchema(schemaDesc1)
 
     if (isStreaming) {
-      externalTableBuilder1.inAppendMode()
+      externalTableBuilder1.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder1.supportsBatch()
     }
 
     val csvRecord2 = Seq(
@@ -126,7 +128,9 @@ object CommonTestData {
       .withSchema(schemaDesc2)
 
     if (isStreaming) {
-      externalTableBuilder2.inAppendMode()
+      externalTableBuilder2.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder2.supportsBatch()
     }
 
     val tempFilePath3 = writeToTempFile("", "csv-test3", "tmp")
@@ -145,7 +149,9 @@ object CommonTestData {
       .withSchema(schemaDesc3)
 
     if (isStreaming) {
-      externalTableBuilder3.inAppendMode()
+      externalTableBuilder3.supportsStreaming().inAppendMode()
+    } else {
+      externalTableBuilder3.supportsBatch()
     }
 
     val catalog = new InMemoryExternalCatalog("test")


### PR DESCRIPTION
## What is the purpose of the change

_Based on #7392.  Please see commits prefixed with FLINK-9172._

Adds support for catalogs to the SQL Client environment file, using descriptors.  For example, here's a sample catalog of type `taxi-data` being registered into `sql-client-defaults.yaml`:
```
catalogs:
  - name: nyc
    type: taxi-data
    rides-file: /Users/david/stuff/flink-training/trainingData/nycTaxiRides.gz
    fares-file: /Users/david/stuff/flink-training/trainingData/nycTaxiFares.gz
```

## Brief change log
[FLINK-9172] [table] [sql-client] - Support external catalogs in SQL-Client
- add `CatalogEntry` to configuration types
- enhance `Environment` to include `catalogs` in overall configuration
- enhance `ExecutionContext` to register the configured catalogs
- cleanup test-table-factories.yaml (references to non-existent classes)
- update test dependencies of sql-client to include flink-table's test classes (for `TestExternalCatalogFactory`)

## Verifying this change

This change added tests and can be verified as follows:

- enhanced unit test `DependencyTest` to test discovery of catalog factories
- enhanced unit test `EnvironmentTest` to test merging of catalog configuration
- enhanced unit test `EnvironmentTest` to test the detection of duplicate catalogs/tables/functions
- enhanced unit test `ExecutionContextTest` to test external catalogs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? not documented (see FLINK-11245)
