### PR TITLE
[hotfix][runtime] fix synchronous snapshots completed log

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -401,7 +401,9 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshotRunner =
 			snapshotStrategy.snapshot(checkpointId, timestamp, streamFactory, checkpointOptions);
 
-		snapshotStrategy.logSyncCompleted(streamFactory, syncStartTime);
+		if(!asynchronousSnapshots){
+			snapshotStrategy.logSyncCompleted(streamFactory, syncStartTime);
+		}
 		return snapshotRunner;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
The log output problems of methods snapshot in optimization DefaultOperatorStateBackend.java are shown in the current version, if asynchronous Snapshots are chosen, synchronous Snapshots' logs are also printed.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)