### PR TITLE
[hotfix] [docs] fix typo in debugging classloading doc

### DIFF
--- a/docs/monitoring/debugging_classloading.md
+++ b/docs/monitoring/debugging_classloading.md
@@ -37,7 +37,7 @@ These classes can be divided into two domains:
     (via REST, CLI, web UI). They are loaded (and unloaded) dynamically per job.
 
 What classes are part of which domain depends on the particular setup in which you run Apache Flink. As a general rule, whenever you start the Flink
-processes first, and the submit jobs, the job's classes are loaded dynamically. If the Flink processes are started together with the job/application,
+processes first, and submit jobs, the job's classes are loaded dynamically. If the Flink processes are started together with the job/application,
 or the application spawns the Flink components (JobManager, TaskManager, etc.) then all classes are in the Java classpath.
 
 In the following are some more details about the different deployment modes:
@@ -93,7 +93,7 @@ The benefit of inverted classloading is that jobs can use different library vers
 useful when the different versions of the libraries are not compatible. The mechanism helps to avoid the common dependency conflict
 errors like `IllegalAccessError` or `NoSuchMethodError`. Different parts of the code simply have separate copies of the
 classes (Flink's core or one of its dependencies can use a different copy than the user code).
-In most cases, this work well and no additional configuration from the user is needed.
+In most cases, this works well and no additional configuration from the user is needed.
 
 However, there are cases when the inverted classloading causes problems (see below, "X cannot be cast to X"). 
 You can revert back to Java's default mode by configuring the ClassLoader resolution order via


### PR DESCRIPTION
## What is the purpose of the change

Fix typo in debugging classloading doc.

## Brief change log

Fix typo


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)