### PR TITLE
[hotfix] [tests] Reduce Kafka connector test duration by disable test…

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err

--- a/flink-connectors/flink-connector-kafka/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-connector-kafka/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target = System.err


### PR DESCRIPTION
… logger

## What is the purpose of the change

Basically, we enable test logger for locally debugging. When running travis test, printing logs cause extra cost. Turn the logger level to OFF for reduing Kafka connector test duration. This would benefit 
especially changes that doesn't touch these modules.

Here is the current situation

```
17:56:57.542 [INFO] flink-connector-kafka-base ......................... SUCCESS [  9.785 s]
17:56:57.542 [INFO] flink-connector-kafka-0.9 .......................... SUCCESS [04:06 min]
17:56:57.542 [INFO] flink-connector-kafka-0.10 ......................... SUCCESS [03:16 min]
17:56:57.542 [INFO] flink-connector-kafka-0.11 ......................... SUCCESS [11:14 min]
17:44:36.339 [INFO] flink-connector-kafka .............................. SUCCESS [11:42 min]
```

and below is that after this changes

(TBD)

## Brief change log

Turn the logger level of Kafka connector tests to OFF

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:(no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)