### PR TITLE
[FLINK-9457][ResourceManager][YARN] Cancel container requests when cancelling pending slot allocations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1054,6 +1054,13 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	public abstract Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile);
 
 	/**
+	 * Cancel a resource request previously submitted via {@link #startNewWorker(ResourceProfile)}.
+	 *
+	 * @param resourceProfile The resource description
+	 */
+	protected void cancelWorkerRequest(ResourceProfile resourceProfile) {}
+
+	/**
 	 * Callback when a worker was started.
 	 * @param resourceID The worker resource id
 	 */
@@ -1084,6 +1091,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		public Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile) {
 			validateRunsInMainThread();
 			return startNewWorker(resourceProfile);
+		}
+
+		@Override
+		public void cancelResourceRequest(ResourceProfile resourceProfile) {
+			validateRunsInMainThread();
+			cancelWorkerRequest(resourceProfile);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -49,6 +49,13 @@ public interface ResourceActions {
 	Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile) throws ResourceManagerException;
 
 	/**
+	 * Cancel a resource request previously submitted via {@link #allocateResource(ResourceProfile)}.
+	 *
+	 * @param resourceProfile for the to be cancelled resource
+	 */
+	void cancelResourceRequest(ResourceProfile resourceProfile);
+
+	/**
 	 * Notifies that an allocation failure has occurred.
 	 *
 	 * @param jobId to which the allocation belonged

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -986,12 +986,24 @@ public class SlotManager implements AutoCloseable {
 	 * @param pendingSlotRequest to cancel
 	 */
 	private void cancelPendingSlotRequest(PendingSlotRequest pendingSlotRequest) {
+		cancelResourceRequest(pendingSlotRequest);
+
 		CompletableFuture<Acknowledge> request = pendingSlotRequest.getRequestFuture();
 
 		returnPendingTaskManagerSlotIfAssigned(pendingSlotRequest);
 
 		if (null != request) {
 			request.cancel(false);
+		}
+	}
+
+	private void cancelResourceRequest(PendingSlotRequest pendingSlotRequest) {
+		if (!pendingSlotRequest.isAssigned()) {
+			final PendingTaskManagerSlot pendingTaskManagerSlot =
+				pendingSlotRequest.getAssignedPendingTaskManagerSlot();
+			if (pendingTaskManagerSlot != null) {
+				resourceActions.cancelResourceRequest(pendingTaskManagerSlot.getResourceProfile());
+			}
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -46,13 +46,18 @@ public class TestingResourceActions implements ResourceActions {
 	@Nonnull
 	private final Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer;
 
+	@Nonnull
+	private final Consumer<ResourceProfile> cancelResourceRequestConsumer;
+
 	public TestingResourceActions(
 			@Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
 			@Nonnull FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> allocateResourceFunction,
-			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer) {
+			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer,
+			@Nonnull Consumer<ResourceProfile> cancelResourceRequestConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
 		this.allocateResourceFunction = allocateResourceFunction;
 		this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
+		this.cancelResourceRequestConsumer = cancelResourceRequestConsumer;
 	}
 
 	@Override
@@ -69,4 +74,10 @@ public class TestingResourceActions implements ResourceActions {
 	public void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause) {
 		notifyAllocationFailureConsumer.accept(Tuple3.of(jobId, allocationId, cause));
 	}
+
+	@Override
+	public void cancelResourceRequest(ResourceProfile resourceProfile) {
+		cancelResourceRequestConsumer.accept(resourceProfile);
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
@@ -38,6 +38,7 @@ public class TestingResourceActionsBuilder {
 	private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
 	private FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> allocateResourceFunction = (ignored) -> Collections.singleton(ResourceProfile.UNKNOWN);
 	private Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer = (ignored) -> {};
+	private Consumer<ResourceProfile> cancelResourceRequestConsumer = (ignored) -> {};
 
 	public TestingResourceActionsBuilder setReleaseResourceConsumer(BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
@@ -62,7 +63,13 @@ public class TestingResourceActionsBuilder {
 		return this;
 	}
 
+	public TestingResourceActionsBuilder setCancelResourceRequestConsumer(Consumer<ResourceProfile> cancelResourceRequestConsumer) {
+		this.cancelResourceRequestConsumer = cancelResourceRequestConsumer;
+		return this;
+	}
+
 	public TestingResourceActions build() {
-		return new TestingResourceActions(releaseResourceConsumer, allocateResourceFunction, notifyAllocationFailureConsumer);
+		return new TestingResourceActions(releaseResourceConsumer, allocateResourceFunction,
+			notifyAllocationFailureConsumer, cancelResourceRequestConsumer);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR cancels container requests when cancelling pending slot allocations for `YarnResourceManager`. `MesosResourceManager` could be updated by a separate PR.

## Brief changelog

  - Add `cancelResourceRequest` to `SlotManager`. When cancelling a pending slot request which no container had been assigned to and has a pending slot, cancel the container request via `cancelResourceRequest`.
  - Add `cancelResourceRequest` to `ResourceAction`.
  - Add `cancelWorkerRequest` to `ResourceManager`.
  - Implement `cancelWorkerRequest` for `YarnResourceManager` to remove container requests. Using a lock to ensure that the retrieval and removal of pending requests are an atomic operation.

## Verifying this change

This change added tests:
  - Add `testCancelResourceRequest` to `SlotManagerTest`.
  - Add `testCancelWorkerRequest` to `YarnResourceManagerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (***yes***)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
