### PR TITLE
[FLINK-11036] Fix test_streaming_classloader.sh end-to-end test

### DIFF
--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
@@ -21,6 +21,11 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+	<!--
+	This is used by the end-to-end test test_streaming_classloader.sh. It contains the library
+	package that we put in the lib/ folder.
+	-->
+
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
@@ -30,18 +35,9 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-parent-child-classloading-test_${scala.binary.version}</artifactId>
-	<name>flink-parent-child-classloading-test</name>
+	<artifactId>flink-parent-child-classloading-test-lib-package_${scala.binary.version}</artifactId>
+	<name>flink-parent-child-classloading-test-lib-package</name>
 	<packaging>jar</packaging>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
 
 	<build>
 		<plugins>
@@ -50,18 +46,13 @@
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>ClassLoaderTestProgram</id>
+						<id>LibPackage</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>ClassLoaderTestProgram</finalName>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>org.apache.flink.streaming.tests.ClassLoaderTestProgram</mainClass>
-								</transformer>
-							</transformers>
+							<finalName>LibPackage</finalName>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/src/main/java/org/apache/flink/streaming/tests/ParentChildTestingVehicle.java
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/src/main/java/org/apache/flink/streaming/tests/ParentChildTestingVehicle.java
@@ -16,15 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.taskmanager;
+package org.apache.flink.streaming.tests;
 
 /**
- * A {@code Taskmanager} in the same package as the proper Flink {@link TaskManager}. We use this
- * to check whether Flink correctly uses the child-first {@link ClassLoader} when configured to do
- * so.
+ * This is used for test_streaming_classloader.sh. We have a version of this in a "lib" package that
+ * we place in the lib/ folder of Flink and a version in the "user" package. We check how they are
+ * resolved in ClassLoaderTestProgram.
  */
-public class TaskManager {
+public class ParentChildTestingVehicle {
 	public static String getMessage() {
-		return "Hello, World!";
+		return "Hello, from lib package!";
 	}
 }

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/src/main/resources/parent-child-test.properties
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/src/main/resources/parent-child-test.properties
@@ -1,0 +1,19 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+message=hello-from-lib-package

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+    -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<!--
+	This is used by the end-to-end test test_streaming_classloader.sh. It contains the user program
+	that we want to test.
+	-->
+
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.8-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-parent-child-classloading-test-program_${scala.binary.version}</artifactId>
+	<name>flink-parent-child-classloading-test-program</name>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>ClassLoaderTestProgram</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>ClassLoaderTestProgram</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.streaming.tests.ClassLoaderTestProgram</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>
+

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/src/main/java/org/apache/flink/streaming/tests/ParentChildTestingVehicle.java
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/src/main/java/org/apache/flink/streaming/tests/ParentChildTestingVehicle.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests;
+
+/**
+ * This is used for test_streaming_classloader.sh. We have a version of this in a "lib" package that
+ * we place in the lib/ folder of Flink and a version in the "user" package. We check how they are
+ * resolved in ClassLoaderTestProgram.
+ */
+public class ParentChildTestingVehicle {
+	public static String getMessage() {
+		return "Hello, from user package!";
+	}
+}

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/src/main/resources/parent-child-test.properties
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/src/main/resources/parent-child-test.properties
@@ -1,0 +1,19 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+message=hello-from-user-package

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/resources/.version.properties
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test/src/main/resources/.version.properties
@@ -1,1 +1,0 @@
-git.commit.id.abbrev=hello-there-42

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -36,7 +36,8 @@ under the License.
 
 	<modules>
 		<module>flink-cli-test</module>
-		<module>flink-parent-child-classloading-test</module>
+		<module>flink-parent-child-classloading-test-program</module>
+		<module>flink-parent-child-classloading-test-lib-package</module>
 		<module>flink-dataset-allround-test</module>
 		<module>flink-datastream-allround-test</module>
 		<module>flink-stream-sql-test</module>

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -19,7 +19,7 @@
 
 source "$(dirname "$0")"/common.sh
 
-TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-parent-child-classloading-test/target/ClassLoaderTestProgram.jar
+TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-parent-child-classloading-test-program/target/ClassLoaderTestProgram.jar
 
 echo "Testing parent-first class loading"
 
@@ -27,6 +27,24 @@ echo "Testing parent-first class loading"
 sed -i -e 's/classloader.resolve-order: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
 sed -i -e 's/classloader.parent-first-patterns: .*//' $FLINK_DIR/conf/flink-conf.yaml
 echo "classloader.resolve-order: parent-first" >> "$FLINK_DIR/conf/flink-conf.yaml"
+
+echo "Moving fake LibPackage.jar from end-to-end tests to lib/"
+cp ${END_TO_END_DIR}/flink-parent-child-classloading-test-lib-package/target/LibPackage.jar ${FLINK_DIR}/lib/
+
+function classloader_cleanup() {
+  # don't call ourselves again for another signal interruption
+  trap "exit -1" INT
+  # don't call ourselves again for normal exit
+  trap "" EXIT
+
+  stop_cluster
+  $FLINK_DIR/bin/taskmanager.sh stop-all
+
+  # remove LibPackage.jar again
+  rm ${FLINK_DIR}/lib/LibPackage.jar
+}
+trap classloader_cleanup INT
+trap classloader_cleanup EXIT
 
 start_cluster
 
@@ -39,9 +57,9 @@ sed -i -e 's/classloader.resolve-order: .*//' $FLINK_DIR/conf/flink-conf.yaml
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_pf`
 # first field: whether we found the method on TaskManager
-# result of getResource(".version.properties"), should be from the parent
-# ordered result of getResources(".version.properties"), should have parent first
-EXPECTED="NoSuchMethodError:[0-9a-f]{6,}:[0-9a-f]{6,}hello-there-42"
+# result of getResource("parent-child-test.properties"), should be from the parent
+# ordered result of getResources("parent-child-test.properties"), should have parent first
+EXPECTED="Hello, from lib package!:hello-from-lib-package:hello-from-lib-packagehello-from-user-package"
 if ! [[ "$OUTPUT" =~ $EXPECTED ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
@@ -69,9 +87,9 @@ sed -i -e 's/classloader.resolve-order: .*//' $FLINK_DIR/conf/flink-conf.yaml
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_cf_pf`
 # first field: whether we found the method on TaskManager
-# result of getResource(".version.properties"), should be from the child
-# ordered result of getResources(".version.properties"), should be child first
-EXPECTED="NoSuchMethodError:hello-there-42:hello-there-42[0-9a-f]{6,}"
+# result of getResource("parent-child-test.properties"), should be from the child
+# ordered result of getResources("parent-child-test.properties"), should be child first
+EXPECTED="Hello, from lib package!:hello-from-user-package:hello-from-user-packagehello-from-lib-package"
 if ! [[ "$OUTPUT" =~ $EXPECTED ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
@@ -98,9 +116,9 @@ sed -i -e 's/classloader.parent-first-patterns: .*//' $FLINK_DIR/conf/flink-conf
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_cf`
 # first field: whether we found the method on TaskManager
-# result of getResource(".version.properties"), should be from the child
-# ordered result of getResources(".version.properties"), should be child first
-EXPECTED="Hello, World!:hello-there-42:hello-there-42[0-9a-f]{6,}"
+# result of getResource("parent-child-test.properties"), should be from the child
+# ordered result of getResources("parent-child-test.properties"), should be child first
+EXPECTED="Hello, from user package!:hello-from-user-package:hello-from-user-packagehello-from-lib-package"
 if ! [[ "$OUTPUT" =~ $EXPECTED ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"


### PR DESCRIPTION
Before, this was relying on .version.properties being available in the
flink-dist jar. This was not the case when building from a Flink source
release.

This is fixed by introducing a fake lib package that we place in the
lib/ folder to test the classloader resolution order. Both the lib
package and the user package contain a parent-child-test.properties and
we check the resolution order in the test