### PR TITLE
[Flink-11315] Make magic number in KvStateSerializer as a constant va…

### DIFF
--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/serialization/KvStateSerializer.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/serialization/KvStateSerializer.java
@@ -35,6 +35,8 @@ import java.util.Map;
  */
 public final class KvStateSerializer {
 
+	//The magic number is as a flag between key and namespace.
+	private static final int MAGIC_NUMBER = 42;
 	// ------------------------------------------------------------------------
 	// Generic serialization utils
 	// ------------------------------------------------------------------------
@@ -63,7 +65,7 @@ public final class KvStateSerializer {
 		DataOutputSerializer dos = new DataOutputSerializer(32);
 
 		keySerializer.serialize(key, dos);
-		dos.writeByte(42);
+		dos.writeByte(MAGIC_NUMBER);
 		namespaceSerializer.serialize(namespace, dos);
 
 		return dos.getCopyOfBuffer();
@@ -93,7 +95,7 @@ public final class KvStateSerializer {
 		try {
 			K key = keySerializer.deserialize(dis);
 			byte magicNumber = dis.readByte();
-			if (magicNumber != 42) {
+			if (magicNumber != MAGIC_NUMBER) {
 				throw new IOException("Unexpected magic number " + magicNumber + ".");
 			}
 			N namespace = namespaceSerializer.deserialize(dis);


### PR DESCRIPTION

## What is the purpose of the change

*To make the magic number more readable as use review the code*


## Brief change log

*(for example:)*
  - *Use constant number in the code logic to replace a int number*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
