### PR TITLE
FLINK-11378 - Allow writing to Hadoop compatible Filesystems via Hado…

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -51,11 +51,11 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 		this.fs = checkNotNull(fs);
 
 		// This writer is only supported on a subset of file systems, and on
-		// specific versions. We check these schemes and versions eagerly for
+		// specific versions. We check versions eagerly for
 		// better error messages.
-		if (!"hdfs".equalsIgnoreCase(fs.getScheme()) || !HadoopUtils.isMinHadoopVersion(2, 7)) {
+		if (!HadoopUtils.isMinHadoopVersion(2, 7)) {
 			throw new UnsupportedOperationException(
-					"Recoverable writers on Hadoop are only supported for HDFS and for Hadoop version 2.7 or newer");
+					"Recoverable writers on Hadoop are only supported for Hadoop version 2.7 or newer");
 		}
 	}
 


### PR DESCRIPTION
Allow HadoopRecoverableWriter to write to Hadoop compatible Filesystems.

## What is the purpose of the change
At a client we're using Flink jobs to read data from Kafka and writing it to GCS. In earlier versions, we've used `BucketingFileSink` for this, but we want to switch to the newer `StreamingFileSink`.

Since we're running Flink on Google's DataProc, we're using the Hadoop compatible GCS [connector](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/gcs) made by Google. This currently doesn't work on Flink, because Flink checks for a HDFS scheme at `HadoopRecoverableWriter`.

We've successfully ran our jobs by creating a custom Flink Distro which has the hdfs scheme check removed.

## Brief change log

- Altered the HadoopRecoverableWriter contructor body to not include the scheme check for HDFS.

## Verifying this change

This change is a trivial rework

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
