### PR TITLE
[hotfix] [test] Reduce test timeout to a reasonable value

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
@@ -106,7 +106,7 @@ import static org.junit.Assert.fail;
  */
 public abstract class AbstractQueryableStateTestBase extends TestLogger {
 
-	private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10000L);
+	private static final Duration TEST_TIMEOUT = Duration.ofSeconds(200L);
 	private static final long RETRY_TIMEOUT = 50L;
 
 	private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(4);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
@@ -153,7 +153,6 @@ public abstract class AbstractQueryableStateTestBase extends TestLogger {
 	 * to query the counts of each key in rounds until all keys have non-zero counts.
 	 */
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testQueryableState() throws Exception {
 		final Deadline deadline = Deadline.now().plus(TEST_TIMEOUT);
 		final int numKeys = 256;
@@ -597,6 +596,7 @@ public abstract class AbstractQueryableStateTestBase extends TestLogger {
 					}
 				}).asQueryableState("matata");
 
+		@SuppressWarnings("unchecked")
 		final ValueStateDescriptor<Tuple2<Integer, Long>> stateDesc =
 				(ValueStateDescriptor<Tuple2<Integer, Long>>) queryableState.getStateDescriptor();
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
@@ -56,8 +56,8 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.QueryableStateStream;
@@ -107,7 +107,7 @@ import static org.junit.Assert.fail;
 public abstract class AbstractQueryableStateTestBase extends TestLogger {
 
 	private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10000L);
-	public static final long RETRY_TIMEOUT = 50L;
+	private static final long RETRY_TIMEOUT = 50L;
 
 	private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(4);
 	private final ScheduledExecutor executor = new ScheduledExecutorServiceAdapter(executorService);
@@ -115,7 +115,7 @@ public abstract class AbstractQueryableStateTestBase extends TestLogger {
 	/**
 	 * State backend to use.
 	 */
-	protected AbstractStateBackend stateBackend;
+	private StateBackend stateBackend;
 
 	/**
 	 * Client shared between all the test.
@@ -142,7 +142,7 @@ public abstract class AbstractQueryableStateTestBase extends TestLogger {
 	 *
 	 * @return a state backend instance for each unit test
 	 */
-	protected abstract AbstractStateBackend createStateBackend() throws Exception;
+	protected abstract StateBackend createStateBackend() throws Exception;
 
 	/**
 	 * Runs a simple topology producing random (key, 1) pairs at the sources (where

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.QueryableStateOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.queryablestate.client.QueryableStateClient;
-import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
@@ -58,7 +58,7 @@ public class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestB
 	private static MiniClusterWithClientResource miniClusterResource;
 
 	@Override
-	protected AbstractStateBackend createStateBackend() throws Exception {
+	protected StateBackend createStateBackend() throws Exception {
 		return new FsStateBackend(temporaryFolder.newFolder().toURI().toString());
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.queryablestate.client.QueryableStateClient;
-import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
@@ -58,7 +58,7 @@ public class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableState
 	private static MiniClusterWithClientResource miniClusterResource;
 
 	@Override
-	protected AbstractStateBackend createStateBackend() throws Exception {
+	protected StateBackend createStateBackend() throws Exception {
 		return new RocksDBStateBackend(temporaryFolder.newFolder().toURI().toString());
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.QueryableStateOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.queryablestate.client.QueryableStateClient;
-import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
@@ -61,7 +61,7 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 			.build());
 
 	@Override
-	protected AbstractStateBackend createStateBackend() throws Exception {
+	protected StateBackend createStateBackend() throws Exception {
 		return new FsStateBackend(temporaryFolder.newFolder().toURI().toString());
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.queryablestate.client.QueryableStateClient;
-import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
@@ -60,7 +60,7 @@ public class NonHAQueryableStateRocksDBBackendITCase extends AbstractQueryableSt
 			.build());
 
 	@Override
-	protected AbstractStateBackend createStateBackend() throws Exception {
+	protected StateBackend createStateBackend() throws Exception {
 		return new RocksDBStateBackend(temporaryFolder.newFolder().toURI().toString());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Test timeout in `AbstractQueryableStateTestBase` is set to `10000 seconds`, but maven test will fail if no output produced for 300 seconds. So reduce the test timeout to `200 seconds` as a reasonable value.

Also in separated commits, remove usage of deprecated method and adjust suppress warnings.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @StefanRRichter @dawidwys 