### PR TITLE
restoreFunctionState() add parameter getOperatorStateBackend()

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -93,7 +93,7 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 	@Override
 	public void initializeState(StateInitializationContext context) throws Exception {
 		super.initializeState(context);
-		StreamingFunctionUtils.restoreFunctionState(context, userFunction);
+		StreamingFunctionUtils.restoreFunctionState(context, getOperatorStateBackend(), userFunction);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/functions/StreamingFunctionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/functions/StreamingFunctionUtils.java
@@ -151,13 +151,14 @@ public final class StreamingFunctionUtils {
 
 	public static void restoreFunctionState(
 			StateInitializationContext context,
+			OperatorStateBackend backend,
 			Function userFunction) throws Exception {
 
 		Preconditions.checkNotNull(context);
 
 		while (true) {
 
-			if (tryRestoreFunction(context, userFunction)) {
+			if (tryRestoreFunction(context, backend, userFunction)) {
 				break;
 			}
 
@@ -172,6 +173,7 @@ public final class StreamingFunctionUtils {
 
 	private static boolean tryRestoreFunction(
 			StateInitializationContext context,
+			OperatorStateBackend backend,
 			Function userFunction) throws Exception {
 
 		if (userFunction instanceof CheckpointedFunction) {
@@ -184,7 +186,7 @@ public final class StreamingFunctionUtils {
 			@SuppressWarnings("unchecked")
 			ListCheckpointed<Serializable> listCheckpointedFun = (ListCheckpointed<Serializable>) userFunction;
 
-			ListState<Serializable> listState = context.getOperatorStateStore().
+			ListState<Serializable> listState = backend.
 					getSerializableListState(DefaultOperatorStateBackend.DEFAULT_OPERATOR_STATE_NAME);
 
 			List<Serializable> list = new ArrayList<>();


### PR DESCRIPTION
… changed to

StreamingFunctionUtils.restoreFunctionState(context, getOperatorStateBackend(),userFunction)，so that the code formats of restoreFunctionState() and snapshotFunctionState() are consistent.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*StreamingFunctionUtils.restoreFunctionState(context, getOperatorStateBackend(),userFunction)，so that the code formats of restoreFunctionState() and snapshotFunctionState() are consistent.*


## Brief change log

*(for example:)*
  - *restoreFunctionState() add parameter getOperatorStateBackend()*


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(org.apache.flink.test.checkpointing.StateCheckpointedITCase)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
