### PR TITLE
[FLINK-11424][metrics]fix remove error type Gauge in DatadogHttpReporter

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -117,6 +117,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	@Override
 	public void report() {
 		DatadogHttpRequest request = new DatadogHttpRequest();
+
 		List<Gauge> gaugesToRemove = new ArrayList<>();
 		for (Map.Entry<Gauge, DGauge> entry : gauges.entrySet()) {
 			DGauge g = entry.getValue();
@@ -129,13 +130,16 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				LOGGER.info("The Gauge {} will not be reported because only number types are supported by this reporter.", g.getMetric());
 				gaugesToRemove.add(entry.getKey());
 			} catch (Exception e) {
-				LOGGER.info("The Gauge {} will not be reported because it threw an exception.", g.getMetric());
-				LOGGER.warn("Failed add gauge metric.", e);
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("The Gauge {} will not be reported because it threw an exception.", g.getMetric(), e);
+				} else {
+					LOGGER.info("The Gauge {} will not be reported because it threw an exception.", g.getMetric());
+				}
 				gaugesToRemove.add(entry.getKey());
 			}
 		}
-		// Remove that Gauge if it's not of Number type
 		gaugesToRemove.forEach(gauges::remove);
+
 		for (DCounter c : counters.values()) {
 			request.addCounter(c);
 		}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -117,7 +117,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	@Override
 	public void report() {
 		DatadogHttpRequest request = new DatadogHttpRequest();
-		List<Gauge> notNumberGauges = new ArrayList<>();
+		List<Gauge> gaugesToRemove = new ArrayList<>();
 		for (Map.Entry<Gauge, DGauge> entry : gauges.entrySet()) {
 			DGauge g = entry.getValue();
 			try {
@@ -126,14 +126,12 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				g.getMetricValue();
 				request.addGauge(g);
 			} catch (Exception e) {
-				LOGGER.warn("the Gauge {} is not of Number type", g.getMetric());
-				notNumberGauges.add(entry.getKey());
+				LOGGER.info("The Gauge {} will not be reported because only number types are supported by this reporter.", g.getMetric());
+				gaugesToRemove.add(entry.getKey());
 			}
 		}
 		// Remove that Gauge if it's not of Number type
-		if (!notNumberGauges.isEmpty()) {
-			notNumberGauges.stream().forEach(g -> gauges.remove(g));
-		}
+		gaugesToRemove.forEach(gauges::remove);
 		for (DCounter c : counters.values()) {
 			request.addCounter(c);
 		}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -117,7 +117,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	@Override
 	public void report() {
 		DatadogHttpRequest request = new DatadogHttpRequest();
-		List<Gauge> notNumberGauge = new ArrayList<>();
+		List<Gauge> notNumberGauges = new ArrayList<>();
 		for (Map.Entry<Gauge, DGauge> entry : gauges.entrySet()) {
 			DGauge g = entry.getValue();
 			try {
@@ -127,12 +127,12 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				request.addGauge(g);
 			} catch (Exception e) {
 				LOGGER.warn("the Gauge {} is not of Number type", g.getMetric());
-				notNumberGauge.add(entry.getKey());
+				notNumberGauges.add(entry.getKey());
 			}
 		}
 		// Remove that Gauge if it's not of Number type
-		if (!notNumberGauge.isEmpty()) {
-			notNumberGauge.stream().forEach(g -> gauges.remove(g));
+		if (!notNumberGauges.isEmpty()) {
+			notNumberGauges.stream().forEach(g -> gauges.remove(g));
 		}
 		for (DCounter c : counters.values()) {
 			request.addCounter(c);

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -117,7 +117,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	@Override
 	public void report() {
 		DatadogHttpRequest request = new DatadogHttpRequest();
-
+		List<Gauge> notNumberGauge = new ArrayList<>();
 		for (Map.Entry<Gauge, DGauge> entry : gauges.entrySet()) {
 			DGauge g = entry.getValue();
 			try {
@@ -126,11 +126,14 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				g.getMetricValue();
 				request.addGauge(g);
 			} catch (Exception e) {
-				// Remove that Gauge if it's not of Number type
-				gauges.remove(entry.getKey());
+				LOGGER.warn("the Gauge {} is not of Number type", g.getMetric());
+				notNumberGauge.add(entry.getKey());
 			}
 		}
-
+		// Remove that Gauge if it's not of Number type
+		if (!notNumberGauge.isEmpty()) {
+			notNumberGauge.stream().forEach(g -> gauges.remove(g));
+		}
 		for (DCounter c : counters.values()) {
 			request.addCounter(c);
 		}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -125,8 +125,12 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				// Flink uses Gauge to store many types other than Number
 				g.getMetricValue();
 				request.addGauge(g);
-			} catch (Exception e) {
+			} catch (ClassCastException e) {
 				LOGGER.info("The Gauge {} will not be reported because only number types are supported by this reporter.", g.getMetric());
+				gaugesToRemove.add(entry.getKey());
+			} catch (Exception e) {
+				LOGGER.info("The Gauge {} will not be reported because it threw an exception.", g.getMetric());
+				LOGGER.warn("Failed add gauge metric.", e);
 				gaugesToRemove.add(entry.getKey());
 			}
 		}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -127,13 +127,13 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				g.getMetricValue();
 				request.addGauge(g);
 			} catch (ClassCastException e) {
-				LOGGER.info("The Gauge {} will not be reported because only number types are supported by this reporter.", g.getMetric());
+				LOGGER.info("The metric {} will not be reported because only number types are supported by this reporter.", g.getMetric());
 				gaugesToRemove.add(entry.getKey());
 			} catch (Exception e) {
 				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("The Gauge {} will not be reported because it threw an exception.", g.getMetric(), e);
+					LOGGER.debug("The metric {} will not be reported because it threw an exception.", g.getMetric(), e);
 				} else {
-					LOGGER.info("The Gauge {} will not be reported because it threw an exception.", g.getMetric());
+					LOGGER.info("The metric {} will not be reported because it threw an exception.", g.getMetric());
 				}
 				gaugesToRemove.add(entry.getKey());
 			}


### PR DESCRIPTION
## What is the purpose of the change
- fix DatadogHttpReporter remove error type Gauge bug

## Brief change log

- add notNumberGauges for error type Gauge


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
