### PR TITLE
[FLINK-11167][runtime] Optimize RocksDBListState#Put by removing the clear before put operation when input is not empty

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -210,8 +210,6 @@ class RocksDBListState<K, N, V>
 	public void updateInternal(List<V> values) {
 		Preconditions.checkNotNull(values, "List of values to add cannot be null.");
 
-		clear();
-
 		if (!values.isEmpty()) {
 			try {
 				backend.db.put(
@@ -222,6 +220,8 @@ class RocksDBListState<K, N, V>
 			} catch (IOException | RocksDBException e) {
 				throw new FlinkRuntimeException("Error while updating data to RocksDB", e);
 			}
+		} else {
+			clear();
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
This pull request adjusts the clear's position in function `updateInternal`, so when the input `values` is not empty, we do not need to call the clear operation.


## Verifying this change
This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
