### PR TITLE
[FLINK-11405][rest]can see task and task attempt exception by start e…

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1789,6 +1789,17 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       </td>
     </tr>
     <tr>
+        <td colspan="2">Query parameters</td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <ul>
+                <li><code>start</code> (optional): Long value that specifies the exception start time.</li>
+                <li><code>end</code> (optional): Long value that specifies the exception end time.</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
       <td colspan="2">
         <button data-toggle="collapse" data-target="#-1011644505">Request</button>
         <div id="-1011644505" class="collapse">

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsHeaders.java
@@ -20,13 +20,14 @@ package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
+import org.apache.flink.runtime.rest.messages.job.JobExceptionsMessageParameters;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Message headers for the {@link JobExceptionsHandler}.
  */
-public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, JobExceptionsInfo, JobMessageParameters> {
+public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, JobExceptionsInfo, JobExceptionsMessageParameters> {
 
 	private static final JobExceptionsHeaders INSTANCE = new JobExceptionsHeaders();
 
@@ -50,8 +51,8 @@ public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, Jo
 	}
 
 	@Override
-	public JobMessageParameters getUnresolvedMessageParameters() {
-		return new JobMessageParameters();
+	public JobExceptionsMessageParameters getUnresolvedMessageParameters() {
+		return new JobExceptionsMessageParameters();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -88,11 +89,15 @@ public class JobExceptionsInfo implements ResponseBody {
 	/**
 	 * Nested class to encapsulate the task execution exception.
 	 */
-	public static final class ExecutionExceptionInfo {
+	public static final class ExecutionExceptionInfo implements Comparable<ExecutionExceptionInfo> {
 		public static final String FIELD_NAME_EXCEPTION = "exception";
 		public static final String FIELD_NAME_TASK = "task";
 		public static final String FIELD_NAME_LOCATION = "location";
 		public static final String FIELD_NAME_TIMESTAMP = "timestamp";
+		public static final String FIELD_NAME_VERTEX_ID = "vertex-id";
+		public static final String FIELD_NAME_VERTEX_NAME = "vertex-name";
+		public static final String FIELD_NAME_SUBTASK_INDEX = "subtask-index";
+		public static final String FIELD_NAME_ATTEMPT_NUM = "attempt-num";
 
 		@JsonProperty(FIELD_NAME_EXCEPTION)
 		private final String exception;
@@ -106,16 +111,36 @@ public class JobExceptionsInfo implements ResponseBody {
 		@JsonProperty(FIELD_NAME_TIMESTAMP)
 		private final long timestamp;
 
+		@JsonProperty(FIELD_NAME_VERTEX_ID)
+		private final String vertexID;
+
+		@JsonProperty(FIELD_NAME_VERTEX_NAME)
+		private final String vertexName;
+
+		@JsonProperty(FIELD_NAME_SUBTASK_INDEX)
+		private final int subtaskIndex;
+
+		@JsonProperty(FIELD_NAME_ATTEMPT_NUM)
+		private final int attemptNum;
+
 		@JsonCreator
 		public ExecutionExceptionInfo(
 			@JsonProperty(FIELD_NAME_EXCEPTION) String exception,
 			@JsonProperty(FIELD_NAME_TASK) String task,
 			@JsonProperty(FIELD_NAME_LOCATION) String location,
-			@JsonProperty(FIELD_NAME_TIMESTAMP) long timestamp) {
+			@JsonProperty(FIELD_NAME_TIMESTAMP) long timestamp,
+			@JsonProperty(FIELD_NAME_VERTEX_ID) String vertexID,
+			@JsonProperty(FIELD_NAME_VERTEX_NAME) String vertexName,
+			@JsonProperty(FIELD_NAME_SUBTASK_INDEX) int subtaskIndex,
+			@JsonProperty(FIELD_NAME_ATTEMPT_NUM) int attemptNum) {
 			this.exception = Preconditions.checkNotNull(exception);
 			this.task = Preconditions.checkNotNull(task);
 			this.location = Preconditions.checkNotNull(location);
 			this.timestamp = timestamp;
+			this.vertexID = vertexID;
+			this.vertexName = vertexName;
+			this.subtaskIndex = subtaskIndex;
+			this.attemptNum = attemptNum;
 		}
 
 		@Override
@@ -128,14 +153,48 @@ public class JobExceptionsInfo implements ResponseBody {
 			}
 			JobExceptionsInfo.ExecutionExceptionInfo that = (JobExceptionsInfo.ExecutionExceptionInfo) o;
 			return timestamp == that.timestamp &&
+				subtaskIndex == subtaskIndex &&
+				attemptNum == attemptNum &&
 				Objects.equals(exception, that.exception) &&
 				Objects.equals(task, that.task) &&
-				Objects.equals(location, that.location);
+				Objects.equals(location, that.location) &&
+				Objects.equals(vertexID, that.vertexID) &&
+				Objects.equals(vertexName, that.vertexName);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(timestamp, exception, task, location);
+			return Objects.hash(timestamp, exception, task, location, vertexID, vertexName, subtaskIndex, attemptNum);
+		}
+
+		@Override
+		public int compareTo(ExecutionExceptionInfo o) {
+			return Long.compare(timestamp, o.timestamp);
+		}
+
+		@JsonIgnore
+		public long getTimestamp() {
+			return timestamp;
+		}
+
+		@JsonIgnore
+		public String getVertexID() {
+			return vertexID;
+		}
+
+		@JsonIgnore
+		public String getVertexName() {
+			return vertexName;
+		}
+
+		@JsonIgnore
+		public int getSubtaskIndex() {
+			return subtaskIndex;
+		}
+
+		@JsonIgnore
+		public int getAttemptNum() {
+			return attemptNum;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsEndFilterQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsEndFilterQueryParameter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+/**
+ * {@link MessageQueryParameter} for selecting failover by end.
+ */
+public class JobExceptionsEndFilterQueryParameter extends MessageQueryParameter<Long> {
+
+	JobExceptionsEndFilterQueryParameter() {
+		super("end", MessageParameterRequisiteness.OPTIONAL);
+	}
+
+	@Override
+	public Long convertStringToValue(String value) {
+		return Long.valueOf(value);
+	}
+
+	@Override
+	public String convertValueToString(Long value) {
+		return value.toString();
+	}
+
+	@Override
+	public String getDescription() {
+		return "filter failover by end time";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link MessageParameters} for {@link JobExceptionsHandler}.
+ */
+public class JobExceptionsMessageParameters extends JobMessageParameters {
+
+	private final JobExceptionsStartFilterQueryParameter start = new JobExceptionsStartFilterQueryParameter();
+	private final JobExceptionsEndFilterQueryParameter end = new JobExceptionsEndFilterQueryParameter();
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.unmodifiableCollection(Arrays.asList(
+			start,
+			end
+		));
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsStartFilterQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsStartFilterQueryParameter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+/**
+ * {@link MessageQueryParameter} for selecting failover by start.
+ */
+public class JobExceptionsStartFilterQueryParameter extends MessageQueryParameter<Long> {
+
+	JobExceptionsStartFilterQueryParameter() {
+		super("start", MessageParameterRequisiteness.OPTIONAL);
+	}
+
+	@Override
+	public Long convertStringToValue(String value) {
+		return Long.valueOf(value);
+	}
+
+	@Override
+	public String convertValueToString(Long value) {
+		return value.toString();
+	}
+
+	@Override
+	public String getDescription() {
+		return "filter failover by start time";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FixedSortedSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FixedSortedSet.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.Comparator;
+import java.util.TreeSet;
+
+/**
+ * A set based structure that accepts element and make it sorted with fixed size.
+ * @param <E> The element.
+ */
+public class FixedSortedSet<E> extends TreeSet<E> {
+	private final long maxSize;
+	private final Comparator<? super E> comparator;
+
+	public FixedSortedSet(long maxSize) {
+		this(maxSize, null);
+	}
+
+	public FixedSortedSet(long maxSize, Comparator<? super E> comparator) {
+		super(comparator);
+
+		this.maxSize = maxSize;
+		this.comparator = comparator;
+	}
+
+	@Override
+	public boolean add(E e) {
+		if (null == e) {
+			throw new NullPointerException();
+		}
+
+		if (maxSize <= 0) {
+			return false;
+		}
+
+		if (size() >= maxSize) {
+			// remove the last one based on the comparator
+			E last = last();
+			if (last != null) {
+				boolean canPut = false;
+
+				if (comparator != null) {
+					if (comparator.compare(last, e) > 0) {
+						canPut = true;
+					}
+				} else {
+					Preconditions.checkState(e instanceof Comparable,
+						"Element should be comparable if there is no comparator provided.");
+
+					@SuppressWarnings("unchecked")
+					Comparable<? super E> comparable = (Comparable<? super E>) last;
+					if (comparable.compareTo(e) > 0) {
+						canPut = true;
+					}
+				}
+
+				if (canPut) {
+					pollLast();
+					return super.add(e);
+				}
+			}
+			return false;
+		} else {
+			return super.add(e);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoNoRootTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoNoRootTest.java
@@ -37,12 +37,20 @@ public class JobExceptionsInfoNoRootTest extends RestResponseMarshallingTestBase
 			"exception1",
 			"task1",
 			"location1",
-			System.currentTimeMillis()));
+			System.currentTimeMillis(),
+			"vertex-id",
+			"vertex-name",
+			1,
+			1));
 		executionTaskExceptionInfoList.add(new JobExceptionsInfo.ExecutionExceptionInfo(
 			"exception2",
 			"task2",
 			"location2",
-			System.currentTimeMillis()));
+			System.currentTimeMillis(),
+			"vertex-id",
+			"vertex-name",
+			2,
+			1));
 		return new JobExceptionsInfo(
 			null,
 			null,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoTest.java
@@ -37,12 +37,20 @@ public class JobExceptionsInfoTest extends RestResponseMarshallingTestBase<JobEx
 			"exception1",
 			"task1",
 			"location1",
-			System.currentTimeMillis()));
+			System.currentTimeMillis(),
+			"vertex-id",
+			"vertex-name",
+			1,
+			1));
 		executionTaskExceptionInfoList.add(new JobExceptionsInfo.ExecutionExceptionInfo(
 			"exception2",
 			"task2",
 			"location2",
-			System.currentTimeMillis()));
+			System.currentTimeMillis(),
+			"vertex-id",
+			"vertex-name",
+			2,
+			1));
 		return new JobExceptionsInfo(
 			"root exception",
 			System.currentTimeMillis(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/FixedSortedSetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/FixedSortedSetTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.junit.Test;
+
+import java.util.Comparator;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * test for FixedSortedSet.
+ */
+public class FixedSortedSetTest {
+
+	@Test
+	public void testAdd() {
+
+		final FixedSortedSet<Long> list = new FixedSortedSet<>(2, Comparator.reverseOrder());
+
+		list.add(2L);
+
+		assertTrue(list.contains(2L));
+		assertEquals(1, list.size());
+
+		list.add(1L);
+
+		assertTrue(list.contains(1L));
+		assertEquals(2, list.size());
+
+		list.add(3L);
+
+		assertTrue(list.contains(3L));
+		assertFalse(list.contains(1L));
+		assertEquals(2, list.size());
+
+		list.add(1L);
+
+		assertTrue(list.contains(2L));
+		assertTrue(list.contains(3L));
+		assertFalse(list.contains(1L));
+		assertEquals(2, list.size());
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

- This pull request makes rest api JobExceptionsHandler can see more exception message. 
    - Add task attempt exception show.
    - can filter exception by time start and end.


## Brief change log
  - JobExceptionsHandler create exception add task attemp exceptions
  - JobExceptionsHandler queryParameter add start and end 
  - JobExceptionsInfo.ExecutionExceptionInfo add fileds(vertexID, vertexName, subtaskIndex, attemptNum)
  - Add FixedSortedSetTest for see FixedSize exception with order


## Verifying this change


- update JobExceptionsInfoNoRootTest and JobExceptionsInfoTest.
- Added FixedSortedSetTest 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)