### PR TITLE
[FLINK-11418][docs] Fix version of bundler to 1.16.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,11 +12,11 @@ dependencies are installed locally when you build the documentation through the
 `build_docs.sh` script. If you want to install the software manually, use Ruby's
 Bundler Gem to install all dependencies:
 
-    gem install bundler
+    gem install bundler -v 1.16.1
     bundle install
 
-Note that in Ubuntu based systems, it may be necessary to install the `ruby-dev`
-via apt to build native code.
+Note that in Ubuntu based systems, it may be necessary to install the following
+packages `rubygems ruby-dev libssl-dev build-essential`.
 
 # Using Dockerized Jekyll
 
@@ -29,7 +29,8 @@ cd flink/docs/docker
 ```
 
 It takes a few moment to build the image for the first time, but will be a second from the second time.
-The run.sh command brings you in a bash session where you can run following doc commands.
+The run.sh command brings you in a bash session where you run the `./build_docs.sh` script mentioned above.
+
 
 # Build
 

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -27,5 +27,5 @@ RUN set -ex; \
     gcc-c++ \
     python-setuptools \
   ; \
-  gem install bundler; \
+  gem install bundler -v 1.16.1; \
   dnf clean all


### PR DESCRIPTION
## What is the purpose of the change

It is currently not possible to build the docs on OS X Mojave, following the instructions from the readme.
Also, the provided Dockerfile does not result in a working build environment.


## Brief change log

- Update `docs/README.md`
- Update the `Dockerfile`


## Verifying this change
- go into the `docs/docker` directory and run `./run.sh` to build the image.
- in the image, run `build_docs.sh`
