### PR TITLE
[FLINK-11329][core] Migrate CRowSerializerConfigSnapshot to new TypeSerializerSnapshot interface

### DIFF
--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/types/CRowSerializerSnapshot.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/types/CRowSerializerSnapshot.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.types;
+
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.Row;
+
+/**
+ * Snapshot class for {@link CRowSerializer}.
+ */
+public class CRowSerializerSnapshot extends CompositeTypeSerializerSnapshot<CRow, CRowSerializer> {
+
+	private static final int CURRENT_VERSION = 1;
+
+	/**
+	 * Constructor for read instantiation.
+	 */
+	public CRowSerializerSnapshot() {
+		super(CRowSerializer.class);
+	}
+
+	/**
+	 * Constructor to create the snapshot for writing.
+	 */
+	public CRowSerializerSnapshot(CRowSerializer serializerInstance) {
+		super(serializerInstance);
+	}
+
+	@Override
+	protected int getCurrentOuterSnapshotVersion() {
+		return CURRENT_VERSION;
+	}
+
+	@Override
+	protected TypeSerializer<?>[] getNestedSerializers(CRowSerializer outerSerializer) {
+		return new TypeSerializer[]{outerSerializer.rowSerializer()};
+	}
+
+	@Override
+	protected CRowSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+
+		@SuppressWarnings("unchecked")
+		TypeSerializer<Row> rowSerializer = (TypeSerializer<Row>) nestedSerializers[0];
+
+		return new CRowSerializer(rowSerializer);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR migrates `CRowSerializerConfigSnapshot` to the new `TypeSerializerSnapshot` interface. As a side note `CRowSerializer` is not supposed to be used for persisting state, therefore there is actually no backwards compatibility. Moreover the java serialization compatibility was broken at least twice before already in flink 1.6 and 1.7. Long term goal is to remove this serializer completely.

## Brief change log

  - Added `CRowSerializerSnapshot`
  - Delegate resolving compatibility from `CRowSerializerConfigSnapshot` to `CRowSerializerSnapshot`


## Verifying this change

* Tests in `CRowSerializerTest` should still pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
