### PR TITLE
[FLINK-11156][tests, runtime] Reconcile ZooKeeperCompletedCheckpointStoreMockitoTest with JDK 9

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
@@ -32,6 +33,7 @@ import org.apache.curator.utils.ZKPaths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -107,34 +109,70 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	 * @throws Exception
 	 */
 	public ZooKeeperCompletedCheckpointStore(
-			int maxNumberOfCheckpointsToRetain,
-			CuratorFramework client,
-			String checkpointsPath,
-			RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage,
-			Executor executor) throws Exception {
-
-		checkArgument(maxNumberOfCheckpointsToRetain >= 1, "Must retain at least one checkpoint.");
-		checkNotNull(stateStorage, "State storage");
-
-		this.maxNumberOfCheckpointsToRetain = maxNumberOfCheckpointsToRetain;
-
-		checkNotNull(client, "Curator client");
-		checkNotNull(checkpointsPath, "Checkpoints path");
-
-		// Ensure that the checkpoints path exists
-		client.newNamespaceAwareEnsurePath(checkpointsPath)
-				.ensure(client.getZookeeperClient());
-
-		// All operations will have the path as root
-		this.client = client.usingNamespace(client.getNamespace() + checkpointsPath);
-
-		this.checkpointsInZooKeeper = new ZooKeeperStateHandleStore<>(this.client, stateStorage);
-
-		this.completedCheckpoints = new ArrayDeque<>(maxNumberOfCheckpointsToRetain + 1);
-
-		this.executor = checkNotNull(executor);
+		int maxNumberOfCheckpointsToRetain,
+		CuratorFramework client,
+		String checkpointsPath,
+		RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage,
+		Executor executor
+	) throws Exception {
+		this(maxNumberOfCheckpointsToRetain,
+			adaptNameSpace(client, checkpointsPath),
+			stateStorage,
+			executor);
 
 		LOG.info("Initialized in '{}'.", checkpointsPath);
+	}
+
+	@VisibleForTesting
+	ZooKeeperCompletedCheckpointStore(
+		int maxNumberOfCheckpointsToRetain,
+		CuratorFramework client,
+		String checkpointsPath,
+		Executor executor,
+		ZooKeeperStateHandleStore<CompletedCheckpoint> checkpointsInZooKeeper
+	) throws Exception {
+		this(maxNumberOfCheckpointsToRetain,
+			adaptNameSpace(client, checkpointsPath),
+			executor,
+			checkpointsInZooKeeper);
+
+		LOG.info("Initialized in '{}'.", checkpointsPath);
+	}
+
+	private ZooKeeperCompletedCheckpointStore(
+		int maxNumberOfCheckpointsToRetain,
+		CuratorFramework client,
+		RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage,
+		Executor executor
+	) {
+		this(maxNumberOfCheckpointsToRetain,
+			client,
+			executor,
+			new ZooKeeperStateHandleStore<>(client, stateStorage));
+	}
+
+	private ZooKeeperCompletedCheckpointStore(
+		int maxNumberOfCheckpointsToRetain,
+		@Nonnull CuratorFramework client,
+		@Nonnull Executor executor,
+		@Nonnull ZooKeeperStateHandleStore<CompletedCheckpoint> checkpointsInZooKeeper
+	) {
+		checkArgument(maxNumberOfCheckpointsToRetain >= 1, "Must retain at least one checkpoint.");
+
+		this.maxNumberOfCheckpointsToRetain = maxNumberOfCheckpointsToRetain;
+		this.client = client;
+		this.executor = executor;
+		this.checkpointsInZooKeeper = checkpointsInZooKeeper;
+		this.completedCheckpoints = new ArrayDeque<>(maxNumberOfCheckpointsToRetain + 1);
+	}
+
+	private static CuratorFramework adaptNameSpace(CuratorFramework client, String checkpointsPath) throws Exception {
+		// Ensure that the checkpoints path exists
+		client.newNamespaceAwareEnsurePath(checkpointsPath)
+			.ensure(client.getZookeeperClient());
+
+		// All operations will have the path as root
+		return client.usingNamespace(client.getNamespace() + checkpointsPath);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -294,12 +294,31 @@ public class ZooKeeperUtils {
 
 		checkpointsPath += ZooKeeperSubmittedJobGraphStore.getPathForJob(jobId);
 
-		return new ZooKeeperCompletedCheckpointStore(
+		final ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			maxNumberOfCheckpointsToRetain,
-			client,
-			checkpointsPath,
-			stateStorage,
+			createZooKeeperStateHandleStore(client, checkpointsPath, stateStorage),
 			executor);
+
+		LOG.info("Initialized {} in '{}'.", ZooKeeperCompletedCheckpointStore.class.getSimpleName(), checkpointsPath);
+		return zooKeeperCompletedCheckpointStore;
+	}
+
+	/**
+	 * Creates an instance of {@link ZooKeeperStateHandleStore}.
+	 *
+	 * @param client       ZK client
+	 * @param path         Path to use for the client namespace
+	 * @param stateStorage RetrievableStateStorageHelper that persist the actual state and whose
+	 *                     returned state handle is then written to ZooKeeper
+	 * @param <T>          Type of state
+	 * @return {@link ZooKeeperStateHandleStore} instance
+	 * @throws Exception ZK errors
+	 */
+	public static <T extends Serializable> ZooKeeperStateHandleStore<T> createZooKeeperStateHandleStore(
+			final CuratorFramework client,
+			final String path,
+			final RetrievableStateStorageHelper<T> stateStorage) throws Exception {
+		return new ZooKeeperStateHandleStore<>(useNamespaceAndEnsurePath(client, path), stateStorage);
 	}
 
 	/**
@@ -360,6 +379,27 @@ public class ZooKeeperUtils {
 		}
 
 		return root + namespace;
+	}
+
+	/**
+	 * Returns a facade of the client that uses the specified namespace, and ensures that all nodes
+	 * in the path exist.
+	 *
+	 * @param client ZK client
+	 * @param path the new namespace
+	 * @return ZK Client that uses the new namespace
+	 * @throws Exception ZK errors
+	 */
+	public static CuratorFramework useNamespaceAndEnsurePath(final CuratorFramework client, final String path) throws Exception {
+		Preconditions.checkNotNull(client, "client must not be null");
+		Preconditions.checkNotNull(path, "path must not be null");
+
+		// Ensure that the checkpoints path exists
+		client.newNamespaceAwareEnsurePath(path)
+			.ensure(client.getZookeeperClient());
+
+		// All operations will have the path as root
+		return client.usingNamespace(generateZookeeperPath(client.getNamespace(), path));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
@@ -422,6 +423,17 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 		if (exception != null) {
 			throw new Exception("Could not properly release all state nodes.", exception);
 		}
+	}
+
+	/**
+	 * Recursively deletes all children.
+	 *
+	 * @throws Exception ZK errors
+	 */
+	public void deleteChildren() throws Exception {
+		final String path = "/" + client.getNamespace();
+		LOG.info("Removing {} from ZooKeeper", path);
+		ZKPaths.deleteChildren(client.getZookeeperClient().getZooKeeper(), path, true);
 	}
 
 	// ---------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperUtilityFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperUtilityFactory.java
@@ -80,13 +80,10 @@ public class ZooKeeperUtilityFactory {
 			String zkStateHandleStorePath,
 			RetrievableStateStorageHelper<T> stateStorageHelper) throws Exception {
 
-		facade.newNamespaceAwareEnsurePath(zkStateHandleStorePath).ensure(facade.getZookeeperClient());
-		CuratorFramework stateHandleStoreFacade = facade.usingNamespace(
-			ZooKeeperUtils.generateZookeeperPath(
-				facade.getNamespace(),
-				zkStateHandleStorePath));
-
-		return new ZooKeeperStateHandleStore<>(stateHandleStoreFacade, stateStorageHelper);
+		return ZooKeeperUtils.createZooKeeperStateHandleStore(
+			facade,
+			zkStateHandleStorePath,
+			stateStorageHelper);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -22,7 +22,9 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
+import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -67,10 +69,14 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
 	@Override
 	protected ZooKeeperCompletedCheckpointStore createCompletedCheckpoints(int maxNumberOfCheckpointsToRetain) throws Exception {
-		return new ZooKeeperCompletedCheckpointStore(maxNumberOfCheckpointsToRetain,
+		final ZooKeeperStateHandleStore<CompletedCheckpoint> checkpointsInZooKeeper = ZooKeeperUtils.createZooKeeperStateHandleStore(
 			ZOOKEEPER.getClient(),
 			CHECKPOINT_PATH,
-			new HeapStateStorageHelper(),
+			new TestingRetrievableStateStorageHelper<>());
+
+		return new ZooKeeperCompletedCheckpointStore(
+			maxNumberOfCheckpointsToRetain,
+			checkpointsInZooKeeper,
 			Executors.directExecutor());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
@@ -34,12 +34,9 @@ import org.apache.curator.framework.api.CuratorEventType;
 import org.apache.curator.framework.api.ErrorListenerPathable;
 import org.apache.curator.utils.EnsurePath;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,21 +52,18 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
-import static org.powermock.api.mockito.PowerMockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 /**
  * Mockito based tests for the {@link ZooKeeperStateHandleStore}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ZooKeeperCompletedCheckpointStore.class)
 public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 
 	/**
@@ -125,7 +119,6 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock));
-		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
 		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllAndLock();
 
 		final int numCheckpointsToRetain = 1;
@@ -165,14 +158,13 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 		});
 
 		final String checkpointsPath = "foobar";
-		final RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
 			client,
 			checkpointsPath,
-			stateStorage,
-			Executors.directExecutor());
+			Executors.directExecutor(),
+			zooKeeperStateHandleStoreMock);
 
 		zooKeeperCompletedCheckpointStore.recover();
 
@@ -213,7 +205,6 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zookeeperStateHandleStoreMock =
 			spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock));
-		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zookeeperStateHandleStoreMock);
 
 		doAnswer(new Answer<RetrievableStateHandle<CompletedCheckpoint>>() {
 			@Override
@@ -231,14 +222,13 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 
 		final int numCheckpointsToRetain = 1;
 		final String checkpointsPath = "foobar";
-		final RetrievableStateStorageHelper<CompletedCheckpoint> stateSotrage = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
 			client,
 			checkpointsPath,
-			stateSotrage,
-			Executors.directExecutor());
+			Executors.directExecutor(),
+			zookeeperStateHandleStoreMock);
 
 		for (long i = 0; i <= numCheckpointsToRetain; ++i) {
 			CompletedCheckpoint checkpointToAdd = mock(CompletedCheckpoint.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
@@ -157,14 +157,10 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 			}
 		});
 
-		final String checkpointsPath = "foobar";
-
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
-			client,
-			checkpointsPath,
-			Executors.directExecutor(),
-			zooKeeperStateHandleStoreMock);
+			zooKeeperStateHandleStoreMock,
+			Executors.directExecutor());
 
 		zooKeeperCompletedCheckpointStore.recover();
 
@@ -221,14 +217,11 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
 		doThrow(new Exception()).when(zookeeperStateHandleStoreMock).releaseAndTryRemove(anyString());
 
 		final int numCheckpointsToRetain = 1;
-		final String checkpointsPath = "foobar";
 
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
-			client,
-			checkpointsPath,
-			Executors.directExecutor(),
-			zookeeperStateHandleStoreMock);
+			zookeeperStateHandleStoreMock,
+			Executors.directExecutor());
 
 		for (long i = 0; i <= numCheckpointsToRetain; ++i) {
 			CompletedCheckpoint checkpointToAdd = mock(CompletedCheckpoint.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
+import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -117,11 +118,14 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 	@Nonnull
 	private ZooKeeperCompletedCheckpointStore createZooKeeperCheckpointStore(CuratorFramework client) throws Exception {
-		return new ZooKeeperCompletedCheckpointStore(
-			1,
+		final ZooKeeperStateHandleStore<CompletedCheckpoint> checkpointsInZooKeeper = ZooKeeperUtils.createZooKeeperStateHandleStore(
 			client,
 			"/checkpoints",
-			new TestingRetrievableStateStorageHelper<>(),
+			new TestingRetrievableStateStorageHelper<>());
+
+		return new ZooKeeperCompletedCheckpointStore(
+			1,
+			checkpointsInZooKeeper,
 			Executors.directExecutor());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -42,10 +42,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
@@ -683,6 +686,18 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 		Stat stat = ZOOKEEPER.getClient().checkExists().forPath("/");
 
 		assertEquals(0, stat.getNumChildren());
+	}
+
+	@Test
+	public void testDeleteAllShouldRemoveAllPaths() throws Exception {
+		final ZooKeeperStateHandleStore<Long> zkStore = new ZooKeeperStateHandleStore<>(
+			ZooKeeperUtils.useNamespaceAndEnsurePath(ZOOKEEPER.getClient(), "/path"),
+			new LongStateStorage());
+
+		zkStore.addAndLock("/state", 1L);
+		zkStore.deleteChildren();
+
+		assertThat(zkStore.getAllPaths(), is(empty()));
 	}
 
 	// ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*This PR is based on #7302. In addition it simplifies the `ZooKeeperCompletedCheckpointStore` constructor.*

## Brief change log

  - *See commits.*

## Verifying this change

This change is already covered by existing tests, such as *ZooKeeperCompletedCheckpointStoreMockitoTest, ZooKeeperCompletedCheckpointStoreTest, etc. (let me know if you need more)*).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
