### PR TITLE
[FLINK-11268][release] Deploy multiple flink-shaded-hadoop2 artifacts

### DIFF
--- a/flink-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-connectors/flink-connector-filesystem/pom.xml
@@ -53,7 +53,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -105,7 +105,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -69,7 +69,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-orc/pom.xml
+++ b/flink-connectors/flink-orc/pom.xml
@@ -71,7 +71,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -179,7 +179,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2-uber</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<!--
 				Exclusion of flink-shaded-hadoop2 not necessary, dependencies
 				are shaded away properly by flink-shaded-hadoop2-uber.

--- a/flink-dist/src/main/assemblies/hadoop.xml
+++ b/flink-dist/src/main/assemblies/hadoop.xml
@@ -31,9 +31,9 @@ under the License.
 	<files>
 		<!-- copy the Hadoop uber jar -->
 		<file>
-			<source>../flink-shaded-hadoop/flink-shaded-hadoop2-uber/target/flink-shaded-hadoop2-uber-${project.version}.jar</source>
+			<source>../flink-shaded-hadoop/flink-shaded-hadoop2-uber/target/flink-shaded-hadoop2-uber-${project.version}-${hadoop.version}.jar</source>
 			<outputDirectory>lib/</outputDirectory>
-			<destName>flink-shaded-hadoop2-uber-${project.version}.jar</destName>
+			<destName>flink-shaded-hadoop2-uber-${project.version}-${hadoop.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 	</files>

--- a/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 			<exclusions>
 				<!-- Needed for proper dependency convergence -->

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -45,7 +45,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -61,7 +61,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -47,7 +47,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -39,7 +39,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -70,7 +70,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/flink-shaded-hadoop/flink-shaded-hadoop2-uber/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2-uber/pom.xml
@@ -34,6 +34,7 @@ under the License.
 	<name>flink-shaded-hadoop2-uber</name>
 
 	<packaging>jar</packaging>
+	<version>1.8-SNAPSHOT-${hadoop.version}</version>
 
 	<!--
 		the only dependency of the 'flink-shaded-hadoop2' artifact, out
@@ -52,19 +53,6 @@ under the License.
 
 	<build>
 		<plugins>
-
-			<!-- 
-				Don't deploy this uber-jar. It is not referenced by any other artifact.
-				Its sole purpose is to be included in the 'flink-dist' build.
-			-->
- 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
 
 			<!-- 
 				Build an uber jar of the shaded-hadoop-dependency

--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -33,6 +33,7 @@ under the License.
 	<name>flink-shaded-hadoop2</name>
 
 	<packaging>jar</packaging>
+	<version>1.8-SNAPSHOT-${hadoop.version}</version>
 
 	<dependencies>
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -55,7 +55,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -119,7 +119,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -56,7 +56,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}</version>
+			<version>${project.version}-${hadoop.version}</version>
 		</dependency>
 
 		<dependency>

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -48,3 +48,11 @@ $MVN clean deploy $COMMON_OPTIONS -Dscala-2.11
 echo "Deploying Scala 2.12 version"
 $MVN clean deploy $COMMON_OPTIONS -Dscala-2.12
 
+COMMON_HADOOP_OPTIONS="-pl flink-shaded-hadoop/flink-shaded-hadoop2,flink-shaded-hadoop/flink-shaded-hadoop2-uber"
+
+HADOOP_VERSIONS=("2.4.1" "2.6.5" "2.7.5" "2.8.3")
+
+for i in "${!HADOOP_VERSIONS[@]}"; do
+echo "Deploying flink-shaded-hadoop $HADOOP_VERSIONS[$i] version"
+    $MVN clean deploy $COMMON_OPTIONS $COMMON_HADOOP_OPTIONS "-Dhadoop.version=${HADOOP_VERSIONS[$i]}"
+done


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the release scripts to deploy multiple `flink-shaded-hadoop2` artifacts, one for each supported hadoop version.

With #7416 we only release hadoop-free Flink. Effectively this means that users have to assemble hadoop-specific distributions themselves (if they need flink-shaded-hadoop2). For convenience we should deploy various `flink-shaded-hadoop2` artifacts that can be copied into /lib, one for each hadoop version.

The current `flink-shaded-hadoop2` modules however do not allow deployment of multiple artifacts for different hadoop versions, as the hadoop.version property is not used in neither the artifactId noror version. Attempting to deploy these modules would lead to them overriding each other, and a random version winning out.
I have opted for including the hadoop.version property in the version of the artifact. We _could_ include it in the artifactId, but we'd either end up with periods in the name (e.g. `flink-shaded-hadoop2-2.4.8`) which is unusual, or require another "version-like" property to be set that doesn't contain periods.
The downside is that `flink-shaded-hadoop2` modules now have to set `<version>1.8-SNAPSHOT-${hadoop.version}</version>`, that is they have to explicitly refer to the SNAPSHOT version. AFAIK there's no way to refer to the parents version instead (`project.version` refers to the current module).

## Brief change log

* enable deployment for flink-shaded-hadoop2-uber
* add hadoop version to flink-shaded-hadoop2(-uber) version
* modify `deploy_staging_jars.sh` to release multiple versions of hadoop artifacts

## Verifying this change

The changes to the release scripts can be verified by running the scrip and checking the uploaded artifacts. For convenience I'd remove the calls that deploy Flink itself.
The pom changes are covered by existing E2E tests and IT cases (the yarn IT cases use flink-dist and require flink-shaded-hadoop to be in /lib).
