### PR TITLE
 [FLINK-10591][table] Introduced functions to return time attributes from MATCH_RECOGNIZE

### DIFF
--- a/docs/dev/table/streaming/match_recognize.md
+++ b/docs/dev/table/streaming/match_recognize.md
@@ -902,6 +902,37 @@ One has to keep in mind that in case of the `SKIP TO FIRST/LAST variable` strate
 variable (e.g. for pattern `A*`). In such cases, a runtime exception will be thrown as the standard requires a valid row to continue the
 matching.
 
+Time attributes
+---------------
+
+In order to apply some subsequent queries on top of the `MATCH_RECOGNIZE` it might be required to use [time attributes](time_attributes.html). To select those there
+are available two functions:
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Function</th>
+      <th class="text-left">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        <code>MATCH_ROWTIME()</code><br/>
+      </td>
+      <td><p>Returns the timestamp of the last row that was mapped to the given pattern.</p>
+      <p>The resulting attribute is a <a href="streaming/time_attributes.html">rowtime attribute</a> that can be used in subsequent time-based operations such as <a href="#joins">time-windowed joins</a> and <a href="#aggregations">group window or over window aggregations</a>.</p></td>
+    </tr>
+    <tr>
+      <td>
+        <code>MATCH_PROCTIME()</code><br/>
+      </td>
+      <td><p>Returns a <a href="streaming/time_attributes.html#processing-time">proctime attribute</a> that can be used in subsequent time-based operations such as <a href="#joins">time-windowed joins</a> and <a href="#aggregations">group window or over window aggregations</a>.</p></td>
+    </tr>
+  </tbody>
+</table>
+
 Controlling Memory Consumption
 ------------------------------
 

--- a/docs/dev/table/streaming/match_recognize.md
+++ b/docs/dev/table/streaming/match_recognize.md
@@ -24,17 +24,26 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-It is a common use case to search for a set of event patterns, especially in case of data streams. Flink
-comes with a [complex event processing (CEP) library]({{ site.baseurl }}/dev/libs/cep.html) which allows for pattern detection in event streams. Furthermore, Flink's
-SQL API provides a relational way of expressing queries with a large set of built-in functions and rule-based optimizations that can be used out of the box.
+It is a common use case to search for a set of event patterns, especially in case of data streams.
+Flink comes with a [complex event processing (CEP) library]({{ site.baseurl }}/dev/libs/cep.html)
+which allows for pattern detection in event streams. Furthermore, Flink's SQL API provides a
+relational way of expressing queries with a large set of built-in functions and rule-based
+optimizations that can be used out of the box.
 
-In December 2016, the International Organization for Standardization (ISO) released a new version of the SQL standard which includes _Row Pattern Recognition in SQL_ ([ISO/IEC TR 19075-5:2016](https://standards.iso.org/ittf/PubliclyAvailableStandards/c065143_ISO_IEC_TR_19075-5_2016.zip)). It allows Flink to consolidate CEP and SQL API using the `MATCH_RECOGNIZE` clause for complex event processing in SQL.
+In December 2016, the International Organization for Standardization (ISO) released a new version
+of the SQL standard which includes _Row Pattern Recognition in SQL_
+([ISO/IEC TR 19075-5:2016](https://standards.iso.org/ittf/PubliclyAvailableStandards/c065143_ISO_IEC_TR_19075-5_2016.zip)).
+It allows Flink to consolidate CEP and SQL API using the `MATCH_RECOGNIZE` clause for complex event
+processing in SQL.
 
 A `MATCH_RECOGNIZE` clause enables the following tasks:
-* Logically partition and order the data that is used with the `PARTITION BY` and `ORDER BY` clauses.
-* Define patterns of rows to seek using the `PATTERN` clause. These patterns use a syntax similar to that of regular expressions.
+* Logically partition and order the data that is used with the `PARTITION BY` and `ORDER BY`
+  clauses.
+* Define patterns of rows to seek using the `PATTERN` clause. These patterns use a syntax similar to
+  that of regular expressions.
 * The logical components of the row pattern variables are specified in the `DEFINE` clause.
-* Define measures, which are expressions usable in other parts of the SQL query, in the `MEASURES` clause.
+* Define measures, which are expressions usable in other parts of the SQL query, in the `MEASURES`
+  clause.
 
 The following example illustrates the syntax for basic pattern recognition:
 
@@ -58,7 +67,10 @@ FROM MyTable
 
 This page will explain each keyword in more detail and will illustrate more complex examples.
 
-<span class="label label-danger">Attention</span> Flink's implementation of the `MATCH_RECOGNIZE` clause is a subset of the full standard. Only those features documented in the following sections are supported. Since the development is still in an early phase, please also take a look at the [known limitations](#known-limitations).
+<span class="label label-danger">Attention</span> Flink's implementation of the `MATCH_RECOGNIZE`
+clause is a subset of the full standard. Only those features documented in the following sections
+are supported. Since the development is still in an early phase, please also take a look at the
+[known limitations](#known-limitations).
 
 * This will be replaced by the TOC
 {:toc}
@@ -68,8 +80,9 @@ Introduction and Examples
 
 ### Installation Guide
 
-The pattern recognition feature uses the Apache Flink's CEP library internally. In order to be able to use the `MATCH_RECOGNIZE` clause,
-the library needs to be added as a dependency to your Maven project.
+The pattern recognition feature uses the Apache Flink's CEP library internally. In order to be able
+to use the `MATCH_RECOGNIZE` clause, the library needs to be added as a dependency to your Maven
+project.
 
 {% highlight xml %}
 <dependency>
@@ -79,29 +92,39 @@ the library needs to be added as a dependency to your Maven project.
 </dependency>
 {% endhighlight %}
 
-Alternatively, you can also add the dependency to the cluster classpath (see the [dependency section]({{ site.baseurl}}/projectsetup/dependencies.html) for more information).
+Alternatively, you can also add the dependency to the cluster classpath (see the
+[dependency section]({{ site.baseurl}}/projectsetup/dependencies.html) for more information).
 
-If you want to use the `MATCH_RECOGNIZE` clause in the [SQL Client]({{ site.baseurl}}/dev/table/sqlClient.html),
-you don't have to do anything as all the dependencies are included by default.
+If you want to use the `MATCH_RECOGNIZE` clause in the
+[SQL Client]({{ site.baseurl}}/dev/table/sqlClient.html), you don't have to do anything as all the
+dependencies are included by default.
 
 ### SQL Semantics
 
 Every `MATCH_RECOGNIZE` query consists of the following clauses:
 
-* [PARTITION BY](#partitioning) - defines the logical partitioning of the table; similar to a `GROUP BY` operation.
-* [ORDER BY](#order-of-events) - specifies how the incoming rows should be ordered; this is essential as patterns depend on an order.
+* [PARTITION BY](#partitioning) - defines the logical partitioning of the table; similar to a
+  `GROUP BY` operation.
+* [ORDER BY](#order-of-events) - specifies how the incoming rows should be ordered; this is
+  essential as patterns depend on an order.
 * [MEASURES](#define--measures) - defines output of the clause; similar to a `SELECT` clause.
-* [ONE ROW PER MATCH](#output-mode) - output mode which defines how many rows per match should be produced.
-* [AFTER MATCH SKIP](#after-match-strategy) - specifies where the next match should start; this is also a way to control how many distinct matches a single event can belong to.
-* [PATTERN](#defining-a-pattern) - allows constructing patterns that will be searched for using a _regular expression_-like syntax.
-* [DEFINE](#define--measures) - this section defines the conditions that the pattern variables must satisfy.
+* [ONE ROW PER MATCH](#output-mode) - output mode which defines how many rows per match should be
+  produced.
+* [AFTER MATCH SKIP](#after-match-strategy) - specifies where the next match should start; this is
+  also a way to control how many distinct matches a single event can belong to.
+* [PATTERN](#defining-a-pattern) - allows constructing patterns that will be searched for using a
+  _regular expression_-like syntax.
+* [DEFINE](#define--measures) - this section defines the conditions that the pattern variables must
+  satisfy.
 
-<span class="label label-danger">Attention</span> Currently, the `MATCH_RECOGNIZE` clause can only be applied to an [append table](dynamic_tables.html#update-and-append-queries). Furthermore, it always produces
-an append table as well.
+<span class="label label-danger">Attention</span> Currently, the `MATCH_RECOGNIZE` clause can only
+be applied to an [append table](dynamic_tables.html#update-and-append-queries). Furthermore, it
+always produces an append table as well.
 
 ### Examples
 
-For our examples, we assume that a table `Ticker` has been registered. The table contains prices of stocks at a particular point in time.
+For our examples, we assume that a table `Ticker` has been registered. The table contains prices of
+stocks at a particular point in time.
 
 The table has a following schema:
 
@@ -113,7 +136,8 @@ Ticker
      |-- rowtime: TimeIndicatorTypeInfo(rowtime)  # point in time when the change to those values happened
 {% endhighlight %}
 
-For simplification, we only consider the incoming data for a single stock `ACME`. A ticker could look similar to the following table where rows are continuously appended.
+For simplification, we only consider the incoming data for a single stock `ACME`. A ticker could
+look similar to the following table where rows are continuously appended.
 
 {% highlight text %}
 symbol         rowtime         price    tax
@@ -131,7 +155,8 @@ symbol         rowtime         price    tax
 'ACME'  '01-Apr-11 10:00:10'   19      1
 {% endhighlight %}
 
-The task is now to find periods of a constantly decreasing price of a single ticker. For this, one could write a query like:
+The task is now to find periods of a constantly decreasing price of a single ticker. For this, one
+could write a query like:
 
 {% highlight sql %}
 SELECT *
@@ -155,19 +180,31 @@ FROM Ticker
     ) MR;
 {% endhighlight %}
 
-The query partitions the `Ticker` table by the `symbol` column and orders it by the `rowtime` time attribute.
+The query partitions the `Ticker` table by the `symbol` column and orders it by the `rowtime`
+time attribute.
 
-The `PATTERN` clause specifies that we are interested in a pattern with a starting event `START_ROW` that is followed by one or more `PRICE_DOWN` events and concluded with a `PRICE_UP` event. If such a pattern can be found, the next pattern match will be seeked at the last `PRICE_UP` event as indicated by the `AFTER MATCH SKIP TO LAST` clause.
+The `PATTERN` clause specifies that we are interested in a pattern with a starting event `START_ROW`
+that is followed by one or more `PRICE_DOWN` events and concluded with a `PRICE_UP` event. If such
+a pattern can be found, the next pattern match will be seeked at the last `PRICE_UP` event as
+indicated by the `AFTER MATCH SKIP TO LAST` clause.
 
-The `DEFINE` clause specifies the conditions that need to be met for a `PRICE_DOWN` and `PRICE_UP` event. Although the `START_ROW` pattern variable is not present it has an implicit condition that is evaluated always as `TRUE`.
+The `DEFINE` clause specifies the conditions that need to be met for a `PRICE_DOWN` and `PRICE_UP`
+event. Although the `START_ROW` pattern variable is not present it has an implicit condition that
+is evaluated always as `TRUE`.
 
-A pattern variable `PRICE_DOWN` is defined as a row with a price that is smaller than the price of the last row that met the `PRICE_DOWN` condition. For the initial case or when there is no last row that met the `PRICE_DOWN` condition, the price of the row should be smaller than the price of the preceding row in the pattern (referenced by `START_ROW`).
+A pattern variable `PRICE_DOWN` is defined as a row with a price that is smaller than the price of
+the last row that met the `PRICE_DOWN` condition. For the initial case or when there is no last row
+that met the `PRICE_DOWN` condition, the price of the row should be smaller than the price of the
+preceding row in the pattern (referenced by `START_ROW`).
 
-A pattern variable `PRICE_UP` is defined as a row with a price that is larger than the price of the last row that met the `PRICE_DOWN` condition.
+A pattern variable `PRICE_UP` is defined as a row with a price that is larger than the price of the
+last row that met the `PRICE_DOWN` condition.
 
-This query produces a summary row for each period in which the price of a stock was continuously decreasing.
+This query produces a summary row for each period in which the price of a stock was continuously
+decreasing.
 
-The exact representation of the output rows is defined in the `MEASURES` part of the query. The number of output rows is defined by the `ONE ROW PER MATCH` output mode.
+The exact representation of the output rows is defined in the `MEASURES` part of the query. The
+number of output rows is defined by the `ONE ROW PER MATCH` output mode.
 
 {% highlight text %}
  symbol       start_tstamp       bottom_tstamp         end_tstamp
@@ -181,44 +218,61 @@ achieved the lowest price at `01-APR-11 10:00:07` that increased again at `01-AP
 Partitioning
 ------------
 
-It is possible to look for patterns in partitioned data, e.g., trends for a single ticker or a particular user. This can be expressed using the `PARTITION BY` clause. The clause is similar to using `GROUP BY` for aggregations.
+It is possible to look for patterns in partitioned data, e.g., trends for a single ticker or a
+particular user. This can be expressed using the `PARTITION BY` clause. The clause is similar to
+using `GROUP BY` for aggregations.
 
-<span class="label label-danger">Attention</span> It is highly advised to partition the incoming data because otherwise the `MATCH_RECOGNIZE` clause will be translated
-into a non-parallel operator to ensure global ordering.
+<span class="label label-danger">Attention</span> It is highly advised to partition the incoming
+data because otherwise the `MATCH_RECOGNIZE` clause will be translated into a non-parallel operator
+to ensure global ordering.
 
 Order of Events
 ---------------
 
-Apache Flink allows for searching for patterns based on time; either [processing time or event time](time_attributes.html).
+Apache Flink allows for searching for patterns based on time; either
+[processing time or event time](time_attributes.html).
 
-In case of event time, the events are sorted before they are passed to the internal pattern state machine. As a consequence, the
-produced output will be correct regardless of the order in which rows are appended to the table. Instead, the pattern is evaluated in the order specified by the time contained in each row.
+In case of event time, the events are sorted before they are passed to the internal pattern state
+machine. As a consequence, the produced output will be correct regardless of the order in which
+rows are appended to the table. Instead, the pattern is evaluated in the order specified by the
+time contained in each row.
 
-The `MATCH_RECOGNIZE` clause assumes a [time attribute](time_attributes.html) with ascending ordering as the first argument to `ORDER BY` clause.
+The `MATCH_RECOGNIZE` clause assumes a [time attribute](time_attributes.html) with ascending
+ordering as the first argument to `ORDER BY` clause.
 
-For the example `Ticker` table, a definition like `ORDER BY rowtime ASC, price DESC` is valid but `ORDER BY price, rowtime` or `ORDER BY rowtime DESC, price ASC` is not.
+For the example `Ticker` table, a definition like `ORDER BY rowtime ASC, price DESC` is valid but
+`ORDER BY price, rowtime` or `ORDER BY rowtime DESC, price ASC` is not.
 
 Define & Measures
 -----------------
 
-The `DEFINE` and `MEASURES` keywords have similar meanings to the `WHERE` and `SELECT` clauses in a simple SQL query.
+The `DEFINE` and `MEASURES` keywords have similar meanings to the `WHERE` and `SELECT` clauses in a
+simple SQL query.
 
-The `MEASURES` clause defines what will be included in the output of a matching pattern. It can project columns and define expressions for evaluation.
-The number of produced rows depends on the [output mode](#output-mode) setting.
+The `MEASURES` clause defines what will be included in the output of a matching pattern. It can
+project columns and define expressions for evaluation. The number of produced rows depends on the
+[output mode](#output-mode) setting.
 
-The `DEFINE` clause specifies conditions that rows have to fulfill in order to be classified to a corresponding [pattern variable](#defining-a-pattern).
-If a condition is not defined for a pattern variable, a default condition will be used which evaluates to `true` for every row.
+The `DEFINE` clause specifies conditions that rows have to fulfill in order to be classified to a
+corresponding [pattern variable](#defining-a-pattern). If a condition is not defined for a pattern
+variable, a default condition will be used which evaluates to `true` for every row.
 
-For a more detailed explanation about expressions that can be used in those clauses, please have a look at the [event stream navigation](#pattern-navigation) section.
+For a more detailed explanation about expressions that can be used in those clauses, please have a
+look at the [event stream navigation](#pattern-navigation) section.
 
 ### Aggregations
 
-Aggregations can be used in `DEFINE` and `MEASURES` clauses. Both [built-in]({{ site.baseurl }}/dev/table/sql.html#built-in-functions) and custom [user defined]({{ site.baseurl }}/dev/table/udfs.html) functions are supported.
+Aggregations can be used in `DEFINE` and `MEASURES` clauses. Both
+[built-in]({{ site.baseurl }}/dev/table/sql.html#built-in-functions) and custom
+[user defined]({{ site.baseurl }}/dev/table/udfs.html) functions are supported.
 
-Aggregate functions are applied to each subset of rows mapped to a match. In order to understand how those subsets are evaluated have a look at the [event stream navigation](#pattern-navigation) section.
+Aggregate functions are applied to each subset of rows mapped to a match. In order to understand
+how those subsets are evaluated have a look at the [event stream navigation](#pattern-navigation)
+section.
 
-The task of the following example is to find the longest period of time for which the average price of a ticker did not go below certain threshold. It shows how expressible `MATCH_RECOGNIZE` can become with aggregations.
-This task can be performed with the following query:
+The task of the following example is to find the longest period of time for which the average price
+of a ticker did not go below certain threshold. It shows how expressible `MATCH_RECOGNIZE` can
+become with aggregations. This task can be performed with the following query:
 
 {% highlight sql %}
 SELECT *
@@ -256,8 +310,10 @@ symbol         rowtime         price    tax
 'ACME'  '01-Apr-11 10:00:10'   30      1
 {% endhighlight %}
 
-The query will accumulate events as part of the pattern variable `A` as long as the average price of them does not exceed `15`. For example, such a limit exceeding happens at `01-Apr-11 10:00:04`.
-The following period exceeds the average price of `15` again at `01-Apr-11 10:00:10`. Thus the results for said query will be:
+The query will accumulate events as part of the pattern variable `A` as long as the average price
+of them does not exceed `15`. For example, such a limit exceeding happens at `01-Apr-11 10:00:04`.
+The following period exceeds the average price of `15` again at `01-Apr-11 10:00:10`. Thus the
+results for said query will be:
 
 {% highlight text %}
  symbol       start_tstamp       end_tstamp          avgPrice
@@ -266,17 +322,20 @@ ACME       01-APR-11 10:00:00  01-APR-11 10:00:03     14.5
 ACME       01-APR-11 10:00:04  01-APR-11 10:00:09     13.5
 {% endhighlight %}
 
-<span class="label label-info">Note</span> Aggregations can be applied to expressions, but only if they reference a single pattern variable. Thus `SUM(A.price * A.tax)` is a valid one, but `AVG(A.price * B.tax)` is not.
+<span class="label label-info">Note</span> Aggregations can be applied to expressions, but only if
+they reference a single pattern variable. Thus `SUM(A.price * A.tax)` is a valid one, but
+`AVG(A.price * B.tax)` is not.
 
 <span class="label label-danger">Attention</span> `DISTINCT` aggregations are not supported.
 
 Defining a Pattern
 ------------------
 
-The `MATCH_RECOGNIZE` clause allows users to search for patterns in event streams using a powerful and expressive syntax
-that is somewhat similar to the widespread regular expression syntax.
+The `MATCH_RECOGNIZE` clause allows users to search for patterns in event streams using a powerful
+and expressive syntax that is somewhat similar to the widespread regular expression syntax.
 
-Every pattern is constructed from basic building blocks, called _pattern variables_, to which operators (quantifiers and other modifiers) can be applied. The whole pattern must be enclosed in
+Every pattern is constructed from basic building blocks, called _pattern variables_, to which
+operators (quantifiers and other modifiers) can be applied. The whole pattern must be enclosed in
 brackets.
 
 An example pattern could look like:
@@ -287,7 +346,8 @@ PATTERN (A B+ C* D)
 
 One may use the following operators:
 
-* _Concatenation_ - a pattern like `(A B)` means that the contiguity is strict between `A` and `B`. Therefore, there can be no rows that were not mapped to `A` or `B` in between.
+* _Concatenation_ - a pattern like `(A B)` means that the contiguity is strict between `A` and `B`.
+  Therefore, there can be no rows that were not mapped to `A` or `B` in between.
 * _Quantifiers_ - modify the number of rows that can be mapped to the pattern variable.
   * `*` — _0_ or more rows
   * `+` — _1_ or more rows
@@ -297,15 +357,17 @@ One may use the following operators:
   * `{ n, m }` — between _n_ and _m_ (inclusive) rows (_0 ≤ n ≤ m, 0 < m_)
   * `{ , m }` — between _0_ and _m_ (inclusive) rows (_m > 0_)
 
-<span class="label label-danger">Attention</span> Patterns that can potentially produce an empty match are not supported.
-Examples of such patterns are `PATTERN (A*)`, `PATTERN  (A? B*)`, `PATTERN (A{0,} B{0,} C*)`, etc.
+<span class="label label-danger">Attention</span> Patterns that can potentially produce an empty
+match are not supported. Examples of such patterns are `PATTERN (A*)`, `PATTERN  (A? B*)`,
+`PATTERN (A{0,} B{0,} C*)`, etc.
 
 ### Greedy & Reluctant Quantifiers
 
-Each quantifier can be either _greedy_ (default behavior) or _reluctant_. Greedy quantifiers try to match
-as many rows as possible while reluctant quantifiers try to match as few as possible.
+Each quantifier can be either _greedy_ (default behavior) or _reluctant_. Greedy quantifiers try to
+match as many rows as possible while reluctant quantifiers try to match as few as possible.
 
-In order to illustrate the difference, one can view the following example with a query where a greedy quantifier is applied to the `B` variable:
+In order to illustrate the difference, one can view the following example with a query where a
+greedy quantifier is applied to the `B` variable:
 
 {% highlight sql %}
 SELECT *
@@ -346,7 +408,8 @@ The pattern above will produce the following output:
  XYZ      16
 {% endhighlight %}
 
-The same query where `B*` is modified to `B*?`, which means that `B*` should be reluctant, will produce:
+The same query where `B*` is modified to `B*?`, which means that `B*` should be reluctant, will
+produce:
 
 {% highlight text %}
  symbol   lastPrice
@@ -355,11 +418,13 @@ The same query where `B*` is modified to `B*?`, which means that `B*` should be 
  XYZ      16
 {% endhighlight %}
 
-The pattern variable `B` matches only to the row with price `12` instead of swallowing the rows with prices `12`, `13`, and `14`.
+The pattern variable `B` matches only to the row with price `12` instead of swallowing the rows
+with prices `12`, `13`, and `14`.
 
-<span class="label label-danger">Attention</span> It is not possible to use a greedy quantifier for the last
-variable of a pattern. Thus, a pattern like `(A B*)` is not allowed. This can be easily worked around by introducing an artificial state
-(e.g. `C`) that has a negated condition of `B`. So you could use a query like:
+<span class="label label-danger">Attention</span> It is not possible to use a greedy quantifier for
+the last variable of a pattern. Thus, a pattern like `(A B*)` is not allowed. This can be easily
+worked around by introducing an artificial state (e.g. `C`) that has a negated condition of `B`. So
+you could use a query like:
 
 {% highlight sql %}
 PATTERN (A B* C)
@@ -369,20 +434,28 @@ DEFINE
     C AS NOT condB()
 {% endhighlight %}
 
-<span class="label label-danger">Attention</span> The optional reluctant quantifier (`A??` or `A{0,1}?`) is not supported right now.
+<span class="label label-danger">Attention</span> The optional reluctant quantifier (`A??` or
+`A{0,1}?`) is not supported right now.
 
 ### Time constraint
 
-Especially for streaming use cases, it is often required that a pattern finishes within a given period of time.
-This allows for limiting the overall state size that Flink has to maintain internally, even in case of greedy quantifiers.
+Especially for streaming use cases, it is often required that a pattern finishes within a given
+period of time. This allows for limiting the overall state size that Flink has to maintain
+internally, even in case of greedy quantifiers.
 
-Therefore, Flink SQL supports the additional (non-standard SQL) `WITHIN` clause for defining a time constraint for a pattern. The clause can be defined after the `PATTERN` clause and takes an interval of millisecond resolution.
+Therefore, Flink SQL supports the additional (non-standard SQL) `WITHIN` clause for defining a time
+constraint for a pattern. The clause can be defined after the `PATTERN` clause and takes an
+interval of millisecond resolution.
 
-If the time between the first and last event of a potential match is longer than the given value, such a match will not be appended to the result table.
+If the time between the first and last event of a potential match is longer than the given value,
+such a match will not be appended to the result table.
 
-<span class="label label-info">Note</span> It is generally encouraged to use the `WITHIN` clause as it helps Flink with efficient memory management. Underlying state can be pruned once the threshold is reached.
+<span class="label label-info">Note</span> It is generally encouraged to use the `WITHIN` clause as
+it helps Flink with efficient memory management. Underlying state can be pruned once the threshold
+is reached.
 
-<span class="label label-danger">Attention</span> However, the `WITHIN` clause is not part of the SQL standard. The recommended way of dealing with time constraints might change in the future.
+<span class="label label-danger">Attention</span> However, the `WITHIN` clause is not part of the
+SQL standard. The recommended way of dealing with time constraints might change in the future.
 
 The use of the `WITHIN` clause is illustrated in the following example query:
 
@@ -432,20 +505,26 @@ symbol         dropTime         dropDiff
 'ACME'  '01-Apr-11 13:00:00'      14
 {% endhighlight %}
 
-The resulting row represents a price drop from `15` (at `01-Apr-11 12:00:00`) to `1` (at `01-Apr-11 13:00:00`). The `dropDiff` column contains the price difference.
+The resulting row represents a price drop from `15` (at `01-Apr-11 12:00:00`) to `1` (at
+`01-Apr-11 13:00:00`). The `dropDiff` column contains the price difference.
 
-Notice that even though prices also drop by higher values, for example, by `11` (between `01-Apr-11 10:00:00` and `01-Apr-11 11:40:00`), the time difference between those two events is larger than 1 hour. Thus, they don't produce a match.
+Notice that even though prices also drop by higher values, for example, by `11` (between
+`01-Apr-11 10:00:00` and `01-Apr-11 11:40:00`), the time difference between those two events is
+larger than 1 hour. Thus, they don't produce a match.
 
 Output Mode
 -----------
 
-The _output mode_ describes how many rows should be emitted for every found match. The SQL standard describes two modes:
+The _output mode_ describes how many rows should be emitted for every found match. The SQL standard
+describes two modes:
 - `ALL ROWS PER MATCH`
 - `ONE ROW PER MATCH`.
 
-Currently, the only supported output mode is `ONE ROW PER MATCH` that will always produce one output summary row for each found match.
+Currently, the only supported output mode is `ONE ROW PER MATCH` that will always produce one
+output summary row for each found match.
 
-The schema of the output row will be a concatenation of `[partitioning columns] + [measures columns]` in that particular order.
+The schema of the output row will be a concatenation of
+`[partitioning columns] + [measures columns]` in that particular order.
 
 The following example shows the output of a query defined as:
 
@@ -486,29 +565,35 @@ The query will produce the following output:
  XYZ      10           13         11
 {% endhighlight %}
 
-The pattern recognition is partitioned by the `symbol` column. Even though not explicitly mentioned in the `MEASURES` clause, the partitioned column is added at the beginning of the result.
+The pattern recognition is partitioned by the `symbol` column. Even though not explicitly mentioned
+in the `MEASURES` clause, the partitioned column is added at the beginning of the result.
 
 Pattern Navigation
 ------------------
 
-The `DEFINE` and `MEASURES` clauses allow for navigating within the list of rows that (potentially) match a pattern.
+The `DEFINE` and `MEASURES` clauses allow for navigating within the list of rows that (potentially)
+match a pattern.
 
 This section discusses this navigation for declaring conditions or producing output results.
 
 ### Pattern Variable Referencing
 
-A _pattern variable reference_ allows a set of rows mapped to a particular pattern variable in the `DEFINE` or `MEASURES` clauses to be referenced.
+A _pattern variable reference_ allows a set of rows mapped to a particular pattern variable in the
+`DEFINE` or `MEASURES` clauses to be referenced.
 
-For example, the expression `A.price` describes a set of rows mapped so far to `A` plus the current row
-if we try to match the current row to `A`. If an expression in the `DEFINE`/`MEASURES` clause requires a single row (e.g. `A.price` or `A.price > 10`),
-it selects the last value belonging to the corresponding set.
+For example, the expression `A.price` describes a set of rows mapped so far to `A` plus the current
+row if we try to match the current row to `A`. If an expression in the `DEFINE`/`MEASURES` clause
+requires a single row (e.g. `A.price` or `A.price > 10`), it selects the last value belonging to
+the corresponding set.
 
-If no pattern variable is specified (e.g. `SUM(price)`), an expression references the default pattern variable `*` which references all variables in the pattern.
-In other words, it creates a list of all the rows mapped so far to any variable plus the current row.
+If no pattern variable is specified (e.g. `SUM(price)`), an expression references the default
+pattern variable `*` which references all variables in the pattern. In other words, it creates a
+list of all the rows mapped so far to any variable plus the current row.
 
 #### Example
 
-For a more thorough example, one can take a look at the following pattern and corresponding conditions:
+For a more thorough example, one can take a look at the following pattern and corresponding
+conditions:
 
 {% highlight sql %}
 PATTERN (A B+)
@@ -520,11 +605,15 @@ DEFINE
 The following table describes how those conditions are evaluated for each incoming event.
 
 The table consists of the following columns:
-  * `#` - the row identifier that uniquely identifies an incoming row in the lists `[A.price]`/`[B.price]`/`[price]`.
+  * `#` - the row identifier that uniquely identifies an incoming row in the lists
+    `[A.price]`/`[B.price]`/`[price]`.
   * `price` - the price of the incoming row.
-  * `[A.price]`/`[B.price]`/`[price]` - describe lists of rows which are used in the `DEFINE` clause to evaluate conditions.
-  * `Classifier` - the classifier of the current row which indicates the pattern variable the row is mapped to.
-  * `A.price`/`B.price`/`SUM(price)`/`SUM(B.price)` - describes the result after those expressions have been evaluated.
+  * `[A.price]`/`[B.price]`/`[price]` - describe lists of rows which are used in the `DEFINE`
+    clause to evaluate conditions.
+  * `Classifier` - the classifier of the current row which indicates the pattern variable the row
+    is mapped to.
+  * `A.price`/`B.price`/`SUM(price)`/`SUM(B.price)` - describes the result after those expressions
+    have been evaluated.
 
 <table class="table table-bordered">
   <thead>
@@ -605,12 +694,15 @@ The table consists of the following columns:
   </tbody>
 </table>
 
-As can be seen in the table, the first row is mapped to pattern variable `A` and subsequent rows are mapped to pattern variable `B`. However, the last row does not fulfill the `B` condition because the sum over all mapped rows `SUM(price)` and the sum over all rows in `B` exceed the specified thresholds.
+As can be seen in the table, the first row is mapped to pattern variable `A` and subsequent rows
+are mapped to pattern variable `B`. However, the last row does not fulfill the `B` condition
+because the sum over all mapped rows `SUM(price)` and the sum over all rows in `B` exceed the
+specified thresholds.
 
 ### Logical Offsets
 
-_Logical offsets_ enable navigation within the events that were mapped to a particular pattern variable. This can be expressed
-with two corresponding functions:
+_Logical offsets_ enable navigation within the events that were mapped to a particular pattern
+variable. This can be expressed with two corresponding functions:
 
 <table class="table table-bordered">
   <thead>
@@ -627,7 +719,8 @@ LAST(variable.field, n)
 {% endhighlight %}
     </td>
     <td>
-      <p>Returns the value of the field from the event that was mapped to the <i>n</i>-th <i>last</i> element of the variable. The counting starts at the last element mapped.</p>
+      <p>Returns the value of the field from the event that was mapped to the <i>n</i>-th
+      <i>last</i> element of the variable. The counting starts at the last element mapped.</p>
     </td>
   </tr>
   <tr>
@@ -637,7 +730,8 @@ FIRST(variable.field, n)
 {% endhighlight %}
     </td>
     <td>
-      <p>Returns the value of the field from the event that was mapped to the <i>n</i>-th element of the variable. The counting starts at the first element mapped.</p>
+      <p>Returns the value of the field from the event that was mapped to the <i>n</i>-th element
+      of the variable. The counting starts at the first element mapped.</p>
     </td>
   </tr>
   </tbody>
@@ -645,7 +739,8 @@ FIRST(variable.field, n)
 
 #### Examples
 
-For a more thorough example, one can take a look at the following pattern and corresponding conditions:
+For a more thorough example, one can take a look at the following pattern and corresponding
+conditions:
 
 {% highlight sql %}
 PATTERN (A B+)
@@ -659,8 +754,10 @@ The following table describes how those conditions are evaluated for each incomi
 
 The table consists of the following columns:
   * `price` - the price of the incoming row.
-  * `Classifier` - the classifier of the current row which indicates the pattern variable the row is mapped to.
-  * `LAST(B.price, 1)`/`LAST(B.price, 2)` - describes the result after those expressions have been evaluated.
+  * `Classifier` - the classifier of the current row which indicates the pattern variable the row
+    is mapped to.
+  * `LAST(B.price, 1)`/`LAST(B.price, 2)` - describes the result after those expressions have been
+    evaluated.
 
 <table class="table table-bordered">
   <thead>
@@ -685,7 +782,8 @@ The table consists of the following columns:
       <td>-&gt; B</td>
       <td>null</td>
       <td>null</td>
-      <td>Notice that <code>LAST(A.price, 1)</code> is null because there is still nothing mapped to <code>B</code>.</td>
+      <td>Notice that <code>LAST(A.price, 1)</code> is null because there is still nothing mapped
+          to <code>B</code>.</td>
     </tr>
     <tr>
       <td>20</td>
@@ -748,7 +846,8 @@ DEFINE
       <td>20</td>
       <td>-&gt; C</td>
       <td>15</td>
-      <td><code>LAST(price, 1)</code> is evaluated as the price of the row mapped to the <code>B</code> variable.</td>
+      <td><code>LAST(price, 1)</code> is evaluated as the price of the row mapped to the
+          <code>B</code> variable.</td>
     </tr>
   </tbody>
 </table>
@@ -775,32 +874,43 @@ If the second row did not map to the `B` variable, we would have the following r
       <td>20</td>
       <td>-&gt; C</td>
       <td>10</td>
-      <td><code>LAST(price, 1)</code> is evaluated as the price of the row mapped to the <code>A</code> variable.</td>
+      <td><code>LAST(price, 1)</code> is evaluated as the price of the row mapped to the
+          <code>A</code> variable.</td>
     </tr>
   </tbody>
 </table>
 
-It is also possible to use multiple pattern variable references in the first argument of the `FIRST/LAST` functions. This way, one can write an expression that accesses multiple columns.
-However, all of them must use the same pattern variable. In other words, the value of the `LAST`/`FIRST` function must be computed in a single row.
+It is also possible to use multiple pattern variable references in the first argument of the
+`FIRST/LAST` functions. This way, one can write an expression that accesses multiple columns.
+However, all of them must use the same pattern variable. In other words, the value of the
+`LAST`/`FIRST` function must be computed in a single row.
 
-Thus, it is possible to use `LAST(A.price * A.tax)`, but an expression like `LAST(A.price * B.tax)` is not allowed.
+Thus, it is possible to use `LAST(A.price * A.tax)`, but an expression like `LAST(A.price * B.tax)`
+is not allowed.
 
 After Match Strategy
 --------------------
 
-The `AFTER MATCH SKIP` clause specifies where to start a new matching procedure after a complete match was found.
+The `AFTER MATCH SKIP` clause specifies where to start a new matching procedure after a complete
+match was found.
 
 There are four different strategies:
-* `SKIP PAST LAST ROW` - resumes the pattern matching at the next row after the last row of the current match.
-* `SKIP TO NEXT ROW` - continues searching for a new match starting at the next row after the starting row of the match.
-* `SKIP TO LAST variable` - resumes the pattern matching at the last row that is mapped to the specified pattern variable.
-* `SKIP TO FIRST variable` - resumes the pattern matching at the first row that is mapped to the specified pattern variable.
+* `SKIP PAST LAST ROW` - resumes the pattern matching at the next row after the last row of the
+  current match.
+* `SKIP TO NEXT ROW` - continues searching for a new match starting at the next row after the
+  starting row of the match.
+* `SKIP TO LAST variable` - resumes the pattern matching at the last row that is mapped to the
+  specified pattern variable.
+* `SKIP TO FIRST variable` - resumes the pattern matching at the first row that is mapped to the
+  specified pattern variable.
 
-This is also a way to specify how many matches a single event can belong to. For example, with the `SKIP PAST LAST ROW` strategy every event can belong to at most one match.
+This is also a way to specify how many matches a single event can belong to. For example, with the
+`SKIP PAST LAST ROW` strategy every event can belong to at most one match.
 
 #### Examples
 
-In order to better understand the differences between those strategies one can take a look at the following example.
+In order to better understand the differences between those strategies one can take a look at the
+following example.
 
 For the following input rows:
 
@@ -835,7 +945,8 @@ FROM Ticker
     )
 {% endhighlight %}
 
-The query returns the sum of the prices of all rows mapped to `A` and the first and last timestamp of the overall match.
+The query returns the sum of the prices of all rows mapped to `A` and the first and last timestamp
+of the overall match.
 
 The query will produce different results based on which `AFTER MATCH` strategy was used:
 
@@ -866,7 +977,8 @@ The second result matched against the rows #5, #6.
 
 Again, the first result matched against the rows #1, #2, #3, #4.
 
-Compared to the previous strategy, the next match includes row #2 again for the next matching. Therefore, the second result matched against the rows #2, #3, #4, #5.
+Compared to the previous strategy, the next match includes row #2 again for the next matching.
+Therefore, the second result matched against the rows #2, #3, #4, #5.
 
 The third result matched against the rows #3, #4, #5.
 
@@ -887,7 +999,8 @@ The last result matched against the rows #5, #6.
 
 Again, the first result matched against the rows #1, #2, #3, #4.
 
-Compared to the previous strategy, the next match includes only row #3 (mapped to `A`) again for the next matching. Therefore, the second result matched against the rows #3, #4, #5.
+Compared to the previous strategy, the next match includes only row #3 (mapped to `A`) again for
+the next matching. Therefore, the second result matched against the rows #3, #4, #5.
 
 The third result matched against the rows #4, #5, #6.
 
@@ -895,18 +1008,18 @@ The last result matched against the rows #5, #6.
 
 ##### `AFTER MATCH SKIP TO FIRST A`
 
-This combination will produce a runtime exception because one would always try to start a new match where the
-last one started. This would produce an infinite loop and, thus, is prohibited.
+This combination will produce a runtime exception because one would always try to start a new match
+where the last one started. This would produce an infinite loop and, thus, is prohibited.
 
-One has to keep in mind that in case of the `SKIP TO FIRST/LAST variable` strategy it might be possible that there are no rows mapped to that
-variable (e.g. for pattern `A*`). In such cases, a runtime exception will be thrown as the standard requires a valid row to continue the
-matching.
+One has to keep in mind that in case of the `SKIP TO FIRST/LAST variable` strategy it might be
+possible that there are no rows mapped to that variable (e.g. for pattern `A*`). In such cases, a
+runtime exception will be thrown as the standard requires a valid row to continue the matching.
 
 Time attributes
 ---------------
 
-In order to apply some subsequent queries on top of the `MATCH_RECOGNIZE` it might be required to use [time attributes](time_attributes.html). To select those there
-are available two functions:
+In order to apply some subsequent queries on top of the `MATCH_RECOGNIZE` it might be required to
+use [time attributes](time_attributes.html). To select those there are available two functions:
 
 <table class="table table-bordered">
   <thead>
@@ -922,13 +1035,19 @@ are available two functions:
         <code>MATCH_ROWTIME()</code><br/>
       </td>
       <td><p>Returns the timestamp of the last row that was mapped to the given pattern.</p>
-      <p>The resulting attribute is a <a href="streaming/time_attributes.html">rowtime attribute</a> that can be used in subsequent time-based operations such as <a href="#joins">time-windowed joins</a> and <a href="#aggregations">group window or over window aggregations</a>.</p></td>
+      <p>The resulting attribute is a <a href="streaming/time_attributes.html">rowtime attribute</a>
+         that can be used in subsequent time-based operations such as
+         <a href="#joins">time-windowed joins</a> and <a href="#aggregations">group window or over
+         window aggregations</a>.</p></td>
     </tr>
     <tr>
       <td>
         <code>MATCH_PROCTIME()</code><br/>
       </td>
-      <td><p>Returns a <a href="streaming/time_attributes.html#processing-time">proctime attribute</a> that can be used in subsequent time-based operations such as <a href="#joins">time-windowed joins</a> and <a href="#aggregations">group window or over window aggregations</a>.</p></td>
+      <td><p>Returns a <a href="streaming/time_attributes.html#processing-time">proctime attribute</a>
+          that can be used in subsequent time-based operations such as
+          <a href="#joins">time-windowed joins</a> and <a href="#aggregations">group window or over
+          window aggregations</a>.</p></td>
     </tr>
   </tbody>
 </table>
@@ -936,10 +1055,13 @@ are available two functions:
 Controlling Memory Consumption
 ------------------------------
 
-Memory consumption is an important consideration when writing `MATCH_RECOGNIZE` queries, as the space of potential matches is built in a breadth-first-like manner.
-Having that in mind, one must make sure that the pattern can finish. Preferably with a reasonable number of rows mapped to the match as they have to fit into memory.
+Memory consumption is an important consideration when writing `MATCH_RECOGNIZE` queries, as the
+space of potential matches is built in a breadth-first-like manner. Having that in mind, one must
+make sure that the pattern can finish. Preferably with a reasonable number of rows mapped to the
+match as they have to fit into memory.
 
-For example, the pattern must not have a quantifier without an upper limit that accepts every single row. Such a pattern could look like this:
+For example, the pattern must not have a quantifier without an upper limit that accepts every
+single row. Such a pattern could look like this:
 
 {% highlight sql %}
 PATTERN (A B+ C)
@@ -948,7 +1070,8 @@ DEFINE
   C as C.price > 20
 {% endhighlight %}
 
-The query will map every incoming row to the `B` variable and thus will never finish. This query could be fixed, e.g., by negating the condition for `C`:
+The query will map every incoming row to the `B` variable and thus will never finish. This query
+could be fixed, e.g., by negating the condition for `C`:
 
 {% highlight sql %}
 PATTERN (A B+ C)
@@ -967,29 +1090,42 @@ DEFINE
   C as C.price > 20
 {% endhighlight %}
 
-<span class="label label-danger">Attention</span> Please note that the `MATCH_RECOGNIZE` clause does not use a configured [state retention time](query_configuration.html#idle-state-retention-time). One may want to use the `WITHIN` [clause](#time-constraint) for this purpose.
+<span class="label label-danger">Attention</span> Please note that the `MATCH_RECOGNIZE` clause
+does not use a configured [state retention time](query_configuration.html#idle-state-retention-time).
+One may want to use the `WITHIN` [clause](#time-constraint) for this purpose.
 
 Known Limitations
 -----------------
 
-Flink's implementation of the `MATCH_RECOGNIZE` clause is an ongoing effort, and some features of the SQL standard are not yet supported.
+Flink's implementation of the `MATCH_RECOGNIZE` clause is an ongoing effort, and some features of
+the SQL standard are not yet supported.
 
 Unsupported features include:
 * Pattern expressions:
-  * Pattern groups - this means that e.g. quantifiers can not be applied to a subsequence of the pattern. Thus, `(A (B C)+)` is not a valid pattern.
-  * Alterations - patterns like `PATTERN((A B | C D) E)`, which means that either a subsequence `A B` or `C D` has to be found before looking for the `E` row.
-  * `PERMUTE` operator - which is equivalent to all permutations of variables that it was applied to e.g. `PATTERN (PERMUTE (A, B, C))` = `PATTERN (A B C | A C B | B A C | B C A | C A B | C B A)`.
-  * Anchors - `^, $`, which denote beginning/end of a partition, those do not make sense in the streaming context and will not be supported.
-  * Exclusion - `PATTERN ({- A -} B)` meaning that `A` will be looked for but will not participate in the output. This works only for the `ALL ROWS PER MATCH` mode.
+  * Pattern groups - this means that e.g. quantifiers can not be applied to a subsequence of the
+    pattern. Thus, `(A (B C)+)` is not a valid pattern.
+  * Alterations - patterns like `PATTERN((A B | C D) E)`, which means that either a subsequence
+    `A B` or `C D` has to be found before looking for the `E` row.
+  * `PERMUTE` operator - which is equivalent to all permutations of variables that it was applied
+    to e.g. `PATTERN (PERMUTE (A, B, C))` = `PATTERN (A B C | A C B | B A C | B C A | C A B | C B A)`.
+  * Anchors - `^, $`, which denote beginning/end of a partition, those do not make sense in the
+    streaming context and will not be supported.
+  * Exclusion - `PATTERN ({- A -} B)` meaning that `A` will be looked for but will not participate
+    in the output. This works only for the `ALL ROWS PER MATCH` mode.
   * Reluctant optional quantifier - `PATTERN A??` only the greedy optional quantifier is supported.
-* `ALL ROWS PER MATCH` output mode - which produces an output row for every row that participated in the creation of a found match. This also means:
+* `ALL ROWS PER MATCH` output mode - which produces an output row for every row that participated
+   in the creation of a found match. This also means:
   * that the only supported semantic for the `MEASURES` clause is `FINAL`
-  * `CLASSIFIER` function, which returns the pattern variable that a row was mapped to, is not yet supported.
-* `SUBSET` - which allows creating logical groups of pattern variables and using those groups in the `DEFINE` and `MEASURES` clauses.
-* Physical offsets - `PREV/NEXT`, which indexes all events seen rather than only those that were mapped to a pattern variable(as in [logical offsets](#logical-offsets) case).
-* Extracting time attributes - there is currently no possibility to get a time attribute for subsequent time-based operations.
+  * `CLASSIFIER` function, which returns the pattern variable that a row was mapped to, is not yet
+    supported.
+* `SUBSET` - which allows creating logical groups of pattern variables and using those groups in
+  the `DEFINE` and `MEASURES` clauses.
+* Physical offsets - `PREV/NEXT`, which indexes all events seen rather than only those that were
+  mapped to a pattern variable (as in [logical offsets](#logical-offsets) case).
+* Extracting time attributes - there is currently no possibility to get a time attribute for
+  subsequent time-based operations.
 * `MATCH_RECOGNIZE` is supported only for SQL. There is no equivalent in the Table API.
 * Aggregations:
   * distinct aggregations are not supported.
-  
+
 {% top %}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.{RelNode, RelShuttle}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.sql.fun.SqlStdOperatorTable.FINAL
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory.{isRowtimeIndicatorType, _}
@@ -107,7 +108,7 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
     val patternDefs = matchRel.getPatternDefinitions.mapValues(_.accept(materializer))
     val measures = matchRel.getMeasures
       .mapValues(_.accept(materializer))
-      .mapValues(materializerUtils.materialize)
+
     val partitionKeys = matchRel.getPartitionKeys
       .map(_.accept(materializer))
       .map(materializerUtils.materialize)
@@ -117,9 +118,13 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
       null
     }
 
+    val isNoLongerTimeIndicator : String => Boolean = fieldName =>
+      measures.get(fieldName).exists(r => !FlinkTypeFactory.isTimeIndicatorType(r.getType))
+
     // materialize all output types
-    // TODO allow passing through for rowtime accessor function, once introduced
-    val outputType = materializerUtils.getRowTypeWithoutIndicators(matchRel.getRowType)
+    val outputType = materializerUtils.getRowTypeWithoutIndicators(
+        matchRel.getRowType,
+        isNoLongerTimeIndicator)
 
     LogicalMatch.create(
       input,
@@ -468,6 +473,17 @@ class RexTimeIndicatorMaterializer(
     }
   }
 
+  private def isMatchTimeIndicator(call: RexNode): Boolean = {
+    call match {
+      case operand: RexCall if
+      operand.getOperator == BasicOperatorTable.MATCH_PROCTIME ||
+      operand.getOperator == BasicOperatorTable.MATCH_ROWTIME =>
+        true
+      case _ =>
+        false
+    }
+  }
+
   override def visitCall(call: RexCall): RexNode = {
     val updatedCall = super.visitCall(call).asInstanceOf[RexCall]
 
@@ -475,7 +491,9 @@ class RexTimeIndicatorMaterializer(
     val materializedOperands = updatedCall.getOperator match {
 
       // skip materialization for special operators
-      case BasicOperatorTable.SESSION | BasicOperatorTable.HOP | BasicOperatorTable.TUMBLE =>
+      case BasicOperatorTable.SESSION |
+           BasicOperatorTable.HOP |
+           BasicOperatorTable.TUMBLE =>
         updatedCall.getOperands.toList
 
       case _ =>
@@ -490,13 +508,22 @@ class RexTimeIndicatorMaterializer(
       isTimeIndicatorType(updatedCall.getOperands.get(0).getType) =>
         updatedCall
 
+      // All calls in MEASURES and DEFINE are wrapped with FINAL/RUNNING, therefore
+      // we should treat FINAL(MATCH_ROWTIME) and FINAL(MATCH_PROCTIME) as a time attribute
+      // extraction
+      case FINAL if
+      updatedCall.getOperands.size() == 1 && isMatchTimeIndicator(updatedCall.getOperands.get(0)) =>
+        updatedCall
+
       // do not modify window time attributes
       case BasicOperatorTable.TUMBLE_ROWTIME |
           BasicOperatorTable.TUMBLE_PROCTIME |
           BasicOperatorTable.HOP_ROWTIME |
           BasicOperatorTable.HOP_PROCTIME |
           BasicOperatorTable.SESSION_ROWTIME |
-          BasicOperatorTable.SESSION_PROCTIME
+          BasicOperatorTable.SESSION_PROCTIME |
+          BasicOperatorTable.MATCH_ROWTIME |
+          BasicOperatorTable.MATCH_PROCTIME
           // since we materialize groupings on time indicators,
           // we cannot check the operands anymore but the return type at least
           if isTimeIndicatorType(updatedCall.getType) =>
@@ -541,19 +568,21 @@ class RexTimeIndicatorMaterializerUtils(rexBuilder: RexBuilder) {
       input.getRowType.getFieldNames)
   }
 
-  def getRowTypeWithoutIndicators(relType: RelDataType): RelDataType = {
+  def getRowTypeWithoutIndicators(
+      relType: RelDataType,
+      shouldMaterialize: String => Boolean): RelDataType = {
     val outputTypeBuilder = rexBuilder
       .getTypeFactory
       .asInstanceOf[FlinkTypeFactory]
       .builder()
 
-    relType.getFieldList.asScala.zipWithIndex.foreach { case (field, idx) =>
-      if (FlinkTypeFactory.isTimeIndicatorType(field.getType)) {
+    relType.getFieldList.asScala.foreach(field =>
+      if (FlinkTypeFactory.isTimeIndicatorType(field.getType) && shouldMaterialize(field.getName)) {
         outputTypeBuilder.add(field.getName, timestamp)
       } else {
         outputTypeBuilder.add(field.getName, field.getType)
       }
-    }
+    )
 
     outputTypeBuilder.build()
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1266,7 +1266,7 @@ abstract class CodeGenerator(
     }
   }
 
-  private def generateNullLiteral(resultType: TypeInformation[_]): GeneratedExpression = {
+  protected def generateNullLiteral(resultType: TypeInformation[_]): GeneratedExpression = {
     val resultTerm = newName("result")
     val resultTypeTerm = primitiveTypeTermForTypeInfo(resultType)
     val defaultValue = primitiveDefaultValue(resultType)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/MatchCodeGenerator.scala
@@ -40,8 +40,10 @@ import org.apache.flink.table.functions.{AggregateFunction => TableAggregateFunc
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.`match`.{IterativeConditionRunner, PatternProcessFunctionRunner}
 import org.apache.flink.table.runtime.aggregate.AggregateUtil
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.table.util.MatchUtil.{ALL_PATTERN_VARIABLE, AggregationPatternVariableFinder}
 import org.apache.flink.table.utils.EncodingUtils
+import org.apache.flink.table.validate.BasicOperatorTable.{MATCH_PROCTIME, MATCH_ROWTIME}
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 import org.apache.flink.util.MathUtils.checkedDownCast
@@ -485,6 +487,13 @@ class MatchCodeGenerator(
         }
 
         matchAgg.generateDeduplicatedAggAccess(call)
+
+      case MATCH_PROCTIME =>
+        generateNullLiteral(TimeIndicatorTypeInfo.PROCTIME_INDICATOR)
+
+      case MATCH_ROWTIME =>
+        generateStreamRecordRowtimeAccess()
+          .copy(resultType = TimeIndicatorTypeInfo.ROWTIME_INDICATOR)
 
       case _ => super.visitCall(call)
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
@@ -59,7 +59,6 @@ import org.apache.flink.table.runtime.{RowKeySelector, RowtimeProcessFunction}
 import org.apache.flink.types.Row
 import org.apache.flink.util.MathUtils
 
-
 /**
   * Flink RelNode which matches along with LogicalMatch.
   */
@@ -188,7 +187,7 @@ class DataStreamMatch(
           schema,
           partitionKeys,
           measures)
-      patternStream.flatSelect[CRow](patternSelectFunction, outTypeInfo)
+      patternStream.process[CRow](patternSelectFunction, outTypeInfo)
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/match/PatternProcessFunctionRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/match/PatternProcessFunctionRunner.scala
@@ -21,10 +21,11 @@ package org.apache.flink.table.runtime.`match`
 import java.util
 
 import org.apache.flink.api.common.functions.util.FunctionUtils
-import org.apache.flink.cep.{RichPatternFlatSelectFunction, RichPatternSelectFunction}
+import org.apache.flink.cep.functions.PatternProcessFunction
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.table.runtime.CRowWrappingCollector
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row
@@ -33,37 +34,36 @@ import org.apache.flink.util.Collector
 /**
   * PatternSelectFunctionRunner with [[Row]] input and [[CRow]] output.
   */
-class PatternSelectFunctionRunner(
+class PatternProcessFunctionRunner(
     name: String,
     code: String)
-  extends RichPatternFlatSelectFunction[Row, CRow]
-  with Compiler[RichPatternSelectFunction[Row, Row]]
+  extends PatternProcessFunction[Row, CRow]
+  with Compiler[PatternProcessFunction[Row, Row]]
   with Logging {
 
-  @transient private var outCRow: CRow = _
+  @transient private var cRowWrappingCollector : CRowWrappingCollector = _
 
-  @transient private var function: RichPatternSelectFunction[Row, Row] = _
+  @transient private var function: PatternProcessFunction[Row, Row] = _
 
   override def open(parameters: Configuration): Unit = {
-    if (outCRow == null) {
-      outCRow = new CRow(null, true)
-    }
+    this.cRowWrappingCollector = new CRowWrappingCollector
 
-    LOG.debug(s"Compiling PatternSelectFunction: $name \n\n Code:\n$code")
+    LOG.debug(s"Compiling PatternProcessFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
-    LOG.debug("Instantiating PatternSelectFunction.")
+    LOG.debug("Instantiating PatternProcessFunction.")
     function = clazz.newInstance()
     FunctionUtils.setFunctionRuntimeContext(function, getRuntimeContext)
     FunctionUtils.openFunction(function, parameters)
   }
 
-  override def flatSelect(
-      pattern: util.Map[String, util.List[Row]],
-      out: Collector[CRow])
-    : Unit = {
-    outCRow.row = function.select(pattern)
+  override def processMatch(
+      `match`: util.Map[String, util.List[Row]],
+      ctx: PatternProcessFunction.Context,
+      out: Collector[CRow]): Unit = {
+
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
-    out.collect(outCRow)
+    cRowWrappingCollector.out = out
+    function.processMatch(`match`, ctx, cRowWrappingCollector)
   }
 
   override def close(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/MatchRecognizeValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/validation/MatchRecognizeValidationTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.sql.validation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
+import org.junit.Test
+
+class MatchRecognizeValidationTest extends TableTestBase {
+
+  private val streamUtil: StreamTableTestUtil = streamTestUtil()
+  streamUtil.addTable[(Int, String, Long)]("MyTable", 'a, 'b, 'c.rowtime, 'proctime.proctime)
+
+  /** Function 'MATCH_ROWTIME()' can only be used in MATCH_RECOGNIZE **/
+  @Test(expected = classOf[ValidationException])
+  def testMatchRowtimeInSelect() = {
+    val sql = "SELECT MATCH_ROWTIME() FROM MyTable"
+    streamUtil.verifySql(sql, "n/a")
+  }
+
+  /** Function 'MATCH_PROCTIME()' can only be used in MATCH_RECOGNIZE **/
+  @Test(expected = classOf[ValidationException])
+  def testMatchProctimeInSelect() = {
+    val sql = "SELECT MATCH_PROCTIME() FROM MyTable"
+    streamUtil.verifySql(sql, "n/a")
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/MatchHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/MatchHarnessTest.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.harness
+
+import java.time.{Instant, ZoneId}
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
+import org.junit.Test
+
+import scala.collection.mutable
+
+class MatchHarnessTest extends HarnessTestBase {
+
+  import RecordBuilder._
+
+  @Test
+  def testAccessingProctime(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = new mutable.MutableList[(Int, String)]
+    val t = env.fromCollection(data).toTable(tEnv, 'id, 'name, 'proctime.proctime)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT *
+         |FROM MyTable
+         |MATCH_RECOGNIZE (
+         |  ORDER BY proctime
+         |  MEASURES
+         |    MATCH_PROCTIME() as proctime,
+         |    HOUR(MATCH_PROCTIME()) as currentHour
+         |  PATTERN (A)
+         |  DEFINE
+         |    A AS A.name LIKE '%a%'
+         |) AS T
+         |""".stripMargin
+
+    val harness = createHarnessTester[Byte, Row, CRow](
+      tEnv.sqlQuery(sqlQuery).toAppendStream[Row],
+      "GlobalCepOperator")
+    harness.open()
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    val now = Instant.ofEpochSecond(1000000)
+    harness.setProcessingTime(now.toEpochMilli)
+
+    harness.processElement(row(Int.box(1), "a").asRecord())
+    val currentHour = now.atZone(ZoneId.of("GMT")).getHour
+    // MATCH_PROCTIME is not materialized, therefore it is null, HOUR(MATCH_PROCTIME) is
+    // materialized
+    expectedOutput.add(cRow(null, Long.box(currentHour)).asRecord())
+
+    verify(expectedOutput, harness.getOutput)
+  }
+
+  private class RecordBuilder[T](record: T) {
+    def asRecord() : StreamRecord[T] = {
+      new StreamRecord[T](record)
+    }
+  }
+
+  private object RecordBuilder {
+    def row(values: AnyRef*) : RecordBuilder[Row] = {
+      new RecordBuilder[Row](Row.of(values : _*))
+    }
+
+    def cRow(values: AnyRef*) : RecordBuilder[CRow] = {
+      new RecordBuilder[CRow](CRow(values : _*))
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces sql functions that allow extracting time attributes from `MATCH_RECOGNIZE` clause. It introduces `MATCH_ROWTIME` and `MATCH_PROCTIME` functions. It also switches to newly introduced in cep library `PatternProcessFunction`. This function provides more fine grained access to contextual information and provides rich interface as well.

## Brief change log
- 3483ef0 - static methods `generateIterativeCondition` and `generateOneRowPerMatchExpression` shared a lot parameters and always worked on top of `MatchCodeGenerator` therefore I converted them into instance methods
- 9155542 - switches from `PatternSelectFunction` to `PatternProcessFunction`
- c5cef52e - adds support for `MATCH_ROWTIME` and `MATCH_PROCTIME`
- b64cea1 - describes the functions in documentation
- 83e5f77 - formats match_recognize.md to keep line length under 100 characters. There are just a few places where this limit is not restricted as that would break the markdown rendering (long markdown links or html tags)


## Verifying this change

It adds tests in `MatchRecognizeITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs**
