### PR TITLE
[hotfix][runtime] remove RejectedExecutionException code in executeAsyncCallRunnable method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1319,16 +1319,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 
 			LOG.debug("Invoking async call {} on task {}", callName, taskNameWithSubtask);
 
-			try {
-				executor.submit(runnable);
-			}
-			catch (RejectedExecutionException e) {
-				// may be that we are concurrently finished or canceled.
-				// if not, report that something is fishy
-				if (executionState == ExecutionState.RUNNING) {
-					throw new RuntimeException("Async call was rejected, even though the task is running.", e);
-				}
-			}
+			executor.submit(runnable);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*optimize `ExecutorService` code* in Task#executeAsyncCallRunnable


## Brief change log

A SingleThreadExecutor will be created in `Task#executeAsyncCallRunnable` which  uses LinkedBlockingQueue as workqueue. So it will never reach RejectedExecutionException.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
