### PR TITLE
[hotfix][javadocs] Fix typos in javadoc

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -258,7 +258,7 @@ public interface RuntimeContext {
 	 *
 	 *     public Tuple2<MyType, Long> map(MyType value) {
 	 *         long count = state.value() + 1;
-	 *         state.update(value);
+	 *         state.update(count);
 	 *         return new Tuple2<>(value, count);
 	 *     }
 	 * });

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * such as whether the fields that are uses as join/grouping keys actually exist.
  *
  * <p>The type information also bridges between the programming languages object model and a
- * logical flat schema. It maps fields from the types to to columns (fields) in a flat schema.
+ * logical flat schema. It maps fields from the types to columns (fields) in a flat schema.
  * Not all fields from a type are mapped to a separate fields in the flat schema and
  * often, entire types are mapped to one field. It is important to notice that the schema must
  * hold for all instances of a type. For that reason, elements in lists and arrays are not

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
@@ -51,7 +51,7 @@ public class FlinkUserCodeClassLoaders {
 			case PARENT_FIRST:
 				return parentFirst(urls, parent);
 			default:
-				throw new IllegalArgumentException("Unkown class resolution order: " + resolveOrder);
+				throw new IllegalArgumentException("Unknown class resolution order: " + resolveOrder);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -125,7 +125,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *         from the JobGraph's corresponding JobVertex.</li>
  *     <li>The {@link ExecutionVertex} represents one parallel subtask. For each ExecutionJobVertex, there are
  *         as many ExecutionVertices as the parallelism. The ExecutionVertex is identified by
- *         the ExecutionJobVertex and the number of the parallel subtask</li>
+ *         the ExecutionJobVertex and the index of the parallel subtask</li>
  *     <li>The {@link Execution} is one attempt to execute a ExecutionVertex. There may be multiple Executions
  *         for the ExecutionVertex, in case of a failure, or in the case where some data needs to be recomputed
  *         because it is no longer available when requested by later operations. An Execution is always

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -32,7 +32,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * Not thread safe class for producing {@link Buffer}.
  *
  * <p>It reads data written by {@link BufferBuilder}.
- * Although it is not thread safe and can be used only by one single thread, this thread can be different then the
+ * Although it is not thread safe and can be used only by one single thread, this thread can be different than the
  * thread using/writing to {@link BufferBuilder}. Pattern here is simple: one thread writes data to
  * {@link BufferBuilder} and there can be a different thread reading from it using {@link BufferConsumer}.
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -151,7 +151,7 @@ class AllocatedSlot implements SlotContext {
 	}
 
 	/**
-	 * Returns true if this slot is not being used (e.g. a logical slot is allocated from this slot).
+	 * Returns true if this slot is being used (e.g. a logical slot is allocated from this slot).
 	 *
 	 * @return true if a logical slot is allocated from this slot, otherwise false
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -79,7 +79,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * The slot pool serves slot request issued by {@link ExecutionGraph}. It will will attempt to acquire new slots
+ * The slot pool serves slot request issued by {@link ExecutionGraph}. It will attempt to acquire new slots
  * from the ResourceManager when it cannot serve a slot request. If no ResourceManager is currently available,
  * or it gets a decline from the ResourceManager, or a request times out, it fails the slot request. The slot pool also
  * holds all the slots that were offered to it and accepted, and can thus provides registered free slots even if the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * thread, we don't have to reason about concurrent accesses, in the same way in the Actor Model
  * of Erlang or Akka.
  *
- * <p>The RPC endpoint provides provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Time)}
+ * <p>The RPC endpoint provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Time)}
  * and the {@link #getMainThreadExecutor()} to execute code in the RPC endpoint's main thread.
  */
 public abstract class RpcEndpoint implements RpcGateway {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimeCharacteristic.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimeCharacteristic.java
@@ -47,7 +47,7 @@ public enum TimeCharacteristic {
 	 * does not affect windowing, but only the speed at which sources receive elements.
 	 *
 	 * <p>Ingestion time is often a good compromise between processing time and event time.
-	 * It does not need and special manual form of watermark generation, and events are typically
+	 * It does not need any special manual form of watermark generation, and events are typically
 	 * not too much out-or-order when they arrive at operators; in fact, out-of-orderness can
 	 * only be introduced by streaming shuffles or split/join/union operations. The fact that
 	 * elements are not very much out-of-order means that the latency increase is moderate,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
@@ -80,7 +80,7 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
  *         countPerKey = context.getKeyedStateStore().getReducingState(
  *                 new ReducingStateDescriptor<>("perKeyCount", new AddFunction<>(), Long.class));
  *
- *         // get the state data structure for the per-key state
+ *         // get the state data structure for the per-partition state
  *         countPerPartition = context.getOperatorStateStore().getOperatorState(
  *                 new ListStateDescriptor<>("perPartitionCount", Long.class));
  *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -1046,7 +1046,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * evaluation of the window. The output of the window function is
 	 * interpreted as a regular non-windowed stream.
 	 *
-	 * <p>Not that this function requires that all data in the windows is buffered until the window
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
 	 * is evaluated, as the function provides no means of incremental aggregation.
 	 *
 	 * @param function The window function.
@@ -1064,7 +1064,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * evaluation of the window. The output of the window function is
 	 * interpreted as a regular non-windowed stream.
 	 *
-	 * <p>Not that this function requires that all data in the windows is buffered until the window
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
 	 * is evaluated, as the function provides no means of incremental aggregation.
 	 *
 	 * @param function The window function.
@@ -1081,7 +1081,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * evaluation of the window. The output of the window function is
 	 * interpreted as a regular non-windowed stream.
 	 *
-	 * <p>Not that this function requires that all data in the windows is buffered until the window
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
 	 * is evaluated, as the function provides no means of incremental aggregation.
 	 *
 	 * @param function The process window function.
@@ -1100,7 +1100,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * evaluation of the window. The output of the window function is
 	 * interpreted as a regular non-windowed stream.
 	 *
-	 * <p>Not that this function requires that all data in the windows is buffered until the window
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
 	 * is evaluated, as the function provides no means of incremental aggregation.
 	 *
 	 * @param function The process window function.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -151,7 +151,7 @@ public class StreamGraphGenerator {
 		if (transform.getMaxParallelism() <= 0) {
 
 			// if the max parallelism hasn't been set, then first use the job wide max parallelism
-			// from theExecutionConfig.
+			// from the ExecutionConfig.
 			int globalMaxParallelismFromConfig = env.getConfig().getMaxParallelism();
 			if (globalMaxParallelismFromConfig > 0) {
 				transform.setMaxParallelism(globalMaxParallelismFromConfig);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -187,7 +187,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 
 			BufferOrEvent bufferOrEvent = next.get();
 			if (isBlocked(bufferOrEvent.getChannelIndex())) {
-				// if the channel is blocked we, we just store the BufferOrEvent
+				// if the channel is blocked, we just store the BufferOrEvent
 				bufferBlocker.add(bufferOrEvent);
 				checkSizeLimit();
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * channels. This distributes only to a subset of downstream nodes because
  * {@link org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator} instantiates
  * a {@link DistributionPattern#POINTWISE} distribution pattern when encountering
- * {@code SemiRebalancePartitioner}.
+ * {@code RescalePartitioner}.
  *
  * <p>The subset of downstream operations to which the upstream operation sends
  * elements depends on the degree of parallelism of both the upstream and downstream operation.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -32,7 +32,7 @@ import org.apache.flink.util.FlinkException;
  *
  * <p>One important aspect of this is that the checkpointing and the emission of elements must never
  * occur at the same time. The execution must be serial. This is achieved by having the contract
- * with the StreamFunction that it must only modify its state or emit elements in
+ * with the {@link SourceFunction} that it must only modify its state or emit elements in
  * a synchronized block that locks on the lock Object. Also, the modification of the state
  * and the emission of elements must happen in the same block of code that is protected by the
  * synchronized block.


### PR DESCRIPTION
Multiple typo fixes since I read Flink docs.