### PR TITLE
[FLINK-11280] [state backends] Let RocksDBSerializedCompositeKeyBuilder accept key serializer lazily

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -134,11 +134,11 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 
 		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
 						new RocksDBSerializedCompositeKeyBuilder<>(
-							safeKeySerializer,
 							backend.getKeyGroupPrefixBytes(),
-							32
+							32,
+							RocksDBKeySerializationUtils.isSerializerTypeVariableSized(safeKeySerializer)
 						);
-		keyBuilder.setKeyAndKeyGroup(keyAndNamespace.f0, keyGroup);
+		keyBuilder.setKeyAndKeyGroup(keyAndNamespace.f0, keyGroup, safeKeySerializer);
 		byte[] key = keyBuilder.buildCompositeKeyNamespace(keyAndNamespace.f1, namespaceSerializer);
 		return backend.db.get(columnFamily, key);
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -261,11 +261,11 @@ class RocksDBMapState<K, N, UK, UV>
 
 		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
 			new RocksDBSerializedCompositeKeyBuilder<>(
-				safeKeySerializer,
 				backend.getKeyGroupPrefixBytes(),
-				32);
+				32,
+				RocksDBKeySerializationUtils.isSerializerTypeVariableSized(safeKeySerializer));
 
-		keyBuilder.setKeyAndKeyGroup(keyAndNamespace.f0, keyGroup);
+		keyBuilder.setKeyAndKeyGroup(keyAndNamespace.f0, keyGroup, safeKeySerializer);
 
 		final byte[] keyPrefixBytes = keyBuilder.buildCompositeKeyNamespace(keyAndNamespace.f1, namespaceSerializer);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
@@ -191,9 +191,4 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 		return keySerializerTypeVariableSized &
 			RocksDBKeySerializationUtils.isSerializerTypeVariableSized(namespaceSerializer);
 	}
-
-	@VisibleForTesting
-	boolean isKeySerializerTypeVariableSized() {
-		return keySerializerTypeVariableSized;
-	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilderTest.java
@@ -88,7 +88,7 @@ public class RocksDBSerializedCompositeKeyBuilderTest {
 
 		final DataInputDeserializer deserializer = new DataInputDeserializer();
 		for (K testKey : testKeys) {
-			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, maxParallelism);
+			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, serializer, maxParallelism);
 			byte[] result = dataOutputSerializer.getCopyOfBuffer();
 			deserializer.setBuffer(result);
 			assertKeyKeyGroupBytes(testKey, keyGroup, prefixBytes, serializer, deserializer, false);
@@ -112,7 +112,7 @@ public class RocksDBSerializedCompositeKeyBuilderTest {
 		final boolean ambiguousPossible = keyBuilder.isAmbiguousCompositeKeyPossible(namespaceSerializer);
 
 		for (K testKey : testKeys) {
-			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, maxParallelism);
+			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, keySerializer, maxParallelism);
 			for (N testNamespace : testNamespaces) {
 				byte[] compositeBytes = keyBuilder.buildCompositeKeyNamespace(testNamespace, namespaceSerializer);
 				deserializer.setBuffer(compositeBytes);
@@ -148,7 +148,7 @@ public class RocksDBSerializedCompositeKeyBuilderTest {
 		final boolean ambiguousPossible = keyBuilder.isAmbiguousCompositeKeyPossible(namespaceSerializer);
 
 		for (K testKey : testKeys) {
-			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, maxParallelism);
+			int keyGroup = setKeyAndReturnKeyGroup(keyBuilder, testKey, keySerializer, maxParallelism);
 			for (N testNamespace : testNamespaces) {
 				for (U testUserKey : testUserKeys) {
 					byte[] compositeBytes = keyBuilder.buildCompositeKeyNamesSpaceUserKey(
@@ -181,7 +181,6 @@ public class RocksDBSerializedCompositeKeyBuilderTest {
 		int prefixBytes) {
 		final boolean variableSize = RocksDBKeySerializationUtils.isSerializerTypeVariableSized(serializer);
 		return new RocksDBSerializedCompositeKeyBuilder<>(
-			serializer,
 			dataOutputSerializer,
 			prefixBytes,
 			variableSize,
@@ -191,10 +190,11 @@ public class RocksDBSerializedCompositeKeyBuilderTest {
 	private <K> int setKeyAndReturnKeyGroup(
 		RocksDBSerializedCompositeKeyBuilder<K> compositeKeyBuilder,
 		K key,
+		TypeSerializer<K> keySerializer,
 		int maxParallelism) {
 
 		int keyGroup = KeyGroupRangeAssignment.assignKeyToParallelOperator(key, maxParallelism, maxParallelism);
-		compositeKeyBuilder.setKeyAndKeyGroup(key, keyGroup);
+		compositeKeyBuilder.setKeyAndKeyGroup(key, keyGroup, keySerializer);
 		return keyGroup;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the failing test in master:
`StateBackendMigrationTestBase.testStateBackendRestoreSucceedsIfNewKeySerializerRequiresReconfiguration`.

The failing test indicates that a key serializer that was supposed to have been reconfigured was still being used. Serializers are assumed to be immutable, and therefore when a reconfiguration occurs, the key serializer instance to use would have changed from the originally provided key serializer.

The problem is in the `RocksDBSerializedCompositeKeyBuilder`, which keeps a reference to the original key serializer and always uses that. This essentially ignores any key serializer reconfiguration that may have happened.

Prior to this PR, the `RocksDBSerializedCompositeKeyBuilder` expects a key serializer when creating the builder. This PR fixes the failing tests by changing the usage of `RocksDBSerializedCompositeKeyBuilder` so that the key serializer is only provided lazily when the builder is used to build a composite serialized key.

## Verifying this change

The previously failing test `StateBackendMigrationTestBase.testStateBackendRestoreSucceedsIfNewKeySerializerRequiresReconfiguration` should now pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
