### PR TITLE
[FLINK-11294][tests] Remove legacy JobInfo usage in valid tests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -265,7 +265,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	private CompletableFuture<Void> persistAndRunJob(JobGraph jobGraph) throws Exception {
-		submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph, null));
+		submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph));
 
 		final CompletableFuture<Void> runJobFuture = runJob(jobGraph);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobSubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobSubmittedJobGraphStore.java
@@ -52,7 +52,7 @@ public class SingleJobSubmittedJobGraphStore implements SubmittedJobGraphStore {
 	@Override
 	public SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception {
 		if (jobGraph.getJobID().equals(jobId)) {
-			return new SubmittedJobGraph(jobGraph, null);
+			return new SubmittedJobGraph(jobGraph);
 		} else {
 			throw new FlinkException("Could not recover job graph " + jobId + '.');
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
@@ -44,8 +44,20 @@ public class SubmittedJobGraph implements Serializable {
 	 * Creates a {@link SubmittedJobGraph}.
 	 *
 	 * @param jobGraph The submitted {@link JobGraph}
-	 * @param jobInfo  The {@link JobInfo}
 	 */
+	public SubmittedJobGraph(JobGraph jobGraph) {
+		this(jobGraph, null);
+	}
+
+	/**
+	 * Creates a {@link SubmittedJobGraph}.
+	 *
+	 * @param jobGraph The submitted {@link JobGraph}
+	 * @param jobInfo  The {@link JobInfo}
+	 *
+	 * @deprecated FLIP-6 code should use {@link #SubmittedJobGraph(JobGraph)}
+	 */
+	@Deprecated
 	public SubmittedJobGraph(JobGraph jobGraph, @Nullable JobInfo jobInfo) {
 		this.jobGraph = checkNotNull(jobGraph, "Job graph");
 		this.jobInfo = jobInfo;
@@ -67,7 +79,10 @@ public class SubmittedJobGraph implements Serializable {
 
 	/**
 	 * Returns the {@link JobInfo} of the client who submitted the {@link JobGraph}.
+	 *
+	 * @deprecated FLIP-6 code should not use this method because it will always return null.
 	 */
+	@Deprecated
 	public JobInfo getJobInfo() throws Exception {
 		return jobInfo;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
@@ -34,7 +34,7 @@ public class SubmittedJobGraph implements Serializable {
 
 	private static final long serialVersionUID = 2836099271734771825L;
 
-	/** The submitted {@link JobGraph} */
+	/** The submitted {@link JobGraph}. */
 	private final JobGraph jobGraph;
 
 	/** The {@link JobInfo}. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
@@ -115,7 +115,7 @@ public class DispatcherHATest extends TestLogger {
 	public void testGrantingRevokingLeadership() throws Exception {
 		final TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
 		final JobGraph nonEmptyJobGraph = createNonEmptyJobGraph();
-		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(nonEmptyJobGraph, null);
+		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(nonEmptyJobGraph);
 
 		final OneShotLatch enterGetJobIdsLatch = new OneShotLatch();
 		final OneShotLatch proceedGetJobIdsLatch = new OneShotLatch();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -325,7 +325,7 @@ public class DispatcherTest extends TestLogger {
 
 		dispatcherLeaderElectionService.isLeader(UUID.randomUUID()).get();
 
-		submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph, null));
+		submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph));
 		dispatcher.onAddedJobGraph(TEST_JOB_ID);
 
 		final CompletableFuture<Throwable> errorFuture = fatalErrorHandler.getErrorFuture();
@@ -343,7 +343,7 @@ public class DispatcherTest extends TestLogger {
 
 		dispatcherLeaderElectionService.isLeader(UUID.randomUUID()).get();
 
-		submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph, null));
+		submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph));
 		runningJobsRegistry.setJobFinished(TEST_JOB_ID);
 		dispatcher.onAddedJobGraph(TEST_JOB_ID);
 
@@ -542,7 +542,7 @@ public class DispatcherTest extends TestLogger {
 
 		dispatcher = createAndStartDispatcher(heartbeatServices, haServices, new ExpectedJobIdJobManagerRunnerFactory(TEST_JOB_ID, createdJobManagerRunnerLatch));
 
-		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(jobGraph, null);
+		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(jobGraph);
 		submittedJobGraphStore.putJobGraph(submittedJobGraph);
 
 		submittedJobGraphStore.setRecoverJobGraphFunction(
@@ -572,7 +572,7 @@ public class DispatcherTest extends TestLogger {
 
 		final JobGraph failingJobGraph = createFailingJobGraph(testException);
 
-		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(failingJobGraph, null);
+		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(failingJobGraph);
 		submittedJobGraphStore.putJobGraph(submittedJobGraph);
 
 		electDispatcher();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import akka.actor.ActorRef;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.junit.Test;
 
@@ -33,12 +31,10 @@ public class StandaloneSubmittedJobGraphStoreTest {
 	 * Tests that all operations work and don't change the state.
 	 */
 	@Test
-	public void testNoOps() throws Exception {
+	public void testNoOps() {
 		StandaloneSubmittedJobGraphStore jobGraphs = new StandaloneSubmittedJobGraphStore();
 
-		SubmittedJobGraph jobGraph = new SubmittedJobGraph(
-				new JobGraph("testNoOps"),
-				new JobInfo(ActorRef.noSender(), ListeningBehaviour.DETACHED, 0, Integer.MAX_VALUE));
+		SubmittedJobGraph jobGraph = new SubmittedJobGraph(new JobGraph("testNoOps"), null);
 
 		assertEquals(0, jobGraphs.getJobIds().size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneSubmittedJobGraphStoreTest.java
@@ -34,7 +34,7 @@ public class StandaloneSubmittedJobGraphStoreTest {
 	public void testNoOps() {
 		StandaloneSubmittedJobGraphStore jobGraphs = new StandaloneSubmittedJobGraphStore();
 
-		SubmittedJobGraph jobGraph = new SubmittedJobGraph(new JobGraph("testNoOps"), null);
+		SubmittedJobGraph jobGraph = new SubmittedJobGraph(new JobGraph("testNoOps"));
 
 		assertEquals(0, jobGraphs.getJobIds().size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStoreTest.java
@@ -72,7 +72,7 @@ public class ZooKeeperSubmittedJobGraphStoreTest extends TestLogger {
 			final ZooKeeperSubmittedJobGraphStore otherSubmittedJobGraphStore = createSubmittedJobGraphStore(client, stateStorage);
 			otherSubmittedJobGraphStore.start(null);
 
-			final SubmittedJobGraph jobGraph = new SubmittedJobGraph(new JobGraph(), null);
+			final SubmittedJobGraph jobGraph = new SubmittedJobGraph(new JobGraph());
 			submittedJobGraphStore.putJobGraph(jobGraph);
 
 			final SubmittedJobGraph recoveredJobGraph = otherSubmittedJobGraphStore.recoverJobGraph(jobGraph.getJobId());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore.SubmittedJobGraphListener;
@@ -32,7 +31,6 @@ import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.ActorRef;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.junit.AfterClass;
@@ -97,7 +95,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 			jobGraphs.start(listener);
 
-			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), 0);
+			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), "JobName");
 
 			// Empty state
 			assertEquals(0, jobGraphs.getJobIds().size());
@@ -114,7 +112,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 			verifyJobGraphs(jobGraph, jobGraphs.recoverJobGraph(jobId));
 
 			// Update (same ID)
-			jobGraph = createSubmittedJobGraph(jobGraph.getJobId(), 1);
+			jobGraph = createSubmittedJobGraph(jobGraph.getJobId(), "Updated JobName");
 			jobGraphs.putJobGraph(jobGraph);
 
 			// Verify updated
@@ -171,9 +169,9 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 			HashMap<JobID, SubmittedJobGraph> expected = new HashMap<>();
 			JobID[] jobIds = new JobID[] { new JobID(), new JobID(), new JobID() };
 
-			expected.put(jobIds[0], createSubmittedJobGraph(jobIds[0], 0));
-			expected.put(jobIds[1], createSubmittedJobGraph(jobIds[1], 1));
-			expected.put(jobIds[2], createSubmittedJobGraph(jobIds[2], 2));
+			expected.put(jobIds[0], createSubmittedJobGraph(jobIds[0]));
+			expected.put(jobIds[1], createSubmittedJobGraph(jobIds[1]));
+			expected.put(jobIds[2], createSubmittedJobGraph(jobIds[2]));
 
 			// Add all
 			for (SubmittedJobGraph jobGraph : expected.values()) {
@@ -215,8 +213,8 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 			otherJobGraphs = createZooKeeperSubmittedJobGraphStore("/testConcurrentAddJobGraph");
 
-			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), 0);
-			SubmittedJobGraph otherJobGraph = createSubmittedJobGraph(new JobID(), 0);
+			SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID());
+			SubmittedJobGraph otherJobGraph = createSubmittedJobGraph(new JobID());
 
 			SubmittedJobGraphListener listener = mock(SubmittedJobGraphListener.class);
 
@@ -274,7 +272,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 		jobGraphs.start(null);
 		otherJobGraphs.start(null);
 
-		SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID(), 0);
+		SubmittedJobGraph jobGraph = createSubmittedJobGraph(new JobID());
 
 		jobGraphs.putJobGraph(jobGraph);
 
@@ -283,32 +281,27 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 	// ---------------------------------------------------------------------------------------------
 
-	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId, long start) {
-		final JobGraph jobGraph = new JobGraph(jobId, "Test JobGraph");
+	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId) {
+		return createSubmittedJobGraph(jobId, "Test JobGraph");
+	}
+
+	private SubmittedJobGraph createSubmittedJobGraph(JobID jobId, String jobName) {
+		final JobGraph jobGraph = new JobGraph(jobId, jobName);
 
 		final JobVertex jobVertex = new JobVertex("Test JobVertex");
 		jobVertex.setParallelism(1);
 
 		jobGraph.addVertex(jobVertex);
 
-		final JobInfo jobInfo = new JobInfo(
-				ActorRef.noSender(), ListeningBehaviour.DETACHED, start, Integer.MAX_VALUE);
-
-		return new SubmittedJobGraph(jobGraph, jobInfo);
+		return new SubmittedJobGraph(jobGraph, null);
 	}
 
-	protected void verifyJobGraphs(SubmittedJobGraph expected, SubmittedJobGraph actual)
-			throws Exception {
+	private void verifyJobGraphs(SubmittedJobGraph expected, SubmittedJobGraph actual) {
 
 		JobGraph expectedJobGraph = expected.getJobGraph();
 		JobGraph actualJobGraph = actual.getJobGraph();
 
 		assertEquals(expectedJobGraph.getName(), actualJobGraph.getName());
 		assertEquals(expectedJobGraph.getJobID(), actualJobGraph.getJobID());
-
-		JobInfo expectedJobInfo = expected.getJobInfo();
-		JobInfo actualJobInfo = actual.getJobInfo();
-
-		assertEquals(expectedJobInfo, actualJobInfo);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
@@ -293,7 +293,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 		jobGraph.addVertex(jobVertex);
 
-		return new SubmittedJobGraph(jobGraph, null);
+		return new SubmittedJobGraph(jobGraph);
 	}
 
 	private void verifyJobGraphs(SubmittedJobGraph expected, SubmittedJobGraph actual) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphsStoreITCase.java
@@ -76,9 +76,7 @@ public class ZooKeeperSubmittedJobGraphsStoreITCase extends TestLogger {
 
 	@AfterClass
 	public static void tearDown() throws Exception {
-		if (ZooKeeper != null) {
-			ZooKeeper.shutdown();
-		}
+		ZooKeeper.shutdown();
 	}
 
 	@Before


### PR DESCRIPTION
## What is the purpose of the change

*This PR is based on #7447.*

## Brief change log

  - *See commits.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

cc: @TisonKun 
