### PR TITLE
[FLINK-11348][tests] Port testClientStartup to new codebase

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -99,18 +99,15 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	}
 
 	/**
-	 * Test regular operation, including command line parameter parsing.
+	 * Tests that a session cluster, that uses the resources from the <i>qa-team</i> queue,
+	 * can be started from the command line.
 	 */
 	@Test
-	public void testClientStartup() throws IOException {
-		assumeTrue("The new mode does not start TMs upfront.", !isNewMode);
-		LOG.info("Starting testClientStartup()");
+	public void testStartYarnSessionClusterInQaTeamQueue() throws IOException {
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
-						"-n", "1",
 						"-jm", "768m",
 						"-tm", "1024m", "-qu", "qa-team"},
-				"Number of connected TaskManagers changed to 1. Slots available: 1", null, RunTypes.YARN_SESSION, 0);
-		LOG.info("Finished testClientStartup()");
+				"Flink JobManager is now running on ", null, RunTypes.YARN_SESSION, 0);
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*See title.*


## Brief change log

  - *Port `YARNSessionCapacitySchedulerITCase#testClientStartup` to new flip6 codebase*
  - *Rename test to `testStartYarnSessionClusterInQaTeamQueue`*
  - *Remove `-n` command line parameter & argument.*


## Verifying this change

This change is already covered by existing tests, such as *itself*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
