### PR TITLE
[FLINK-11267][release] Only create hadoop-free binary by default

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -95,27 +95,15 @@ make_binary_release() {
   cd ${FLINK_DIR}
 }
 
-HADOOP_CLASSIFIERS=("24" "26" "27" "28")
-HADOOP_VERSIONS=("2.4.1" "2.6.5" "2.7.5" "2.8.3")
-
 if [ "$SCALA_VERSION" == "none" ] && [ "$HADOOP_VERSION" == "none" ]; then
   make_binary_release "" "-DwithoutHadoop" "2.12"
-  for i in "${!HADOOP_CLASSIFIERS[@]}"; do
-    make_binary_release "hadoop${HADOOP_CLASSIFIERS[$i]}" "-Dhadoop.version=${HADOOP_VERSIONS[$i]}" "2.12"
-  done
   make_binary_release "" "-DwithoutHadoop" "2.11"
-  for i in "${!HADOOP_CLASSIFIERS[@]}"; do
-    make_binary_release "hadoop${HADOOP_CLASSIFIERS[$i]}" "-Dhadoop.version=${HADOOP_VERSIONS[$i]}" "2.11"
-  done
 elif [ "$SCALA_VERSION" == none ] && [ "$HADOOP_VERSION" != "none" ]
 then
   make_binary_release "hadoop2" "-Dhadoop.version=$HADOOP_VERSION" "2.11"
 elif [ "$SCALA_VERSION" != none ] && [ "$HADOOP_VERSION" == "none" ]
 then
   make_binary_release "" "-DwithoutHadoop" "$SCALA_VERSION"
-  for i in "${!HADOOP_CLASSIFIERS[@]}"; do
-    make_binary_release "hadoop${HADOOP_CLASSIFIERS[$i]}" "-Dhadoop.version=${HADOOP_VERSIONS[$i]}" "$SCALA_VERSION"
-  done
 else
   make_binary_release "hadoop2x" "-Dhadoop.version=$HADOOP_VERSION" "$SCALA_VERSION"
 fi


### PR DESCRIPTION
## What is the purpose of the change

With this PR the `create_binary_release` script only creates hadoop-free Flink by default. This significantly reduces the size of our release and the time it takes to assemble it.

The script can still be used to create hadoop/scala specific distributions if explicitly told to do so.

## Verifying this change

The change itself is a trivial change without test coverage.

However this change implies that users have to copy flink-shaded-hadoop2 themselves into /lib if desired. This action is equivalent to the assembly of an hadoop-specific flink-dist, which really only copies flink-shaded-hadoop2 into /lib during the build, and thus is covered by existing tests. (hadoop free yarn+kerberos on docker; Yarn IT cases)
