### PR TITLE
[FLINK-11296][Table API & SQL] Support truncate in TableAPI

### DIFF
--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1454,6 +1454,31 @@ HEX(string)
         <p>E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".</p>
       </td>
     </tr>
+ 
+    <tr>
+      <td>
+        {% highlight text %}
+TRUNCATE(numeric1)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns a <i>numeric</i> after the truncation.</p>
+        <p>E.g. truncate(42.345) to 42.0.</p>
+      </td>
+    </tr>   
+    
+    <tr>
+      <td>
+        {% highlight text %}
+TRUNCATE(numeric1, integer2)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns a <i>numeric</i> after the truncation.</p>
+        <p>E.g. truncate(42.345, 2) to 42.34.</p>
+      </td>
+    </tr>
+        
   </tbody>
 </table>
 </div>
@@ -1926,6 +1951,31 @@ STRING.hex()
       <p>E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".</p>
     </td>
    </tr>
+
+       <tr>
+         <td>
+           {% highlight text %}
+numeric1.truncate()
+   {% endhighlight %}
+         </td>
+         <td>
+           <p>Returns a <i>numeric</i> after the truncation.</p>
+           <p>E.g. 42.324.truncate() to 42.0.</p>
+         </td>
+       </tr>
+  
+       <tr>
+         <td>
+           {% highlight text %}
+numeric1.truncate(INTEGER2)
+   {% endhighlight %}
+         </td>
+         <td>
+           <p>Returns a <i>numeric</i> after the truncation.</p>
+           <p>E.g. 42.324.truncate(2) to 42.34.</p>
+         </td>
+       </tr>
+   
   </tbody>
 </table>
 </div>

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1454,19 +1454,7 @@ HEX(string)
         <p>E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".</p>
       </td>
     </tr>
- 
-    <tr>
-      <td>
-        {% highlight text %}
-TRUNCATE(numeric1)
-{% endhighlight %}
-      </td>
-      <td>
-        <p>Returns a <i>numeric</i> after the truncation.</p>
-        <p>E.g. truncate(42.345) to 42.0.</p>
-      </td>
-    </tr>   
-    
+        
     <tr>
       <td>
         {% highlight text %}
@@ -1474,8 +1462,8 @@ TRUNCATE(numeric1, integer2)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns a <i>numeric</i> after the truncation.</p>
-        <p>E.g. truncate(42.345, 2) to 42.34.</p>
+        <p>Returns a <i>number</i> of truncated to integer2 decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.Integer2 can also be left blank by default.</p>
+        <p>E.g. <code>truncate(42.345, 2)</code> to 42.34. and <code>truncate(42.345)</code> to 42.0.</p>
       </td>
     </tr>
         
@@ -1951,19 +1939,7 @@ STRING.hex()
       <p>E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".</p>
     </td>
    </tr>
-
-       <tr>
-         <td>
-           {% highlight text %}
-numeric1.truncate()
-   {% endhighlight %}
-         </td>
-         <td>
-           <p>Returns a <i>numeric</i> after the truncation.</p>
-           <p>E.g. 42.324.truncate() to 42.0.</p>
-         </td>
-       </tr>
-  
+ 
        <tr>
          <td>
            {% highlight text %}
@@ -1971,8 +1947,8 @@ numeric1.truncate(INTEGER2)
    {% endhighlight %}
          </td>
          <td>
-           <p>Returns a <i>numeric</i> after the truncation.</p>
-           <p>E.g. 42.324.truncate(2) to 42.34.</p>
+           <p>Returns a <i>number</i> of truncated to integer2 decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.Integer2 can also be left blank by default.</p>
+           <p>E.g. <code>42.324.truncate(2)</code> to 42.34. and <code>42.324.truncate()</code> to 42.0.</p>
          </td>
        </tr>
    

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1462,7 +1462,7 @@ TRUNCATE(numeric1, integer2)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns a <i>number</i> of truncated to integer2 decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.Integer2 can also be left blank by default.</p>
+           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.<i>Integer2</i> can also be left blank by default.</p>
         <p>E.g. <code>truncate(42.345, 2)</code> to 42.34. and <code>truncate(42.345)</code> to 42.0.</p>
       </td>
     </tr>
@@ -1947,7 +1947,7 @@ numeric1.truncate(INTEGER2)
    {% endhighlight %}
          </td>
          <td>
-           <p>Returns a <i>number</i> of truncated to integer2 decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.Integer2 can also be left blank by default.</p>
+           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.<i>Integer2</i> can also be left blank by default.</p>
            <p>E.g. <code>42.324.truncate(2)</code> to 42.34. and <code>42.324.truncate()</code> to 42.0.</p>
          </td>
        </tr>

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1462,7 +1462,7 @@ TRUNCATE(numeric1, integer2)
 {% endhighlight %}
       </td>
       <td>
-           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.This function can also pass in only one <i>numeric1</i> parameter and not set <i>Integer2</i> to use.</p>
+        <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.This function can also pass in only one <i>numeric1</i> parameter and not set <i>Integer2</i> to use.If <i>Integer2</i> is not set, the function truncates as if <i>Integer2</i> were 0.</p>
         <p>E.g. <code>truncate(42.345, 2)</code> to 42.34. and <code>truncate(42.345)</code> to 42.0.</p>
       </td>
     </tr>
@@ -1947,7 +1947,7 @@ numeric1.truncate(INTEGER2)
    {% endhighlight %}
          </td>
          <td>
-           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.This function can also pass in only one <i>numeric1</i> parameter and not set <i>Integer2</i> to use.</p>
+           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.This function can also pass in only one <i>numeric1</i> parameter and not set <i>Integer2</i> to use.If <i>Integer2</i> is not set, the function truncates as if <i>Integer2</i> were 0.</p>
            <p>E.g. <code>42.324.truncate(2)</code> to 42.34. and <code>42.324.truncate()</code> to 42.0.</p>
          </td>
        </tr>

--- a/docs/dev/table/functions.md
+++ b/docs/dev/table/functions.md
@@ -1462,7 +1462,7 @@ TRUNCATE(numeric1, integer2)
 {% endhighlight %}
       </td>
       <td>
-           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.<i>Integer2</i> can also be left blank by default.</p>
+           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.This function can also pass in only one <i>numeric1</i> parameter and not set <i>Integer2</i> to use.</p>
         <p>E.g. <code>truncate(42.345, 2)</code> to 42.34. and <code>truncate(42.345)</code> to 42.0.</p>
       </td>
     </tr>
@@ -1947,7 +1947,7 @@ numeric1.truncate(INTEGER2)
    {% endhighlight %}
          </td>
          <td>
-           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.<i>Integer2</i> can also be left blank by default.</p>
+           <p>Returns a <i>numeric</i> of truncated to <i>integer2</i> decimal places. Returns NULL if <i>numeric1</i> or <i>integer2</i> is NULL.If <i>integer2</i> is 0,the result has no decimal point or fractional part.<i>integer2</i> can be negative to cause <i>integer2</i> digits left of the decimal point of the value to become zero.This function can also pass in only one <i>numeric1</i> parameter and not set <i>Integer2</i> to use.</p>
            <p>E.g. <code>42.324.truncate(2)</code> to 42.34. and <code>42.324.truncate()</code> to 42.0.</p>
          </td>
        </tr>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -442,6 +442,20 @@ trait ImplicitExpressionOperations {
     */
   def hex() = Hex(expr)
 
+  /**
+    * Returns a number of truncated to n decimal places.
+    * If n is 0,the result has no decimal point or fractional part.
+    * n can be negative to cause n digits left of the decimal point of the value to become zero.
+    * E.g. truncate(42.345, 2) to 42.34.
+    */
+  def truncate(n: Expression) = Truncate(expr, n)
+
+  /**
+    * Returns a number of truncated to 0 decimal places.
+    * E.g. truncate(42.345) to 42.0.
+    */
+  def truncate() = Truncate(expr)
+
   // String operations
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/ExpressionReducer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/ExpressionReducer.scala
@@ -127,7 +127,11 @@ class ExpressionReducer(config: TableConfig)
           val reducedValue = reduced.getField(reducedIdx)
           // RexBuilder handle double literal incorrectly, convert it into BigDecimal manually
           val value = if (unreduced.getType.getSqlTypeName == SqlTypeName.DOUBLE) {
-            new java.math.BigDecimal(reducedValue.asInstanceOf[Number].doubleValue())
+            if (reducedValue == null) {
+              reducedValue
+            } else {
+              new java.math.BigDecimal(reducedValue.asInstanceOf[Number].doubleValue())
+            }
           } else {
             reducedValue
           }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -176,4 +176,22 @@ object BuiltInMethods {
     "repeat",
     classOf[String],
     classOf[Int])
+
+  val TRUNCATE_DOUBLE_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[Double])
+  val TRUNCATE_INT_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[Int])
+  val TRUNCATE_LONG_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[Long])
+  val TRUNCATE_DEC_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[JBigDecimal])
+
+  val TRUNCATE_DOUBLE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[Double], classOf[Int])
+  val TRUNCATE_INT = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[Int], classOf[Int])
+  val TRUNCATE_LONG = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[Long], classOf[Int])
+  val TRUNCATE_DEC = Types.lookupMethod(classOf[SqlFunctions], "struncate",
+    classOf[JBigDecimal], classOf[Int])
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -552,6 +552,54 @@ object FunctionGenerator {
     STRING_TYPE_INFO,
     BuiltInMethods.HEX_STRING)
 
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(LONG_TYPE_INFO),
+    LONG_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_LONG_ONE)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(INT_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_INT_ONE)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(BIG_DEC_TYPE_INFO),
+    BIG_DEC_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_DEC_ONE)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(DOUBLE_TYPE_INFO),
+    DOUBLE_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_DOUBLE_ONE)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(LONG_TYPE_INFO, INT_TYPE_INFO),
+    LONG_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_LONG)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(INT_TYPE_INFO, INT_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_INT)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(BIG_DEC_TYPE_INFO, INT_TYPE_INFO),
+    BIG_DEC_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_DEC)
+
+  addSqlFunctionMethod(
+    TRUNCATE,
+    Seq(DOUBLE_TYPE_INFO, INT_TYPE_INFO),
+    DOUBLE_TYPE_INFO,
+    BuiltInMethods.TRUNCATE_DOUBLE)
+
   // ----------------------------------------------------------------------------------------------
   // Temporal functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -250,6 +250,7 @@ object FunctionCatalog {
     "randInteger" -> classOf[RandInteger],
     "bin" -> classOf[Bin],
     "hex" -> classOf[Hex],
+    "truncate" -> classOf[Truncate],
 
     // temporal functions
     "extract" -> classOf[Extract],
@@ -475,6 +476,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.RTRIM,
     ScalarSqlFunctions.REPEAT,
     ScalarSqlFunctions.REGEXP_REPLACE,
+    SqlStdOperatorTable.TRUNCATE,
 
     // MATCH_RECOGNIZE
     SqlStdOperatorTable.FIRST,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1979,19 +1979,19 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f29.truncate('f30),
       "f29.truncate(f30)",
       "truncate(f29, f30)",
-      0.4.toString)
+      "0.4")
 
     testAllApis(
       'f31.truncate('f7),
       "f31.truncate(f7)",
       "truncate(f31, f7)",
-      (-0.123).toString)
+      "-0.123")
 
     testAllApis(
       'f4.truncate('f32),
       "f4.truncate(f32)",
       "truncate(f4, f32)",
-      40.toString)
+      "40")
 
     testAllApis(
       'f28.cast(Types.DOUBLE).truncate(1),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1973,6 +1973,94 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     )
   }
 
+  @Test
+  def testTruncate(): Unit = {
+    testAllApis(
+      'f29.truncate('f30),
+      "f29.truncate(f30)",
+      "truncate(f29, f30)",
+      0.4.toString)
+
+    testAllApis(
+      'f31.truncate('f7),
+      "f31.truncate(f7)",
+      "truncate(f31, f7)",
+      (-0.123).toString)
+
+    testAllApis(
+      'f4.truncate('f32),
+      "f4.truncate(f32)",
+      "truncate(f4, f32)",
+      40.toString)
+
+    testAllApis(
+      'f28.cast(Types.DOUBLE).truncate(1),
+      "f28.cast(DOUBLE).truncate(1)",
+      "truncate(cast(f28 as DOUBLE), 1)",
+      "0.4")
+
+    testAllApis(
+      'f31.cast(Types.DECIMAL).truncate(2),
+      "f31.cast(DECIMAL).truncate(2)",
+      "truncate(cast(f31 as decimal), 2)",
+      "-0.12")
+
+    testAllApis(
+      'f36.cast(Types.DECIMAL).truncate(),
+      "f36.cast(DECIMAL).truncate()",
+      "truncate(42.324)",
+      "42")
+
+    testAllApis(
+      'f5.cast(Types.FLOAT).truncate(),
+      "f5.cast(FLOAT).truncate()",
+      "truncate(cast(f5 as float))",
+      "4.0")
+
+    testAllApis(
+      42.truncate(-1),
+      "42.truncate(-1)",
+      "truncate(42, -1)",
+      "40")
+
+    testAllApis(
+      42.truncate(-3),
+      "42.truncate(-3)",
+      "truncate(42, -3)",
+      "0")
+
+    //    The validation parameter is null
+    testAllApis(
+      'f33.cast(Types.INT).truncate(1),
+      "f33.cast(INT).truncate(1)",
+      "truncate(cast(null as integer), 1)",
+      "null")
+
+    testAllApis(
+      43.21.truncate('f33.cast(Types.INT)),
+      "43.21.truncate(f33.cast(INT))",
+      "truncate(43.21, cast(null as integer))",
+      "null")
+
+    testAllApis(
+      'f33.cast(Types.DOUBLE).truncate(1),
+      "f33.cast(DOUBLE).truncate(1)",
+      "truncate(cast(null as double), 1)",
+      "null")
+
+    testAllApis(
+      'f33.cast(Types.INT).truncate(1),
+      "f33.cast(INT).truncate(1)",
+      "truncate(cast(null as integer))",
+      "null")
+
+    testAllApis(
+      'f33.cast(Types.DOUBLE).truncate(),
+      "f33.cast(DOUBLE).truncate()",
+      "truncate(cast(null as double))",
+      "null")
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Temporal functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -126,6 +126,8 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("PI", "3.141592653589793")
     testSqlApi("E()", "2.718281828459045")
     testSqlApi("BIN(12)", "1100")
+    testSqlApi("truncate(42.345)", "42")
+    testSqlApi("truncate(cast(42.345 as decimal(2, 3)), 2)", "42.34")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ScalarTypesTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ScalarTypesTestBase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.types.Row
 class ScalarTypesTestBase extends ExpressionTestBase {
 
   def testData: Row = {
-    val testData = new Row(36)
+    val testData = new Row(37)
     testData.setField(0, "This is a test String.")
     testData.setField(1, true)
     testData.setField(2, 42.toByte)
@@ -65,6 +65,7 @@ class ScalarTypesTestBase extends ExpressionTestBase {
     testData.setField(33, null)
     testData.setField(34, 256)
     testData.setField(35, "aGVsbG8gd29ybGQ=")
+    testData.setField(36, BigDecimal("42.345").bigDecimal)
     testData
   }
 
@@ -105,6 +106,7 @@ class ScalarTypesTestBase extends ExpressionTestBase {
       Types.INT,
       Types.STRING,
       Types.INT,
-      Types.STRING).asInstanceOf[TypeInformation[Any]]
+      Types.STRING,
+      Types.DECIMAL).asInstanceOf[TypeInformation[Any]]
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.expressions.validation
 import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{SqlParserException, ValidationException}
+import org.apache.flink.table.codegen.CodeGenException
 import org.apache.flink.table.expressions.TimePointUnit
 import org.apache.flink.table.expressions.utils.ScalarTypesTestBase
 import org.junit.Test
@@ -62,6 +63,42 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
   @Test(expected = classOf[ValidationException])
   def testInvalidBin3(): Unit = {
     testSqlApi("BIN(f16)", "101010") // Date type
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidTruncate1(): Unit = {
+    // The all arguments is of type String
+    testSqlApi(
+      "TRUNCATE('abc', 'def')",
+      "FAIL")
+
+    // The second argument is of type String
+    testSqlApi(
+      "TRUNCATE(f12, f0)",
+      "FAIL")
+
+    // The second argument is of type Float
+    testSqlApi(
+      "TRUNCATE(f12,f12)",
+      "FAIL")
+
+    // The second argument is of type Double
+    testSqlApi(
+      "TRUNCATE(f12, cast(f28 as DOUBLE))",
+      "FAIL")
+
+    // The second argument is of type BigDecimal
+    testSqlApi(
+      "TRUNCATE(f12,f15)",
+      "FAIL")
+  }
+
+  @Test(expected = classOf[CodeGenException])
+  def testInvalidTruncate2(): Unit = {
+    // The one argument is of type String
+    testSqlApi(
+      "TRUNCATE('abc')",
+      "FAIL")
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -67,7 +67,7 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
 
   @Test(expected = classOf[ValidationException])
   def testInvalidTruncate1(): Unit = {
-    // The all arguments is of type String
+    // All arguments are string type
     testSqlApi(
       "TRUNCATE('abc', 'def')",
       "FAIL")


### PR DESCRIPTION
## What is the purpose of the change

*This PR   add `truncate` as core scalar operators in then codegen.*

## Brief change log

*(for example:)*

- docs/dev/table/functions.md
- table/api/scala/expressionDsl.scala
- table/codegen/calls/BuiltInMethods.scala
- table/codegen/calls/FunctionGenerator.scala
- table/expressions/mathExpressions.scala
- table/validate/FunctionCatalog.scala
- table/expressions/ScalarFunctionsTest.scala
- table/expressions/SqlExpressionTest.scala

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `ScalarOperatorsTest` and `SqlExpressionTest`

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)