### PR TITLE
[FLINK-11373] CliFrontend cuts off reason for error messages

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -204,7 +204,7 @@ public class CliFrontend {
 			program = buildProgram(runOptions);
 		}
 		catch (FileNotFoundException e) {
-			throw new CliArgsException("Could not build the program from JAR file.", e);
+			throw new CliArgsException("JAR file does not exist: " + runOptions.getJarFilePath(), e);
 		}
 
 		final CustomCommandLine<?> customCommandLine = getActiveCustomCommandLine(commandLine);
@@ -881,7 +881,7 @@ public class CliFrontend {
 	private static int handleArgException(CliArgsException e) {
 		LOG.error("Invalid command line arguments.", e);
 
-		e.printStackTrace();
+		System.out.println(e.getMessage());
 		System.out.println();
 		System.out.println("Use the help option (-h or --help) to get help on the command.");
 		return 1;

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -881,7 +881,7 @@ public class CliFrontend {
 	private static int handleArgException(CliArgsException e) {
 		LOG.error("Invalid command line arguments.", e);
 
-		System.out.println(e.getMessage());
+		e.printStackTrace();
 		System.out.println();
 		System.out.println("Use the help option (-h or --help) to get help on the command.");
 		return 1;


### PR DESCRIPTION

## What is the purpose of the change

Show error message of CliArgsException in CliFrontend.


## Brief change log

Change System.out.println(e.getMessage()) to e.printStackTrace().


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
