### PR TITLE
[hotfix][docs] Remove reference to non-existent function 'mapPartitio…

### DIFF
--- a/docs/dev/scala_api_extensions.md
+++ b/docs/dev/scala_api_extensions.md
@@ -235,17 +235,6 @@ data.mapWith {
       </td>
     </tr>
     <tr>
-      <td><strong>mapPartitionWith</strong></td>
-      <td><strong>mapPartition (DataStream)</strong></td>
-      <td>
-{% highlight scala %}
-data.mapPartitionWith {
-  case head #:: _ => head
-}
-{% endhighlight %}
-      </td>
-    </tr>
-    <tr>
       <td><strong>flatMapWith</strong></td>
       <td><strong>flatMap (DataStream)</strong></td>
       <td>


### PR DESCRIPTION
…nWith' from DataStream docs

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

Remove reference to `mapPartition` from DataStream extensions. This was likely a copy paste issue from the DataSet documentation. 


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
