### PR TITLE
[hotfix][docs] Fulfill some empty description in Config Doc

### DIFF
--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td></td>
+            <td>The config parameter defining the default parallelism for jobs.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>

--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td>The config parameter defining the default parallelism for jobs.</td>
+            <td>Default parallelism for jobs.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -25,12 +25,12 @@
         <tr>
             <td><h5>io.tmp.dirs</h5></td>
             <td style="word-wrap: break-word;">'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty("java.io.tmpdir") in standalone.</td>
-            <td>The config parameter defining the directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
+            <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td>The config parameter defining the default parallelism for jobs.</td>
+            <td>Default parallelism for jobs.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -25,12 +25,12 @@
         <tr>
             <td><h5>io.tmp.dirs</h5></td>
             <td style="word-wrap: break-word;">'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty("java.io.tmpdir") in standalone.</td>
-            <td></td>
+            <td>The config parameter defining the directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td></td>
+            <td>The config parameter defining the default parallelism for jobs.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/history_server_configuration.html
+++ b/docs/_includes/generated/history_server_configuration.html
@@ -30,7 +30,7 @@
         <tr>
             <td><h5>historyserver.web.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
-            <td></td>
+            <td>The refresh interval for the HistoryServer web-frontend in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.ssl.enabled</h5></td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -10,7 +10,7 @@
         <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>Define the location where the JobManager stores the archives of completed jobs.</td>
+            <td>Dictionary for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -10,7 +10,7 @@
         <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td></td>
+            <td>Define the location where the JobManager stores the archives of completed jobs.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>

--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -50,12 +50,12 @@
         <tr>
             <td><h5>metrics.reporters</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td></td>
+            <td>An optional list of reporter names. If configured, only reporters whose name matches any of the names in the list will be started. Otherwise, all reporters that could be found in the configuration will be started.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.delimiter</h5></td>
             <td style="word-wrap: break-word;">"."</td>
-            <td></td>
+            <td>Defined the delimiter used to assemble the metric identifier.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.jm</h5></td>
@@ -90,12 +90,12 @@
         <tr>
             <td><h5>metrics.system-resource</h5></td>
             <td style="word-wrap: break-word;">false</td>
-            <td></td>
+            <td>Flag indicating whether Flink should report system resource metrics such as machine's CPU, memory or network usage.</td>
         </tr>
         <tr>
             <td><h5>metrics.system-resource-probing-interval</h5></td>
             <td style="word-wrap: break-word;">5000</td>
-            <td></td>
+            <td>Interval between probing of system resource metrics specified in milliseconds. Has an effect only when SYSTEM_RESOURCE_METRICS is enabled</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -55,7 +55,7 @@
         <tr>
             <td><h5>metrics.scope.delimiter</h5></td>
             <td style="word-wrap: break-word;">"."</td>
-            <td>Defined the delimiter used to assemble the metric identifier.</td>
+            <td>Delimiter used to assemble the metric identifier.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.jm</h5></td>

--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -95,7 +95,7 @@
         <tr>
             <td><h5>metrics.system-resource-probing-interval</h5></td>
             <td style="word-wrap: break-word;">5000</td>
-            <td>Interval between probing of system resource metrics specified in milliseconds. Has an effect only when SYSTEM_RESOURCE_METRICS is enabled</td>
+            <td>Interval between probing of system resource metrics specified in milliseconds. Has an effect only when 'metrics.system-resource' is enabled.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>local.number-resourcemanager</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td></td>
+            <td>The config parameter defining the number of resource managers start.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.job.timeout</h5></td>

--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>local.number-resourcemanager</h5></td>
             <td style="word-wrap: break-word;">1</td>
-            <td>The config parameter defining the number of resource managers start.</td>
+            <td>The number of resource managers start.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.job.timeout</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>task.cancellation.timers.timeout</h5></td>
             <td style="word-wrap: break-word;">7500</td>
-            <td></td>
+            <td>This configures how long we wait for the timers to finish all pending timer threads when the stream task is cancelled.</td>
         </tr>
         <tr>
             <td><h5>task.checkpoint.alignment.max-size</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -20,7 +20,7 @@
         <tr>
             <td><h5>task.cancellation.timers.timeout</h5></td>
             <td style="word-wrap: break-word;">7500</td>
-            <td>This configures how long we wait for the timers to finish all pending timer threads when the stream task is cancelled.</td>
+            <td>Time we wait for the timers in milliseconds to finish all pending timer threads when the stream task is cancelled.</td>
         </tr>
         <tr>
             <td><h5>task.checkpoint.alignment.max-size</h5></td>

--- a/docs/_includes/generated/web_configuration.html
+++ b/docs/_includes/generated/web_configuration.html
@@ -10,77 +10,77 @@
         <tr>
             <td><h5>web.access-control-allow-origin</h5></td>
             <td style="word-wrap: break-word;">"*"</td>
-            <td></td>
+            <td>The config parameter defining the Access-Control-Allow-Origin header for all responses from the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td></td>
+            <td>Config parameter defining the runtime monitor web-frontend server address.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.cleanup-interval</h5></td>
             <td style="word-wrap: break-word;">600000</td>
-            <td></td>
+            <td>Config parameter defining time after which cached stats are cleaned up if not accessed.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.delay-between-samples</h5></td>
             <td style="word-wrap: break-word;">50</td>
-            <td></td>
+            <td>Config parameter defining delay between stack trace samples to determine back pressure.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.num-samples</h5></td>
             <td style="word-wrap: break-word;">100</td>
-            <td></td>
+            <td>Config parameter defining number of stack trace samples to take to determine back pressure.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">60000</td>
-            <td></td>
+            <td>Define time after which available stats are deprecated and need to be refreshed (by resampling).</td>
         </tr>
         <tr>
             <td><h5>web.checkpoints.history</h5></td>
             <td style="word-wrap: break-word;">10</td>
-            <td></td>
+            <td>Config parameter defining the number of checkpoints to remember for recent history.</td>
         </tr>
         <tr>
             <td><h5>web.history</h5></td>
             <td style="word-wrap: break-word;">5</td>
-            <td></td>
+            <td>The config parameter defining the number of archived jobs for the jobmanager.</td>
         </tr>
         <tr>
             <td><h5>web.log.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td></td>
+            <td>Define the log file location (may be in /log for standalone but under log directory when using YARN).</td>
         </tr>
         <tr>
             <td><h5>web.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">3000</td>
-            <td></td>
+            <td>The config parameter defining the refresh interval for the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
-            <td></td>
+            <td>Config parameter to override SSL support for the JobManager Web UI.</td>
         </tr>
         <tr>
             <td><h5>web.submit.enable</h5></td>
             <td style="word-wrap: break-word;">true</td>
-            <td></td>
+            <td>Config parameter indicating whether jobs can be uploaded and run from the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.timeout</h5></td>
             <td style="word-wrap: break-word;">10000</td>
-            <td></td>
+            <td>Define timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.tmpdir</h5></td>
             <td style="word-wrap: break-word;">System.getProperty("java.io.tmpdir")</td>
-            <td></td>
+            <td>The config parameter defining the flink web directory to be used by the webmonitor.</td>
         </tr>
         <tr>
             <td><h5>web.upload.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td></td>
+            <td>The config parameter defining the directory for uploading the job jars. If not specified a dynamic directory will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/web_configuration.html
+++ b/docs/_includes/generated/web_configuration.html
@@ -10,77 +10,77 @@
         <tr>
             <td><h5>web.access-control-allow-origin</h5></td>
             <td style="word-wrap: break-word;">"*"</td>
-            <td>The config parameter defining the Access-Control-Allow-Origin header for all responses from the web-frontend.</td>
+            <td>Access-Control-Allow-Origin header for all responses from the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>Config parameter defining the runtime monitor web-frontend server address.</td>
+            <td>Address for runtime monitor web-frontend server.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.cleanup-interval</h5></td>
             <td style="word-wrap: break-word;">600000</td>
-            <td>Config parameter defining time after which cached stats are cleaned up if not accessed.</td>
+            <td>Time, in milliseconds, after which cached stats are cleaned up if not accessed.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.delay-between-samples</h5></td>
             <td style="word-wrap: break-word;">50</td>
-            <td>Config parameter defining delay between stack trace samples to determine back pressure.</td>
+            <td>Delay between stack trace samples to determine back pressure in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.num-samples</h5></td>
             <td style="word-wrap: break-word;">100</td>
-            <td>Config parameter defining number of stack trace samples to take to determine back pressure.</td>
+            <td>Number of stack trace samples to take to determine back pressure.</td>
         </tr>
         <tr>
             <td><h5>web.backpressure.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">60000</td>
-            <td>Define time after which available stats are deprecated and need to be refreshed (by resampling).</td>
+            <td>Time, in milliseconds, after which available stats are deprecated and need to be refreshed (by resampling).</td>
         </tr>
         <tr>
             <td><h5>web.checkpoints.history</h5></td>
             <td style="word-wrap: break-word;">10</td>
-            <td>Config parameter defining the number of checkpoints to remember for recent history.</td>
+            <td>Number of checkpoints to remember for recent history.</td>
         </tr>
         <tr>
             <td><h5>web.history</h5></td>
             <td style="word-wrap: break-word;">5</td>
-            <td>The config parameter defining the number of archived jobs for the jobmanager.</td>
+            <td>Number of archived jobs for the JobManager.</td>
         </tr>
         <tr>
             <td><h5>web.log.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>Define the log file location (may be in /log for standalone but under log directory when using YARN).</td>
+            <td>Path to the log file (may be in /log for standalone but under log directory when using YARN).</td>
         </tr>
         <tr>
             <td><h5>web.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">3000</td>
-            <td>The config parameter defining the refresh interval for the web-frontend.</td>
+            <td>Refresh interval for the web-frontend in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.ssl.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
-            <td>Config parameter to override SSL support for the JobManager Web UI.</td>
+            <td>Flag indicating whether to override SSL support for the JobManager Web UI.</td>
         </tr>
         <tr>
             <td><h5>web.submit.enable</h5></td>
             <td style="word-wrap: break-word;">true</td>
-            <td>Config parameter indicating whether jobs can be uploaded and run from the web-frontend.</td>
+            <td>Flag indicating whether jobs can be uploaded and run from the web-frontend.</td>
         </tr>
         <tr>
             <td><h5>web.timeout</h5></td>
             <td style="word-wrap: break-word;">10000</td>
-            <td>Define timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.</td>
+            <td>Timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>web.tmpdir</h5></td>
             <td style="word-wrap: break-word;">System.getProperty("java.io.tmpdir")</td>
-            <td>The config parameter defining the flink web directory to be used by the webmonitor.</td>
+            <td>Flink web directory which is used by the webmonitor.</td>
         </tr>
         <tr>
             <td><h5>web.upload.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The config parameter defining the directory for uploading the job jars. If not specified a dynamic directory will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.</td>
+            <td>Directory for uploading the job jars. If not specified a dynamic directory will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -217,8 +217,7 @@ public class CoreOptions {
 		key("io.tmp.dirs")
 			.defaultValue(System.getProperty("java.io.tmpdir"))
 			.withDeprecatedKeys("taskmanager.tmp.dirs")
-			.withDescription("The config parameter defining the directories for temporary files, separated by\",\", \"|\"," +
-				" or the system's java.io.File.pathSeparator.");
+			.withDescription("Directories for temporary files, separated by\",\", \"|\", or the system's java.io.File.pathSeparator.");
 
 	// ------------------------------------------------------------------------
 	//  program
@@ -228,7 +227,7 @@ public class CoreOptions {
 	public static final ConfigOption<Integer> DEFAULT_PARALLELISM = ConfigOptions
 		.key("parallelism.default")
 		.defaultValue(1)
-		.withDescription("The config parameter defining the default parallelism for jobs.");
+		.withDescription("Default parallelism for jobs.");
 
 	// ------------------------------------------------------------------------
 	//  file systems

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -216,7 +216,9 @@ public class CoreOptions {
 	public static final ConfigOption<String> TMP_DIRS =
 		key("io.tmp.dirs")
 			.defaultValue(System.getProperty("java.io.tmpdir"))
-			.withDeprecatedKeys("taskmanager.tmp.dirs");
+			.withDeprecatedKeys("taskmanager.tmp.dirs")
+			.withDescription("The config parameter defining the directories for temporary files, separated by\",\", \"|\"," +
+				" or the system's java.io.File.pathSeparator.");
 
 	// ------------------------------------------------------------------------
 	//  program
@@ -225,7 +227,8 @@ public class CoreOptions {
 	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_PARALLELISM_SLOTS)
 	public static final ConfigOption<Integer> DEFAULT_PARALLELISM = ConfigOptions
 		.key("parallelism.default")
-		.defaultValue(1);
+		.defaultValue(1)
+		.withDescription("The config parameter defining the default parallelism for jobs.");
 
 	// ------------------------------------------------------------------------
 	//  file systems

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -76,7 +76,8 @@ public class HistoryServerOptions {
 	 */
 	public static final ConfigOption<Long> HISTORY_SERVER_WEB_REFRESH_INTERVAL =
 		key("historyserver.web.refresh-interval")
-			.defaultValue(10000L);
+			.defaultValue(10000L)
+			.withDescription("The refresh interval for the HistoryServer web-frontend in milliseconds.");
 
 	/**
 	 * Enables/Disables SSL support for the HistoryServer web-frontend. Only relevant if

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -77,7 +77,7 @@ public class HistoryServerOptions {
 	public static final ConfigOption<Long> HISTORY_SERVER_WEB_REFRESH_INTERVAL =
 		key("historyserver.web.refresh-interval")
 			.defaultValue(10000L)
-			.withDescription("The refresh interval for the HistoryServer web-frontend in milliseconds.");
+			.withDescription("The config parameter defining the refresh interval for the HistoryServer web-frontend in milliseconds.");
 
 	/**
 	 * Enables/Disables SSL support for the HistoryServer web-frontend. Only relevant if

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -77,7 +77,7 @@ public class HistoryServerOptions {
 	public static final ConfigOption<Long> HISTORY_SERVER_WEB_REFRESH_INTERVAL =
 		key("historyserver.web.refresh-interval")
 			.defaultValue(10000L)
-			.withDescription("The config parameter defining the refresh interval for the HistoryServer web-frontend in milliseconds.");
+			.withDescription("The refresh interval for the HistoryServer web-frontend in milliseconds.");
 
 	/**
 	 * Enables/Disables SSL support for the HistoryServer web-frontend. Only relevant if

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -137,7 +137,7 @@ public class JobManagerOptions {
 	public static final ConfigOption<String> ARCHIVE_DIR =
 		key("jobmanager.archive.fs.dir")
 			.noDefaultValue()
-			.withDescription("Define the location where the JobManager stores the archives of completed jobs.");
+			.withDescription("The config parameter defining the location where the JobManager stores the archives of completed jobs.");
 
 	/**
 	 * The job store cache size in bytes which is used to keep completed

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -137,7 +137,7 @@ public class JobManagerOptions {
 	public static final ConfigOption<String> ARCHIVE_DIR =
 		key("jobmanager.archive.fs.dir")
 			.noDefaultValue()
-			.withDescription("The config parameter defining the location where the JobManager stores the archives of completed jobs.");
+			.withDescription("Dictionary for JobManager to store the archives of completed jobs.");
 
 	/**
 	 * The job store cache size in bytes which is used to keep completed

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -136,7 +136,8 @@ public class JobManagerOptions {
 	 */
 	public static final ConfigOption<String> ARCHIVE_DIR =
 		key("jobmanager.archive.fs.dir")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("Define the location where the JobManager stores the archives of completed jobs.");
 
 	/**
 	 * The job store cache size in bytes which is used to keep completed

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -72,7 +72,7 @@ public class MetricOptions {
 	public static final ConfigOption<String> SCOPE_DELIMITER =
 		key("metrics.scope.delimiter")
 			.defaultValue(".")
-			.withDescription("Defined the delimiter used to assemble the metric identifier.");
+			.withDescription("Delimiter used to assemble the metric identifier.");
 
 	/** The scope format string that is applied to all metrics scoped to a JobManager. */
 	public static final ConfigOption<String> SCOPE_NAMING_JM =

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -47,7 +47,10 @@ public class MetricOptions {
 	 */
 	public static final ConfigOption<String> REPORTERS_LIST =
 		key("metrics.reporters")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("An optional list of reporter names. If configured, only reporters whose name matches" +
+				" any of the names in the list will be started. Otherwise, all reporters that could be found in" +
+				" the configuration will be started.");
 
 	public static final ConfigOption<String> REPORTER_CLASS =
 		key("metrics.reporter.<name>.class")
@@ -68,7 +71,8 @@ public class MetricOptions {
 	/** The delimiter used to assemble the metric identifier. */
 	public static final ConfigOption<String> SCOPE_DELIMITER =
 		key("metrics.scope.delimiter")
-			.defaultValue(".");
+			.defaultValue(".")
+			.withDescription("Defined the delimiter used to assemble the metric identifier.");
 
 	/** The scope format string that is applied to all metrics scoped to a JobManager. */
 	public static final ConfigOption<String> SCOPE_NAMING_JM =
@@ -135,14 +139,18 @@ public class MetricOptions {
 	 */
 	public static final ConfigOption<Boolean> SYSTEM_RESOURCE_METRICS =
 		key("metrics.system-resource")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Flag indicating whether Flink should report system resource metrics such as machine's CPU," +
+				" memory or network usage.");
 	/**
 	 * Interval between probing of system resource metrics specified in milliseconds. Has an effect only when
 	 * {@link #SYSTEM_RESOURCE_METRICS} is enabled.
 	 */
 	public static final ConfigOption<Long> SYSTEM_RESOURCE_METRICS_PROBING_INTERVAL =
 		key("metrics.system-resource-probing-interval")
-			.defaultValue(5000L);
+			.defaultValue(5000L)
+			.withDescription("Interval between probing of system resource metrics specified in milliseconds. Has an effect" +
+				" only when SYSTEM_RESOURCE_METRICS is enabled");
 
 	/**
 	 * The default network port range for Flink's internal metric query service. The {@code "0"} means that

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -150,7 +150,7 @@ public class MetricOptions {
 		key("metrics.system-resource-probing-interval")
 			.defaultValue(5000L)
 			.withDescription("Interval between probing of system resource metrics specified in milliseconds. Has an effect" +
-				" only when SYSTEM_RESOURCE_METRICS is enabled");
+				" only when '" + SYSTEM_RESOURCE_METRICS.key() + "' is enabled.");
 
 	/**
 	 * The default network port range for Flink's internal metric query service. The {@code "0"} means that

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -35,10 +35,19 @@ public class ResourceManagerOptions {
 		.defaultValue("5 minutes")
 		.withDescription("Timeout for jobs which don't have a job manager as leader assigned.");
 
+	/**
+	 * The config parameter defining the number of resource managers start.
+	 */
 	public static final ConfigOption<Integer> LOCAL_NUMBER_RESOURCE_MANAGER = ConfigOptions
 		.key("local.number-resourcemanager")
-		.defaultValue(1);
+		.defaultValue(1)
+		.withDescription("The config parameter defining the number of resource managers start.");
 
+	/**
+	 * Defines the network port to connect to for communication with the resource manager.
+	 * By default, the port of the JobManager, because the same ActorSystem is used. Its not
+	 * possible to use this configuration key to define port ranges.
+	 */
 	public static final ConfigOption<Integer> IPC_PORT = ConfigOptions
 		.key("resourcemanager.rpc.port")
 		.defaultValue(0)

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -36,12 +36,12 @@ public class ResourceManagerOptions {
 		.withDescription("Timeout for jobs which don't have a job manager as leader assigned.");
 
 	/**
-	 * The config parameter defining the number of resource managers start.
+	 * The number of resource managers start.
 	 */
 	public static final ConfigOption<Integer> LOCAL_NUMBER_RESOURCE_MANAGER = ConfigOptions
 		.key("local.number-resourcemanager")
 		.defaultValue(1)
-		.withDescription("The config parameter defining the number of resource managers start.");
+		.withDescription("The number of resource managers start.");
 
 	/**
 	 * Defines the network port to connect to for communication with the resource manager.

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -375,14 +375,14 @@ public class TaskManagerOptions {
 				" leads to a fatal TaskManager error. A value of 0 deactivates" +
 				" the watch dog.");
 	/**
-	 * This configures how long we wait for the timers to finish all pending timer threads
+	 * This configures how long we wait for the timers in milliseconds to finish all pending timer threads
 	 * when the stream task is cancelled.
 	 */
 	public static final ConfigOption<Long> TASK_CANCELLATION_TIMEOUT_TIMERS = ConfigOptions
 			.key("task.cancellation.timers.timeout")
 			.defaultValue(7500L)
 			.withDeprecatedKeys("timerservice.exceptional.shutdown.timeout")
-			.withDescription("This configures how long we wait for the timers to finish all pending timer threads" +
+			.withDescription("Time we wait for the timers in milliseconds to finish all pending timer threads" +
 				" when the stream task is cancelled.");
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -376,12 +376,14 @@ public class TaskManagerOptions {
 				" the watch dog.");
 	/**
 	 * This configures how long we wait for the timers to finish all pending timer threads
-	 * when the stream task is cancelled .
+	 * when the stream task is cancelled.
 	 */
 	public static final ConfigOption<Long> TASK_CANCELLATION_TIMEOUT_TIMERS = ConfigOptions
 			.key("task.cancellation.timers.timeout")
 			.defaultValue(7500L)
-			.withDeprecatedKeys("timerservice.exceptional.shutdown.timeout");
+			.withDeprecatedKeys("timerservice.exceptional.shutdown.timeout")
+			.withDescription("This configures how long we wait for the timers to finish all pending timer threads" +
+				" when the stream task is cancelled.");
 
 	/**
 	 * The maximum number of bytes that a checkpoint alignment may buffer.

--- a/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
@@ -35,7 +35,8 @@ public class WebOptions {
 	public static final ConfigOption<String> ADDRESS =
 		key("web.address")
 			.noDefaultValue()
-			.withDeprecatedKeys("jobmanager.web.address");
+			.withDeprecatedKeys("jobmanager.web.address")
+			.withDescription("Config parameter defining the runtime monitor web-frontend server address.");
 
 	/**
 	 * The port for the runtime monitor web-frontend server.
@@ -55,7 +56,9 @@ public class WebOptions {
 	public static final ConfigOption<String> ACCESS_CONTROL_ALLOW_ORIGIN =
 		key("web.access-control-allow-origin")
 			.defaultValue("*")
-			.withDeprecatedKeys("jobmanager.web.access-control-allow-origin");
+			.withDeprecatedKeys("jobmanager.web.access-control-allow-origin")
+			.withDescription("The config parameter defining the Access-Control-Allow-Origin header for all" +
+				" responses from the web-frontend.");
 
 	/**
 	 * The config parameter defining the refresh interval for the web-frontend.
@@ -63,7 +66,8 @@ public class WebOptions {
 	public static final ConfigOption<Long> REFRESH_INTERVAL =
 		key("web.refresh-interval")
 			.defaultValue(3000L)
-			.withDeprecatedKeys("jobmanager.web.refresh-interval");
+			.withDeprecatedKeys("jobmanager.web.refresh-interval")
+			.withDescription("The config parameter defining the refresh interval for the web-frontend.");
 
 	/**
 	 * Config parameter to override SSL support for the JobManager Web UI.
@@ -71,7 +75,8 @@ public class WebOptions {
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("web.ssl.enabled")
 			.defaultValue(true)
-			.withDeprecatedKeys("jobmanager.web.ssl.enabled");
+			.withDeprecatedKeys("jobmanager.web.ssl.enabled")
+			.withDescription("Config parameter to override SSL support for the JobManager Web UI.");
 
 	/**
 	 * The config parameter defining the flink web directory to be used by the webmonitor.
@@ -80,7 +85,8 @@ public class WebOptions {
 	public static final ConfigOption<String> TMP_DIR =
 		key("web.tmpdir")
 			.defaultValue(System.getProperty("java.io.tmpdir"))
-			.withDeprecatedKeys("jobmanager.web.tmpdir");
+			.withDeprecatedKeys("jobmanager.web.tmpdir")
+			.withDescription("The config parameter defining the flink web directory to be used by the webmonitor.");
 
 	/**
 	 * The config parameter defining the directory for uploading the job jars. If not specified a dynamic directory
@@ -89,7 +95,9 @@ public class WebOptions {
 	public static final ConfigOption<String> UPLOAD_DIR =
 		key("web.upload.dir")
 			.noDefaultValue()
-			.withDeprecatedKeys("jobmanager.web.upload.dir");
+			.withDeprecatedKeys("jobmanager.web.upload.dir")
+			.withDescription("The config parameter defining the directory for uploading the job jars. If not" +
+				" specified a dynamic directory will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.");
 
 	/**
 	 * The config parameter defining the number of archived jobs for the jobmanager.
@@ -97,7 +105,8 @@ public class WebOptions {
 	public static final ConfigOption<Integer> ARCHIVE_COUNT =
 		key("web.history")
 			.defaultValue(5)
-			.withDeprecatedKeys("jobmanager.web.history");
+			.withDeprecatedKeys("jobmanager.web.history")
+			.withDescription("The config parameter defining the number of archived jobs for the jobmanager.");
 
 	/**
 	 * The log file location (may be in /log for standalone but under log directory when using YARN).
@@ -105,7 +114,8 @@ public class WebOptions {
 	public static final ConfigOption<String> LOG_PATH =
 		key("web.log.path")
 			.noDefaultValue()
-			.withDeprecatedKeys("jobmanager.web.log.path");
+			.withDeprecatedKeys("jobmanager.web.log.path")
+			.withDescription("Define the log file location (may be in /log for standalone but under log directory when using YARN).");
 
 	/**
 	 * Config parameter indicating whether jobs can be uploaded and run from the web-frontend.
@@ -113,7 +123,8 @@ public class WebOptions {
 	public static final ConfigOption<Boolean> SUBMIT_ENABLE =
 		key("web.submit.enable")
 			.defaultValue(true)
-			.withDeprecatedKeys("jobmanager.web.submit.enable");
+			.withDeprecatedKeys("jobmanager.web.submit.enable")
+			.withDescription("Config parameter indicating whether jobs can be uploaded and run from the web-frontend.");
 
 	/**
 	 * Config parameter defining the number of checkpoints to remember for recent history.
@@ -121,7 +132,8 @@ public class WebOptions {
 	public static final ConfigOption<Integer> CHECKPOINTS_HISTORY_SIZE =
 		key("web.checkpoints.history")
 			.defaultValue(10)
-			.withDeprecatedKeys("jobmanager.web.checkpoints.history");
+			.withDeprecatedKeys("jobmanager.web.checkpoints.history")
+			.withDescription("Config parameter defining the number of checkpoints to remember for recent history.");
 
 	/**
 	 * Time after which cached stats are cleaned up if not accessed.
@@ -129,7 +141,8 @@ public class WebOptions {
 	public static final ConfigOption<Integer> BACKPRESSURE_CLEANUP_INTERVAL =
 		key("web.backpressure.cleanup-interval")
 			.defaultValue(10 * 60 * 1000)
-			.withDeprecatedKeys("jobmanager.web.backpressure.cleanup-interval");
+			.withDeprecatedKeys("jobmanager.web.backpressure.cleanup-interval")
+			.withDescription("Config parameter defining time after which cached stats are cleaned up if not accessed.");
 
 	/**
 	 * Time after which available stats are deprecated and need to be refreshed (by resampling).
@@ -137,7 +150,8 @@ public class WebOptions {
 	public static final ConfigOption<Integer> BACKPRESSURE_REFRESH_INTERVAL =
 		key("web.backpressure.refresh-interval")
 			.defaultValue(60 * 1000)
-			.withDeprecatedKeys("jobmanager.web.backpressure.refresh-interval");
+			.withDeprecatedKeys("jobmanager.web.backpressure.refresh-interval")
+			.withDescription("Define time after which available stats are deprecated and need to be refreshed (by resampling).");
 
 	/**
 	 * Number of stack trace samples to take to determine back pressure.
@@ -145,7 +159,8 @@ public class WebOptions {
 	public static final ConfigOption<Integer> BACKPRESSURE_NUM_SAMPLES =
 		key("web.backpressure.num-samples")
 			.defaultValue(100)
-			.withDeprecatedKeys("jobmanager.web.backpressure.num-samples");
+			.withDeprecatedKeys("jobmanager.web.backpressure.num-samples")
+			.withDescription("Config parameter defining number of stack trace samples to take to determine back pressure.");
 
 	/**
 	 * Delay between stack trace samples to determine back pressure.
@@ -153,14 +168,16 @@ public class WebOptions {
 	public static final ConfigOption<Integer> BACKPRESSURE_DELAY =
 		key("web.backpressure.delay-between-samples")
 			.defaultValue(50)
-			.withDeprecatedKeys("jobmanager.web.backpressure.delay-between-samples");
+			.withDeprecatedKeys("jobmanager.web.backpressure.delay-between-samples")
+			.withDescription("Config parameter defining delay between stack trace samples to determine back pressure.");
 
 	/**
 	 * Timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.
 	 */
 	public static final ConfigOption<Long> TIMEOUT =
 		key("web.timeout")
-		.defaultValue(10L * 1000L);
+		.defaultValue(10L * 1000L)
+		.withDescription("Define timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
@@ -36,7 +36,7 @@ public class WebOptions {
 		key("web.address")
 			.noDefaultValue()
 			.withDeprecatedKeys("jobmanager.web.address")
-			.withDescription("Config parameter defining the runtime monitor web-frontend server address.");
+			.withDescription("Address for runtime monitor web-frontend server.");
 
 	/**
 	 * The port for the runtime monitor web-frontend server.
@@ -57,17 +57,16 @@ public class WebOptions {
 		key("web.access-control-allow-origin")
 			.defaultValue("*")
 			.withDeprecatedKeys("jobmanager.web.access-control-allow-origin")
-			.withDescription("The config parameter defining the Access-Control-Allow-Origin header for all" +
-				" responses from the web-frontend.");
+			.withDescription("Access-Control-Allow-Origin header for all responses from the web-frontend.");
 
 	/**
-	 * The config parameter defining the refresh interval for the web-frontend.
+	 * The config parameter defining the refresh interval for the web-frontend in milliseconds.
 	 */
 	public static final ConfigOption<Long> REFRESH_INTERVAL =
 		key("web.refresh-interval")
 			.defaultValue(3000L)
 			.withDeprecatedKeys("jobmanager.web.refresh-interval")
-			.withDescription("The config parameter defining the refresh interval for the web-frontend.");
+			.withDescription("Refresh interval for the web-frontend in milliseconds.");
 
 	/**
 	 * Config parameter to override SSL support for the JobManager Web UI.
@@ -76,7 +75,7 @@ public class WebOptions {
 		key("web.ssl.enabled")
 			.defaultValue(true)
 			.withDeprecatedKeys("jobmanager.web.ssl.enabled")
-			.withDescription("Config parameter to override SSL support for the JobManager Web UI.");
+			.withDescription("Flag indicating whether to override SSL support for the JobManager Web UI.");
 
 	/**
 	 * The config parameter defining the flink web directory to be used by the webmonitor.
@@ -86,7 +85,7 @@ public class WebOptions {
 		key("web.tmpdir")
 			.defaultValue(System.getProperty("java.io.tmpdir"))
 			.withDeprecatedKeys("jobmanager.web.tmpdir")
-			.withDescription("The config parameter defining the flink web directory to be used by the webmonitor.");
+			.withDescription("Flink web directory which is used by the webmonitor.");
 
 	/**
 	 * The config parameter defining the directory for uploading the job jars. If not specified a dynamic directory
@@ -96,17 +95,17 @@ public class WebOptions {
 		key("web.upload.dir")
 			.noDefaultValue()
 			.withDeprecatedKeys("jobmanager.web.upload.dir")
-			.withDescription("The config parameter defining the directory for uploading the job jars. If not" +
-				" specified a dynamic directory will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.");
+			.withDescription("Directory for uploading the job jars. If not specified a dynamic directory will be used" +
+				" under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.");
 
 	/**
-	 * The config parameter defining the number of archived jobs for the jobmanager.
+	 * The config parameter defining the number of archived jobs for the JobManager.
 	 */
 	public static final ConfigOption<Integer> ARCHIVE_COUNT =
 		key("web.history")
 			.defaultValue(5)
 			.withDeprecatedKeys("jobmanager.web.history")
-			.withDescription("The config parameter defining the number of archived jobs for the jobmanager.");
+			.withDescription("Number of archived jobs for the JobManager.");
 
 	/**
 	 * The log file location (may be in /log for standalone but under log directory when using YARN).
@@ -115,7 +114,7 @@ public class WebOptions {
 		key("web.log.path")
 			.noDefaultValue()
 			.withDeprecatedKeys("jobmanager.web.log.path")
-			.withDescription("Define the log file location (may be in /log for standalone but under log directory when using YARN).");
+			.withDescription("Path to the log file (may be in /log for standalone but under log directory when using YARN).");
 
 	/**
 	 * Config parameter indicating whether jobs can be uploaded and run from the web-frontend.
@@ -124,7 +123,7 @@ public class WebOptions {
 		key("web.submit.enable")
 			.defaultValue(true)
 			.withDeprecatedKeys("jobmanager.web.submit.enable")
-			.withDescription("Config parameter indicating whether jobs can be uploaded and run from the web-frontend.");
+			.withDescription("Flag indicating whether jobs can be uploaded and run from the web-frontend.");
 
 	/**
 	 * Config parameter defining the number of checkpoints to remember for recent history.
@@ -133,25 +132,26 @@ public class WebOptions {
 		key("web.checkpoints.history")
 			.defaultValue(10)
 			.withDeprecatedKeys("jobmanager.web.checkpoints.history")
-			.withDescription("Config parameter defining the number of checkpoints to remember for recent history.");
+			.withDescription("Number of checkpoints to remember for recent history.");
 
 	/**
-	 * Time after which cached stats are cleaned up if not accessed.
+	 * Time, in milliseconds, after which cached stats are cleaned up if not accessed.
 	 */
 	public static final ConfigOption<Integer> BACKPRESSURE_CLEANUP_INTERVAL =
 		key("web.backpressure.cleanup-interval")
 			.defaultValue(10 * 60 * 1000)
 			.withDeprecatedKeys("jobmanager.web.backpressure.cleanup-interval")
-			.withDescription("Config parameter defining time after which cached stats are cleaned up if not accessed.");
+			.withDescription("Time, in milliseconds, after which cached stats are cleaned up if not accessed.");
 
 	/**
-	 * Time after which available stats are deprecated and need to be refreshed (by resampling).
+	 * Time, in milliseconds, after which available stats are deprecated and need to be refreshed (by resampling).
 	 */
 	public static final ConfigOption<Integer> BACKPRESSURE_REFRESH_INTERVAL =
 		key("web.backpressure.refresh-interval")
 			.defaultValue(60 * 1000)
 			.withDeprecatedKeys("jobmanager.web.backpressure.refresh-interval")
-			.withDescription("Define time after which available stats are deprecated and need to be refreshed (by resampling).");
+			.withDescription("Time, in milliseconds, after which available stats are deprecated and need to be refreshed" +
+				" (by resampling).");
 
 	/**
 	 * Number of stack trace samples to take to determine back pressure.
@@ -160,16 +160,16 @@ public class WebOptions {
 		key("web.backpressure.num-samples")
 			.defaultValue(100)
 			.withDeprecatedKeys("jobmanager.web.backpressure.num-samples")
-			.withDescription("Config parameter defining number of stack trace samples to take to determine back pressure.");
+			.withDescription("Number of stack trace samples to take to determine back pressure.");
 
 	/**
-	 * Delay between stack trace samples to determine back pressure.
+	 * Delay between stack trace samples to determine back pressure in milliseconds.
 	 */
 	public static final ConfigOption<Integer> BACKPRESSURE_DELAY =
 		key("web.backpressure.delay-between-samples")
 			.defaultValue(50)
 			.withDeprecatedKeys("jobmanager.web.backpressure.delay-between-samples")
-			.withDescription("Config parameter defining delay between stack trace samples to determine back pressure.");
+			.withDescription("Delay between stack trace samples to determine back pressure in milliseconds.");
 
 	/**
 	 * Timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.
@@ -177,7 +177,7 @@ public class WebOptions {
 	public static final ConfigOption<Long> TIMEOUT =
 		key("web.timeout")
 		.defaultValue(10L * 1000L)
-		.withDescription("Define timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.");
+		.withDescription("Timeout for asynchronous operations by the WebRuntimeMonitor in milliseconds.");
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fulfill some empty description in Config Doc and relevance javadoc.

## Brief change log

Fulfill empty description in
  - common section
  - core configuration section
  - history server configuration
  - job manager configuration
  - metric configuration
  - resource manager configuration
  - task manager configuration
  - web configuration

javadoc in ResourceManagerOptions.java

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts(all no):

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? no