### PR TITLE
[FLINK-11403][network] Introduce ResultPartitionWithConsumableNotifier in task for notifying consumable result partition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -39,7 +38,6 @@ import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionFactory;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
@@ -50,7 +48,6 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFac
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
-import org.apache.flink.runtime.taskmanager.TaskActions;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -218,10 +215,7 @@ public class NetworkEnvironment {
 
 	public ResultPartition[] createResultPartitionWriters(
 			String taskName,
-			JobID jobId,
 			ExecutionAttemptID executionId,
-			TaskActions taskActions,
-			ResultPartitionConsumableNotifier partitionConsumableNotifier,
 			Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
 			MetricGroup outputGroup,
 			MetricGroup buffersGroup) {
@@ -231,8 +225,7 @@ public class NetworkEnvironment {
 			ResultPartition[] resultPartitions = new ResultPartition[resultPartitionDeploymentDescriptors.size()];
 			int counter = 0;
 			for (ResultPartitionDeploymentDescriptor rpdd : resultPartitionDeploymentDescriptors) {
-				resultPartitions[counter++] = resultPartitionFactory.create(
-					taskName, taskActions, jobId, executionId, rpdd, partitionConsumableNotifier);
+				resultPartitions[counter++] = resultPartitionFactory.create(taskName, executionId, rpdd);
 			}
 
 			registerOutputMetrics(outputGroup, buffersGroup, resultPartitions);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -50,16 +50,15 @@ public interface ResultPartitionWriter extends AutoCloseable {
 	/**
 	 * Adds the bufferConsumer to the subpartition with the given index.
 	 *
-	 * <p>For PIPELINED {@link org.apache.flink.runtime.io.network.partition.ResultPartitionType}s,
-	 * this will trigger the deployment of consuming tasks after the first buffer has been added.
-	 *
 	 * <p>This method takes the ownership of the passed {@code bufferConsumer} and thus is responsible for releasing
 	 * it's resources.
 	 *
 	 * <p>To avoid problems with data re-ordering, before adding new {@link BufferConsumer} the previously added one
 	 * the given {@code subpartitionIndex} must be marked as {@link BufferConsumer#isFinished()}.
+	 *
+	 * @return true if operation succeeded and bufferConsumer was enqueued for consumption.
 	 */
-	void addBufferConsumer(BufferConsumer bufferConsumer, int subpartitionIndex) throws IOException;
+	boolean addBufferConsumer(BufferConsumer bufferConsumer, int subpartitionIndex) throws IOException;
 
 	/**
 	 * Manually trigger consumption from enqueued {@link BufferConsumer BufferConsumers} in all subpartitions.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -19,14 +19,12 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferPoolFactory;
 import org.apache.flink.runtime.io.network.buffer.BufferPoolOwner;
-import org.apache.flink.runtime.taskmanager.TaskActions;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.FunctionWithException;
@@ -74,51 +72,36 @@ public class ResultPartitionFactory {
 
 	public ResultPartition create(
 		@Nonnull String taskNameWithSubtaskAndId,
-		@Nonnull TaskActions taskActions,
-		@Nonnull JobID jobId,
 		@Nonnull ExecutionAttemptID executionAttemptID,
-		@Nonnull ResultPartitionDeploymentDescriptor desc,
-		@Nonnull ResultPartitionConsumableNotifier partitionConsumableNotifier) {
+		@Nonnull ResultPartitionDeploymentDescriptor desc) {
 
 		return create(
 			taskNameWithSubtaskAndId,
-			taskActions,
-			jobId,
 			new ResultPartitionID(desc.getPartitionId(), executionAttemptID),
 			desc.getPartitionType(),
 			desc.getNumberOfSubpartitions(),
 			desc.getMaxParallelism(),
-			partitionConsumableNotifier,
-			desc.sendScheduleOrUpdateConsumersMessage(),
 			createBufferPoolFactory(desc.getNumberOfSubpartitions(), desc.getPartitionType()));
 	}
 
 	@VisibleForTesting
 	public ResultPartition create(
 		@Nonnull String taskNameWithSubtaskAndId,
-		@Nonnull TaskActions taskActions,
-		@Nonnull JobID jobId,
 		@Nonnull ResultPartitionID id,
 		@Nonnull ResultPartitionType type,
 		int numberOfSubpartitions,
 		int maxParallelism,
-		@Nonnull ResultPartitionConsumableNotifier partitionConsumableNotifier,
-		boolean sendScheduleOrUpdateConsumersMessage,
 		FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
 
 		ResultSubpartition[] subpartitions = new ResultSubpartition[numberOfSubpartitions];
 
 		ResultPartition partition = new ResultPartition(
 			taskNameWithSubtaskAndId,
-			taskActions,
-			jobId,
 			id,
 			type,
 			subpartitions,
 			maxParallelism,
 			partitionManager,
-			partitionConsumableNotifier,
-			sendScheduleOrUpdateConsumersMessage,
 			bufferPoolFactory);
 
 		createSubpartitions(partition, type, subpartitions);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A wrapper of result partition writer for handling the logic of consumable notification.
+ *
+ * <p>Before a consuming task can request the result, it has to be deployed. The time of deployment
+ * depends on the PIPELINED vs. BLOCKING characteristic of the result partition. With pipelined
+ * results, receivers are deployed as soon as the first buffer is added to the result partition.
+ * With blocking results on the other hand, receivers are deployed after the partition is finished.
+ */
+public class ConsumableNotifyingResultPartitionWriterDecorator implements ResultPartitionWriter {
+
+	private final TaskActions taskActions;
+
+	private final JobID jobId;
+
+	private final ResultPartitionWriter partitionWriter;
+
+	private final ResultPartitionConsumableNotifier partitionConsumableNotifier;
+
+	private boolean hasNotifiedPipelinedConsumers;
+
+	public ConsumableNotifyingResultPartitionWriterDecorator(
+			TaskActions taskActions,
+			JobID jobId,
+			ResultPartitionWriter partitionWriter,
+			ResultPartitionConsumableNotifier partitionConsumableNotifier) {
+		this.taskActions = checkNotNull(taskActions);
+		this.jobId = checkNotNull(jobId);
+		this.partitionWriter = checkNotNull(partitionWriter);
+		this.partitionConsumableNotifier = checkNotNull(partitionConsumableNotifier);
+	}
+
+	@Override
+	public BufferBuilder getBufferBuilder() throws IOException, InterruptedException {
+		return partitionWriter.getBufferBuilder();
+	}
+
+	@Override
+	public ResultPartitionID getPartitionId() {
+		return partitionWriter.getPartitionId();
+	}
+
+	@Override
+	public int getNumberOfSubpartitions() {
+		return partitionWriter.getNumberOfSubpartitions();
+	}
+
+	@Override
+	public int getNumTargetKeyGroups() {
+		return partitionWriter.getNumTargetKeyGroups();
+	}
+
+	@Override
+	public void setup() throws IOException {
+		partitionWriter.setup();
+	}
+
+	@Override
+	public boolean addBufferConsumer(BufferConsumer bufferConsumer, int subpartitionIndex) throws IOException {
+		boolean success = partitionWriter.addBufferConsumer(bufferConsumer, subpartitionIndex);
+		if (success) {
+			notifyPipelinedConsumers();
+		}
+
+		return success;
+	}
+
+	@Override
+	public void flushAll() {
+		partitionWriter.flushAll();
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+		partitionWriter.flush(subpartitionIndex);
+	}
+
+	@Override
+	public void finish() throws IOException {
+		partitionWriter.finish();
+
+		notifyPipelinedConsumers();
+	}
+
+	@Override
+	public void fail(Throwable throwable) {
+		partitionWriter.fail(throwable);
+	}
+
+	@Override
+	public void close() throws Exception {
+		partitionWriter.close();
+	}
+
+	/**
+	 * Notifies pipelined consumers of this result partition once.
+	 *
+	 * <p>For PIPELINED {@link org.apache.flink.runtime.io.network.partition.ResultPartitionType}s,
+	 * this will trigger the deployment of consuming tasks after the first buffer has been added.
+	 */
+	private void notifyPipelinedConsumers() {
+		if (!hasNotifiedPipelinedConsumers) {
+			partitionConsumableNotifier.notifyPartitionConsumable(jobId, partitionWriter.getPartitionId(), taskActions);
+
+			hasNotifiedPipelinedConsumers = true;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Factory
+	// ------------------------------------------------------------------------
+
+	public static ResultPartitionWriter[] decorate(
+			Collection<ResultPartitionDeploymentDescriptor> descs,
+			ResultPartitionWriter[] partitionWriters,
+			TaskActions taskActions,
+			JobID jobId,
+			ResultPartitionConsumableNotifier notifier) {
+
+		ResultPartitionWriter[] consumableNotifyingPartitionWriters = new ResultPartitionWriter[partitionWriters.length];
+		int counter = 0;
+		for (ResultPartitionDeploymentDescriptor desc : descs) {
+			if (desc.sendScheduleOrUpdateConsumersMessage() && desc.getPartitionType().isPipelined()) {
+				consumableNotifyingPartitionWriters[counter] = new ConsumableNotifyingResultPartitionWriterDecorator(
+					taskActions,
+					jobId,
+					partitionWriters[counter],
+					notifier);
+			} else {
+				consumableNotifyingPartitionWriters[counter] = partitionWriters[counter];
+			}
+			counter++;
+		}
+		return consumableNotifyingPartitionWriters;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -70,10 +70,11 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 	}
 
 	@Override
-	public synchronized void addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
+	public synchronized boolean addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
 		checkState(targetChannel < getNumberOfSubpartitions());
 		bufferConsumers.add(bufferConsumer);
 		processBufferConsumers();
+		return true;
 	}
 
 	private void processBufferConsumers() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -500,8 +500,8 @@ public class RecordWriterTest {
 		}
 
 		@Override
-		public void addBufferConsumer(BufferConsumer buffer, int targetChannel) throws IOException {
-			queues[targetChannel].add(buffer);
+		public boolean addBufferConsumer(BufferConsumer buffer, int targetChannel) throws IOException {
+			return queues[targetChannel].add(buffer);
 		}
 
 		@Override
@@ -575,8 +575,9 @@ public class RecordWriterTest {
 		}
 
 		@Override
-		public void addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
+		public boolean addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
 			bufferConsumer.close();
+			return true;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -36,17 +36,6 @@ public class PartitionTestUtils {
 	}
 
 	public static ResultPartition createPartition(
-			ResultPartitionConsumableNotifier notifier,
-			ResultPartitionType type,
-			boolean sendScheduleOrUpdateConsumersMessage) {
-		return new ResultPartitionBuilder()
-			.setResultPartitionConsumableNotifier(notifier)
-			.setResultPartitionType(type)
-			.setSendScheduleOrUpdateConsumersMessage(sendScheduleOrUpdateConsumersMessage)
-			.build();
-	}
-
-	public static ResultPartition createPartition(
 			NetworkEnvironment environment,
 			ResultPartitionType partitionType,
 			int numChannels) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -18,15 +18,12 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferPoolOwner;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
-import org.apache.flink.runtime.taskmanager.TaskActions;
 import org.apache.flink.util.function.FunctionWithException;
 
 import java.io.IOException;
@@ -36,9 +33,6 @@ import java.util.Optional;
  * Utility class to encapsulate the logic of building a {@link ResultPartition} instance.
  */
 public class ResultPartitionBuilder {
-	private JobID jobId = new JobID();
-
-	private final TaskActions taskActions = new NoOpTaskActions();
 
 	private ResultPartitionID partitionId = new ResultPartitionID();
 
@@ -50,11 +44,7 @@ public class ResultPartitionBuilder {
 
 	private ResultPartitionManager partitionManager = new ResultPartitionManager();
 
-	private ResultPartitionConsumableNotifier partitionConsumableNotifier = new NoOpResultPartitionConsumableNotifier();
-
 	private IOManager ioManager = new IOManagerAsync();
-
-	private boolean sendScheduleOrUpdateConsumersMessage = false;
 
 	private NetworkBufferPool networkBufferPool = new NetworkBufferPool(1, 1, 1);
 
@@ -64,11 +54,6 @@ public class ResultPartitionBuilder {
 
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private Optional<FunctionWithException<BufferPoolOwner, BufferPool, IOException>> bufferPoolFactory = Optional.empty();
-
-	public ResultPartitionBuilder setJobId(JobID jobId) {
-		this.jobId = jobId;
-		return this;
-	}
 
 	public ResultPartitionBuilder setResultPartitionId(ResultPartitionID partitionId) {
 		this.partitionId = partitionId;
@@ -95,20 +80,8 @@ public class ResultPartitionBuilder {
 		return this;
 	}
 
-	ResultPartitionBuilder setResultPartitionConsumableNotifier(ResultPartitionConsumableNotifier notifier) {
-		this.partitionConsumableNotifier = notifier;
-		return this;
-	}
-
 	public ResultPartitionBuilder setIOManager(IOManager ioManager) {
 		this.ioManager = ioManager;
-		return this;
-	}
-
-	public ResultPartitionBuilder setSendScheduleOrUpdateConsumersMessage(
-		boolean sendScheduleOrUpdateConsumersMessage) {
-
-		this.sendScheduleOrUpdateConsumersMessage = sendScheduleOrUpdateConsumersMessage;
 		return this;
 	}
 
@@ -152,14 +125,10 @@ public class ResultPartitionBuilder {
 
 		return resultPartitionFactory.create(
 			"Result Partition task",
-			taskActions,
-			jobId,
 			partitionId,
 			partitionType,
 			numberOfSubpartitions,
 			numTargetKeyGroups,
-			partitionConsumableNotifier,
-			sendScheduleOrUpdateConsumersMessage,
 			factory);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -19,22 +19,29 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.NetworkEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.taskmanager.ConsumableNotifyingResultPartitionWriterDecorator;
+import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -52,40 +59,32 @@ public class ResultPartitionTest {
 	 */
 	@Test
 	public void testSendScheduleOrUpdateConsumersMessage() throws Exception {
+		JobID jobId = new JobID();
+		TaskActions taskActions = new NoOpTaskActions();
+
 		{
 			// Pipelined, send message => notify
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
-			ResultPartition partition = createPartition(notifier, ResultPartitionType.PIPELINED, true);
-			partition.addBufferConsumer(createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE), 0);
+			ResultPartitionWriter consumableNotifyingPartitionWriter = createConsumableNotifyingResultPartitionWriter(
+				ResultPartitionType.PIPELINED,
+				taskActions,
+				jobId,
+				notifier);
+			consumableNotifyingPartitionWriter.addBufferConsumer(createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE), 0);
 			verify(notifier, times(1))
-				.notifyPartitionConsumable(
-					eq(partition.getJobId()),
-					eq(partition.getPartitionId()),
-					any(TaskActions.class));
-		}
-
-		{
-			// Pipelined, don't send message => don't notify
-			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
-			ResultPartition partition = createPartition(notifier, ResultPartitionType.PIPELINED, false);
-			partition.addBufferConsumer(createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE), 0);
-			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
+				.notifyPartitionConsumable(eq(jobId), eq(consumableNotifyingPartitionWriter.getPartitionId()), eq(taskActions));
 		}
 
 		{
 			// Blocking, send message => don't notify
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
-			ResultPartition partition = createPartition(notifier, ResultPartitionType.BLOCKING, true);
+			ResultPartitionWriter partition = createConsumableNotifyingResultPartitionWriter(
+				ResultPartitionType.BLOCKING,
+				taskActions,
+				jobId,
+				notifier);
 			partition.addBufferConsumer(createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE), 0);
-			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
-		}
-
-		{
-			// Blocking, don't send message => don't notify
-			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
-			ResultPartition partition = createPartition(notifier, ResultPartitionType.BLOCKING, false);
-			partition.addBufferConsumer(createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE), 0);
-			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
+			verify(notifier, never()).notifyPartitionConsumable(eq(jobId), eq(partition.getPartitionId()), eq(taskActions));
 		}
 	}
 
@@ -102,18 +101,23 @@ public class ResultPartitionTest {
 	/**
 	 * Tests {@link ResultPartition#addBufferConsumer} on a partition which has already finished.
 	 *
-	 * @param pipelined the result partition type to set up
+	 * @param partitionType the result partition type to set up
 	 */
-	protected void testAddOnFinishedPartition(final ResultPartitionType pipelined)
-		throws Exception {
+	private void testAddOnFinishedPartition(final ResultPartitionType partitionType) throws Exception {
 		BufferConsumer bufferConsumer = createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE);
 		ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
+		JobID jobId = new JobID();
+		TaskActions taskActions = new NoOpTaskActions();
+		ResultPartitionWriter consumableNotifyingPartitionWriter = createConsumableNotifyingResultPartitionWriter(
+			partitionType,
+			taskActions,
+			jobId,
+			notifier);
 		try {
-			ResultPartition partition = createPartition(notifier, pipelined, true);
-			partition.finish();
+			consumableNotifyingPartitionWriter.finish();
 			reset(notifier);
 			// partition.add() should fail
-			partition.addBufferConsumer(bufferConsumer, 0);
+			consumableNotifyingPartitionWriter.addBufferConsumer(bufferConsumer, 0);
 			Assert.fail("exception expected");
 		} catch (IllegalStateException e) {
 			// expected => ignored
@@ -123,7 +127,10 @@ public class ResultPartitionTest {
 				Assert.fail("bufferConsumer not recycled");
 			}
 			// should not have notified either
-			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
+			verify(notifier, never()).notifyPartitionConsumable(
+				eq(jobId),
+				eq(consumableNotifyingPartitionWriter.getPartitionId()),
+				eq(taskActions));
 		}
 	}
 
@@ -140,17 +147,24 @@ public class ResultPartitionTest {
 	/**
 	 * Tests {@link ResultPartition#addBufferConsumer} on a partition which has already been released.
 	 *
-	 * @param pipelined the result partition type to set up
+	 * @param partitionType the result partition type to set up
 	 */
-	protected void testAddOnReleasedPartition(final ResultPartitionType pipelined)
-		throws Exception {
+	private void testAddOnReleasedPartition(final ResultPartitionType partitionType) throws Exception {
 		BufferConsumer bufferConsumer = createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE);
 		ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
+		JobID jobId = new JobID();
+		TaskActions taskActions = new NoOpTaskActions();
+		ResultPartition partition = createPartition(partitionType);
+		ResultPartitionWriter consumableNotifyingPartitionWriter = ConsumableNotifyingResultPartitionWriterDecorator.decorate(
+			Collections.singleton(createPartitionDeploymentDescriptor(partitionType)),
+			new ResultPartitionWriter[] {partition},
+			taskActions,
+			jobId,
+			notifier)[0];
 		try {
-			ResultPartition partition = createPartition(notifier, pipelined, true);
 			partition.release();
 			// partition.add() silently drops the bufferConsumer but recycles it
-			partition.addBufferConsumer(bufferConsumer, 0);
+			consumableNotifyingPartitionWriter.addBufferConsumer(bufferConsumer, 0);
 			assertTrue(partition.isReleased());
 		} finally {
 			if (!bufferConsumer.isRecycled()) {
@@ -158,7 +172,7 @@ public class ResultPartitionTest {
 				Assert.fail("bufferConsumer not recycled");
 			}
 			// should not have notified either
-			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
+			verify(notifier, never()).notifyPartitionConsumable(eq(jobId), eq(partition.getPartitionId()), eq(taskActions));
 		}
 	}
 
@@ -175,28 +189,30 @@ public class ResultPartitionTest {
 	/**
 	 * Tests {@link ResultPartition#addBufferConsumer(BufferConsumer, int)} on a working partition.
 	 *
-	 * @param pipelined the result partition type to set up
+	 * @param partitionType the result partition type to set up
 	 */
-	protected void testAddOnPartition(final ResultPartitionType pipelined)
-		throws Exception {
+	private void testAddOnPartition(final ResultPartitionType partitionType) throws Exception {
 		ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
-		ResultPartition partition = createPartition(notifier, pipelined, true);
+		JobID jobId = new JobID();
+		TaskActions taskActions = new NoOpTaskActions();
+		ResultPartitionWriter consumableNotifyingPartitionWriter = createConsumableNotifyingResultPartitionWriter(
+			partitionType,
+			taskActions,
+			jobId,
+			notifier);
 		BufferConsumer bufferConsumer = createFilledBufferConsumer(BufferBuilderTestUtils.BUFFER_SIZE);
 		try {
 			// partition.add() adds the bufferConsumer without recycling it (if not spilling)
-			partition.addBufferConsumer(bufferConsumer, 0);
+			consumableNotifyingPartitionWriter.addBufferConsumer(bufferConsumer, 0);
 			assertFalse("bufferConsumer should not be recycled (still in the queue)", bufferConsumer.isRecycled());
 		} finally {
 			if (!bufferConsumer.isRecycled()) {
 				bufferConsumer.close();
 			}
 			// should have been notified for pipelined partitions
-			if (pipelined.isPipelined()) {
+			if (partitionType.isPipelined()) {
 				verify(notifier, times(1))
-					.notifyPartitionConsumable(
-						eq(partition.getJobId()),
-						eq(partition.getPartitionId()),
-						any(TaskActions.class));
+					.notifyPartitionConsumable(eq(jobId), eq(consumableNotifyingPartitionWriter.getPartitionId()), eq(taskActions));
 			}
 		}
 	}
@@ -242,5 +258,28 @@ public class ResultPartitionTest {
 			resultPartition.release();
 			network.shutdown();
 		}
+	}
+
+	private ResultPartitionWriter createConsumableNotifyingResultPartitionWriter(
+			ResultPartitionType partitionType,
+			TaskActions taskActions,
+			JobID jobId,
+			ResultPartitionConsumableNotifier notifier) {
+		return ConsumableNotifyingResultPartitionWriterDecorator.decorate(
+			Collections.singleton(createPartitionDeploymentDescriptor(partitionType)),
+			new ResultPartitionWriter[] {createPartition(partitionType)},
+			taskActions,
+			jobId,
+			notifier)[0];
+	}
+
+	private ResultPartitionDeploymentDescriptor createPartitionDeploymentDescriptor(ResultPartitionType partitionType) {
+		return new ResultPartitionDeploymentDescriptor(
+			new IntermediateDataSetID(),
+			new IntermediateResultPartitionID(),
+			partitionType,
+			1,
+			1,
+			true);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -117,7 +117,6 @@ public class LocalInputChannelTest {
 				.setNumberOfSubpartitions(parallelism)
 				.setNumTargetKeyGroups(parallelism)
 				.setResultPartitionManager(partitionManager)
-				.setSendScheduleOrUpdateConsumersMessage(true)
 				.setBufferPoolFactory(p ->
 					networkBuffers.createBufferPool(producerBufferPoolSize, producerBufferPoolSize))
 				.build();


### PR DESCRIPTION
## What is the purpose of the change

*The consumable notification shuould belong to the scheduler scope, so it is not general for all the `ResultPartitionWriter` implementations. The current creation of `ResultPartitionWriter` from `NetworkEnvironment` relies on `JobID`, `TaskAction`, `ResultPartitionConsumableNotifier` for handling the consumable notification logic. For breaking this tie to make `ShuffleService#createResultPartitionWriters` simple, `Task` could wrap `ResultPartitionWriter`
into `ResultPartitionWithConsumableNotifier` for handling the notification.*

## Brief change log

  - *Wrap `ResultPartitionWithConsumableNotifier` in task for handing the notification logic*
  - *Remove the notification logic from `ResultPartition`*

## Verifying this change

This change is already covered by existing tests, such as `ResultPartitionTest` .

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)