### PR TITLE
[FLINK-11249] FlinkKafkaProducer011 can not be migrated to FlinkKafkaProducer

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.configuration.Configuration;
@@ -174,7 +173,7 @@ public class FlinkKafkaProducer011<IN>
 	 * Descriptor of the transactional IDs list.
 	 */
 	private static final ListStateDescriptor<NextTransactionalIdHint> NEXT_TRANSACTIONAL_ID_HINT_DESCRIPTOR =
-		new ListStateDescriptor<>("next-transactional-id-hint", TypeInformation.of(NextTransactionalIdHint.class));
+		new ListStateDescriptor<>("next-transactional-id-hint", new NextTransactionalIdHintSerializer());
 
 	/**
 	 * State for nextTransactionalIdHint.
@@ -1329,5 +1328,103 @@ public class FlinkKafkaProducer011<IN>
 			this.lastParallelism = parallelism;
 			this.nextFreeTransactionalId = nextFreeTransactionalId;
 		}
+
+		@Override
+		public String toString() {
+			return "NextTransactionalIdHint[" +
+				"lastParallelism=" + lastParallelism +
+				", nextFreeTransactionalId=" + nextFreeTransactionalId +
+				']';
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			NextTransactionalIdHint that = (NextTransactionalIdHint) o;
+
+			if (lastParallelism != that.lastParallelism) {
+				return false;
+			}
+			return nextFreeTransactionalId == that.nextFreeTransactionalId;
+		}
+
+		@Override
+		public int hashCode() {
+			int result = lastParallelism;
+			result = 31 * result + (int) (nextFreeTransactionalId ^ (nextFreeTransactionalId >>> 32));
+			return result;
+		}
 	}
+
+	/**
+	 * {@link org.apache.flink.api.common.typeutils.TypeSerializer} for
+	 * {@link NextTransactionalIdHint}.
+	 */
+	@VisibleForTesting
+	@Internal
+	public static class NextTransactionalIdHintSerializer extends TypeSerializerSingleton<NextTransactionalIdHint> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public boolean isImmutableType() {
+			return true;
+		}
+
+		@Override
+		public NextTransactionalIdHint createInstance() {
+			return new NextTransactionalIdHint();
+		}
+
+		@Override
+		public NextTransactionalIdHint copy(NextTransactionalIdHint from) {
+			return from;
+		}
+
+		@Override
+		public NextTransactionalIdHint copy(NextTransactionalIdHint from, NextTransactionalIdHint reuse) {
+			return from;
+		}
+
+		@Override
+		public int getLength() {
+			return Long.BYTES + Integer.BYTES;
+		}
+
+		@Override
+		public void serialize(NextTransactionalIdHint record, DataOutputView target) throws IOException {
+			target.writeLong(record.nextFreeTransactionalId);
+			target.writeInt(record.lastParallelism);
+		}
+
+		@Override
+		public NextTransactionalIdHint deserialize(DataInputView source) throws IOException {
+			long nextFreeTransactionalId = source.readLong();
+			int lastParallelism = source.readInt();
+			return new NextTransactionalIdHint(lastParallelism, nextFreeTransactionalId);
+		}
+
+		@Override
+		public NextTransactionalIdHint deserialize(NextTransactionalIdHint reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			target.writeLong(source.readLong());
+			target.writeInt(source.readInt());
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return obj instanceof FlinkKafkaProducer011.NextTransactionalIdHintSerializer;
+		}
+	}
+
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/NextTransactionalIdHintSerializerTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/NextTransactionalIdHintSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/**
+ * A test for the {@link TypeSerializer TypeSerializers} used for
+ * {@link FlinkKafkaProducer011.NextTransactionalIdHint}.
+ */
+public class NextTransactionalIdHintSerializerTest extends
+	SerializerTestBase<FlinkKafkaProducer011.NextTransactionalIdHint> {
+
+	@Override
+	protected TypeSerializer<FlinkKafkaProducer011.NextTransactionalIdHint> createSerializer() {
+		return new FlinkKafkaProducer011.NextTransactionalIdHintSerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return Long.BYTES + Integer.BYTES;
+	}
+
+	@Override
+	protected Class<FlinkKafkaProducer011.NextTransactionalIdHint> getTypeClass() {
+		return (Class) FlinkKafkaProducer011.NextTransactionalIdHint.class;
+	}
+
+	@Override
+	protected FlinkKafkaProducer011.NextTransactionalIdHint[] getTestData() {
+		return new FlinkKafkaProducer011.NextTransactionalIdHint[] {
+			new FlinkKafkaProducer011.NextTransactionalIdHint(1, 0L),
+			new FlinkKafkaProducer011.NextTransactionalIdHint(1, 1L),
+			new FlinkKafkaProducer011.NextTransactionalIdHint(1, -1L),
+			new FlinkKafkaProducer011.NextTransactionalIdHint(2, 0L),
+			new FlinkKafkaProducer011.NextTransactionalIdHint(2, 1L),
+			new FlinkKafkaProducer011.NextTransactionalIdHint(2, -1L),
+		};
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/NextTransactionalIdHintSerializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/NextTransactionalIdHintSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/**
+ * A test for the {@link TypeSerializer TypeSerializers} used for
+ * {@link FlinkKafkaProducer.NextTransactionalIdHint}.
+ */
+public class NextTransactionalIdHintSerializerTest extends
+	SerializerTestBase<FlinkKafkaProducer.NextTransactionalIdHint> {
+
+	@Override
+	protected TypeSerializer<FlinkKafkaProducer.NextTransactionalIdHint> createSerializer() {
+		return new FlinkKafkaProducer.NextTransactionalIdHintSerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return Long.BYTES + Integer.BYTES;
+	}
+
+	@Override
+	protected Class<FlinkKafkaProducer.NextTransactionalIdHint> getTypeClass() {
+		return (Class) FlinkKafkaProducer.NextTransactionalIdHint.class;
+	}
+
+	@Override
+	protected FlinkKafkaProducer.NextTransactionalIdHint[] getTestData() {
+		return new FlinkKafkaProducer.NextTransactionalIdHint[] {
+			new FlinkKafkaProducer.NextTransactionalIdHint(1, 0L),
+			new FlinkKafkaProducer.NextTransactionalIdHint(1, 1L),
+			new FlinkKafkaProducer.NextTransactionalIdHint(1, -1L),
+			new FlinkKafkaProducer.NextTransactionalIdHint(2, 0L),
+			new FlinkKafkaProducer.NextTransactionalIdHint(2, 1L),
+			new FlinkKafkaProducer.NextTransactionalIdHint(2, -1L),
+		};
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed FlinkKafkaProducer011 can not be migrated to FlinkKafkaProducer*


## Brief change log

  - *Implemented a new `TypeSerializer` for state class `NextTransactionalIdHint`*

## Verifying this change

This change added tests and can be verified as follows:

  - *NextTransactionalIdHintSerializerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
