### PR TITLE
[FLINK-11226] Lack of getKeySelector in Scala KeyedStream API unlike Java KeyedStream

### DIFF
--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -44,6 +44,13 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
   // ------------------------------------------------------------------------
 
   /**
+    * Gets the key selector that can get the key by which the stream
+    * if partitioned from the elements.
+    */
+  @Internal
+  def getKeySelector = javaStream.getKeySelector()
+
+  /**
    * Gets the type of the key by which this stream is keyed.
    */
   @Internal

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/KeyedStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/KeyedStreamTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.test.util.AbstractTestBase
+import org.junit.Test
+
+/**
+  * Unit test for [[org.apache.flink.streaming.api.scala.KeyedStream]].
+  */
+class KeyedStreamTest extends AbstractTestBase{
+
+  @Test
+  def testGetKeySelector(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val dataStream = env.generateSequence(0, 0).name("testSource1")
+      .keyBy(x=>x)
+
+    assert(dataStream.getKeySelector != null)
+    assert(dataStream.getKeySelector.getKey(0) == 0)
+  }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request provides a internal API `getKeySelector` for `KeyedStream.scala`*


## Brief change log

  - *Provide a internal API `getKeySelector` for `KeyedStream.scala`*
  - *Add unit test case for `getKeySelector`* 


## Verifying this change

This change is already covered by existing tests, such as *KeyedStreamTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
