### PR TITLE
[FLINK-11406] [core] Return INCOMPATIBLE when nested serializers arity don't match in CompositeTypeSerializerSnapshot

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -166,9 +166,13 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
 			return TypeSerializerSchemaCompatibility.incompatible();
 		}
 
-		return constructFinalSchemaCompatibilityResult(
-			getNestedSerializers(castedNewSerializer),
-			snapshots);
+		final TypeSerializer<?>[] newNestedSerializers = getNestedSerializers(castedNewSerializer);
+		// check that nested serializer arity remains identical; if not, short circuit result
+		if (newNestedSerializers.length != snapshots.length) {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+
+		return constructFinalSchemaCompatibilityResult(newNestedSerializers, snapshots);
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
@@ -52,6 +52,7 @@ public class CompositeTypeSerializerSnapshotTest {
 		TypeSerializerSchemaCompatibility<String> compatibility =
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
+				testNestedSerializers,
 				OUTER_CONFIG,
 				OUTER_CONFIG);
 
@@ -71,6 +72,7 @@ public class CompositeTypeSerializerSnapshotTest {
 		TypeSerializerSchemaCompatibility<String> compatibility =
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
+				testNestedSerializers,
 				OUTER_CONFIG,
 				OUTER_CONFIG);
 
@@ -88,6 +90,7 @@ public class CompositeTypeSerializerSnapshotTest {
 
 		TypeSerializerSchemaCompatibility<String> compatibility =
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
+				testNestedSerializers,
 				testNestedSerializers,
 				OUTER_CONFIG,
 				OUTER_CONFIG);
@@ -114,6 +117,7 @@ public class CompositeTypeSerializerSnapshotTest {
 		TypeSerializerSchemaCompatibility<String> compatibility =
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
+				testNestedSerializers,
 				OUTER_CONFIG,
 				OUTER_CONFIG);
 
@@ -131,6 +135,7 @@ public class CompositeTypeSerializerSnapshotTest {
 		TypeSerializerSchemaCompatibility<String> compatibility =
 			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
 				testNestedSerializers,
+				testNestedSerializers,
 				INIT_OUTER_CONFIG,
 				INCOMPAT_OUTER_CONFIG);
 
@@ -139,12 +144,38 @@ public class CompositeTypeSerializerSnapshotTest {
 		Assert.assertTrue(compatibility.isIncompatible());
 	}
 
+	@Test
+	public void testNestedFieldSerializerArityMismatchPrecedence() throws IOException {
+		final String OUTER_CONFIG = "outer-config";
+
+		final TypeSerializer<?>[] initialNestedSerializers = {
+			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
+		};
+
+		final TypeSerializer<?>[] newNestedSerializers = {
+			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
+			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
+			new NestedSerializer(TargetCompatibility.COMPATIBLE_AS_IS),
+		};
+
+		TypeSerializerSchemaCompatibility<String> compatibility =
+			snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
+				initialNestedSerializers,
+				newNestedSerializers,
+				OUTER_CONFIG,
+				OUTER_CONFIG);
+
+		// arity mismatch in the nested serializers should return incompatible as the result
+		Assert.assertTrue(compatibility.isIncompatible());
+	}
+
 	private TypeSerializerSchemaCompatibility<String> snapshotCompositeSerializerAndGetSchemaCompatibilityAfterRestore(
-			TypeSerializer<?>[] testNestedSerializers,
+			TypeSerializer<?>[] initialNestedSerializers,
+			TypeSerializer<?>[] newNestedSerializer,
 			String initialOuterConfiguration,
 			String newOuterConfiguration) throws IOException {
 		TestCompositeTypeSerializer testSerializer =
-			new TestCompositeTypeSerializer(initialOuterConfiguration, testNestedSerializers);
+			new TestCompositeTypeSerializer(initialOuterConfiguration, initialNestedSerializers);
 
 		TypeSerializerSnapshot<String> testSerializerSnapshot = testSerializer.snapshotConfiguration();
 
@@ -156,7 +187,7 @@ public class CompositeTypeSerializerSnapshotTest {
 			in, Thread.currentThread().getContextClassLoader());
 
 		TestCompositeTypeSerializer newTestSerializer =
-			new TestCompositeTypeSerializer(newOuterConfiguration, testNestedSerializers);
+			new TestCompositeTypeSerializer(newOuterConfiguration, newNestedSerializer);
 		return testSerializerSnapshot.resolveSchemaCompatibility(newTestSerializer);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Right now, in `CompositeTypeSerializerSnapshot.resolveSchemaCompatibility(...)`, if arity of nested serializers don't match between the snapshot and the provided new serializer, a runtime exception is thrown.

More ideally, this should return `TypeSerializerSchemaCompatibility.incompatible()`.

## Verifying this change

A new unit test `CompositeTypeSerializerSnapshotTest.testNestedFieldSerializerArityMismatchPrecedence` covers this change.
