### PR TITLE
[hotfix] Remove redundant word in BarrierBuffer comment

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -187,7 +187,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 
 			BufferOrEvent bufferOrEvent = next.get();
 			if (isBlocked(bufferOrEvent.getChannelIndex())) {
-				// if the channel is blocked we, we just store the BufferOrEvent
+				// if the channel is blocked, we just store the BufferOrEvent
 				bufferBlocker.add(bufferOrEvent);
 				checkSizeLimit();
 			}


### PR DESCRIPTION


## What is the purpose of the change

Remove redundant word 'we' in BarrierBuffer.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? no)
  - If yes, how is the feature documented? (not documented)
