### PR TITLE
[hotfix] [utils] Implement utils without cost of "enum"

### DIFF
--- a/flink-docs/src/main/java/org/apache/flink/docs/util/Utils.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/util/Utils.java
@@ -21,9 +21,7 @@ package org.apache.flink.docs.util;
 /**
  * Contains various shared utility functions.
  */
-public enum Utils {
-	;
-
+public final class Utils {
 	/**
 	 * Placeholder that is used to prevent certain sections from being escaped. We don't need a sophisticated value
 	 * but only something that won't show up in config options.
@@ -36,5 +34,12 @@ public enum Utils {
 			.replaceAll("<", "&lt;")
 			.replaceAll(">", "&gt;")
 			.replaceAll(TEMPORARY_PLACEHOLDER, "<wbr>");
+	}
+
+	/**
+	 * Private constructor to prevent instantiation.
+	 */
+	private Utils() {
+		throw new RuntimeException();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/ClientUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/ClientUtils.java
@@ -37,9 +37,7 @@ import java.util.stream.Collectors;
 /**
  * Contains utility methods for clients.
  */
-public enum ClientUtils {
-	;
-
+public final class ClientUtils {
 	/**
 	 * Extracts all files required for the execution from the given {@link JobGraph} and uploads them using the {@link BlobClient}
 	 * from the given {@link Supplier}.
@@ -138,5 +136,12 @@ public enum ClientUtils {
 			jobGraph.setUserArtifactBlobKey(blobKey.f0, blobKey.f1);
 		}
 		jobGraph.writeUserArtifactEntriesToConfiguration();
+	}
+
+	/**
+	 * Private constructor to prevent instantiation.
+	 */
+	private ClientUtils() {
+		throw new RuntimeException();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

`org.apache.flink.docs.util.Utils` and `org.apache.flink.runtime.client.ClientUtils` uses `enum` mechanism to implement. This would cause additional cost of abstraction.

## Brief change log

We don't really need a enum. Thus implement it as a general final class.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @dawidwys @twalthr 
