### PR TITLE
[FLINK-11358][tests] Port LeaderChangeStateCleanupTest to new code base

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
+import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.DefaultSlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Singleton default factory for {@link JobManagerRunner}.
+ */
+public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
+	INSTANCE;
+
+	@Override
+	public JobManagerRunner createJobManagerRunner(
+			JobGraph jobGraph,
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			JobManagerSharedServices jobManagerServices,
+			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+
+		final JobMasterConfiguration jobMasterConfiguration = JobMasterConfiguration.fromConfiguration(configuration);
+
+		final SlotPoolFactory slotPoolFactory = DefaultSlotPoolFactory.fromConfiguration(
+			configuration,
+			rpcService);
+
+		final JobMasterServiceFactory jobMasterFactory = new DefaultJobMasterServiceFactory(
+			jobMasterConfiguration,
+			slotPoolFactory,
+			rpcService,
+			highAvailabilityServices,
+			jobManagerServices,
+			heartbeatServices,
+			jobManagerJobMetricGroupFactory,
+			fatalErrorHandler);
+
+		return new JobManagerRunner(
+			jobGraph,
+			jobMasterFactory,
+			highAvailabilityServices,
+			jobManagerServices.getLibraryCacheManager(),
+			jobManagerServices.getScheduledExecutorService(),
+			fatalErrorHandler);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -45,7 +45,6 @@ import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.RescalingBehaviour;
 import org.apache.flink.runtime.jobmaster.factories.DefaultJobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -308,7 +307,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		final CompletableFuture<JobManagerRunner> jobManagerRunnerFuture = CompletableFuture.supplyAsync(
 			CheckedSupplier.unchecked(() ->
 				jobManagerRunnerFactory.createJobManagerRunner(
-					ResourceID.generate(),
 					jobGraph,
 					configuration,
 					rpcService,
@@ -1008,56 +1006,5 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				onFatalError(new DispatcherException(String.format("Could not remove job %s.", jobId), e));
 			}
 		});
-	}
-
-	//------------------------------------------------------
-	// Factories
-	//------------------------------------------------------
-
-	/**
-	 * Factory for a {@link JobManagerRunner}.
-	 */
-	@FunctionalInterface
-	public interface JobManagerRunnerFactory {
-		JobManagerRunner createJobManagerRunner(
-			ResourceID resourceId,
-			JobGraph jobGraph,
-			Configuration configuration,
-			RpcService rpcService,
-			HighAvailabilityServices highAvailabilityServices,
-			HeartbeatServices heartbeatServices,
-			JobManagerSharedServices jobManagerServices,
-			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-			FatalErrorHandler fatalErrorHandler) throws Exception;
-	}
-
-	/**
-	 * Singleton default factory for {@link JobManagerRunner}.
-	 */
-	public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
-		INSTANCE;
-
-		@Override
-		public JobManagerRunner createJobManagerRunner(
-				ResourceID resourceId,
-				JobGraph jobGraph,
-				Configuration configuration,
-				RpcService rpcService,
-				HighAvailabilityServices highAvailabilityServices,
-				HeartbeatServices heartbeatServices,
-				JobManagerSharedServices jobManagerServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-				FatalErrorHandler fatalErrorHandler) throws Exception {
-			return new JobManagerRunner(
-				resourceId,
-				jobGraph,
-				configuration,
-				rpcService,
-				highAvailabilityServices,
-				heartbeatServices,
-				jobManagerServices,
-				jobManagerJobMetricGroupFactory,
-				fatalErrorHandler);
-		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -75,7 +75,7 @@ public class JobDispatcherFactory implements DispatcherFactory<MiniDispatcher> {
 			jobManagerMetricGroup,
 			metricQueryServicePath,
 			archivedExecutionGraphStore,
-			Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE,
+			DefaultJobManagerRunnerFactory.INSTANCE,
 			fatalErrorHandler,
 			historyServerArchivist,
 			jobGraph,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Factory for a {@link JobManagerRunner}.
+ */
+@FunctionalInterface
+public interface JobManagerRunnerFactory {
+
+	JobManagerRunner createJobManagerRunner(
+		JobGraph jobGraph,
+		Configuration configuration,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		HeartbeatServices heartbeatServices,
+		JobManagerSharedServices jobManagerServices,
+		JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+		FatalErrorHandler fatalErrorHandler) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
@@ -60,7 +60,7 @@ public enum SessionDispatcherFactory implements DispatcherFactory<Dispatcher> {
 			jobManagerMetricGroup,
 			metricQueryServicePath,
 			archivedExecutionGraphStore,
-			Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE,
+			DefaultJobManagerRunnerFactory.INSTANCE,
 			fatalErrorHandler,
 			historyServerArchivist);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.HashMap;
@@ -54,10 +55,10 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 
 	public EmbeddedHaServices(Executor executor) {
 		this.executor = Preconditions.checkNotNull(executor);
-		this.resourceManagerLeaderService = new EmbeddedLeaderService(executor);
-		this.dispatcherLeaderService = new EmbeddedLeaderService(executor);
+		this.resourceManagerLeaderService = createEmbeddedLeaderService(executor);
+		this.dispatcherLeaderService = createEmbeddedLeaderService(executor);
 		this.jobManagerLeaderServices = new HashMap<>();
-		this.webMonitorLeaderService = new EmbeddedLeaderService(executor);
+		this.webMonitorLeaderService = createEmbeddedLeaderService(executor);
 	}
 
 	// ------------------------------------------------------------------------
@@ -125,11 +126,24 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 	// internal
 	// ------------------------------------------------------------------------
 
+	EmbeddedLeaderService getDispatcherLeaderService() {
+		return dispatcherLeaderService;
+	}
+
+	EmbeddedLeaderService getJobManagerLeaderService(JobID jobId) {
+		return jobManagerLeaderServices.get(jobId);
+	}
+
+	@Nonnull
+	private EmbeddedLeaderService createEmbeddedLeaderService(Executor executor) {
+		return new EmbeddedLeaderService(executor);
+	}
+
 	@GuardedBy("lock")
 	private EmbeddedLeaderService getOrCreateJobManagerService(JobID jobID) {
 		EmbeddedLeaderService service = jobManagerLeaderServices.get(jobID);
 		if (service == null) {
-			service = new EmbeddedLeaderService(executor);
+			service = createEmbeddedLeaderService(executor);
 			jobManagerLeaderServices.put(jobID, service);
 		}
 		return service;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.factories;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Default implementation of the {@link JobMasterServiceFactory}.
+ */
+public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
+
+	private final JobMasterConfiguration jobMasterConfiguration;
+
+	private final SlotPoolFactory slotPoolFactory;
+
+	private final RpcService rpcService;
+
+	private final HighAvailabilityServices haServices;
+
+	private final JobManagerSharedServices jobManagerSharedServices;
+
+	private final HeartbeatServices heartbeatServices;
+
+	private final JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory;
+
+	private final FatalErrorHandler fatalErrorHandler;
+
+	public DefaultJobMasterServiceFactory(
+			JobMasterConfiguration jobMasterConfiguration,
+			SlotPoolFactory slotPoolFactory,
+			RpcService rpcService,
+			HighAvailabilityServices haServices,
+			JobManagerSharedServices jobManagerSharedServices,
+			HeartbeatServices heartbeatServices,
+			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+			FatalErrorHandler fatalErrorHandler) {
+		this.jobMasterConfiguration = jobMasterConfiguration;
+		this.slotPoolFactory = slotPoolFactory;
+		this.rpcService = rpcService;
+		this.haServices = haServices;
+		this.jobManagerSharedServices = jobManagerSharedServices;
+		this.heartbeatServices = heartbeatServices;
+		this.jobManagerJobMetricGroupFactory = jobManagerJobMetricGroupFactory;
+		this.fatalErrorHandler = fatalErrorHandler;
+	}
+
+	@Override
+	public JobMaster createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, ClassLoader userCodeClassloader) throws Exception {
+		return new JobMaster(
+			rpcService,
+			jobMasterConfiguration,
+			ResourceID.generate(),
+			jobGraph,
+			haServices,
+			slotPoolFactory,
+			jobManagerSharedServices,
+			heartbeatServices,
+			jobManagerJobMetricGroupFactory,
+			jobCompletionActions,
+			fatalErrorHandler,
+			userCodeClassloader);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobMasterServiceFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.factories;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobMasterService;
+
+/**
+ * Factory for a {@link JobMasterService}.
+ */
+public interface JobMasterServiceFactory {
+
+	JobMasterService createJobMasterService(
+		JobGraph jobGraph,
+		OnCompletionActions jobCompletionActions,
+		ClassLoader userCodeClassloader) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -242,7 +242,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 	 * Suspends this pool, meaning it has lost its authority to accept and distribute slots.
 	 */
 	@Override
-	public void suspend() {
+	public CompletableFuture<Acknowledge> suspend() {
 		log.info("Suspending SlotPool.");
 
 		validateRunsInMainThread();
@@ -265,6 +265,8 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 		// Clear (but not release!) the available slots. The TaskManagers should re-register them
 		// at the new leader JobManager/SlotPool
 		clear();
+
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
@@ -48,7 +48,7 @@ public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 	//  shutdown
 	// ------------------------------------------------------------------------
 
-	void suspend();
+	CompletableFuture<Acknowledge> suspend();
 
 	// ------------------------------------------------------------------------
 	//  resource manager connection

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -100,6 +100,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -305,11 +306,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					this.resourceManagerRpcService = resourceManagerRpcService;
 				}
 
-				// create the high-availability services
-				LOG.info("Starting high-availability services");
-				haServices = HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-					configuration,
-					commonRpcService.getExecutor());
+				haServices = createHighAvailabilityServices(configuration, commonRpcService.getExecutor());
 
 				blobServer = new BlobServer(configuration, haServices.createBlobStore());
 				blobServer.start();
@@ -431,6 +428,13 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 			LOG.info("Flink Mini Cluster started successfully");
 		}
+	}
+
+	protected HighAvailabilityServices createHighAvailabilityServices(Configuration configuration, Executor executor) throws Exception {
+		LOG.info("Starting high-availability services");
+		return HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
+			configuration,
+			executor);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.dispatcher.DefaultJobManagerRunnerFactory;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
@@ -400,7 +401,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					jobManagerMetricGroup,
 					metricRegistry.getMetricQueryServicePath(),
 					new MemoryArchivedExecutionGraphStore(),
-					Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE,
+					DefaultJobManagerRunnerFactory.INSTANCE,
 					new ShutDownFatalErrorHandler(),
 					historyServerArchivist);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FailingPermanentBlobService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FailingPermanentBlobService.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+/**
+ * Testing implementation of {@link PermanentBlobService} which always fails the
+ * {@link #getFile(JobID, PermanentBlobKey)} call.
+ */
+public enum FailingPermanentBlobService implements PermanentBlobService {
+	INSTANCE;
+
+	@Override
+	public File getFile(JobID jobId, PermanentBlobKey key) throws IOException {
+		throw new FileNotFoundException(String.format("Could not find file for blob key %s belonging to job %s.", key, jobId));
+	}
+
+	@Override
+	public void close() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
@@ -293,11 +293,6 @@ public class DispatcherHATest extends TestLogger {
 		return new TestingJobManagerRunnerFactory(new CompletableFuture<>(), new CompletableFuture<>(), CompletableFuture.completedFuture(null));
 	}
 
-	@Nonnull
-	private HATestingDispatcher createDispatcherWithJobManagerRunnerFactory(HighAvailabilityServices highAvailabilityServices, Dispatcher.JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
-		return createDispatcher(highAvailabilityServices, null, jobManagerRunnerFactory);
-	}
-
 	private HATestingDispatcher createDispatcher(HighAvailabilityServices haServices) throws Exception {
 		return createDispatcher(
 			haServices,
@@ -309,7 +304,7 @@ public class DispatcherHATest extends TestLogger {
 	private HATestingDispatcher createDispatcher(
 		HighAvailabilityServices highAvailabilityServices,
 		@Nullable Queue<DispatcherId> fencingTokens,
-		Dispatcher.JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
+		JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
 		final Configuration configuration = new Configuration();
 
 		return new HATestingDispatcher(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointV2;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -201,7 +200,7 @@ public class DispatcherTest extends TestLogger {
 	}
 
 	@Nonnull
-	private TestingDispatcher createAndStartDispatcher(HeartbeatServices heartbeatServices, TestingHighAvailabilityServices haServices, Dispatcher.JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
+	private TestingDispatcher createAndStartDispatcher(HeartbeatServices heartbeatServices, TestingHighAvailabilityServices haServices, JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
 		final TestingDispatcher dispatcher = createDispatcher(heartbeatServices, haServices, jobManagerRunnerFactory);
 		dispatcher.start();
 
@@ -209,7 +208,7 @@ public class DispatcherTest extends TestLogger {
 	}
 
 	@Nonnull
-	private TestingDispatcher createDispatcher(HeartbeatServices heartbeatServices, TestingHighAvailabilityServices haServices, Dispatcher.JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
+	private TestingDispatcher createDispatcher(HeartbeatServices heartbeatServices, TestingHighAvailabilityServices haServices, JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
 		return new TestingDispatcher(
 			rpcService,
 			Dispatcher.DISPATCHER_NAME + '_' + name.getMethodName(),
@@ -668,7 +667,7 @@ public class DispatcherTest extends TestLogger {
 		final InMemorySubmittedJobGraphStore submittedJobGraphStore = new InMemorySubmittedJobGraphStore();
 		haServices.setSubmittedJobGraphStore(submittedJobGraphStore);
 
-		dispatcher = createAndStartDispatcher(heartbeatServices, haServices, Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE);
+		dispatcher = createAndStartDispatcher(heartbeatServices, haServices, DefaultJobManagerRunnerFactory.INSTANCE);
 
 		// grant leadership and submit a single job
 		final DispatcherId expectedDispatcherId = DispatcherId.generate();
@@ -697,10 +696,10 @@ public class DispatcherTest extends TestLogger {
 		}
 
 		@Override
-		public JobManagerRunner createJobManagerRunner(ResourceID resourceId, JobGraph jobGraph, Configuration configuration, RpcService rpcService, HighAvailabilityServices highAvailabilityServices, HeartbeatServices heartbeatServices, JobManagerSharedServices jobManagerSharedServices, JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory, FatalErrorHandler fatalErrorHandler) throws Exception {
+		public JobManagerRunner createJobManagerRunner(JobGraph jobGraph, Configuration configuration, RpcService rpcService, HighAvailabilityServices highAvailabilityServices, HeartbeatServices heartbeatServices, JobManagerSharedServices jobManagerSharedServices, JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory, FatalErrorHandler fatalErrorHandler) throws Exception {
 			jobManagerRunnerCreationLatch.run();
 
-			return super.createJobManagerRunner(resourceId, jobGraph, configuration, rpcService, highAvailabilityServices, heartbeatServices, jobManagerSharedServices, jobManagerJobMetricGroupFactory, fatalErrorHandler);
+			return super.createJobManagerRunner(jobGraph, configuration, rpcService, highAvailabilityServices, heartbeatServices, jobManagerSharedServices, jobManagerJobMetricGroupFactory, fatalErrorHandler);
 		}
 	}
 
@@ -735,7 +734,7 @@ public class DispatcherTest extends TestLogger {
 		}
 	}
 
-	private static final class ExpectedJobIdJobManagerRunnerFactory implements Dispatcher.JobManagerRunnerFactory {
+	private static final class ExpectedJobIdJobManagerRunnerFactory implements JobManagerRunnerFactory {
 
 		private final JobID expectedJobId;
 
@@ -748,7 +747,6 @@ public class DispatcherTest extends TestLogger {
 
 		@Override
 		public JobManagerRunner createJobManagerRunner(
-				ResourceID resourceId,
 				JobGraph jobGraph,
 				Configuration configuration,
 				RpcService rpcService,
@@ -761,8 +759,7 @@ public class DispatcherTest extends TestLogger {
 
 			createdJobManagerRunnerLatch.countDown();
 
-			return Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE.createJobManagerRunner(
-				resourceId,
+			return DefaultJobManagerRunnerFactory.INSTANCE.createJobManagerRunner(
 				jobGraph,
 				configuration,
 				rpcService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -38,10 +37,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link org.apache.flink.runtime.dispatcher.Dispatcher.JobManagerRunnerFactory} implementation for
+ * {@link JobManagerRunnerFactory} implementation for
  * testing purposes.
  */
-class TestingJobManagerRunnerFactory implements Dispatcher.JobManagerRunnerFactory {
+class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
 
 	private final CompletableFuture<JobGraph> jobGraphFuture;
 	private final CompletableFuture<ArchivedExecutionGraph> resultFuture;
@@ -68,7 +67,6 @@ class TestingJobManagerRunnerFactory implements Dispatcher.JobManagerRunnerFacto
 
 	@Override
 	public JobManagerRunner createJobManagerRunner(
-			ResourceID resourceId,
 			JobGraph jobGraph,
 			Configuration configuration,
 			RpcService rpcService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ZooKeeperHADispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ZooKeeperHADispatcherTest.java
@@ -325,7 +325,7 @@ public class ZooKeeperHADispatcherTest extends TestLogger {
 	}
 
 	@Nonnull
-	private TestingDispatcher createDispatcher(HighAvailabilityServices highAvailabilityServices, Dispatcher.JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
+	private TestingDispatcher createDispatcher(HighAvailabilityServices highAvailabilityServices, JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
 		return new TestingDispatcher(
 			rpcService,
 			Dispatcher.DISPATCHER_NAME + '_' + name.getMethodName() + UUID.randomUUID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingEmbeddedHaServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingEmbeddedHaServices.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.embedded;
+
+import org.apache.flink.api.common.JobID;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@link EmbeddedHaServices} extension for testing purposes.
+ */
+public class TestingEmbeddedHaServices extends EmbeddedHaServices {
+
+	public TestingEmbeddedHaServices(Executor executor) {
+		super(executor);
+	}
+
+	public CompletableFuture<Void> revokeDispatcherLeadership() {
+		final EmbeddedLeaderService dispatcherLeaderService = getDispatcherLeaderService();
+		return dispatcherLeaderService.revokeLeadership();
+	}
+
+	public CompletableFuture<Void> grantDispatcherLeadership() {
+		final EmbeddedLeaderService dispatcherLeaderService = getDispatcherLeaderService();
+		return dispatcherLeaderService.grantLeadership();
+	}
+
+	public CompletableFuture<Void> revokeJobMasterLeadership(JobID jobId) {
+		final EmbeddedLeaderService jobMasterLeaderService = getJobManagerLeaderService(jobId);
+		return jobMasterLeaderService.revokeLeadership();
+	}
+
+	public CompletableFuture<Void> grantJobMasterLeadership(JobID jobId) {
+		final EmbeddedLeaderService jobMasterLeaderService = getJobManagerLeaderService(jobId);
+		return jobMasterLeaderService.grantLeadership();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
@@ -31,9 +31,10 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterFactory;
+import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterServiceFactory;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -51,8 +52,11 @@ import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nonnull;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -73,9 +77,11 @@ public class JobManagerRunnerTest extends TestLogger {
 
 	private static LibraryCacheManager libraryCacheManager;
 
-	private static JobMasterServiceFactory jobMasterFactory;
+	private static JobMasterServiceFactory defaultJobMasterServiceFactory;
 
 	private TestingHighAvailabilityServices haServices;
+
+	private TestingLeaderElectionService leaderElectionService;
 
 	private TestingFatalErrorHandler fatalErrorHandler;
 
@@ -86,7 +92,7 @@ public class JobManagerRunnerTest extends TestLogger {
 			FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 			new String[]{});
 
-		jobMasterFactory = TestingJobMasterFactory.INSTANCE;
+		defaultJobMasterServiceFactory = new TestingJobMasterServiceFactory();
 
 		final JobVertex jobVertex = new JobVertex("Test vertex");
 		jobVertex.setInvokableClass(NoOpInvokable.class);
@@ -100,8 +106,9 @@ public class JobManagerRunnerTest extends TestLogger {
 
 	@Before
 	public void setup() {
+		leaderElectionService = new TestingLeaderElectionService();
 		haServices = new TestingHighAvailabilityServices();
-		haServices.setJobMasterLeaderElectionService(jobGraph.getJobID(), new TestingLeaderElectionService());
+		haServices.setJobMasterLeaderElectionService(jobGraph.getJobID(), leaderElectionService);
 		haServices.setResourceManagerLeaderRetriever(new SettableLeaderRetrievalService());
 		haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
 
@@ -209,19 +216,106 @@ public class JobManagerRunnerTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the {@link JobManagerRunner} always waits for the previous leadership operation
+	 * (granting or revoking leadership) to finish before starting a new leadership operation.
+	 */
+	@Test
+	public void testConcurrentLeadershipOperationsBlockingSuspend() throws Exception {
+		final CompletableFuture<Acknowledge> suspendedFuture = new CompletableFuture<>();
+
+		TestingJobMasterServiceFactory jobMasterServiceFactory = new TestingJobMasterServiceFactory(
+			() -> new TestingJobMasterService(
+				"localhost",
+				e -> suspendedFuture));
+		JobManagerRunner jobManagerRunner = createJobManagerRunner(jobMasterServiceFactory);
+
+		jobManagerRunner.start();
+
+		leaderElectionService.isLeader(UUID.randomUUID()).get();
+
+		leaderElectionService.notLeader();
+
+		final CompletableFuture<UUID> leaderFuture = leaderElectionService.isLeader(UUID.randomUUID());
+
+		// the new leadership should wait first for the suspension to happen
+		assertThat(leaderFuture.isDone(), is(false));
+
+		try {
+			leaderFuture.get(1L, TimeUnit.MILLISECONDS);
+			fail("Granted leadership even though the JobMaster has not been suspended.");
+		} catch (TimeoutException expected) {
+			// expected
+		}
+
+		suspendedFuture.complete(Acknowledge.get());
+
+		leaderFuture.get();
+	}
+
+	/**
+	 * Tests that the {@link JobManagerRunner} always waits for the previous leadership operation
+	 * (granting or revoking leadership) to finish before starting a new leadership operation.
+	 */
+	@Test
+	public void testConcurrentLeadershipOperationsBlockingGainLeadership() throws Exception {
+		final CompletableFuture<Exception> suspendFuture = new CompletableFuture<>();
+		final CompletableFuture<Acknowledge> startFuture = new CompletableFuture<>();
+
+		TestingJobMasterServiceFactory jobMasterServiceFactory = new TestingJobMasterServiceFactory(
+			() -> new TestingJobMasterService(
+				"localhost",
+				e -> {
+					suspendFuture.complete(e);
+					return CompletableFuture.completedFuture(Acknowledge.get());
+				},
+				ignored -> startFuture));
+		JobManagerRunner jobManagerRunner = createJobManagerRunner(jobMasterServiceFactory);
+
+		jobManagerRunner.start();
+
+		leaderElectionService.isLeader(UUID.randomUUID());
+
+		leaderElectionService.notLeader();
+
+		// suspending should wait for the start to happen first
+		assertThat(suspendFuture.isDone(), is(false));
+
+		try {
+			suspendFuture.get(1L, TimeUnit.MILLISECONDS);
+			fail("Suspended leadership even though the JobMaster has not been started.");
+		} catch (TimeoutException expected) {
+			// expected
+		}
+
+		startFuture.complete(Acknowledge.get());
+
+		suspendFuture.get();
+	}
+
 	@Nonnull
 	private JobManagerRunner createJobManagerRunner(LibraryCacheManager libraryCacheManager) throws Exception {
-		return new JobManagerRunner(
-			jobGraph,
-			jobMasterFactory,
-			haServices,
-			libraryCacheManager,
-			TestingUtils.defaultExecutor(),
-			fatalErrorHandler);
+		return createJobManagerRunner(defaultJobMasterServiceFactory, libraryCacheManager);
 	}
 
 	@Nonnull
 	private JobManagerRunner createJobManagerRunner() throws Exception {
-		return createJobManagerRunner(libraryCacheManager);
+		return createJobManagerRunner(defaultJobMasterServiceFactory, libraryCacheManager);
+	}
+
+	@Nonnull
+	private JobManagerRunner createJobManagerRunner(JobMasterServiceFactory jobMasterServiceFactory) throws Exception {
+		return createJobManagerRunner(jobMasterServiceFactory, libraryCacheManager);
+	}
+
+	@Nonnull
+	private JobManagerRunner createJobManagerRunner(JobMasterServiceFactory jobMasterServiceFactory, LibraryCacheManager libraryCacheManager) throws Exception{
+		return new JobManagerRunner(
+			jobGraph,
+			jobMasterServiceFactory,
+			haServices,
+			libraryCacheManager,
+			TestingUtils.defaultExecutor(),
+			fatalErrorHandler);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterService.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Implementation of the {@link JobMasterService} for testing purposes.
+ */
+public class TestingJobMasterService implements JobMasterService {
+
+	@Nonnull
+	private final String address;
+
+	private JobMasterGateway jobMasterGateway;
+
+	public TestingJobMasterService(@Nonnull String address) {
+		this.address = address;
+	}
+
+	public TestingJobMasterService() {
+		this("localhost");
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> start(JobMasterId jobMasterId) {
+			jobMasterGateway = new TestingJobMasterGatewayBuilder().build();
+			return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> suspend(Exception cause) {
+		jobMasterGateway = null;
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
+	public JobMasterGateway getGateway() {
+		Preconditions.checkNotNull(jobMasterGateway, "TestingJobMasterService has not been started yet.");
+		return jobMasterGateway;
+	}
+
+	@Override
+	public String getAddress() {
+		return address;
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		jobMasterGateway = null;
+		return CompletableFuture.completedFuture(null);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.factories;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterService;
+import org.apache.flink.runtime.jobmaster.TestingJobMasterService;
+
+/**
+ * Testing implementation of the {@link JobMasterServiceFactory} which returns a {@link JobMaster} mock.
+ */
+public enum TestingJobMasterFactory implements JobMasterServiceFactory {
+	INSTANCE;
+
+	@Override
+	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, ClassLoader userCodeClassloader) {
+		return new TestingJobMasterService();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
@@ -24,14 +24,25 @@ import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterService;
 import org.apache.flink.runtime.jobmaster.TestingJobMasterService;
 
+import java.util.function.Supplier;
+
 /**
  * Testing implementation of the {@link JobMasterServiceFactory} which returns a {@link JobMaster} mock.
  */
-public enum TestingJobMasterFactory implements JobMasterServiceFactory {
-	INSTANCE;
+public class TestingJobMasterServiceFactory implements JobMasterServiceFactory {
+
+	private final Supplier<JobMasterService> jobMasterServiceSupplier;
+
+	public TestingJobMasterServiceFactory(Supplier<JobMasterService> jobMasterServiceSupplier) {
+		this.jobMasterServiceSupplier = jobMasterServiceSupplier;
+	}
+
+	public TestingJobMasterServiceFactory() {
+		this(TestingJobMasterService::new);
+	}
 
 	@Override
 	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, ClassLoader userCodeClassloader) {
-		return new TestingJobMasterService();
+		return jobMasterServiceSupplier.get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeStateCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeStateCleanupTest.java
@@ -19,281 +19,156 @@
 package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.TestingManualHighAvailabilityServices;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.highavailability.nonha.embedded.TestingEmbeddedHaServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.jobmanager.Tasks;
-import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.testingUtils.TestingCluster;
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobRemoved;
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunningOrFinished;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.minicluster.TestingMiniCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
-import org.junit.After;
+
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import scala.concurrent.Await;
-import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
 
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+/**
+ * Tests which verify the cluster behaviour in case of leader changes.
+ */
 public class LeaderChangeStateCleanupTest extends TestLogger {
 
-	private static Logger LOG = LoggerFactory.getLogger(LeaderChangeStateCleanupTest.class);
+	private static final int SLOTS_PER_TM = 2;
+	private static final int NUM_TMS = 2;
+	public static final int PARALLELISM = SLOTS_PER_TM * NUM_TMS;
 
-	private static FiniteDuration timeout = TestingUtils.TESTING_DURATION();
+	private static TestingMiniCluster miniCluster;
 
-	private int numJMs = 2;
-	private int numTMs = 2;
-	private int numSlotsPerTM = 2;
-	private int parallelism = numTMs * numSlotsPerTM;
+	private static TestingEmbeddedHaServices highAvailabilityServices;
+
+	private JobGraph jobGraph;
 
 	private JobID jobId;
-	private Configuration configuration;
-	private TestingManualHighAvailabilityServices highAvailabilityServices;
-	private TestingCluster cluster = null;
-	private JobGraph job = createBlockingJob(parallelism);
+
+	@BeforeClass
+	public static void setupClass() throws Exception  {
+		highAvailabilityServices = new TestingEmbeddedHaServices(TestingUtils.defaultExecutor());
+
+		miniCluster = new TestingMiniCluster(
+			new MiniClusterConfiguration.Builder()
+				.setNumSlotsPerTaskManager(SLOTS_PER_TM)
+				.setNumSlotsPerTaskManager(NUM_TMS)
+				.build(),
+			() -> highAvailabilityServices);
+
+		miniCluster.start();
+	}
 
 	@Before
-	public void before() throws Exception {
-		jobId = HighAvailabilityServices.DEFAULT_JOB_ID;
-
-		Tasks.BlockingOnceReceiver$.MODULE$.blocking_$eq(true);
-
-		configuration = new Configuration();
-
-		configuration.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, numJMs);
-		configuration.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTMs);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, numSlotsPerTM);
-
-		highAvailabilityServices = new TestingManualHighAvailabilityServices();
-
-		cluster = new TestingCluster(
-			configuration,
-			highAvailabilityServices,
-			true,
-			false);
-		cluster.start(false); // TaskManagers don't have to register at the JobManager
-
-		cluster.waitForActorsToBeAlive(); // we only wait until all actors are alive
+	public void setup() throws Exception  {
+		jobGraph = createJobGraph(PARALLELISM);
+		jobId = jobGraph.getJobID();
 	}
 
-	@After
-	public void after() {
-		if(cluster != null) {
-			cluster.stop();
+	@AfterClass
+	public static void teardownClass() throws Exception {
+		if (miniCluster != null) {
+			miniCluster.close();
 		}
 	}
 
-	/**
-	 * Tests that a job is properly canceled in the case of a leader change. In such an event all
-	 * TaskManagers have to disconnect from the previous leader and connect to the newly elected
-	 * leader.
-	 */
 	@Test
-	public void testStateCleanupAfterNewLeaderElectionAndListenerNotification() throws Exception {
-		UUID leaderSessionID1 = UUID.randomUUID();
-		UUID leaderSessionID2 = UUID.randomUUID();
+	public void testReelectionOfDispatcher() throws Exception {
+		final CompletableFuture<JobSubmissionResult> submissionFuture = miniCluster.submitJob(jobGraph);
 
-		// first make JM(0) the leader
-		highAvailabilityServices.grantLeadership(jobId, 0, leaderSessionID1);
-		// notify all listeners
-		highAvailabilityServices.notifyRetrievers(jobId, 0, leaderSessionID1);
+		submissionFuture.get();
 
-		cluster.waitForTaskManagersToBeRegistered(timeout);
+		CompletableFuture<JobResult> jobResultFuture = miniCluster.requestJobResult(jobId);
 
-		// submit blocking job so that it is not finished when we cancel it
-		cluster.submitJobDetached(job);
+		highAvailabilityServices.revokeDispatcherLeadership().get();
 
-		ActorGateway jm = cluster.getLeaderGateway(timeout);
-
-		Future<Object> wait = jm.ask(new WaitForAllVerticesToBeRunningOrFinished(job.getJobID()), timeout);
-
-		Await.ready(wait, timeout);
-
-		Future<Object> jobRemoval = jm.ask(new NotifyWhenJobRemoved(job.getJobID()), timeout);
-
-		// make the JM(1) the new leader
-		highAvailabilityServices.grantLeadership(jobId, 1, leaderSessionID2);
-		// notify all listeners about the event
-		highAvailabilityServices.notifyRetrievers(jobId, 1, leaderSessionID2);
-
-		Await.ready(jobRemoval, timeout);
-
-		cluster.waitForTaskManagersToBeRegistered(timeout);
-
-		ActorGateway jm2 = cluster.getLeaderGateway(timeout);
-
-		Future<Object> futureNumberSlots = jm2.ask(JobManagerMessages.getRequestTotalNumberOfSlots(), timeout);
-
-		// check that all TMs have registered at the new leader
-		int numberSlots = (Integer)Await.result(futureNumberSlots, timeout);
-
-		assertEquals(parallelism, numberSlots);
-
-		// try to resubmit now the non-blocking job, it should complete successfully
-		Tasks.BlockingOnceReceiver$.MODULE$.blocking_$eq(false);
-		cluster.submitJobAndWait(job, false, timeout);
-	}
-
-	/**
-	 * Tests that a job is properly canceled in the case of a leader change. However, this time only the
-	 * JMs are notified about the leader change and the TMs still believe the old leader to have
-	 * leadership.
-	 */
-	@Test
-	public void testStateCleanupAfterNewLeaderElection() throws Exception {
-		UUID leaderSessionID = UUID.randomUUID();
-		UUID newLeaderSessionID = UUID.randomUUID();
-
-		highAvailabilityServices.grantLeadership(jobId, 0, leaderSessionID);
-		highAvailabilityServices.notifyRetrievers(jobId, 0, leaderSessionID);
-
-		cluster.waitForTaskManagersToBeRegistered(timeout);
-
-		// submit blocking job so that we can test job clean up
-		cluster.submitJobDetached(job);
-
-		ActorGateway jm = cluster.getLeaderGateway(timeout);
-
-		Future<Object> wait = jm.ask(new WaitForAllVerticesToBeRunningOrFinished(job.getJobID()), timeout);
-
-		Await.ready(wait, timeout);
-
-		Future<Object> jobRemoval = jm.ask(new NotifyWhenJobRemoved(job.getJobID()), timeout);
-
-		// only notify the JMs about the new leader JM(1)
-		highAvailabilityServices.grantLeadership(jobId, 1, newLeaderSessionID);
-
-		// job should be removed anyway
-		Await.ready(jobRemoval, timeout);
-	}
-
-	/**
-	 * Tests that a job is properly canceled in the event of a leader change. However, this time
-	 * only the TMs are notified about the changing leader. This should be enough to cancel the
-	 * currently running job, though.
-	 */
-	@Test
-	public void testStateCleanupAfterListenerNotification() throws Exception {
-		UUID leaderSessionID = UUID.randomUUID();
-		UUID newLeaderSessionID = UUID.randomUUID();
-
-		highAvailabilityServices.grantLeadership(jobId, 0, leaderSessionID);
-		highAvailabilityServices.notifyRetrievers(jobId, 0, leaderSessionID);
-
-		cluster.waitForTaskManagersToBeRegistered(timeout);
-
-		// submit blocking job
-		cluster.submitJobDetached(job);
-
-		ActorGateway jm = cluster.getLeaderGateway(timeout);
-
-		Future<Object> wait = jm.ask(new WaitForAllVerticesToBeRunningOrFinished(job.getJobID()), timeout);
-
-		Await.ready(wait, timeout);
-
-		Future<Object> jobRemoval = jm.ask(new NotifyWhenJobRemoved(job.getJobID()), timeout);
-
-		// notify listeners (TMs) about the leader change
-		highAvailabilityServices.notifyRetrievers(jobId, 1, newLeaderSessionID);
-
-		Await.ready(jobRemoval, timeout);
-	}
-
-	/**
-	 * Tests that the same JobManager can be reelected as the leader. Even though, the same JM
-	 * is elected as the next leader, all currently running jobs should be canceled properly and
-	 * all TMs should disconnect from the leader and then reconnect to it.
-	 */
-	@Test
-	public void testReelectionOfSameJobManager() throws Exception {
-		UUID leaderSessionID = UUID.randomUUID();
-		UUID newLeaderSessionID = UUID.randomUUID();
-
-		FiniteDuration shortTimeout = new FiniteDuration(10, TimeUnit.SECONDS);
-
-		highAvailabilityServices.grantLeadership(jobId, 0, leaderSessionID);
-		highAvailabilityServices.notifyRetrievers(jobId, 0, leaderSessionID);
-
-		cluster.waitForTaskManagersToBeRegistered(timeout);
-
-		// submit blocking job
-		cluster.submitJobDetached(job);
-
-		ActorGateway jm = cluster.getLeaderGateway(timeout);
-
-		Future<Object> wait = jm.ask(new WaitForAllVerticesToBeRunningOrFinished(job.getJobID()), timeout);
-
-		Await.ready(wait, timeout);
-
-		Future<Object> jobRemoval = jm.ask(new NotifyWhenJobRemoved(job.getJobID()), timeout);
-
-		LOG.info("Make JM(0) again the leader. This should first revoke the leadership.");
-
-		// make JM(0) again the leader --> this implies first a leadership revocation
-		highAvailabilityServices.grantLeadership(jobId, 0, newLeaderSessionID);
-
-		Await.ready(jobRemoval, timeout);
-
-		LOG.info("Job removed.");
-
-		// The TMs should not be able to reconnect since they don't know the current leader
-		// session ID
 		try {
-			cluster.waitForTaskManagersToBeRegistered(shortTimeout);
-			fail("TaskManager should not be able to register at JobManager.");
-		} catch (TimeoutException e) {
-			// expected exception since the TMs have still the old leader session ID
+			jobResultFuture.get();
+			fail("Expected JobNotFinishedException");
+		} catch (ExecutionException ee) {
+			assertThat(ExceptionUtils.findThrowable(ee, JobNotFinishedException.class).isPresent(), is(true));
 		}
 
-		LOG.info("Notify TMs about the new (old) leader.");
+		highAvailabilityServices.grantDispatcherLeadership();
 
-		// notify the TMs about the new (old) leader
-		highAvailabilityServices.notifyRetrievers(jobId,0, newLeaderSessionID);
+		BlockingOperator.isBlocking = false;
 
-		cluster.waitForTaskManagersToBeRegistered(timeout);
+		final CompletableFuture<JobSubmissionResult> submissionFuture2 = miniCluster.submitJob(jobGraph);
 
-		ActorGateway leaderGateway = cluster.getLeaderGateway(timeout);
+		submissionFuture2.get();
 
-		// try to resubmit now the non-blocking job, it should complete successfully
-		Tasks.BlockingOnceReceiver$.MODULE$.blocking_$eq(false);
-		cluster.submitJobAndWait(job, false, timeout);
+		final CompletableFuture<JobResult> jobResultFuture2 = miniCluster.requestJobResult(jobId);
+
+		JobResult jobResult = jobResultFuture2.get();
+
+		assertThat(jobResult.isSuccess(), is(true));
 	}
 
-	public JobGraph createBlockingJob(int parallelism) {
-		Tasks.BlockingOnceReceiver$.MODULE$.blocking_$eq(true);
+	@Test
+	public void testReelectionOfJobMaster() throws Exception {
+		final CompletableFuture<JobSubmissionResult> submissionFuture = miniCluster.submitJob(jobGraph);
 
-		JobVertex sender = new JobVertex("sender");
-		JobVertex receiver = new JobVertex("receiver");
+		submissionFuture.get();
 
-		sender.setInvokableClass(Tasks.Sender.class);
-		receiver.setInvokableClass(Tasks.BlockingOnceReceiver.class);
+		CompletableFuture<JobResult> jobResultFuture = miniCluster.requestJobResult(jobId);
 
-		sender.setParallelism(parallelism);
-		receiver.setParallelism(parallelism);
+		highAvailabilityServices.revokeJobMasterLeadership(jobId).get();
 
-		receiver.connectNewDataSetAsInput(sender, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+		assertThat(jobResultFuture.isDone(), is(false));
+		BlockingOperator.isBlocking = false;
 
-		SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
-		sender.setSlotSharingGroup(slotSharingGroup);
-		receiver.setSlotSharingGroup(slotSharingGroup);
+		highAvailabilityServices.grantJobMasterLeadership(jobId);
 
-		return new JobGraph("Blocking test job", sender, receiver);
+		JobResult jobResult = jobResultFuture.get();
+
+		assertThat(jobResult.isSuccess(), is(true));
+	}
+
+	private JobGraph createJobGraph(int parallelism) {
+		BlockingOperator.isBlocking = true;
+		final JobVertex vertex = new JobVertex("blocking operator");
+		vertex.setParallelism(parallelism);
+		vertex.setInvokableClass(BlockingOperator.class);
+
+		return new JobGraph("Blocking test job", vertex);
+	}
+
+	/**
+	 * Blocking invokable which is controlled by a static field.
+	 */
+	public static class BlockingOperator extends AbstractInvokable {
+		static boolean isBlocking = true;
+
+		public BlockingOperator(Environment environment) {
+			super(environment);
+		}
+
+		@Override
+		public void invoke() throws Exception {
+			if (isBlocking) {
+				synchronized (this) {
+					while (true) {
+						wait();
+					}
+				}
+			}
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.minicluster;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * {@link MiniCluster} extension which allows to set a custom {@link HighAvailabilityServices}.
+ */
+public class TestingMiniCluster extends MiniCluster {
+
+	@Nonnull
+	private final Supplier<HighAvailabilityServices> highAvailabilityServicesSupplier;
+
+	public TestingMiniCluster(
+			MiniClusterConfiguration miniClusterConfiguration,
+			@Nonnull Supplier<HighAvailabilityServices> highAvailabilityServicesSupplier) {
+		super(miniClusterConfiguration);
+		this.highAvailabilityServicesSupplier = highAvailabilityServicesSupplier;
+	}
+
+	@Override
+	protected HighAvailabilityServices createHighAvailabilityServices(Configuration configuration, Executor executor) {
+		return highAvailabilityServicesSupplier.get();
+	}
+}

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=OFF, testlogger
+log4j.rootLogger=DEBUG, testlogger
 
 # testlogger is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=DEBUG, testlogger
+log4j.rootLogger=OFF, testlogger
 
 # testlogger is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
## What is the purpose of the change

This commit pots the LeaderChangeStateCleanupTest to the new code base. The new
tests test that revoking and granting of the leadership to the Dispatcher and the
JobMaster will leave the system in a clean state.

Moreover, this commit adds TaskExecutorTest#testDisconnectFromJobMasterWhenNewLeader which
ensures that the TaskExecutor sends a disconnect message to the JobMaster if it is notified
about a leader change.

Additionally, we test via DispatcherTest#testJobSuspensionWhenDispatcherLosesLeadership that
a job is failed if the Dispatcher loses leadership.

Introduce a `TestingMiniCluster` which allows to control the `HighAvailabilityServices`.

This PR is based on #7565.

## Verifying this change

- Executed ported tests multiple times

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
