### PR TITLE
[FLINK-9142] Lower the minimum number of buffers for incoming channels to 1

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -100,12 +100,12 @@
         <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
-            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
+            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel). It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
             <td style="word-wrap: break-word;">8</td>
-            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
+            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.fraction</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -292,9 +292,8 @@ public class TaskManagerOptions {
 			key("taskmanager.network.memory.buffers-per-channel")
 			.defaultValue(2)
 			.withDescription("Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel)." +
-				"In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be" +
-				" configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is" +
-				" for parallel serialization.");
+				" It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition" +
+				" and 1 buffer is for parallel serialization.");
 
 	/**
 	 * Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).
@@ -303,7 +302,6 @@ public class TaskManagerOptions {
 			key("taskmanager.network.memory.floating-buffers-per-gate")
 			.defaultValue(8)
 			.withDescription("Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate)." +
-				" In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels." +
 				" The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can" +
 				" help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be" +
 				" increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -264,11 +264,15 @@ public class NetworkEnvironment {
 		int maxNumberOfMemorySegments;
 		try {
 			if (enableCreditBased) {
+				Preconditions.checkArgument(networkBuffersPerChannel > 0,
+					"In credit-based flow control mode, networkBuffersPerChannel must be configured greater than 0.");
 				maxNumberOfMemorySegments = gate.getConsumedPartitionType().isBounded() ?
-					extraNetworkBuffersPerGate : Integer.MAX_VALUE;
+					gate.getNumberOfInputChannels() * (networkBuffersPerChannel - 1) +
+						extraNetworkBuffersPerGate : Integer.MAX_VALUE;
 
 				// assign exclusive buffers to input channels directly and use the rest for floating buffers
-				gate.assignExclusiveSegments(networkBufferPool, networkBuffersPerChannel);
+				// (see FLINK-9142)
+				gate.assignExclusiveSegments(networkBufferPool, 1);
 				bufferPool = networkBufferPool.createBufferPool(0, maxNumberOfMemorySegments);
 			} else {
 				maxNumberOfMemorySegments = gate.getConsumedPartitionType().isBounded() ?

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -416,12 +416,11 @@ public class SingleInputGateTest {
 				RemoteInputChannel remote = (RemoteInputChannel) inputGate.getInputChannels()
 					.get(resultPartitionId.getPartitionId());
 				// only the exclusive buffers should be assigned/available now
-				assertEquals(buffersPerChannel, remote.getNumberOfAvailableBuffers());
-
-				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - buffersPerChannel,
+				assertEquals(1, remote.getNumberOfAvailableBuffers());
+				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - 1,
 					bufferPool.getNumberOfAvailableMemorySegments());
 				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
-				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
+				assertEquals(buffersPerChannel - 1 + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			} else {
 				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			}
@@ -454,7 +453,7 @@ public class SingleInputGateTest {
 				assertEquals(bufferPool.getTotalNumberOfMemorySegments(),
 					bufferPool.getNumberOfAvailableMemorySegments());
 				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
-				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
+				assertEquals(buffersPerChannel - 1 + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			} else {
 				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			}
@@ -469,12 +468,11 @@ public class SingleInputGateTest {
 				RemoteInputChannel remote = (RemoteInputChannel) inputGate.getInputChannels()
 					.get(resultPartitionId.getPartitionId());
 				// only the exclusive buffers should be assigned/available now
-				assertEquals(buffersPerChannel, remote.getNumberOfAvailableBuffers());
-
-				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - buffersPerChannel,
+				assertEquals(1, remote.getNumberOfAvailableBuffers());
+				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - 1,
 					bufferPool.getNumberOfAvailableMemorySegments());
 				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
-				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
+				assertEquals(buffersPerChannel - 1 + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			} else {
 				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.streaming.runtime.io.benchmark;
 
-import org.apache.flink.configuration.TaskManagerOptions;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -82,7 +80,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 		expectedException.expect(IOException.class);
 		expectedException.expectMessage("Insufficient number of network buffers");
 
-		env.setUp(writers, channels, 100, false, writers * channels - 1, writers * channels * TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue());
+		env.setUp(writers, channels, 100, false, writers * channels - 1, writers * channels);
 	}
 
 	@Test
@@ -94,7 +92,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 		expectedException.expect(IOException.class);
 		expectedException.expectMessage("Insufficient number of network buffers");
 
-		env.setUp(writers, channels, 100, false, writers * channels, writers * channels * TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue() - 1);
+		env.setUp(writers, channels, 100, false, writers * channels, writers * channels - 1);
 	}
 
 	@Test
@@ -103,8 +101,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 		int writers = 2;
 		int channels = 2;
 
-		env.setUp(writers, channels, 100, false, writers * channels, writers * channels *
-			TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue());
+		env.setUp(writers, channels, 100, false, writers * channels, writers * channels);
 		env.executeBenchmark(10_000);
 		env.tearDown();
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -62,7 +62,7 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
 		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
-		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 800);
+		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 600);
 		return config;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request lower the minimum number of buffers for incoming channels to 1.

## Brief change log

  - Just update `NetworkEnvironment#setupInputGate` to achieve this.

## Verifying this change

  - Update `NetworkEnvironmentTest` to test this change.
  - Update `SingleInputGateTest` to test this change.
  - Update `StreamNetworkThroughputBenchmarkTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
