### PR TITLE
[FLINK-11023][kafka] Add NOTICE files

### DIFF
--- a/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
@@ -66,9 +66,14 @@ under the License.
 							</artifactSet>
 							<filters>
 								<filter>
-									<artifact>*:*</artifact>
+									<artifact>org.apache.kafka:*</artifact>
 									<excludes>
 										<exclude>kafka/kafka-version.properties</exclude>
+										<exclude>LICENSE</exclude>
+										<!-- Does not contain anything relevant.
+											Cites a binary dependency on jersey, but this is neither reflected in the
+											dependency graph, nor are any jersey files bundled. -->
+										<exclude>NOTICE</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-sql-connector-kafka-0.10
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.kafka:kafka-clients:0.10.2.1

--- a/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
@@ -67,9 +67,14 @@ under the License.
 							</artifactSet>
 							<filters>
 								<filter>
-									<artifact>*:*</artifact>
+									<artifact>org.apache.kafka:*</artifact>
 									<excludes>
 										<exclude>kafka/kafka-version.properties</exclude>
+										<exclude>LICENSE</exclude>
+										<!-- Does not contain anything relevant.
+											Cites a binary dependency on jersey, but this is neither reflected in the
+											dependency graph, nor are any jersey files bundled. -->
+										<exclude>NOTICE</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-connectors/flink-sql-connector-kafka-0.11/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-sql-connector-kafka-0.9
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.kafka:kafka-clients:0.11.0.2

--- a/flink-connectors/flink-sql-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.9/pom.xml
@@ -65,9 +65,12 @@ under the License.
 							</artifactSet>
 							<filters>
 								<filter>
-									<artifact>*:*</artifact>
+									<artifact>org.apache.kafka:*</artifact>
 									<excludes>
 										<exclude>kafka/kafka-version.properties</exclude>
+										<exclude>LICENSE</exclude>
+										<!-- Does not contain anything relevant -->
+										<exclude>NOTICE</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-connectors/flink-sql-connector-kafka-0.9/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.9/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-sql-connector-kafka-0.9
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.kafka:kafka-clients:0.9.0.1

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -66,9 +66,14 @@ under the License.
 							</artifactSet>
 							<filters>
 								<filter>
-									<artifact>*:*</artifact>
+									<artifact>org.apache.kafka:*</artifact>
 									<excludes>
 										<exclude>kafka/kafka-version.properties</exclude>
+										<exclude>LICENSE</exclude>
+										<!-- Does not contain anything relevant.
+											Cites a binary dependency on jersey, but this is neither reflected in the
+											dependency graph, nor are any jersey files bundled. -->
+										<exclude>NOTICE</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-sql-connector-kafka
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.kafka:kafka-clients:2.0.1


### PR DESCRIPTION
## What is the purpose of the change

This PR adds NOTICE files for the kafka connectors. This is rather straight-forward since they only bundle `kafka-clients`.
One significant detail is that we're excluding the kafka NOTICE file. In some cases it is seemingly incorrect as it cites a binary dependency on `jersey`, which I believe to not apply to the client. In the remaining cases the file is simply blank, so we may just as well omit it.