### PR TITLE
[FLINK-11419][filesystem] For recovery, wait until lease is revoked before truncate file

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -86,6 +86,8 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 		this.targetFile = checkNotNull(recoverable.targetFile());
 		this.tempFile = checkNotNull(recoverable.tempFile());
 
+		waitUntilLeaseIsRevoked(tempFile);
+
 		// truncate back and append
 		try {
 			truncate(fs, tempFile, recoverable.offset());
@@ -93,7 +95,6 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 			throw new IOException("Missing data in tmp file: " + tempFile, e);
 		}
 
-		waitUntilLeaseIsRevoked(tempFile);
 		out = fs.append(tempFile);
 
 		// sanity check

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -89,10 +89,16 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 		waitUntilLeaseIsRevoked(tempFile);
 
 		// truncate back and append
+		boolean truncated;
 		try {
-			truncate(fs, tempFile, recoverable.offset());
+			truncated = truncate(fs, tempFile, recoverable.offset());
 		} catch (Exception e) {
 			throw new IOException("Missing data in tmp file: " + tempFile, e);
+		}
+
+		if (!truncated) {
+			// Truncate did not complete immediately, we must wait for the operation to complete and release the lease
+			waitUntilLeaseIsRevoked(tempFile);
 		}
 
 		out = fs.append(tempFile);
@@ -174,10 +180,10 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 		}
 	}
 
-	static void truncate(FileSystem hadoopFs, Path file, long length) throws IOException {
+	static boolean truncate(FileSystem hadoopFs, Path file, long length) throws IOException {
 		if (truncateHandle != null) {
 			try {
-				truncateHandle.invoke(hadoopFs, file, length);
+				return (Boolean) truncateHandle.invoke(hadoopFs, file, length);
 			}
 			catch (InvocationTargetException e) {
 				ExceptionUtils.rethrowIOException(e.getTargetException());
@@ -191,6 +197,7 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 		else {
 			throw new IllegalStateException("Truncation handle has not been initialized");
 		}
+		return true;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This pull request performs the truncate of the hadoop file only after waiting for the lease to be revoked.

## Brief change log
- When resuming execution after a failure, wait until lease is revoked before performing truncate on the file.

## Verifying this change

This change is already covered by existing tests, such as `testRecoverWithState`, `testRecoverAfterMultiplePersistsState`, etc in AbstractRecoverableWriterTest class.

An additional integration test could be added to test the case when this is used with a StreamingFileSink and simulate a taskmanager failure (?)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
