### PR TITLE
[hotfix][docs] Fix documentation of DataStream API Tutorial

### DIFF
--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -71,9 +71,7 @@ wiki-edits/
         ├── java
         │   └── wikiedits
         │       ├── BatchJob.java
-        │       ├── SocketTextStreamWordCount.java
-        │       ├── StreamingJob.java
-        │       └── WordCount.java
+        │       └── StreamingJob.java
         └── resources
             └── log4j.properties
 {% endhighlight %}
@@ -355,7 +353,7 @@ We also have to create the Kafka Topic, so that our program can write to it:
 
 {% highlight bash %}
 $ cd my/kafka/directory
-$ bin/kafka-topics.sh --create --zookeeper localhost:2181 --topic wiki-results
+$ bin/kafka-create-topic.sh --zookeeper localhost:2181 --topic wiki-results
 {% endhighlight %}
 
 Now we are ready to run our jar file on the local Flink cluster:

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -292,7 +292,7 @@ your own machine and writing results to [Kafka](http://kafka.apache.org).
 ## Bonus Exercise: Running on a Cluster and Writing to Kafka
 
 Please follow our [local setup tutorial](local_setup.html) for setting up a Flink distribution
-on your machine and refer to the [Kafka quickstart](https://kafka.apache.org/documentation.html#quickstart)
+on your machine and refer to the [Kafka quickstart](https://kafka.apache.org/0110/documentation.html#quickstart)
 for setting up a Kafka installation before we proceed.
 
 As a first step, we have to add the Flink Kafka connector as a dependency so that we can
@@ -301,7 +301,7 @@ use the Kafka sink. Add this to the `pom.xml` file in the dependencies section:
 {% highlight xml %}
 <dependency>
     <groupId>org.apache.flink</groupId>
-    <artifactId>flink-connector-kafka-0.8_2.11</artifactId>
+    <artifactId>flink-connector-kafka-0.11_2.11</artifactId>
     <version>${flink.version}</version>
 </dependency>
 {% endhighlight %}
@@ -318,12 +318,12 @@ result
             return tuple.toString();
         }
     })
-    .addSink(new FlinkKafkaProducer08<>("localhost:9092", "wiki-result", new SimpleStringSchema()));
+    .addSink(new FlinkKafkaProducer011<>("localhost:9092", "wiki-result", new SimpleStringSchema()));
 {% endhighlight %}
 
 The related classes also need to be imported:
 {% highlight java %}
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer08;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.functions.MapFunction;
 {% endhighlight %}
@@ -353,7 +353,7 @@ We also have to create the Kafka Topic, so that our program can write to it:
 
 {% highlight bash %}
 $ cd my/kafka/directory
-$ bin/kafka-create-topic.sh --zookeeper localhost:2181 --topic wiki-results
+$ bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic wiki-results
 {% endhighlight %}
 
 Now we are ready to run our jar file on the local Flink cluster:


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the documentation error of datastream_api.md*


## Brief change log

  - *Remove the documentation about SocketTextStreamWordCount.java and WordCount.java as they are already removed from the archetype resources*
  - *Update the script about how to create a kafka topic. Kafka 0.8.0 uses script kafka-create-topic.sh instead of kafka-topics.sh to create a topic*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
