### PR TITLE
[FLINK-10245] [Streaming Connector] Support UpsertHBaseSink and UpsertHBaseTableSink

### DIFF
--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -212,6 +212,11 @@ under the License.
 					<groupId>org.jamon</groupId>
 					<artifactId>jamon-runtime</artifactId>
 				</exclusion>
+				<!-- remove guava -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -250,6 +255,12 @@ under the License.
 			<version>${hbase.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/HBaseSinkFunctionBase.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/HBaseSinkFunctionBase.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.hbase;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.connectors.hbase.util.HBaseUtils;
+
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * HBaseSinkFunctionBase is the common abstract class of HBaseSinkFunction.
+ *
+ * @param <IN> Type of the elements emitted by this sink
+ */
+public abstract class HBaseSinkFunctionBase<IN> extends RichSinkFunction<IN> implements CheckpointedFunction {
+
+	private static final Logger log = LoggerFactory.getLogger(HBaseSinkFunctionBase.class);
+
+	// ------------------------------------------------------------------------
+	//  Internal bulk processor configuration
+	// ------------------------------------------------------------------------
+
+	public static final String CONFIG_KEY_BATCH_FLUSH_ENABLE = "connector.batch-flush.enable";
+	public static final String CONFIG_KEY_BATCH_FLUSH_MAX_MUTATIONS = "connector.batch-flush.max-mutations";
+	public static final String CONFIG_KEY_BATCH_FLUSH_MAX_SIZE_MB = "connector.batch-flush.max-size.mb";
+	public static final String CONFIG_KEY_BATCH_FLUSH_INTERVAL_MS = "connector.batch-flush.interval.ms";
+
+	protected final int rowKeyIndex;
+	protected final String[] fieldNames;
+	protected final TypeInformation<?>[] fieldTypes;
+	protected final String[] columnFamilies;
+	protected final String[] qualifiers;
+	protected final int[] fieldElementIndexMapping;
+
+	private final HBaseTableBuilder tableBuilder;
+	/** The timer that triggers periodic flush to HBase. */
+	private transient ScheduledThreadPoolExecutor executor;
+
+	/** The lock to safeguard the flush commits. */
+	private transient Object lock;
+
+	private transient Connection connection;
+	private transient Table table;
+
+	private List<Mutation> mutaionBuffer = new LinkedList<>();
+	private long estimateSize = 0;
+
+	private final boolean batchFlushEnable;
+	private final long batchFlushMaxMutations;
+	private final long batchFlushMaxSizeInBits;
+	private final long batchFlushIntervalMillis;
+
+	private boolean isRunning = false;
+
+	public HBaseSinkFunctionBase(
+		HBaseTableBuilder tableBuilder,
+		Map<String, String> userConfig,
+		int rowKeyIndex,
+		String[] outputFieldNames,
+		String[] fieldNames,
+		String[] columnFamilies,
+		String[] qualifiers,
+		TypeInformation<?>[] fieldTypes){
+		this.tableBuilder = tableBuilder;
+		this.rowKeyIndex = rowKeyIndex;
+		this.fieldNames = fieldNames;
+		this.columnFamilies = columnFamilies;
+		this.qualifiers = qualifiers;
+		this.fieldTypes = fieldTypes;
+		this.fieldElementIndexMapping = createFieldIndexMapping(fieldNames, outputFieldNames);
+
+		this.batchFlushEnable = userConfig.getOrDefault(CONFIG_KEY_BATCH_FLUSH_ENABLE, "false").equals("true");
+		this.batchFlushMaxMutations = Long.parseLong(userConfig.getOrDefault(CONFIG_KEY_BATCH_FLUSH_MAX_MUTATIONS, "128"));
+		this.batchFlushMaxSizeInBits = Long.parseLong(userConfig.getOrDefault(CONFIG_KEY_BATCH_FLUSH_MAX_SIZE_MB, "2")) * 1024 * 1024 * 8;
+		this.batchFlushIntervalMillis = Long.parseLong(userConfig.getOrDefault(CONFIG_KEY_BATCH_FLUSH_INTERVAL_MS, "1000"));
+	}
+
+	@Override
+	public void open(Configuration configuration) throws Exception {
+		this.lock = new Object();
+		this.connection = tableBuilder.buildConnection();
+		this.table = tableBuilder.buildTable(connection);
+
+		if (batchFlushEnable && batchFlushIntervalMillis > 0) {
+			this.executor = new ScheduledThreadPoolExecutor(1);
+			((HTable) table).setAutoFlush(false, false);
+			executor.scheduleAtFixedRate(() -> {
+				if (this.table != null && this.table instanceof HTable) {
+					synchronized (lock) {
+						try {
+							flushToHBase();
+						} catch (Exception e){
+							log.warn("Scheduled flush operation to HBase cannot be finished.", e);
+						}
+					}
+				}
+			}, batchFlushIntervalMillis, batchFlushIntervalMillis, TimeUnit.MILLISECONDS);
+		}
+		isRunning = true;
+	}
+
+	@Override
+	public void invoke(IN value, Context context) throws Exception {
+		Mutation mutation = extract(value);
+		long mutationSize = mutation.heapSize();
+		if (batchFlushEnable) {
+			if (estimateSize != 0 && (estimateSize + mutationSize > batchFlushMaxSizeInBits || mutaionBuffer.size() + 1 > batchFlushMaxMutations)) {
+				synchronized (lock){
+					if (estimateSize != 0 && (estimateSize + mutationSize > batchFlushMaxSizeInBits
+						|| mutaionBuffer.size() + 1 > batchFlushMaxMutations)) {
+						long start = System.currentTimeMillis();
+						Exception testException = null;
+						try {
+							flushToHBase();
+						} catch (Exception e) {
+							testException = e;
+						}
+						long end = System.currentTimeMillis();
+						log.debug("Flush tasks " + (end - start) + " milliseconds with exception: " + testException);
+					}
+				}
+			}
+			synchronized (lock) {
+				mutaionBuffer.add(mutation);
+				estimateSize += mutation.heapSize();
+			}
+		} else if (mutation instanceof Put){
+			table.put((Put) mutation);
+		} else if (mutation instanceof Delete) {
+			table.delete((Delete) mutation);
+		} else if (mutation instanceof Append) {
+			table.append((Append) mutation);
+		} else if (mutation instanceof Increment) {
+			table.increment((Increment) mutation);
+		}
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws ExecutionException, InterruptedException {
+		if (batchFlushEnable && this.table != null && this.table instanceof HTable) {
+			synchronized (lock) {
+				flushToHBase();
+			}
+		}
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		// Do nothing here
+	}
+
+	protected Put generatePutMutation(IN value) {
+		byte[] rowKey = HBaseUtils.serialize(fieldTypes[rowKeyIndex], produceElementWithIndex(value, rowKeyIndex));
+		Put put = new Put(rowKey);
+		for (int i = 0; i < fieldNames.length; i++) {
+			if (i != rowKeyIndex) {
+				Object fieldValue = produceElementWithIndex(value, i);
+				if (fieldValue != null) {
+					put.addColumn(columnFamilies[i].getBytes(), qualifiers[i].getBytes(), HBaseUtils.serialize(fieldTypes[i], fieldValue));
+				}
+			}
+		}
+		return put;
+	}
+
+	protected Delete generateDeleteMutation(IN value) {
+		byte[] rowKey = HBaseUtils.serialize(fieldTypes[rowKeyIndex], produceElementWithIndex(value, rowKeyIndex));
+		Delete delete = new Delete(rowKey);
+		for (int i = 0; i < fieldNames.length; i++) {
+			if (i != rowKeyIndex) {
+				delete.addColumn(columnFamilies[i].getBytes(), qualifiers[i].getBytes());
+			}
+		}
+		return delete;
+	}
+
+	protected abstract Mutation extract(IN value);
+
+	protected abstract Object produceElementWithIndex(IN value, int index);
+
+	private void flushToHBase() {
+		long start = System.currentTimeMillis();
+		try {
+			if (isRunning && mutaionBuffer.size() > 0) {
+				if (table == null) {
+					log.error("HBase table cannot be null during flush.");
+				} else {
+					log.debug("mutation size is " + mutaionBuffer.size());
+					table.batch(mutaionBuffer, new Object[mutaionBuffer.size()]);
+					mutaionBuffer.clear();
+					estimateSize = 0;
+				}
+			}
+		} catch (Exception e) {
+			log.warn("Fail to flush data into HBase due to: ", e);
+			throw new RuntimeException(e);
+		}
+
+		log.debug("Flush mutations to HBase takes {} ms. ", System.currentTimeMillis() - start);
+	}
+
+	@Override
+	public void close() {
+		isRunning = false;
+
+		if (executor != null) {
+			executor.shutdown();
+		}
+
+		if (this.table != null) {
+			try {
+				this.table.close();
+			} catch (IOException ioe) {
+				log.warn("Exception occurs while closing HBase table.", ioe);
+			}
+			this.table = null;
+		}
+
+		if (this.connection != null) {
+			try {
+				this.connection.close();
+			} catch (IOException ioe) {
+				log.warn("Exception occurs while closing HBase connection.", ioe);
+			}
+			this.connection = null;
+		}
+	}
+
+	private int[] createFieldIndexMapping(String[] fieldNames, String[] outputFieldNames) {
+		int[] fieldElementIndexMapping = new int[fieldNames.length];
+		for (int i = 0; i < fieldNames.length; i++) {
+			fieldElementIndexMapping[i] = -1;
+			for (int j = 0; j < outputFieldNames.length; j++) {
+				if (fieldNames[i].equals(outputFieldNames[j])) {
+					fieldElementIndexMapping[i] = j;
+					break;
+				}
+			}
+			if (fieldElementIndexMapping[i] == -1) {
+				throw new RuntimeException("The field " + outputFieldNames[i] + " is not found in the result stream.");
+			}
+		}
+		return fieldElementIndexMapping;
+	}
+}

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/HBaseTableBuilder.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/HBaseTableBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.hbase;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Table;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is used to configure a {@link Connection} and a {@link Table} after deployment.
+ * The connection represents the connection that will be established to HBase.
+ * The table represents a table can be manipulated in the hbase.
+ */
+public class HBaseTableBuilder implements Serializable {
+
+	private Map<String, String> configurationMap = new HashMap<>();
+
+	private String tableName;
+
+	public static HBaseTableBuilder builder() {
+		return new HBaseTableBuilder();
+	}
+
+	public HBaseTableBuilder zkQuorum(String zkQuorum) {
+		configurationMap.put(HConstants.ZOOKEEPER_QUORUM, zkQuorum);
+		return this;
+	}
+
+	public HBaseTableBuilder zkClientPort(int port) {
+		configurationMap.put(HConstants.ZOOKEEPER_CLIENT_PORT, String.valueOf(port));
+		return this;
+	}
+
+	public HBaseTableBuilder zkPath(String zkPath) {
+		configurationMap.put(HConstants.ZOOKEEPER_ZNODE_PARENT, zkPath);
+		return this;
+	}
+
+	public HBaseTableBuilder addProperty(String key, String value) {
+		configurationMap.put(key, value);
+		return this;
+	}
+
+	public HBaseTableBuilder addProperties(Map<String, String> properties) {
+		configurationMap.putAll(properties);
+		return this;
+	}
+
+	public HBaseTableBuilder tableName(String tableName) {
+		this.tableName = tableName;
+		return this;
+	}
+
+	public Connection buildConnection() throws IOException {
+		Preconditions.checkNotNull(configurationMap.get(HConstants.ZOOKEEPER_QUORUM),
+			"Zookeeper quorum must be configured for HBase sink.");
+		Preconditions.checkNotNull(configurationMap.get(HConstants.ZOOKEEPER_CLIENT_PORT),
+			"Zookeeper client port must be configured for HBase sink.");
+		Preconditions.checkNotNull(configurationMap.get(HConstants.ZOOKEEPER_ZNODE_PARENT),
+			"Zookeeper path must be configured for HBase sink.");
+
+		Configuration configuration = new Configuration();
+		for (Map.Entry<String, String> entry: configurationMap.entrySet()) {
+			configuration.set(entry.getKey(), entry.getValue());
+		}
+		return ConnectionFactory.createConnection(configuration);
+	}
+
+	public Table buildTable(Connection connection) throws IOException {
+		Preconditions.checkNotNull(connection, "No connection created for HBase sink.");
+		Preconditions.checkNotNull(tableName, "Tablename must be configured for HBase sink");
+		try (Table table = connection.getTable(TableName.valueOf(tableName));
+			Admin admin = connection.getAdmin()) {
+			if (!admin.isTableAvailable(TableName.valueOf(this.tableName))) {
+				throw new IOException("Table is not available.");
+			}
+			return table;
+		}
+	}
+}

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/HBaseUpsertTableSink.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/HBaseUpsertTableSink.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.hbase;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.sinks.UpsertStreamTableSink;
+import org.apache.flink.table.util.TableConnectorUtil;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.hbase.client.Mutation;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Upsert table sink for HBase.
+ */
+public class HBaseUpsertTableSink implements UpsertStreamTableSink<Row> {
+
+	/** Flag that indicates that only inserts are accepted. */
+	private boolean isAppendOnly;
+
+	/** Schema of the table. */
+	private final TableSchema schema;
+
+	private final HBaseTableBuilder tableBuilder;
+
+	private final Map<String, String> userConfig;
+
+	/** The rowkey field of each row. */
+	private final String rowKeyField;
+
+	private final String delimiter;
+
+	/** Key field indices determined by the query. */
+	private int[] keyFieldIndices = new int[0];
+
+	public HBaseUpsertTableSink(
+		TableSchema schema,
+		HBaseTableBuilder tableBuilder,
+		Map<String, String> userConfig,
+		String rowKeyField,
+		String delimiter) {
+		this.schema = schema;
+		this.tableBuilder = tableBuilder;
+		this.userConfig = userConfig;
+		this.rowKeyField = rowKeyField;
+		this.delimiter = delimiter;
+	}
+
+	@Override
+	public void setKeyFields(String[] keyNames) {
+		// HBase update rely on rowkey
+	}
+
+	@Override
+	public void setIsAppendOnly(Boolean isAppendOnly) {
+		this.isAppendOnly = isAppendOnly;
+	}
+
+	@Override
+	public TypeInformation<Row> getRecordType() {
+		return schema.toRowType();
+	}
+
+	@Override
+	public void emitDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
+		String[] fieldNames = getFieldNames();
+		String[] columnFamilies = new String[fieldNames.length];
+		String[] qualifiers = new String[fieldNames.length];
+		int rowKeyIndex = -1;
+		for (int i = 0; i < fieldNames.length; i++) {
+			if (fieldNames[i].equals(rowKeyField)) {
+				rowKeyIndex = i;
+			} else {
+				String[] split = fieldNames[i].split(delimiter);
+				if (split.length != 2) {
+					throw new RuntimeException("Column family and qualifer cannot be derived with field " + fieldNames[i]
+						+ " and delimiter " + delimiter + ".");
+				}
+				columnFamilies[i] = split[0];
+				qualifiers[i] = split[1];
+			}
+		}
+		if (rowKeyIndex == -1) {
+			throw new RuntimeException("Row key field " + rowKeyField + " cannot be found.");
+		}
+
+		final HBaseUpsertSinkFunction upsertSinkFunction =
+			new HBaseUpsertSinkFunction(
+				tableBuilder,
+				userConfig,
+				rowKeyIndex,
+				getFieldNames(),
+				columnFamilies,
+				qualifiers,
+				getFieldTypes(),
+				(RowTypeInfo) getRecordType()
+			);
+
+		dataStream.addSink(upsertSinkFunction)
+			.name(TableConnectorUtil.generateRuntimeName(this.getClass(), getFieldNames()));
+	}
+
+	@Override
+	public TypeInformation<Tuple2<Boolean, Row>> getOutputType() {
+		return Types.TUPLE(Types.BOOLEAN, getRecordType());
+	}
+
+	@Override
+	public String[] getFieldNames() {
+		return schema.getFieldNames();
+	}
+
+	@Override
+	public TypeInformation<?>[] getFieldTypes() {
+		return schema.getFieldTypes();
+	}
+
+	@Override
+	public TableSink<Tuple2<Boolean, Row>> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		if (!Arrays.equals(getFieldNames(), fieldNames) || !Arrays.equals(getFieldTypes(), fieldTypes)) {
+			throw new ValidationException("Reconfiguration with different fields is not allowed. " +
+				"Expected: " + Arrays.toString(getFieldNames()) + " / " + Arrays.toString(getFieldTypes()) + ". " +
+				"But was: " + Arrays.toString(fieldNames) + " / " + Arrays.toString(fieldTypes));
+		}
+		return new HBaseUpsertTableSink(schema, tableBuilder, userConfig, rowKeyField, delimiter);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Sink to write row values into a HBase cluster in upsert mode.
+	 */
+	public static class HBaseUpsertSinkFunction extends HBaseSinkFunctionBase<Tuple2<Boolean, Row>> {
+
+		public HBaseUpsertSinkFunction(
+			HBaseTableBuilder tableBuilder,
+			Map<String, String> userConfig,
+			int rowKeyIndex,
+			String[] fieldNames,
+			String[] columnFamilies,
+			String[] qualifiers,
+			TypeInformation<?>[] fieldTypes,
+			RowTypeInfo typeInfo) {
+			super(tableBuilder, userConfig, rowKeyIndex, typeInfo.getFieldNames(), fieldNames, columnFamilies, qualifiers, fieldTypes);
+		}
+
+		@Override
+		protected Mutation extract(Tuple2<Boolean, Row> value) {
+			if (value.f0) {
+				return generatePutMutation(value);
+			} else {
+				return generateDeleteMutation(value);
+			}
+		}
+
+		@Override
+		protected Object produceElementWithIndex(Tuple2<Boolean, Row> value, int index) {
+			return value.f1.getField(fieldElementIndexMapping[index]);
+		}
+	}
+
+	/**
+	 * Builder for {@link HBaseUpsertTableSink}.
+	 */
+	public static class Builder {
+		private TableSchema schema;
+		private HBaseTableBuilder tableBuilder;
+		private Map<String, String> userConfig;
+		private String rowKeyField;
+		private String delimiter;
+
+		public Builder setSchema(TableSchema schema) {
+			this.schema = schema;
+			return this;
+		}
+
+		public Builder setTableBuilder(HBaseTableBuilder tableBuilder) {
+			this.tableBuilder = tableBuilder;
+			return this;
+		}
+
+		public Builder setUserConfig(Map<String, String> userConfig) {
+			this.userConfig = userConfig;
+			return this;
+		}
+
+		public Builder setRowKeyField(String rowKeyField) {
+			this.rowKeyField = rowKeyField;
+			return this;
+		}
+
+		public Builder setDelimiter(String delimiter) {
+			this.delimiter = delimiter;
+			return this;
+		}
+
+		public HBaseUpsertTableSink build() {
+			return new HBaseUpsertTableSink(schema, tableBuilder, userConfig, rowKeyField, delimiter);
+		}
+	}
+}

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/util/HBaseUtils.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/streaming/connectors/hbase/util/HBaseUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.hbase.util;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Map;
+
+/**
+ * Suite of utility methods for HBase.
+ */
+public class HBaseUtils {
+
+	public static byte[] serialize(TypeInformation<?> typeInfo, Object obj) {
+		Class clazz = typeInfo.getTypeClass();
+		if (byte[].class.equals(clazz)) {
+			return (byte[]) obj;
+		} else if (String.class.equals(clazz)) {
+			return Bytes.toBytes((String) obj);
+		} else if (Byte.class.equals(clazz)) {
+			return Bytes.toBytes((Byte) obj);
+		} else if (Short.class.equals(clazz)) {
+			return Bytes.toBytes((Short) obj);
+		} else if (Integer.class.equals(clazz)) {
+			return Bytes.toBytes((Integer) obj);
+		} else if (Long.class.equals(clazz)) {
+			return Bytes.toBytes((Long) obj);
+		} else if (Float.class.equals(clazz)) {
+			return Bytes.toBytes((Float) obj);
+		} else if (Double.class.equals(clazz)) {
+			return Bytes.toBytes((Double) obj);
+		} else if (Boolean.class.equals(clazz)) {
+			return Bytes.toBytes((Boolean) obj);
+		} else if (Timestamp.class.equals(clazz)) {
+			return Bytes.toBytes(((Timestamp) obj).getTime());
+		} else if (Date.class.equals(clazz)) {
+			return Bytes.toBytes(((Date) obj).getTime());
+		} else if (Time.class.equals(clazz)) {
+			return Bytes.toBytes(((Time) obj).getTime());
+		} else if (BigDecimal.class.equals(clazz)) {
+			return Bytes.toBytes((BigDecimal) obj);
+		} else if (BigInteger.class.equals(clazz)) {
+			return ((BigInteger) obj).toByteArray();
+		} else {
+			throw new RuntimeException("Unsupported type " + clazz.getName());
+		}
+	}
+
+	public static Connection createConnection(Map<String, String> hbaseConfig) throws IOException {
+		Configuration configuration = new Configuration();
+		for (Map.Entry<String, String> entry: hbaseConfig.entrySet()) {
+			configuration.set(entry.getKey(), entry.getValue());
+		}
+		return ConnectionFactory.createConnection(configuration);
+	}
+
+	public static Table createTable(Connection connection, String tableName) throws IOException {
+		try (Table table = connection.getTable(TableName.valueOf(tableName));
+			Admin admin = connection.getAdmin()) {
+			if (!admin.isTableAvailable(TableName.valueOf(tableName))) {
+				throw new IOException("Table is not available.");
+			}
+			return table;
+		}
+	}
+}

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/streaming/connectors/hbase/HBaseSinkITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/streaming/connectors/hbase/HBaseSinkITCase.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.hbase;
+
+import org.apache.flink.addons.hbase.HBaseTestingClusterAutostarter;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkContextUtil;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.streaming.connectors.hbase.util.HBaseUtils;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+
+/**
+ * IT cases for all HBase sinks.
+ */
+public class HBaseSinkITCase extends HBaseTestingClusterAutostarter {
+
+	private static final String TEST_TABLE = "testTable";
+
+	private static final ArrayList<Row> rowCollection = new ArrayList<>(20);
+
+	private static HTable table;
+
+	static {
+		for (int i = 0; i < 20; i++) {
+			rowCollection.add(Row.of(String.valueOf(i), i, 0));
+		}
+	}
+
+	private static final String FAMILY1 = "family1";
+	private static final String F1COL1 = "col1";
+
+	private static final String FAMILY2 = "family2";
+	private static final String F2COL1 = "col1";
+
+	private static final int rowKeyIndex = 0;
+	private static final String[] columnFamilies = new String[] {null, FAMILY1, FAMILY2};
+	private static final String[] qualifiers = new String[] {null, F1COL1, F2COL1};
+	private static final TypeInformation<?>[] fieldTypes = new TypeInformation<?>[] {Types.STRING, Types.INT, Types.INT};
+
+	@BeforeClass
+	public static void activateHBaseCluster() throws Exception {
+		registerHBaseMiniClusterInClasspath();
+		table = prepareTable();
+	}
+
+	public static DataStream<Tuple3<Integer, Long, String>> get3TupleDataStream(StreamExecutionEnvironment env) {
+		List<Tuple3<Integer, Long, String>> data = new ArrayList<>();
+		data.add(new Tuple3<>(1, 1L, "Hi"));
+		data.add(new Tuple3<>(2, 2L, "Hello"));
+		data.add(new Tuple3<>(3, 2L, "Hello world"));
+		data.add(new Tuple3<>(4, 3L, "Hello world, how are you?"));
+		data.add(new Tuple3<>(5, 3L, "I am fine."));
+		data.add(new Tuple3<>(6, 3L, "Luke Skywalker"));
+		data.add(new Tuple3<>(7, 4L, "Comment#1"));
+		data.add(new Tuple3<>(8, 4L, "Comment#2"));
+		data.add(new Tuple3<>(9, 4L, "Comment#3"));
+		data.add(new Tuple3<>(10, 4L, "Comment#4"));
+		data.add(new Tuple3<>(11, 5L, "Comment#5"));
+		data.add(new Tuple3<>(12, 5L, "Comment#6"));
+		data.add(new Tuple3<>(13, 5L, "Comment#7"));
+		data.add(new Tuple3<>(14, 5L, "Comment#8"));
+		data.add(new Tuple3<>(15, 5L, "Comment#9"));
+		data.add(new Tuple3<>(16, 6L, "Comment#10"));
+		data.add(new Tuple3<>(17, 6L, "Comment#11"));
+		data.add(new Tuple3<>(18, 6L, "Comment#12"));
+		data.add(new Tuple3<>(19, 6L, "Comment#13"));
+		data.add(new Tuple3<>(20, 6L, "Comment#14"));
+		data.add(new Tuple3<>(21, 6L, "Comment#15"));
+
+		Collections.shuffle(data);
+		return env.fromCollection(data);
+	}
+
+	private static HTable prepareTable() throws IOException {
+		// create a table
+		TableName tableName = TableName.valueOf(TEST_TABLE);
+		// column families
+		byte[][] families = new byte[][]{
+			Bytes.toBytes(FAMILY1),
+			Bytes.toBytes(FAMILY2),
+		};
+		// split keys
+		byte[][] splitKeys = new byte[][]{ Bytes.toBytes(4) };
+
+		createTable(tableName, families, splitKeys);
+
+		// get the HTable instance
+		HTable table = openTable(tableName);
+		return table;
+	}
+
+	@Test
+	public void testHBaseUpsertSink() throws Exception {
+		String[] rowFieldNames = new String[] {"key", "value", "oldValue"};
+		RowTypeInfo typeInfo = (RowTypeInfo) Types.ROW_NAMED(rowFieldNames, fieldTypes);
+		HBaseUpsertTableSink.HBaseUpsertSinkFunction sink =
+			new HBaseUpsertTableSink.HBaseUpsertSinkFunction(
+				new TestHBaseTableBuilder(),
+				new HashMap<>(),
+				rowKeyIndex,
+				rowFieldNames,
+				columnFamilies,
+				qualifiers,
+				fieldTypes,
+				typeInfo);
+
+		ArrayList<byte[]> rowKeys = new ArrayList<>();
+		Map<String, Row> validationMap = new HashMap<>();
+
+		sink.open(null);
+		for (Row value : rowCollection) {
+			sink.invoke(Tuple2.of(true, value), SinkContextUtil.forTimestamp(0));
+			String valueKey = (String) value.getField(rowKeyIndex);
+			rowKeys.add(Bytes.toBytes(valueKey));
+			validationMap.put(valueKey, value);
+		}
+		validate(rowKeys, validationMap, (row, i) -> row.getField(i));
+
+		for (Row value : rowCollection) {
+			sink.invoke(Tuple2.of(false, value), SinkContextUtil.forTimestamp(0));
+			String valueKey = (String) value.getField(rowKeyIndex);
+			rowKeys.add(Bytes.toBytes(valueKey));
+			validationMap.put(valueKey, value);
+		}
+		validateNull(rowKeys);
+	}
+
+	@Test
+	public void testHBaseUpsertSinkWithBatchMode() throws Exception {
+		HashMap<String, String> userConfig = new HashMap<>();
+		userConfig.put(HBaseSinkFunctionBase.CONFIG_KEY_BATCH_FLUSH_ENABLE, "true");
+		userConfig.put(HBaseSinkFunctionBase.CONFIG_KEY_BATCH_FLUSH_INTERVAL_MS, "100000");
+
+		String[] rowFieldNames = new String[] {"key", "value", "oldValue"};
+		RowTypeInfo typeInfo = (RowTypeInfo) Types.ROW_NAMED(rowFieldNames, fieldTypes);
+
+		HBaseUpsertTableSink.HBaseUpsertSinkFunction sink =
+			new HBaseUpsertTableSink.HBaseUpsertSinkFunction(
+				new TestHBaseTableBuilder(),
+				userConfig,
+				rowKeyIndex,
+				rowFieldNames,
+				columnFamilies,
+				qualifiers,
+				fieldTypes,
+				typeInfo);
+
+		ArrayList<byte[]> rowKeys = new ArrayList<>();
+		Map<String, Row> validationMap = new HashMap<>();
+
+		sink.open(null);
+		for (Row value : rowCollection) {
+			sink.invoke(Tuple2.of(true, value), SinkContextUtil.forTimestamp(0));
+			String valueKey = (String) value.getField(rowKeyIndex);
+			rowKeys.add(Bytes.toBytes(valueKey));
+			validationMap.put(valueKey, value);
+		}
+		validateNull(rowKeys);
+		sink.snapshotState(null);
+		validate(rowKeys, validationMap, (row, i) -> row.getField(i));
+
+		for (Row value : rowCollection) {
+			sink.invoke(Tuple2.of(false, value), SinkContextUtil.forTimestamp(0));
+			String valueKey = (String) value.getField(rowKeyIndex);
+			rowKeys.add(Bytes.toBytes(valueKey));
+			validationMap.put(valueKey, value);
+		}
+		validate(rowKeys, validationMap, (row, i) -> row.getField(i));
+		sink.snapshotState(null);
+		validateNull(rowKeys);
+	}
+
+	@Test
+	public void testHBaseUpsertTableSink() throws Exception {
+		Map<String, String> userConfig = new HashMap<>();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().enableObjectReuse();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+		env.setParallelism(1);
+
+		org.apache.flink.table.api.Table t = tEnv.fromDataStream(get3TupleDataStream(env).assignTimestampsAndWatermarks(
+			new AscendingTimestampExtractor<Tuple3<Integer, Long, String>>() {
+				@Override
+				public long extractAscendingTimestamp(Tuple3<Integer, Long, String> element) {
+					return element.f0;
+				}}), "id, num, text");
+
+		tEnv.registerTable("T", t);
+
+		String[] fields = {"rowkey", FAMILY1 + ":cnt", FAMILY1 + ":lencnt", FAMILY1 + ":cTag"};
+		tEnv.registerTableSink("upsertSink", HBaseUpsertTableSink.builder()
+			.setTableBuilder(new TestHBaseTableBuilder())
+			.setSchema(TableSchema.builder().fields(fields, new DataType[] {STRING(), BIGINT(), BIGINT(), INT()}).build())
+			.setUserConfig(userConfig)
+			.setRowKeyField("rowkey")
+			.setDelimiter(":")
+			.build());
+
+		tEnv.sqlUpdate("INSERT INTO upsertSink SELECT CAST(cnt AS VARCHAR) || CAST(cTag AS VARCHAR) as rowkey, "
+			+ "cnt AS `" + fields[0] + "`, COUNT(len) AS `" + fields[1] + "`, cTag AS `" + fields[3] + "` FROM" +
+			" (SELECT len, COUNT(id) as cnt, cTag FROM" +
+			" (SELECT id, CHAR_LENGTH(text) AS len, (CASE WHEN id > 0 THEN 1 ELSE 0 END) cTag FROM T)" +
+			" GROUP BY len, cTag)" +
+			" GROUP BY cnt, cTag");
+		env.execute();
+
+		// Validate result
+		ArrayList<byte[]> rowKeys = new ArrayList<>();
+		rowKeys.add("11".getBytes());
+		rowKeys.add("71".getBytes());
+		rowKeys.add("91".getBytes());
+
+		Map<String, Row> validationMap = new HashMap<>();
+		validationMap.put("11", Row.of("11", Long.valueOf(1), Long.valueOf(5), 1));
+		validationMap.put("71", Row.of("71", Long.valueOf(7), Long.valueOf(1), 1));
+		validationMap.put("91", Row.of("91", Long.valueOf(9), Long.valueOf(1), 1));
+
+		validate(
+			rowKeys,
+			0,
+			new TypeInformation<?>[]{Types.STRING, Types.LONG, Types.LONG, Types.INT},
+			new String[]{null, FAMILY1, FAMILY1, FAMILY1},
+			new String[]{"rowkey", "cnt", "lencnt", "cTag"},
+			validationMap,
+			(row, i) -> row.getField(i));
+	}
+
+	private <T> void validate(
+		ArrayList<byte[]> rowKeys,
+		int rowKeyIndex,
+		TypeInformation<?>[] fieldTypes,
+		String[] columnFamilies,
+		String[] qualifiers,
+		Map<String, T> validationMap,
+		BiFunction<T, Integer, Object> biFunction) throws IOException {
+		for (byte[] rowKey : rowKeys) {
+			for (int i = 0; i < fieldTypes.length; i++) {
+				if (i != rowKeyIndex) {
+					byte[] result = table.get(new Get(rowKey)).getValue(columnFamilies[i].getBytes(), qualifiers[i].getBytes());
+					byte[] validation = HBaseUtils.serialize(fieldTypes[i], biFunction.apply(validationMap.get(new String(rowKey)), i));
+					Assert.assertTrue(Arrays.equals(result, validation));
+				}
+			}
+		}
+	}
+
+	private <T> void validate(ArrayList<byte[]> rowKeys, Map<String, T> validationMap, BiFunction<T, Integer, Object> biFunction)
+		throws IOException {
+		validate(rowKeys, rowKeyIndex, fieldTypes, columnFamilies, qualifiers, validationMap, biFunction);
+	}
+
+	private void validateNull(ArrayList<byte[]> rowKeys) throws IOException {
+		for (byte[] rowKey : rowKeys) {
+			for (int i = 0; i < fieldTypes.length; i++) {
+				if (i != rowKeyIndex) {
+					byte[] result = table.get(new Get(rowKey)).getValue(columnFamilies[i].getBytes(), qualifiers[i].getBytes());
+					Assert.assertNull(result);
+				}
+			}
+		}
+	}
+
+	private final class TestHBaseTableBuilder extends HBaseTableBuilder {
+
+		@Override
+		public Connection buildConnection() throws IOException {
+			return null;
+		}
+
+		@Override
+		public Table buildTable(Connection connection) throws IOException {
+			return table;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
- Add datastream sink and upsert table sink for HBase

## Brief change log
- Add HBase connector, details are in the doc.

## Verifying this change
This change added tests and can be verified as follows:
- org.apache.flink.streaming.connectors.hbase.HBaseSinkITCase: starts a mini HBase cluster to verify all sink functions.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs and https://docs.google.com/document/d/1of0cYd73CtKGPt-UL3WVFTTBsVEre-TNRzoAt5u2PdQ/edit#
