### PR TITLE
[Flink-11314] Reuse RocksDBWriteBatchWrapper in the flush function of…

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -37,7 +37,6 @@ import org.apache.flink.util.Preconditions;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.WriteBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -218,7 +217,7 @@ class RocksDBMapState<K, N, UK, UV>
 	public void clear() {
 		try {
 			try (RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(backend.db, columnFamily);
-				WriteBatch writeBatch = new WriteBatch(128)) {
+				RocksDBWriteBatchWrapper rocksDBWriteBatchWrapper = new RocksDBWriteBatchWrapper(backend.db, backend.getWriteOptions())) {
 
 				final byte[] keyPrefixBytes = serializeCurrentKeyAndNamespace();
 				iterator.seek(keyPrefixBytes);
@@ -226,14 +225,12 @@ class RocksDBMapState<K, N, UK, UV>
 				while (iterator.isValid()) {
 					byte[] keyBytes = iterator.key();
 					if (startWithKeyPrefix(keyPrefixBytes, keyBytes)) {
-						writeBatch.remove(columnFamily, keyBytes);
+						rocksDBWriteBatchWrapper.remove(columnFamily, keyBytes);
 					} else {
 						break;
 					}
 					iterator.next();
 				}
-
-				backend.db.write(writeOptions, writeBatch);
 			}
 		} catch (Exception e) {
 			LOG.warn("Error while cleaning the state.", e);


### PR DESCRIPTION

## What is the purpose of the change

*Reuse `RocksDBWriteBatchWrapper` in the clear method of RocksDBMapState*


## Brief change log

*(for example:)*
  - *Use the Wrapper class `RocksDBWriteBatchWrapper` to replace the class `WriteBatch`*



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)