### PR TITLE
[FLINK-11278] [docs] Add documentation for TableAPI&SQL in scala-shell

### DIFF
--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -89,8 +89,10 @@ The Flink Shell comes with command history and auto-completion.
 ### Table API
 
 The example below is a streaming wordcount program using Table API:
-
+<div class="codetabs" markdown="1">
+<div data-lang="stream" markdown="1">
 {% highlight scala %}
+Scala-Flink> import org.apache.flink.table.functions.TableFunction
 Scala-Flink> val textSource = stenv.fromDataStream(
   senv.fromElements(
     "To be, or not to be,--that is the question:--",
@@ -98,26 +100,50 @@ Scala-Flink> val textSource = stenv.fromDataStream(
     "The slings and arrows of outrageous fortune",
     "Or to take arms against a sea of troubles,"), 
   'text)
-Scala-Flink> import org.apache.flink.table.functions.TableFunction
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {
       s.toLowerCase.split("\\W+").foreach(collect)
     }
   }
 Scala-Flink> val split = new $Split
-Scala-Flink> textSource.join(split('text) as 'word)
-    .groupBy('word).select('word, 'word.count as 'count)
-    .toRetractStream[(String, Long)].print
+Scala-Flink> textSource.join(split('text) as 'word).
+    groupBy('word).select('word, 'word.count as 'count).
+    toRetractStream[(String, Long)].print
 Scala-Flink> senv.execute("Table Wordcount")
 {% endhighlight %}
+</div>
+<div data-lang="batch" markdown="1">
+{% highlight scala %}
+Scala-Flink> import org.apache.flink.table.functions.TableFunction
+Scala-Flink> val textSource = btenv.fromDataSet(
+  benv.fromElements(
+    "To be, or not to be,--that is the question:--",
+    "Whether 'tis nobler in the mind to suffer",
+    "The slings and arrows of outrageous fortune",
+    "Or to take arms against a sea of troubles,"), 
+  'text)
+Scala-Flink> class $Split extends TableFunction[String] {
+    def eval(s: String): Unit = {
+      s.toLowerCase.split("\\W+").foreach(collect)
+    }
+  }
+Scala-Flink> val split = new $Split
+Scala-Flink> textSource.join(split('text) as 'word).
+    groupBy('word).select('word, 'word.count as 'count).
+    toDataSet[(String, Long)].print
+{% endhighlight %}
+</div>
+</div>
 
 Note that the $ prefix of the TableFunction classname is a walkaround of a scala issue about incorrectly generated inner class name. 
 
 ### SQL
 
 The following example is a streaming wordcount program written in SQL:
-
+<div class="codetabs" markdown="1">
+<div data-lang="stream" markdown="1">
 {% highlight scala %}
+Scala-Flink> import org.apache.flink.table.functions.TableFunction
 Scala-Flink> val textSource = stenv.fromDataStream(
   senv.fromElements(
     "To be, or not to be,--that is the question:--",
@@ -126,17 +152,47 @@ Scala-Flink> val textSource = stenv.fromDataStream(
     "Or to take arms against a sea of troubles,"), 
   'text)
 Scala-Flink> stenv.registerTable("text_source", textSource)
-Scala-Flink> import org.apache.flink.table.functions.TableFunction
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {
       s.toLowerCase.split("\\W+").foreach(collect)
     }
   }
 Scala-Flink> stenv.registerFunction("split", new $Split)
-Scala-Flink> val result = stenv.sqlQuery("SELECT T.word, count(T.word) AS `count` FROM text_source JOIN LATERAL table(split(text)) AS T(word) ON TRUE GROUP BY T.word")
+Scala-Flink> val result = stenv.sqlQuery("""SELECT T.word, count(T.word) AS `count` 
+    FROM text_source 
+    JOIN LATERAL table(split(text)) AS T(word) 
+    ON TRUE 
+    GROUP BY T.word""")
 Scala-Flink> result.toRetractStream[(String, Long)].print
 Scala-Flink> senv.execute("SQL Wordcount")
 {% endhighlight %}
+</div>
+<div data-lang="batch" markdown="1">
+{% highlight scala %}
+Scala-Flink> import org.apache.flink.table.functions.TableFunction
+Scala-Flink> val textSource = btenv.fromDataSet(
+  benv.fromElements(
+    "To be, or not to be,--that is the question:--",
+    "Whether 'tis nobler in the mind to suffer",
+    "The slings and arrows of outrageous fortune",
+    "Or to take arms against a sea of troubles,"), 
+  'text)
+Scala-Flink> btenv.registerTable("text_source", textSource)
+Scala-Flink> class $Split extends TableFunction[String] {
+    def eval(s: String): Unit = {
+      s.toLowerCase.split("\\W+").foreach(collect)
+    }
+  }
+Scala-Flink> btenv.registerFunction("split", new $Split)
+Scala-Flink> val result = btenv.sqlQuery("""SELECT T.word, count(T.word) AS `count` 
+    FROM text_source 
+    JOIN LATERAL table(split(text)) AS T(word) 
+    ON TRUE 
+    GROUP BY T.word""")
+Scala-Flink> result.toDataSet[(String, Long)].print
+{% endhighlight %}
+</div>
+</div>
 
 ## Adding external dependencies
 

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -38,8 +38,8 @@ cluster, please see the Setup section below.
 
 The shell supports Batch, Streaming, Table API and SQL. 
 Four different Environments are automatically prebound after startup. 
-Use “benv” and “senv” to access the Batch and Streaming ExecutionEnvironment respectively. 
-Use "btenv" and “stenv” to access BatchTableEnvironment and StreamTableEnvironment respectively.
+Use "benv" and "senv" to access the Batch and Streaming ExecutionEnvironment respectively. 
+Use "btenv" and "stenv" to access BatchTableEnvironment and StreamTableEnvironment respectively.
 
 ### DataSet API
 
@@ -135,7 +135,7 @@ Scala-Flink> textSource.join(split('text) as 'word).
 </div>
 </div>
 
-Note, that the $ prefix of the TableFunction classname is a walkaround of a scala issue about incorrectly generated inner class name. 
+Note, that the $ prefix of the TableFunction class name is a workaround of a scala issue about incorrectly generated inner class name. 
 
 ### SQL
 

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -88,7 +88,7 @@ The Flink Shell comes with command history and auto-completion.
 
 ### Table API
 
-The example below is a streaming wordcount program using Table API:
+The example below is a wordcount program using Table API:
 <div class="codetabs" markdown="1">
 <div data-lang="stream" markdown="1">
 {% highlight scala %}
@@ -135,11 +135,11 @@ Scala-Flink> textSource.join(split('text) as 'word).
 </div>
 </div>
 
-Note that the $ prefix of the TableFunction classname is a walkaround of a scala issue about incorrectly generated inner class name. 
+Note, that the $ prefix of the TableFunction classname is a walkaround of a scala issue about incorrectly generated inner class name. 
 
 ### SQL
 
-The following example is a streaming wordcount program written in SQL:
+The following example is a wordcount program written in SQL:
 <div class="codetabs" markdown="1">
 <div data-lang="stream" markdown="1">
 {% highlight scala %}

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -98,7 +98,7 @@ Scala-Flink> val textSource = stenv.fromDataStream(
     "To be, or not to be,--that is the question:--",
     "Whether 'tis nobler in the mind to suffer",
     "The slings and arrows of outrageous fortune",
-    "Or to take arms against a sea of troubles,"), 
+    "Or to take arms against a sea of troubles,"),
   'text)
 Scala-Flink> class $Split extends TableFunction[String] {
     def eval(s: String): Unit = {

--- a/docs/ops/scala_shell.md
+++ b/docs/ops/scala_shell.md
@@ -36,7 +36,7 @@ cluster, please see the Setup section below.
 
 ## Usage
 
-The shell supports Batch, Streaming, Table API and SQL. 
+The shell supports DataSet, DataStream, Table API and SQL. 
 Four different Environments are automatically prebound after startup. 
 Use "benv" and "senv" to access the Batch and Streaming ExecutionEnvironment respectively. 
 Use "btenv" and "stenv" to access BatchTableEnvironment and StreamTableEnvironment respectively.
@@ -135,7 +135,7 @@ Scala-Flink> textSource.join(split('text) as 'word).
 </div>
 </div>
 
-Note, that the $ prefix of the TableFunction class name is a workaround of a scala issue about incorrectly generated inner class name. 
+Note, that using $ as a prefix for the class name of TableFunction is a workaround of the issue that scala incorrectly generated inner class name.
 
 ### SQL
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds documentation for TableAPI&SQL in scala-shell.


## Brief change log

  - add documentation for TableAPI&SQL in scala-shell


## Verifying this change
This change is not need to add verify  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
