### PR TITLE
[FLINK-11154][network] bump Netty to 4.1.32

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 The Netty Project
- * Copy from netty 4.1.24.Final
+ * Copy from netty 4.1.32.Final
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.CharBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -77,7 +78,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * An abstract test class for channel buffers.
  *
- * Copy from netty 4.1.24.Final.
+ * Copy from netty 4.1.32.Final.
  */
 public abstract class AbstractByteBufTest extends TestLogger {
 
@@ -3656,11 +3657,23 @@ public abstract class AbstractByteBufTest extends TestLogger {
         testSetGetCharSequence(CharsetUtil.UTF_16);
     }
 
+    private static final CharBuffer EXTENDED_ASCII_CHARS, ASCII_CHARS;
+
+    static {
+        char[] chars = new char[256];
+        for (char c = 0; c < chars.length; c++) {
+            chars[c] = c;
+        }
+        EXTENDED_ASCII_CHARS = CharBuffer.wrap(chars);
+        ASCII_CHARS = CharBuffer.wrap(chars, 0, 128);
+    }
+
     private void testSetGetCharSequence(Charset charset) {
-        ByteBuf buf = newBuffer(16);
-        String sequence = "AB";
+        ByteBuf buf = newBuffer(1024);
+        CharBuffer sequence = CharsetUtil.US_ASCII.equals(charset)
+                ? ASCII_CHARS : EXTENDED_ASCII_CHARS;
         int bytes = buf.setCharSequence(1, sequence, charset);
-        assertEquals(sequence, buf.getCharSequence(1, bytes, charset));
+        assertEquals(sequence, CharBuffer.wrap(buf.getCharSequence(1, bytes, charset)));
         buf.release();
     }
 
@@ -3685,12 +3698,13 @@ public abstract class AbstractByteBufTest extends TestLogger {
     }
 
     private void testWriteReadCharSequence(Charset charset) {
-        ByteBuf buf = newBuffer(16);
-        String sequence = "AB";
+        ByteBuf buf = newBuffer(1024);
+        CharBuffer sequence = CharsetUtil.US_ASCII.equals(charset)
+                ? ASCII_CHARS : EXTENDED_ASCII_CHARS;
         buf.writerIndex(1);
         int bytes = buf.writeCharSequence(sequence, charset);
         buf.readerIndex(1);
-        assertEquals(sequence, buf.readCharSequence(bytes, charset));
+        assertEquals(sequence, CharBuffer.wrap(buf.readCharSequence(bytes, charset)));
         buf.release();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty</artifactId>
-				<version>4.1.24.Final-5.0</version>
+				<version>4.1.32.Final-${flink.shaded.version}</version>
 			</dependency>
 
 			<!-- This manages the 'javax.annotation' annotations (JSR305) -->


### PR DESCRIPTION
## What is the purpose of the change

This pull request bumps Netty to a newer version (4.1.32) for the following improvements/changes done since 4.1.24:
- big improvements (performance, feature set) for using openSSL based SSL engine (useful for FLINK-9816)
- allow multiple shaded versions of the same netty artifact (as long as the shaded prefix is different)
- Ensure ByteToMessageDecoder.Cumulator implementations always release
- Don't re-arm timerfd each epoll_wait
- Use a non-volatile read for ensureAccessible() whenever possible to reduce overhead and allow better inlining.
- Do not fail on runtime when an older version of Log4J2 is on the classpath
- Fix leak and corruption bugs in CompositeByteBuf
- Add support for TLSv1.3
- Harden ref-counting concurrency semantics
- bug fixes
- Java 9-12 related fixes

Please note that this PR is based on https://github.com/apache/flink-shaded/pull/55 and temporarily fetches from that repository to run the tests with the upgraded netty version.
Beware NOT to merge the according commit marked as `[DO-NOT-MERGE]` - and then only merge it once a new version of `flink-shaded` has been released that contains the new Netty version.

## Brief change log

- bump netty dependency
- update `AbstractByteBufTest` to the updated code

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
