### PR TITLE
[FLINK-11310][table] Convert predicates to IN or NOT_IN for Project

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.plan.rules
 import org.apache.calcite.rel.core.RelFactories
 import org.apache.calcite.rel.rules._
 import org.apache.calcite.tools.{RuleSet, RuleSets}
-import org.apache.flink.table.plan.nodes.logical
 import org.apache.flink.table.plan.rules.common._
 import org.apache.flink.table.plan.rules.logical._
 import org.apache.flink.table.plan.rules.dataSet._

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/CalcTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/CalcTest.scala
@@ -47,40 +47,4 @@ class CalcTest extends TableTestBase {
       "SELECT MyTable.a.*, c, MyTable.b.* FROM MyTable",
       expected)
   }
-
-  @Test
-  def testIn(): Unit = {
-    val util = batchTestUtil()
-    util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
-
-    val resultStr = (1 to 30).mkString(", ")
-    val expected = unaryNode(
-      "DataSetCalc",
-      batchTableNode(0),
-      term("select", "a", "b", "c"),
-      term("where", s"IN(b, $resultStr)")
-    )
-
-    util.verifySql(
-      s"SELECT * FROM MyTable WHERE b in ($resultStr)",
-      expected)
-  }
-
-  @Test
-  def testNotIn(): Unit = {
-    val util = batchTestUtil()
-    util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
-
-    val resultStr = (1 to 30).mkString(", ")
-    val expected = unaryNode(
-      "DataSetCalc",
-      batchTableNode(0),
-      term("select", "a", "b", "c"),
-      term("where", s"NOT IN(b, $resultStr)")
-    )
-
-    util.verifySql(
-      s"SELECT * FROM MyTable WHERE b NOT IN ($resultStr)",
-      expected)
-  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SetOperatorsTest.scala
@@ -34,12 +34,13 @@ class SetOperatorsTest extends TableTestBase {
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
-      term("select", "a", "b", "c"),
+      term("select", s"CASE(IN(a, $resultStr), 1, 2) AS a", "b", "c"),
       term("where", s"IN(b, $resultStr)")
     )
 
     util.verifySql(
-      s"SELECT * FROM MyTable WHERE b in ($resultStr)",
+      s"SELECT CASE WHEN a IN ($resultStr) THEN 1 ELSE 2 END AS a, b, c FROM MyTable " +
+        s"WHERE b in ($resultStr)",
       expected)
   }
 
@@ -52,12 +53,13 @@ class SetOperatorsTest extends TableTestBase {
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
-      term("select", "a", "b", "c"),
+      term("select", s"CASE(NOT IN(a, $resultStr), 1, 2) AS a", "b", "c"),
       term("where", s"NOT IN(b, $resultStr)")
     )
 
     util.verifySql(
-      s"SELECT * FROM MyTable WHERE b NOT IN ($resultStr)",
+      s"SELECT CASE WHEN a NOT IN ($resultStr) THEN 1 ELSE 2 END AS a, b, c FROM MyTable " +
+        s"WHERE b NOT IN ($resultStr)",
       expected)
   }
 


### PR DESCRIPTION

## What is the purpose of the change

This pull request convert predicates to IN or NOT_IN for `Project`. In [FLINK-10474](https://issues.apache.org/jira/browse/FLINK-10474), we force translate IN into a predicate to avoid translating to a JOIN. In addition, we add a Rule to convert the predicates back to IN so that we can generate code using a HashSet for the IN.

However, [FLINK-10474](https://issues.apache.org/jira/browse/FLINK-10474) only takes Filter into consideration. It would be great to also convert predicates in Project to IN. It not only will improve the performance for the Project, but also will avoid the problem raised in [FLINK-11308](https://issues.apache.org/jira/browse/FLINK-11308), as all predicates will be converted into one IN expression.

## Brief change log

  - Support convert predicates to IN or NOT IN for `Project` in `ConvertToNotInOrInRule`. Note: We don't need to convert predicates for `Calc` since there is no Calc during  `optimizeNormalizeLogicalPlan`.


## Verifying this change

This change added tests and can be verified as follows:

  - Added tests in `CalcTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
