### PR TITLE
[FLINK-11380][tests] Finish mocking of resourceManagerClient before using it

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFlinkResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFlinkResourceManagerTest.java
@@ -115,6 +115,9 @@ public class YarnFlinkResourceManagerTest extends TestLogger {
 			int numInitialTaskManagers = 5;
 			final YarnResourceManagerCallbackHandler callbackHandler = new YarnResourceManagerCallbackHandler();
 			AMRMClientAsync<AMRMClient.ContainerRequest> resourceManagerClient = mock(AMRMClientAsync.class);
+			doReturn(Collections.singletonList(Collections.nCopies(numInitialTaskManagers, new AMRMClient.ContainerRequest(Resource.newInstance(1024 * 1024, 1), null, null, Priority.newInstance(0)))))
+				.when(resourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
+
 			NMClient nodeManagerClient = mock(NMClient.class);
 			UUID leaderSessionID = UUID.randomUUID();
 
@@ -180,9 +183,6 @@ public class YarnFlinkResourceManagerTest extends TestLogger {
 						resourceManagerClient,
 						nodeManagerClient
 					));
-
-				doReturn(Collections.singletonList(Collections.nCopies(numInitialTaskManagers, new AMRMClient.ContainerRequest(Resource.newInstance(1024 * 1024, 1), null, null, Priority.newInstance(0)))))
-					.when(resourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
 
 				leaderRetrievalService.notifyListener(leader1.path().toString(), leaderSessionID);
 


### PR DESCRIPTION
## What is the purpose of the change

The problem was that we started the ResourceManager before we finished the mocking of the
resourceManagerClient. This lead then to concurrent modifications of the mock which made
the test fail.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
