### PR TITLE
[FLINK-10910][e2e] Hardened Kubernetes e2e test.

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -22,6 +22,8 @@ source "$(dirname "$0")"/common.sh
 DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
 KUBERNETES_MODULE_DIR=${END_TO_END_DIR}/../flink-container/kubernetes
 CONTAINER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
+MINIKUBE_START_RETRIES=3
+MINIKUBE_START_BACKOFF=5
 
 export FLINK_JOB=org.apache.flink.examples.java.wordcount.WordCount
 export FLINK_IMAGE_NAME=test_kubernetes_embedded_job
@@ -37,9 +39,28 @@ function cleanup {
     rm -rf ${OUTPUT_VOLUME}
 }
 
+function check_kubernetes_status {
+    local status=`minikube status`
+    echo ${status} | grep -q "minikube: Running cluster: Running kubectl: Correctly Configured"
+    return $?
+}
+
+function start_kubernetes_if_not_running {
+    if ! check_kubernetes_status; then
+        minikube start
+    fi
+
+    return $(check_kubernetes_status)
+}
+
 trap cleanup EXIT
 
 mkdir -p $OUTPUT_VOLUME
+
+if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} start_kubernetes_if_not_running; then
+    echo "Minikube not running. Could not start minikube. Aborting..."
+    exit 1
+fi
 
 eval $(minikube docker-env)
 cd "$DOCKER_MODULE_DIR"


### PR DESCRIPTION
Added check if minikube is running. If it is not we try to start it couple of times. If we do not succeed we fail with a descriptive message.

## What is the purpose of the change

This PR should harden kubernetes e2e test. It checks if kubernetes is running. If not it tries to start it. If it fails it exits with a descriptive error message.

## Verifying this change

Run `test_kubernetes_embedded_job.sh` script. I've run ~100 times this test on travis, without a single failure (https://travis-ci.org/dawidwys/flink/builds/480346541). I also checked locally if it succeeds if minikube is not started. 

