### PR TITLE
[hotfix][docs] Update the conditions when Make state checkpointing As…

### DIFF
--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -110,12 +110,11 @@ To get state to be snapshotted asynchronously, applications have to do two thing
 
   1. Use state that is [managed by Flink](../../dev/stream/state/state.html): Managed state means that Flink provides the data
      structure in which the state is stored. Currently, this is true for *keyed state*, which is abstracted behind the
-     interfaces like `ValueState`, `ListState`, `ReducingState`, ...
+     interfaces like `ValueState`, `ListState`, `ReducingState`, ... For operator state, we can make it managed by 
+     [implementing CheckpointedFunction](../../dev/stream/state/state.html#using-managed-operator-state).
 
   2. Use a state backend that supports asynchronous snapshots. In Flink 1.2, only the RocksDB state backend uses
      fully asynchronous snapshots. Starting from Flink 1.3, heap-based state backends also support asynchronous snapshots.
-
-The above two points imply that large state should generally be kept as keyed state, not as operator state.
 
 ## Tuning RocksDB
 


### PR DESCRIPTION
…ynchronous

## What is the purpose of the change

According to [FLINK-6048](https://issues.apache.org/jira/browse/FLINK-6048), it seems that operator state could be snapshotted asynchronous. This PR update the conditions when we want to make state checkpointing asynchronous.

## Brief change log

- This PR update the conditions when we want to make state checkpointing asynchronous.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts(all no):

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? no

cc @StefanRRichter 