### PR TITLE
[FLINK-10076][table] Upgrade Calcite dependency to 1.18

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -229,7 +229,6 @@ public class LocalExecutorITCase extends TestLogger {
 		final SessionContext session = new SessionContext("test-session", new Environment());
 
 		final List<String> expectedTableHints = Arrays.asList(
-			"TABLE",
 			"TableNumber1",
 			"TableNumber2",
 			"TableSourceSink");
@@ -238,7 +237,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final List<String> expectedClause = Collections.singletonList("WHERE");
 		assertEquals(expectedClause, executor.completeStatement(session, "SELECT * FROM TableNumber2 WH", 29));
 
-		final List<String> expectedField = Arrays.asList("INTERVAL", "IntegerField1");
+		final List<String> expectedField = Arrays.asList("IntegerField1");
 		assertEquals(expectedField, executor.completeStatement(session, "SELECT * FROM TableNumber1 WHERE Inte", 37));
 	}
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -16,7 +16,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -56,6 +56,47 @@ under the License.
 				<groupId>org.codehaus.janino</groupId>
 				<artifactId>janino</artifactId>
 				<version>${janino.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.9.6</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.9.6</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.9.6</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-annotations</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-yaml</artifactId>
+				<version>2.9.6</version>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>2.4.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -114,7 +155,7 @@ under the License.
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
 			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
-			<version>1.17.0</version>
+			<version>1.18.0</version>
 			<exclusions>
 				<!-- Dependencies that are not needed for how we use Calcite right now -->
 				<exclusion>
@@ -122,16 +163,8 @@ under the License.
 					<artifactId>avatica-metrics</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
+					<groupId>com.fasterxml.jackson.dataformat</groupId>
+					<artifactId>jackson-dataformat-yaml</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.google.protobuf</groupId>
@@ -277,6 +310,7 @@ under the License.
 										<exclude>digesterRules.xml</exclude>
 										<!-- not relocated for now, because it is needed by Calcite -->
 										<!--<exclude>org.codehaus.commons.compiler.properties</exclude>-->
+										<!--<exclude>com.fasterxml.jackson.*</exclude>-->
 									</excludes>
 								</filter>
 							</filters>
@@ -288,6 +322,8 @@ under the License.
 									<!-- Calcite's dependencies -->
 									<include>com.google.guava:guava</include>
 									<include>net.hydromatic:*</include>
+									<include>com.fasterxml.jackson.*:*</include>
+									<include>com.jayway.jsonpath:*</include>
 
 									<!-- flink-table-planner dependencies -->
 									<include>org.codehaus.janino:*</include>

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -20,5 +20,5 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details
 
-- org.codehaus.janino:janino:3.0.7
-- org.codehaus.janino:commons-compiler:3.0.7
+- org.codehaus.janino:janino:3.0.9
+- org.codehaus.janino:commons-compiler:3.0.9

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -7,6 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.guava:guava:19.0
+- com.fasterxml.jackson.core:jackson-annotations:2.9.6
+- com.fasterxml.jackson.core:jackson-core:2.9.6
+- com.fasterxml.jackson.core:jackson-databind:2.9.6
+- com.jayway.jsonpath:json-path:2.4.0
 - joda-time:joda-time:2.5
 - net.hydromatic:aggdesigner-algorithm:6.0
 - org.apache.calcite:calcite-core:1.17.0

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -807,7 +807,7 @@ abstract class StreamTableEnvironment(
   private[flink] def optimize(relNode: RelNode, updatesAsRetraction: Boolean): RelNode = {
     val convSubQueryPlan = optimizeConvertSubQueries(relNode)
     val expandedPlan = optimizeExpandPlan(convSubQueryPlan)
-    val decorPlan = RelDecorrelator.decorrelateQuery(expandedPlan)
+    val decorPlan = RelDecorrelator.decorrelateQuery(expandedPlan, getRelBuilder)
     val planWithMaterializedTimeAttributes =
       RelTimeIndicatorConverter.convert(decorPlan, getRelBuilder.getRexBuilder)
     val normalizedPlan = optimizeNormalizeLogicalPlan(planWithMaterializedTimeAttributes)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -46,7 +46,7 @@ import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment =>
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecEnv}
 import org.apache.flink.table.api.java.{BatchTableEnvironment => JavaBatchTableEnv, StreamTableEnvironment => JavaStreamTableEnv}
 import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv, StreamTableEnvironment => ScalaStreamTableEnv}
-import org.apache.flink.table.calcite.{FlinkPlannerImpl, FlinkRelBuilder, FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.calcite._
 import org.apache.flink.table.catalog.{ExternalCatalog, ExternalCatalogSchema}
 import org.apache.flink.table.codegen.{ExpressionReducer, FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.descriptors.{ConnectorDescriptor, TableDescriptor}
@@ -132,6 +132,7 @@ abstract class TableEnvironment(val config: TableConfig) {
           .withTrimUnusedFields(false)
           .withConvertTableAccess(false)
           .withInSubQueryThreshold(Integer.MAX_VALUE)
+          .withRelBuilderFactory(FlinkRelBuilderFactory)
           .build()
 
       case Some(c) => c

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -76,7 +76,7 @@ class FlinkPlannerImpl(
       createCatalogReader(true), // ignore cases for lenient completion
       typeFactory,
       config.getParserConfig.conformance())
-    val advisor = new SqlAdvisor(advisorValidator)
+    val advisor = new SqlAdvisor(advisorValidator, config.getParserConfig)
     val replaced = Array[String](null)
     val hints = advisor.getCompletionHints(sql, cursor, replaced)
       .map(item => item.toIdentifier.toString)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
@@ -52,6 +52,8 @@ class FlinkRelBuilder(
 
   def getCluster: RelOptCluster = relOptCluster
 
+  override def shouldMergeProject(): Boolean = false
+
   override def getTypeFactory: FlinkTypeFactory =
     super.getTypeFactory.asInstanceOf[FlinkTypeFactory]
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilderFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilderFactory.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import org.apache.calcite.plan.{Context, Contexts, RelOptCluster, RelOptSchema}
+import org.apache.calcite.rel.core.RelFactories
+import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider
+import org.apache.calcite.tools.{RelBuilder, RelBuilderFactory}
+import org.apache.flink.table.plan.cost.FlinkDefaultRelMetadataProvider
+import RelFactories._
+/**
+  * The utility class is to create special [[RelBuilder]] instance
+  * this factory ignores merge projection operations.
+  */
+object FlinkRelBuilderFactory extends RelBuilderFactory {
+
+  val context: Context = Contexts.of(Array[AnyRef](
+    DEFAULT_PROJECT_FACTORY,
+    DEFAULT_FILTER_FACTORY,
+    DEFAULT_JOIN_FACTORY,
+    DEFAULT_SEMI_JOIN_FACTORY,
+    DEFAULT_SORT_FACTORY,
+    DEFAULT_EXCHANGE_FACTORY,
+    DEFAULT_SORT_EXCHANGE_FACTORY,
+    DEFAULT_AGGREGATE_FACTORY,
+    DEFAULT_MATCH_FACTORY,
+    DEFAULT_SET_OP_FACTORY,
+    DEFAULT_VALUES_FACTORY,
+    DEFAULT_TABLE_SCAN_FACTORY))
+
+  override def create(relOptCluster: RelOptCluster, relOptSchema: RelOptSchema): RelBuilder = {
+    new FlinkRelBuilder(context, relOptCluster, relOptSchema)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/utils/AggSqlFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/utils/AggSqlFunction.scala
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.`type`._
 import org.apache.calcite.sql.`type`.SqlOperandTypeChecker.Consistency
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.sql.validate.SqlUserDefinedAggFunction
+import org.apache.calcite.util.Optionality
 import org.apache.flink.api.common.typeinfo._
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.calcite.FlinkTypeFactory
@@ -63,6 +64,7 @@ class AggSqlFunction(
     null,
     false,
     requiresOver,
+    Optionality.FORBIDDEN,
     typeFactory
   ) {
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/TimeIndicatorRelDataType.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/TimeIndicatorRelDataType.scala
@@ -34,6 +34,10 @@ class TimeIndicatorRelDataType(
     originalType.getSqlTypeName,
     originalType.getPrecision) {
 
+  override def computeDigest(): Unit = {
+    this.digest = toString
+  }
+
   override def equals(other: Any): Boolean = other match {
     case that: TimeIndicatorRelDataType =>
       super.equals(that) &&

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/GroupWindowTest.scala
@@ -326,26 +326,22 @@ class GroupWindowTest extends TableTestBase {
           unaryNode(
             "DataSetCalc",
             batchTableNode(0),
-            term("select", "rowtime", "c",
-              "*(c, c) AS $f2", "*(c, c) AS $f3", "*(c, c) AS $f4", "*(c, c) AS $f5")
+            term("select", "rowtime", "c", "*(c, c) AS $f2")
           ),
           term("window", TumblingGroupWindow('w$, 'rowtime, 900000.millis)),
           term("select",
             "SUM($f2) AS $f0",
             "SUM(c) AS $f1",
             "COUNT(c) AS $f2",
-            "SUM($f3) AS $f3",
-            "SUM($f4) AS $f4",
-            "SUM($f5) AS $f5",
             "start('w$) AS w$start",
             "end('w$) AS w$end",
             "rowtime('w$) AS w$rowtime")
         ),
         term("select",
-          "CAST(/(-($f0, /(*($f1, $f1), $f2)), $f2)) AS EXPR$0",
-          "CAST(/(-($f3, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1)))) AS EXPR$1",
-          "CAST(POWER(/(-($f4, /(*($f1, $f1), $f2)), $f2), 0.5)) AS EXPR$2",
-          "CAST(POWER(/(-($f5, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
+          "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS EXPR$0",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS EXPR$1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS EXPR$2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
             "AS EXPR$3",
           "CAST(w$start) AS EXPR$4",
           "CAST(w$end) AS EXPR$5")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/GroupWindowTest.scala
@@ -468,25 +468,21 @@ class GroupWindowTest extends TableTestBase {
           unaryNode(
             "DataSetCalc",
             batchTableNode(0),
-            term("select", "c", "rowtime",
-              "*(c, c) AS $f2", "*(c, c) AS $f3", "*(c, c) AS $f4", "*(c, c) AS $f5")
+            term("select", "c", "rowtime", "*(c, c) AS $f2")
           ),
           term("window", TumblingGroupWindow('w, 'rowtime, 900000.millis)),
           term("select",
             "SUM($f2) AS $f0",
             "SUM(c) AS $f1",
             "COUNT(c) AS $f2",
-            "SUM($f3) AS $f3",
-            "SUM($f4) AS $f4",
-            "SUM($f5) AS $f5",
             "start('w) AS TMP_4",
             "end('w) AS TMP_5")
         ),
         term("select",
-          "CAST(/(-($f0, /(*($f1, $f1), $f2)), $f2)) AS TMP_0",
-          "CAST(/(-($f3, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1)))) AS TMP_1",
-          "CAST(POWER(/(-($f4, /(*($f1, $f1), $f2)), $f2), 0.5)) AS TMP_2",
-          "CAST(POWER(/(-($f5, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
+          "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS TMP_0",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS TMP_1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS TMP_2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
             "AS TMP_3",
           "TMP_4",
           "TMP_5")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/SetOperatorsTest.scala
@@ -71,7 +71,7 @@ class SetOperatorsTest extends TableTestBase {
     val expected = unaryNode(
       "DataSetCalc",
       batchTableNode(0),
-      term("select", "IN(b, 1972-02-22 07:12:00.333) AS b2")
+      term("select", "IN(b, CAST('1972-02-22 07:12:00.333')) AS b2")
     )
 
     util.verifyTable(in, expected)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/GroupWindowTest.scala
@@ -279,27 +279,23 @@ class GroupWindowTest extends TableTestBase {
           unaryNode(
             "DataStreamCalc",
             streamTableNode(0),
-            term("select", "rowtime", "c",
-              "*(c, c) AS $f2", "*(c, c) AS $f3", "*(c, c) AS $f4", "*(c, c) AS $f5")
+            term("select", "rowtime", "c", "*(c, c) AS $f2")
           ),
           term("window", TumblingGroupWindow('w$, 'rowtime, 900000.millis)),
           term("select",
             "SUM($f2) AS $f0",
             "SUM(c) AS $f1",
             "COUNT(c) AS $f2",
-            "SUM($f3) AS $f3",
-            "SUM($f4) AS $f4",
-            "SUM($f5) AS $f5",
             "start('w$) AS w$start",
             "end('w$) AS w$end",
             "rowtime('w$) AS w$rowtime",
             "proctime('w$) AS w$proctime")
         ),
         term("select",
-          "CAST(/(-($f0, /(*($f1, $f1), $f2)), $f2)) AS EXPR$0",
-          "CAST(/(-($f3, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1)))) AS EXPR$1",
-          "CAST(POWER(/(-($f4, /(*($f1, $f1), $f2)), $f2), 0.5)) AS EXPR$2",
-          "CAST(POWER(/(-($f5, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
+          "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS EXPR$0",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS EXPR$1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS EXPR$2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
             "AS EXPR$3",
           "w$start AS EXPR$4",
           "w$end AS EXPR$5")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/OverWindowTest.scala
@@ -71,8 +71,8 @@ class OverWindowTest extends TableTestBase {
           term("select", "a", "b", "c", "proctime", "COUNT(a) AS w0$o0, $SUM0(a) AS w0$o1, " +
             "COUNT(DISTINCT a) AS w0$o2, COUNT(DISTINCT c) AS w0$o3, $SUM0(DISTINCT c) AS w0$o4")
         ),
-        term("select", "b", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), CAST(w0$o1), null) AS sum1, " +
-          "w0$o2 AS cnt2, CASE(>(w0$o3, 0), CAST(w0$o4), null) AS sum2")
+        term("select", "b", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), w0$o1, null) AS sum1, " +
+          "w0$o2 AS cnt2, CASE(>(w0$o3, 0), w0$o4, null) AS sum2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -112,7 +112,7 @@ class OverWindowTest extends TableTestBase {
           term("select", "a", "c", "proctime",
             "COUNT(DISTINCT a) AS w0$o0, $SUM0(DISTINCT a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), CAST(w0$o1), null) AS sum1")
+        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), w0$o1, null) AS sum1")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -151,7 +151,7 @@ class OverWindowTest extends TableTestBase {
           term("rows", "BETWEEN 2 PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "proctime", "COUNT(a) AS w0$o0, $SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), CAST(w0$o1), null) AS sum1")
+        term("select", "c", "w0$o0 AS cnt1, CASE(>(w0$o0, 0), w0$o1, null) AS sum1")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -312,7 +312,7 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "proctime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "CAST(w0$o1), null) AS cnt2")
+        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -378,7 +378,7 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "proctime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "CAST(w0$o1), null) AS cnt2")
+        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -553,7 +553,7 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "rowtime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "CAST(w0$o1), null) AS cnt2")
+        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -593,7 +593,7 @@ class OverWindowTest extends TableTestBase {
           "c",
           "w0$o0 AS cnt1",
           "CASE(>(w0$o0, 0)",
-          "CAST(w0$o1), null) AS cnt2"
+          "w0$o1, null) AS cnt2"
         )
       )
     streamUtil.verifySql(sql, expected)
@@ -621,7 +621,7 @@ class OverWindowTest extends TableTestBase {
           term("range", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
           term("select", "a", "c", "rowtime", "COUNT(a) AS w0$o0", "$SUM0(a) AS w0$o1")
         ),
-        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "CAST(w0$o1), null) AS cnt2")
+        term("select", "c", "w0$o0 AS cnt1", "CASE(>(w0$o0, 0)", "w0$o1, null) AS cnt2")
       )
     streamUtil.verifySql(sql, expected)
   }
@@ -660,7 +660,7 @@ class OverWindowTest extends TableTestBase {
           "c",
           "w0$o0 AS cnt1",
           "CASE(>(w0$o0, 0)",
-          "CAST(w0$o1), null) AS cnt2"
+          "w0$o1, null) AS cnt2"
         )
       )
     streamUtil.verifySql(sql, expected)
@@ -699,7 +699,7 @@ class OverWindowTest extends TableTestBase {
           term("select", "a", "c", "proctime", "COUNT(c) AS w0$o0",
             "$SUM0(c) AS w0$o1")
         ),
-        term("select", "a", "CASE(>(w0$o0, 0)", "CAST(w0$o1), null) AS EXPR$1", "w1$o0 AS EXPR$2")
+        term("select", "a", "CASE(>(w0$o0, 0)", "w0$o1, null) AS EXPR$1", "w1$o0 AS EXPR$2")
       )
 
     streamUtil.verifySql(sql, expected)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/GroupWindowTest.scala
@@ -784,6 +784,7 @@ class GroupWindowTest extends TableTestBase {
   }
 
   @Test
+  // reduce expression remove duplicate *(c, c) RexNode
   def testDecomposableAggFunctions(): Unit = {
     val util = streamTestUtil()
     val table = util.addTable[(Long, Int, String, Long)]('rowtime.rowtime, 'a, 'b, 'c)
@@ -801,25 +802,21 @@ class GroupWindowTest extends TableTestBase {
           unaryNode(
             "DataStreamCalc",
             streamTableNode(0),
-            term("select", "c", "rowtime",
-              "*(c, c) AS $f2", "*(c, c) AS $f3", "*(c, c) AS $f4", "*(c, c) AS $f5")
+            term("select", "c", "rowtime", "*(c, c) AS $f2")
           ),
           term("window", TumblingGroupWindow('w, 'rowtime, 900000.millis)),
           term("select",
             "SUM($f2) AS $f0",
             "SUM(c) AS $f1",
             "COUNT(c) AS $f2",
-            "SUM($f3) AS $f3",
-            "SUM($f4) AS $f4",
-            "SUM($f5) AS $f5",
             "start('w) AS TMP_4",
             "end('w) AS TMP_5")
         ),
         term("select",
-          "CAST(/(-($f0, /(*($f1, $f1), $f2)), $f2)) AS TMP_0",
-          "CAST(/(-($f3, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1)))) AS TMP_1",
-          "CAST(POWER(/(-($f4, /(*($f1, $f1), $f2)), $f2), 0.5)) AS TMP_2",
-          "CAST(POWER(/(-($f5, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
+          "/(-($f0, /(*($f1, $f1), $f2)), $f2) AS TMP_0",
+          "/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))) AS TMP_1",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), $f2), 0.5)) AS TMP_2",
+          "CAST(POWER(/(-($f0, /(*($f1, $f1), $f2)), CASE(=($f2, 1), null, -($f2, 1))), 0.5)) " +
             "AS TMP_3",
           "TMP_4",
           "TMP_5")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/OverWindowTest.scala
@@ -53,12 +53,13 @@ class OverWindowTest extends TableTestBase {
           unaryNode(
             "DataStreamCalc",
             streamTableNode(0),
-            term("select", "a", "b", "c", "proctime")
+            // RexSimplify didn't simplify "CAST(1):BIGINT NOT NULL", see [CALCITE-2862]
+            term("select", "a", "b", "c", "proctime", "1 AS $4")
           ),
           term("partitionBy", "b"),
           term("orderBy", "proctime"),
           term("rows", "BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
-          term("select", "a", "b", "c", "proctime",
+          term("select", "a", "b", "c", "proctime", "$4",
                "SUM(a) AS w0$o0",
                "COUNT(a) AS w0$o1",
                "WeightedAvgWithRetract(c, a) AS w0$o2")
@@ -66,7 +67,7 @@ class OverWindowTest extends TableTestBase {
         term("select",
              s"Func1$$(w0$$o0) AS d",
              "EXP(CAST(w0$o1)) AS _c1",
-             "+(w0$o2, 1) AS _c2",
+             "+(w0$o2, $4) AS _c2",
              "||('AVG:', CAST(w0$o2)) AS _c3",
              "ARRAY(w0$o2, w0$o1) AS _c4")
       )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/QueryDecorrelationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/QueryDecorrelationTest.scala
@@ -127,7 +127,7 @@ class QueryDecorrelationTest extends TableTestBase {
             unaryNode(
               "DataSetCalc",
               batchTableNode(0),
-              term("select", "salary", "deptno"),
+              term("select", "deptno", "salary"),
               term("where", "IS NOT NULL(deptno)")
             ),
             term("groupBy", "deptno"),

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -47,6 +47,6 @@ under the License.
 
 	<properties>
 		<!-- When updating Janino, make sure that Calcite supports it as well. -->
-		<janino.version>3.0.7</janino.version>
+		<janino.version>3.0.9</janino.version>
 	</properties>
 </project>


### PR DESCRIPTION

## What is the purpose of the change

Upgrade Calcite dependency to 1.18 for flink-table package. including various bug fixes and improvements ( details can be found in JIRA discussion )


## Brief change log
- Fix TimeIndicator type optimization 
  - Due to: [CALCITE-1413], [CALCITE-2695] 
  - Fix: include `digest` for `TimeIndicatorRelDataType`
- Under-simplify rexcall chain
  - Due to: [CALCITE-2726] RexSimplify does not simplify enough for some of the nested operations, doesn't do nested visitCall
  - Fix: updated tests, future fixes needed on calcite
- Optimized CAST operation
  - Due to: [CALCITE-2695] in RexSimplify
  - Fix: update tests
- Remove duplicated expressions
  - Due to: [CALCITE-1413], [CALCITE-2631], [CALCITE-2639]
  - Fix: update tests
- Nested selected time indicator type not working properly 
--> Due to: [CALCITE-2470], project method combines expressions if the underlying node is a project; Fix: pulled in `RelBuilder` from calcite and changes flag to not optimize project merge.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
    - Updated Calcite dependency and list of exclusions
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? N/A
