### PR TITLE
[FLINK-11294] [test] Remove legacy JobInfo usage in valid tests

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import akka.actor.ActorRef;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.junit.Test;
 
@@ -33,12 +31,10 @@ public class StandaloneSubmittedJobGraphStoreTest {
 	 * Tests that all operations work and don't change the state.
 	 */
 	@Test
-	public void testNoOps() throws Exception {
+	public void testNoOps() {
 		StandaloneSubmittedJobGraphStore jobGraphs = new StandaloneSubmittedJobGraphStore();
 
-		SubmittedJobGraph jobGraph = new SubmittedJobGraph(
-				new JobGraph("testNoOps"),
-				new JobInfo(ActorRef.noSender(), ListeningBehaviour.DETACHED, 0, Integer.MAX_VALUE));
+		SubmittedJobGraph jobGraph = new SubmittedJobGraph(new JobGraph("testNoOps"), null);
 
 		assertEquals(0, jobGraphs.getJobIds().size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore.SubmittedJobGraphListener;
@@ -32,7 +31,6 @@ import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.ActorRef;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.junit.AfterClass;
@@ -97,7 +95,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 			jobGraphs.start(listener);
 
-			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), 0);
+			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), "JobName");
 
 			// Empty state
 			assertEquals(0, jobGraphs.getJobIds().size());
@@ -114,7 +112,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 			verifyJobGraphs(jobGraph, jobGraphs.recoverJobGraph(jobId));
 
 			// Update (same ID)
-			jobGraph = createSubmittedJobGraph(jobGraph.getJobId(), 1);
+			jobGraph = createSubmittedJobGraph(jobGraph.getJobId(), "Updated JobName");
 			jobGraphs.putJobGraph(jobGraph);
 
 			// Verify updated
@@ -171,9 +169,9 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 			HashMap<JobID, SubmittedJobGraph> expected = new HashMap<>();
 			JobID[] jobIds = new JobID[] { new JobID(), new JobID(), new JobID() };
 
-			expected.put(jobIds[0], createSubmittedJobGraph(jobIds[0], 0));
-			expected.put(jobIds[1], createSubmittedJobGraph(jobIds[1], 1));
-			expected.put(jobIds[2], createSubmittedJobGraph(jobIds[2], 2));
+			expected.put(jobIds[0], createSubmittedJobGraph(jobIds[0]));
+			expected.put(jobIds[1], createSubmittedJobGraph(jobIds[1]));
+			expected.put(jobIds[2], createSubmittedJobGraph(jobIds[2]));
 
 			// Add all
 			for (SubmittedJobGraph jobGraph : expected.values()) {
@@ -215,8 +213,8 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 			otherJobGraphs = createZooKeeperSubmittedJobGraphStore("/testConcurrentAddJobGraph");
 
-			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), 0);
-			SubmittedJobGraph otherJobGraph = createSubmittedJobGraph(new JobID(), 0);
+			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID());
+			SubmittedJobGraph otherJobGraph = createSubmittedJobGraph(new JobID());
 
 			SubmittedJobGraphListener listener = mock(SubmittedJobGraphListener.class);
 
@@ -274,7 +272,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 		jobGraphs.start(null);
 		otherJobGraphs.start(null);
 
-		SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), 0);
+		SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID());
 
 		jobGraphs.putJobGraph(jobGraph);
 
@@ -283,32 +281,27 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 	// ---------------------------------------------------------------------------------------------
 
-	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId, long start) {
-		final JobGraph jobGraph = new JobGraph(jobId, "Test JobGraph");
+	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId) {
+		return createSubmittedJobGraph(jobId, "Test JobGraph");
+	}
+
+	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId, String jobName) {
+		final JobGraph jobGraph = new JobGraph(jobId, jobName);
 
 		final JobVertex jobVertex = new JobVertex("Test JobVertex");
 		jobVertex.setParallelism(1);
 
 		jobGraph.addVertex(jobVertex);
 
-		final JobInfo jobInfo = new JobInfo(
-				ActorRef.noSender(), ListeningBehaviour.DETACHED, start, Integer.MAX_VALUE);
-
-		return new SubmittedJobGraph(jobGraph, jobInfo);
+		return new SubmittedJobGraph(jobGraph, null);
 	}
 
-	protected void verifyJobGraphs(SubmittedJobGraph expected, SubmittedJobGraph actual)
-			throws Exception {
+	private void verifyJobGraphs(SubmittedJobGraph expected, SubmittedJobGraph actual) {
 
 		JobGraph expectedJobGraph = expected.getJobGraph();
 		JobGraph actualJobGraph = actual.getJobGraph();
 
 		assertEquals(expectedJobGraph.getName(), actualJobGraph.getName());
 		assertEquals(expectedJobGraph.getJobID(), actualJobGraph.getJobID());
-
-		JobInfo expectedJobInfo = expected.getJobInfo();
-		JobInfo actualJobInfo = actual.getJobInfo();
-
-		assertEquals(expectedJobInfo, actualJobInfo);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Remove legacy JobInfo usage in valid tests, StandaloneSubmittedJobGraphStoreTest.java and ZooKeeperSubmittedJobGraphsStoreITCase.java

## Verifying this change

This change is a trivial rework / code cleanup and it itself is a test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  (no)
  - The serializers:  (no)
  - The runtime per-record code paths (performance sensitive):  (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

cc @tillrohrmann 
