### PR TITLE
[hotfix][docs] The CLI doc could not properly shown due to markdown i…

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -30,11 +30,6 @@ distributed setups. It is located under `<flink-home>/bin/flink`
 and connects by default to the running Flink master (JobManager) that was
 started from the same installation directory.
 
-A prerequisite to using the command line interface is that the Flink
-master (JobManager) has been started (via
-`<flink-home>/bin/start-cluster.sh`) or that a YARN environment is
-available.
-
 The command line can be used to
 
 - submit jobs for execution,
@@ -43,6 +38,11 @@ The command line can be used to
 - list running and waiting jobs,
 - trigger and dispose savepoints, and
 - modify a running job
+
+A prerequisite to using the command line interface is that the Flink
+master (JobManager) has been started (via
+`<flink-home>/bin/start-cluster.sh`) or that a YARN environment is
+available.
 
 * This will be replaced by the TOC
 {:toc}


### PR DESCRIPTION
…ssue

## What is the purpose of the change

The markdown treats the TOC as the last item in CLI use list, thus this list could not be shown properly. This PR revert the two paragraph to fix this issue.
[CLI doc](https://ci.apache.org/projects/flink/flink-docs-master/ops/cli.html)

## Brief change log

- Rever two paragraph to make CLI use list shown properly

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no