### PR TITLE
[hotfix] [docs] fix typo in restart strategies

### DIFF
--- a/docs/dev/restart_strategies.md
+++ b/docs/dev/restart_strategies.md
@@ -264,7 +264,7 @@ env.setRestartStrategy(RestartStrategies.noRestart())
 ### Fallback Restart Strategy
 
 The cluster defined restart strategy is used. 
-This helpful for streaming programs which enable checkpointing.
-Per default, a fixed delay restart strategy is chosen if there is no other restart strategy defined.
+This is helpful for streaming programs which enable checkpointing.
+By default, a fixed delay restart strategy is chosen if there is no other restart strategy defined.
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

fix typo in restart strategies documentation.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)