### PR TITLE
[FLINK-11304][docs][table] Fix typo in time attributes doc

### DIFF
--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -284,13 +284,19 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 	}
 
 	@Override
-	public List[RowtimeAttributeDescriptor] getRowtimeAttributeDescriptors() {
-		// Mark the "UserActionTime" attribute as event-time attribute. 
-		// return List<RowtimeAttributeDescriptor>;
+	public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
+		// Mark the "UserActionTime" attribute as event-time attribute.
+		// here we create one attribute descriptor of "UserActionTime"
+        RowtimeAttributeDescriptor rowtimeAttrDescr = new RowtimeAttributeDescriptor(
+        	"UserActionTime",
+        	new ExistingField("UserActionTime"),
+        	new AscendingTimestamps());
+        List<RowtimeAttributeDescriptor> listRowtimeAttrDescr = Collections.singletonList(rowtimeAttrDescr);
+        return listRowtimeAttrDescr;
 	}
 }
 
-// register the table source
+// register tweerererereerrerehe table source
 tEnv.registerTableSource("UserActions", new UserActionSource());
 
 WindowedTable windowedTable = tEnv
@@ -319,7 +325,13 @@ class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribu
 
 	override def getRowtimeAttributeDescriptors: util.List[RowtimeAttributeDescriptor] = {
 		// Mark the "UserActionTime" attribute as event-time attribute.
-		// List<RowtimeAttributeDescriptor>
+        // here we create one attribute descriptor of "UserActionTime"
+        val rowtimeAttrDescr = new RowtimeAttributeDescriptor(
+            "UserActionTime",
+            new ExistingField("UserActionTime"),
+            new AscendingTimestamps)
+        val listRowtimeAttrDescr = Collections.singletonList(rowtimeAttrDescr)
+        listRowtimeAttrDescr
 	}
 }
 

--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -284,9 +284,9 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 	}
 
 	@Override
-	public String getRowtimeAttribute() {
-		// Mark the "UserActionTime" attribute as event-time attribute.
-		return "UserActionTime";
+	public List[RowtimeAttributeDescriptor] getRowtimeAttributeDescriptors() {
+		// Mark the "UserActionTime" attribute as event-time attribute. 
+		// return List<RowtimeAttributeDescriptor>;
 	}
 }
 
@@ -317,9 +317,9 @@ class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribu
 		stream
 	}
 
-	override def getRowtimeAttribute = {
+	override def getRowtimeAttributeDescriptors: util.List[RowtimeAttributeDescriptor] = {
 		// Mark the "UserActionTime" attribute as event-time attribute.
-		"UserActionTime"
+		// List<RowtimeAttributeDescriptor>
 	}
 }
 

--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -287,12 +287,12 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 	public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
 		// Mark the "UserActionTime" attribute as event-time attribute.
 		// here we create one attribute descriptor of "UserActionTime"
-        RowtimeAttributeDescriptor rowtimeAttrDescr = new RowtimeAttributeDescriptor(
-        	"UserActionTime",
-        	new ExistingField("UserActionTime"),
-        	new AscendingTimestamps());
-        List<RowtimeAttributeDescriptor> listRowtimeAttrDescr = Collections.singletonList(rowtimeAttrDescr);
-        return listRowtimeAttrDescr;
+		RowtimeAttributeDescriptor rowtimeAttrDescr = new RowtimeAttributeDescriptor(
+		    "UserActionTime",
+		    new ExistingField("UserActionTime"),
+		    new AscendingTimestamps());
+		List<RowtimeAttributeDescriptor> listRowtimeAttrDescr = Collections.singletonList(rowtimeAttrDescr);
+		return listRowtimeAttrDescr;
 	}
 }
 
@@ -325,13 +325,13 @@ class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribu
 
 	override def getRowtimeAttributeDescriptors: util.List[RowtimeAttributeDescriptor] = {
 		// Mark the "UserActionTime" attribute as event-time attribute.
-        // here we create one attribute descriptor of "UserActionTime"
-        val rowtimeAttrDescr = new RowtimeAttributeDescriptor(
-            "UserActionTime",
-            new ExistingField("UserActionTime"),
-            new AscendingTimestamps)
-        val listRowtimeAttrDescr = Collections.singletonList(rowtimeAttrDescr)
-        listRowtimeAttrDescr
+		// here we create one attribute descriptor of "UserActionTime"
+		val rowtimeAttrDescr = new RowtimeAttributeDescriptor(
+		    "UserActionTime",
+		    new ExistingField("UserActionTime"),
+		    new AscendingTimestamps)
+		val listRowtimeAttrDescr = Collections.singletonList(rowtimeAttrDescr)
+		listRowtimeAttrDescr
 	}
 }
 

--- a/docs/dev/table/streaming/time_attributes.md
+++ b/docs/dev/table/streaming/time_attributes.md
@@ -264,7 +264,7 @@ Moreover, the `DataStream` returned by the `getDataStream()` method must have wa
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // define a table source with a rowtime attribute
-public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeAttribute {
+public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeAttributes {
 
 	@Override
 	public TypeInformation<Row> getReturnType() {
@@ -301,7 +301,7 @@ WindowedTable windowedTable = tEnv
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // define a table source with a rowtime attribute
-class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribute {
+class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttributes {
 
 	override def getReturnType = {
 		val names = Array[String]("Username" , "Data", "UserActionTime")


### PR DESCRIPTION

## What is the purpose of the change

This pull request fix typo in  time attributes docs  **DefinedRowtimeAttribute** should be **DefinedRowtimeAttributes**


## Brief change log

fix typo in  time attributes doc

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
 
