### PR TITLE
[FLINK-11343][tests] Force order that TaskExecutor shutdown after Task exit

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -288,7 +288,7 @@ public class MemoryManager {
 		// -------------------- BEGIN CRITICAL SECTION -------------------
 		synchronized (lock) {
 			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
+				return;
 			}
 
 			// in the case of pre-allocated memory, the 'numNonAllocatedPages' is zero, in the
@@ -349,7 +349,7 @@ public class MemoryManager {
 				return;
 			}
 			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
+				return;
 			}
 
 			// remove the reference in the map for the owner
@@ -397,7 +397,7 @@ public class MemoryManager {
 		// -------------------- BEGIN CRITICAL SECTION -------------------
 		synchronized (lock) {
 			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
+				return;
 			}
 
 			// since concurrent modifications to the collection
@@ -477,7 +477,7 @@ public class MemoryManager {
 		// -------------------- BEGIN CRITICAL SECTION -------------------
 		synchronized (lock) {
 			if (isShutDown) {
-				throw new IllegalStateException("Memory manager has been shut down.");
+				return;
 			}
 
 			// get all segments

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -288,7 +288,7 @@ public class MemoryManager {
 		// -------------------- BEGIN CRITICAL SECTION -------------------
 		synchronized (lock) {
 			if (isShutDown) {
-				return;
+				throw new IllegalStateException("Memory manager has been shut down.");
 			}
 
 			// in the case of pre-allocated memory, the 'numNonAllocatedPages' is zero, in the
@@ -349,7 +349,7 @@ public class MemoryManager {
 				return;
 			}
 			if (isShutDown) {
-				return;
+				throw new IllegalStateException("Memory manager has been shut down.");
 			}
 
 			// remove the reference in the map for the owner
@@ -397,7 +397,7 @@ public class MemoryManager {
 		// -------------------- BEGIN CRITICAL SECTION -------------------
 		synchronized (lock) {
 			if (isShutDown) {
-				return;
+				throw new IllegalStateException("Memory manager has been shut down.");
 			}
 
 			// since concurrent modifications to the collection
@@ -477,7 +477,7 @@ public class MemoryManager {
 		// -------------------- BEGIN CRITICAL SECTION -------------------
 		synchronized (lock) {
 			if (isShutDown) {
-				return;
+				throw new IllegalStateException("Memory manager has been shut down.");
 			}
 
 			// get all segments


### PR DESCRIPTION
…f IllegalStateException

## What is the purpose of the change

>org.apache.flink.runtime.util.TestingFatalErrorHandler$TestingException: java.lang.IllegalStateException: Memory manager has been shut down.
	at org.apache.flink.runtime.util.TestingFatalErrorHandler.rethrowError(TestingFatalErrorHandler.java:51)
	at org.apache.flink.runtime.taskexecutor.TaskExecutorTest.teardown(TaskExecutorTest.java:223)
Caused by: java.lang.IllegalStateException: Memory manager has been shut down.
	at org.apache.flink.runtime.memory.MemoryManager.releaseAll(MemoryManager.java:480)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:821)
	at java.lang.Thread.run(Thread.java:748)

After an investigation, I notice that it occurred when

1. Task#run set task state as FINISHED
2. Test case get the FINISHED future, call taskExecutor#shutdown, so the MemoryManager shutdown.
3. In `finally` block of Task#run, call MemoryManager#releaseAll(owner)
4. cause `IllegalStateException`

Here, I find that after MemoryManager#shutdown, `allocatedSegments` and `memoryPool` are released properly. Thus a following #releaseAll can be safely omitted and an `IllegalStateException` is no-need.

**UPDATE** basically it is an issue about execute order, I add a follow-up commit to ensure that the TaskExecutor shutdown after Task exit. We can revert the first commit but as pointed out above, maybe it is a better choice to omit a `#releaseAll` following `#shutdown` instead of causing a fatal error.

## Brief change log

Omit actions in memory manager after shutdown instead of throwing IllegalStateException


## Verifying this change

This change is already covered by existing tests, such as *TaskExecutorTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann @NicoK @zhijiangW 