### PR TITLE
[FLINK-11363][test] Check and remove TaskManagerConfigurationTest

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
@@ -309,7 +310,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		}
 	}
 
-	private static Configuration loadConfiguration(String[] args) throws FlinkParseException {
+	@VisibleForTesting
+	static Configuration loadConfiguration(String[] args) throws FlinkParseException {
 		final CommandLineParser<ClusterConfiguration> commandLineParser = new CommandLineParser<>(new ClusterConfigurationParserFactory());
 
 		final ClusterConfiguration clusterConfiguration;


### PR DESCRIPTION

## What is the purpose of the change
Check whether `TaskManagerConfigurationTest` contains any relevant tests for the new code base and then remove this test.


## Brief change log

`TaskManagerConfigurationTest` contains tests for `TaskManager` with configuration of host name, port and filesystem. Theses tests could be merged (host name and port) to test `TaskManagerRunner`, which I create a new test named `TaskManagerRunnerConfigurationTest`.


## Verifying this change

This change added tests and can be verified as follows:

`TaskManagerRunnerConfigurationTest` to test `TaskManagerRunner` with configuration of host name, port and filesystem.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
