### PR TITLE
[FLINK-11422] Prefer testing class to mock StreamTask in AbstractStre…

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/MockStreamStatusMaintainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/MockStreamStatusMaintainer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+
+/**
+ * A testing implementation of {@link StreamStatusMaintainer}.
+ */
+public class MockStreamStatusMaintainer implements StreamStatusMaintainer {
+	private StreamStatus currentStreamStatus = StreamStatus.ACTIVE;
+
+	@Override
+	public void toggleStreamStatus(StreamStatus streamStatus) {
+		if (!currentStreamStatus.equals(streamStatus)) {
+			currentStreamStatus = streamStatus;
+		}
+	}
+
+	@Override
+	public StreamStatus getStreamStatus() {
+		return currentStreamStatus;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSourceContextIdleDetectionTests.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSourceContextIdleDetectionTests.java
@@ -23,8 +23,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.CollectorOutput;
 
@@ -300,22 +298,6 @@ public class StreamSourceContextIdleDetectionTests {
 		processingTimeService.setCurrentTime(initialTime + 11 * watermarkInterval);
 		assertTrue(mockStreamStatusMaintainer.getStreamStatus().isIdle());
 		assertEquals(expectedOutput, output);
-	}
-
-	private static class MockStreamStatusMaintainer implements StreamStatusMaintainer {
-		StreamStatus currentStreamStatus = StreamStatus.ACTIVE;
-
-		@Override
-		public void toggleStreamStatus(StreamStatus streamStatus) {
-			if (!currentStreamStatus.equals(streamStatus)) {
-				currentStreamStatus = streamStatus;
-			}
-		}
-
-		@Override
-		public StreamStatus getStreamStatus() {
-			return currentStreamStatus;
-		}
 	}
 
 	@Parameterized.Parameters(name = "TestMethod = {0}")

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,8 +48,6 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for stream operator chaining behaviour.
@@ -274,18 +273,13 @@ public class StreamOperatorChainingTest {
 
 	private <IN, OT extends StreamOperator<IN>> StreamTask<IN, OT> createMockTask(
 			StreamConfig streamConfig,
-			Environment environment) {
-		final Object checkpointLock = new Object();
+			Environment environment) throws Exception {
 
-		@SuppressWarnings("unchecked")
-		StreamTask<IN, OT> mockTask = mock(StreamTask.class);
-		when(mockTask.getName()).thenReturn("Mock Task");
-		when(mockTask.getCheckpointLock()).thenReturn(checkpointLock);
-		when(mockTask.getConfiguration()).thenReturn(streamConfig);
-		when(mockTask.getEnvironment()).thenReturn(environment);
-		when(mockTask.getExecutionConfig()).thenReturn(new ExecutionConfig().enableObjectReuse());
-
-		return mockTask;
+		//noinspection unchecked
+		return new MockStreamTaskBuilder(environment)
+			.setConfig(streamConfig)
+			.setExecutionConfig(new ExecutionConfig().enableObjectReuse())
+			.build();
 	}
 
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.operators;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.execution.Environment;
@@ -34,28 +33,24 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.CollectorOutput;
+import org.apache.flink.streaming.util.MockStreamTask;
+import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doAnswer;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the emission of latency markers by {@link StreamSource} operators.
@@ -205,29 +200,18 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 		cfg.setTimeCharacteristic(TimeCharacteristic.EventTime);
 		cfg.setOperatorID(new OperatorID());
 
-		StreamStatusMaintainer streamStatusMaintainer = mock(StreamStatusMaintainer.class);
-		when(streamStatusMaintainer.getStreamStatus()).thenReturn(StreamStatus.ACTIVE);
+		try {
+			MockStreamTask mockTask = new MockStreamTaskBuilder(env)
+				.setConfig(cfg)
+				.setExecutionConfig(executionConfig)
+				.setProcessingTimeService(timeProvider)
+				.build();
 
-		StreamTask<?, ?> mockTask = mock(StreamTask.class);
-		when(mockTask.getName()).thenReturn("Mock Task");
-		when(mockTask.getCheckpointLock()).thenReturn(new Object());
-		when(mockTask.getConfiguration()).thenReturn(cfg);
-		when(mockTask.getEnvironment()).thenReturn(env);
-		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
-		when(mockTask.getAccumulatorMap()).thenReturn(Collections.<String, Accumulator<?, ?>>emptyMap());
-		when(mockTask.getStreamStatusMaintainer()).thenReturn(streamStatusMaintainer);
-
-		doAnswer(new Answer<ProcessingTimeService>() {
-			@Override
-			public ProcessingTimeService answer(InvocationOnMock invocation) throws Throwable {
-				if (timeProvider == null) {
-					throw new RuntimeException("The time provider is null.");
-				}
-				return timeProvider;
-			}
-		}).when(mockTask).getProcessingTimeService();
-
-		operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
+			operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * A settable testing {@link StreamTask}.
+ */
+public class MockStreamTask extends StreamTask {
+
+	private final String name;
+	private final Object checkpointLock;
+	private final StreamConfig config;
+	private final ExecutionConfig executionConfig;
+	private StreamTaskStateInitializer streamTaskStateInitializer;
+	private final CloseableRegistry closableRegistry;
+	private final StreamStatusMaintainer streamStatusMaintainer;
+	private final CheckpointStorage checkpointStorage;
+	private final ProcessingTimeService processingTimeService;
+	private final BiConsumer<String, Throwable> handleAsyncException;
+	private final Map<String, Accumulator<?, ?>> accumulatorMap;
+
+	public MockStreamTask(
+		Environment environment,
+		String name,
+		Object checkpointLock,
+		StreamConfig config,
+		ExecutionConfig executionConfig,
+		StreamTaskStateInitializer streamTaskStateInitializer,
+		CloseableRegistry closableRegistry,
+		StreamStatusMaintainer streamStatusMaintainer,
+		CheckpointStorage checkpointStorage,
+		ProcessingTimeService processingTimeService,
+		BiConsumer<String, Throwable> handleAsyncException,
+		Map<String, Accumulator<?, ?>> accumulatorMap
+	) {
+		super(environment);
+		this.name = name;
+		this.checkpointLock = checkpointLock;
+		this.config = config;
+		this.executionConfig = executionConfig;
+		this.streamTaskStateInitializer = streamTaskStateInitializer;
+		this.closableRegistry = closableRegistry;
+		this.streamStatusMaintainer = streamStatusMaintainer;
+		this.checkpointStorage = checkpointStorage;
+		this.processingTimeService = processingTimeService;
+		this.handleAsyncException = handleAsyncException;
+		this.accumulatorMap = accumulatorMap;
+	}
+
+	@Override
+	public void init() { }
+
+	@Override
+	protected void run() { }
+
+	@Override
+	protected void cleanup() { }
+
+	@Override
+	protected void cancelTask() { }
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public Object getCheckpointLock() {
+		return checkpointLock;
+	}
+
+	@Override
+	public StreamConfig getConfiguration() {
+		return config;
+	}
+
+	@Override
+	public Environment getEnvironment() {
+		return super.getEnvironment();
+	}
+
+	@Override
+	public ExecutionConfig getExecutionConfig() {
+		return executionConfig;
+	}
+
+	@Override
+	public StreamTaskStateInitializer createStreamTaskStateInitializer() {
+		return streamTaskStateInitializer;
+	}
+
+	public void setStreamTaskStateInitializer(StreamTaskStateInitializer streamTaskStateInitializer) {
+		this.streamTaskStateInitializer = streamTaskStateInitializer;
+	}
+
+	@Override
+	public CloseableRegistry getCancelables() {
+		return closableRegistry;
+	}
+
+	@Override
+	public StreamStatusMaintainer getStreamStatusMaintainer() {
+		return streamStatusMaintainer;
+	}
+
+	@Override
+	public CheckpointStorage getCheckpointStorage() {
+		return checkpointStorage;
+	}
+
+	@Override
+	public ProcessingTimeService getProcessingTimeService() {
+		return processingTimeService;
+	}
+
+	@Override
+	public void handleAsyncException(String message, Throwable exception) {
+		handleAsyncException.accept(message, exception);
+	}
+
+	@Override
+	public Map<String, Accumulator<?, ?>> getAccumulatorMap() {
+		return accumulatorMap;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.MockStreamStatusMaintainer;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * A builder of {@link MockStreamTask}.
+ */
+public class MockStreamTaskBuilder {
+	private final Environment environment;
+	private String name = "Mock Task";
+	private Object checkpointLock = new Object();
+	private StreamConfig config = new StreamConfig(new Configuration());
+	private ExecutionConfig executionConfig = new ExecutionConfig();
+	private CloseableRegistry closableRegistry = new CloseableRegistry();
+	private StreamStatusMaintainer streamStatusMaintainer = new MockStreamStatusMaintainer();
+	private CheckpointStorage checkpointStorage;
+	private ProcessingTimeService processingTimeService = new TestProcessingTimeService();
+	private StreamTaskStateInitializer streamTaskStateInitializer;
+	private BiConsumer<String, Throwable> handleAsyncException = (message, throwable) -> { };
+	private Map<String, Accumulator<?, ?>> accumulatorMap = Collections.emptyMap();
+
+	public MockStreamTaskBuilder(Environment environment) throws Exception {
+		this.environment = environment;
+
+		StateBackend stateBackend = new MemoryStateBackend();
+		this.checkpointStorage = stateBackend.createCheckpointStorage(new JobID());
+		this.streamTaskStateInitializer = new StreamTaskStateInitializerImpl(environment, stateBackend, processingTimeService);
+	}
+
+	public MockStreamTaskBuilder setName(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setCheckpointLock(Object checkpointLock) {
+		this.checkpointLock = checkpointLock;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setConfig(StreamConfig config) {
+		this.config = config;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setExecutionConfig(ExecutionConfig executionConfig) {
+		this.executionConfig = executionConfig;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setStreamTaskStateInitializer(StreamTaskStateInitializer streamTaskStateInitializer) {
+		this.streamTaskStateInitializer = streamTaskStateInitializer;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setClosableRegistry(CloseableRegistry closableRegistry) {
+		this.closableRegistry = closableRegistry;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setStreamStatusMaintainer(StreamStatusMaintainer streamStatusMaintainer) {
+		this.streamStatusMaintainer = streamStatusMaintainer;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setCheckpointStorage(CheckpointStorage checkpointStorage) {
+		this.checkpointStorage = checkpointStorage;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setProcessingTimeService(ProcessingTimeService processingTimeService) {
+		this.processingTimeService = processingTimeService;
+		return this;
+	}
+
+	public MockStreamTaskBuilder setHandleAsyncException(BiConsumer<String, Throwable> handleAsyncException) {
+		this.handleAsyncException = handleAsyncException;
+		return this;
+	}
+
+	public MockStreamTask build() {
+		return new MockStreamTask(
+			environment,
+			name,
+			checkpointLock,
+			config,
+			executionConfig,
+			streamTaskStateInitializer,
+			closableRegistry,
+			streamStatusMaintainer,
+			checkpointStorage,
+			processingTimeService,
+			handleAsyncException,
+			accumulatorMap);
+	}
+}


### PR DESCRIPTION
…amOperatorTestHarness

## What is the purpose of the change

As title, we prefer using a testing class to a mockito mock.

## Brief change log

Introduce an inner class `MockStreamTask` and replace mock StreamTask with it.

## Verifying this change

This change is already covered by existing tests that using StreamOperatorTestHarness.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @pnowojski 
