### PR TITLE
[hotfix] [blob] Generalize usage of NoOpTransientBlobService

### DIFF
--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.blob.NoOpTransientBlobService;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
@@ -348,7 +349,7 @@ public class RestAPIDocGenerator {
 				config,
 				handlerConfig,
 				resourceManagerGatewayRetriever,
-				NoOpTransientBlobService.INSTANCE,
+				new NoOpTransientBlobService(),
 				Executors.newFixedThreadPool(1),
 				VoidMetricFetcher.INSTANCE,
 				NoOpElectionService.INSTANCE,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/NoOpTransientBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/NoOpTransientBlobService.java
@@ -16,21 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.docs.rest;
+package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.blob.TransientBlobKey;
-import org.apache.flink.runtime.blob.TransientBlobService;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * No-op implementation of {@link TransientBlobService} used by the {@link RestAPIDocGenerator}.
+ * No-op implementation of {@link TransientBlobService}.
  */
-enum NoOpTransientBlobService implements TransientBlobService {
-	INSTANCE;
+public class NoOpTransientBlobService implements TransientBlobService {
 
 	@Override
 	public File getFile(TransientBlobKey key) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

A dummy implementation of `TransientBlobService` is general for further extension. Also replace enum to class so that we reduce the cost of abstraction.

## Brief change log

Move `org.apache.flink.docs.rest.NoOpTransientBlobService` to `org.apache.flink.runtime.blob.NoOpTransientBlobService`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann 