### PR TITLE
[FLINK-11246][table] Fix distinct AGG visibility issue

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
@@ -56,7 +56,7 @@ abstract sealed class Aggregation extends Expression {
 
 case class DistinctAgg(child: Expression) extends Aggregation {
 
-  private[flink] def distinct: Expression = DistinctAgg(child)
+  def distinct: Expression = DistinctAgg(child)
 
   override private[flink] def resultType: TypeInformation[_] = child.resultType
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/DistinctAggregateFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/DistinctAggregateFunction.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.{getAccum
 private[flink] case class DistinctAggregateFunction[T: TypeInformation, ACC: TypeInformation]
     (aggFunction: AggregateFunction[T, ACC]) {
 
-  private[flink] def distinct(params: Expression*): Expression = {
+  def distinct(params: Expression*): Expression = {
     val resultTypeInfo: TypeInformation[_] = getResultTypeOfAggregateFunction(
       aggFunction,
       implicitly[TypeInformation[T]])


### PR DESCRIPTION
## What is the purpose of the change

*This pull request Fixes the visibility issue of distinct in Table API*

## Brief change log

*(for example:)*
  - *Remove private[flink] of DistinctAggregateFunction#distinct*
  - *Remove private[flink] of DistinctAgg#distinct*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
