### PR TITLE
[FLINK-11487] Support for writing data to Apache Flume

### DIFF
--- a/flink-connectors/flink-connector-flume/pom.xml
+++ b/flink-connectors/flink-connector-flume/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.8-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-flume_${scala.binary.version}</artifactId>
+	<name>flink-connector-flume</name>
+
+	<packaging>jar</packaging>
+
+	<!-- Allow users to pass custom connector versions -->
+	<properties>
+		<flume.version>1.6.0</flume.version>
+	</properties>
+
+	<dependencies>
+		<!-- core dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- flink-java dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-java</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- flink-scala dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- streaming-scala dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- table dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<!-- Projects depending on this project,
+			won't depend on flink-table. -->
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop2</artifactId>
+			<version>${project.version}-${hadoop.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- flume dependencies -->
+		<dependency>
+			<groupId>org.apache.flume</groupId>
+			<artifactId>flume-ng-sdk</artifactId>
+			<version>${flume.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flume</groupId>
+			<artifactId>flume-ng-core</artifactId>
+			<version>${flume.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flume</groupId>
+			<artifactId>flume-ng-configuration</artifactId>
+			<version>${flume.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/flink-connectors/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeEventBuilder.java
+++ b/flink-connectors/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeEventBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.flume;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.RuntimeContext;
+
+import org.apache.flume.Event;
+
+import java.io.Serializable;
+
+/**
+ * A function that can create a Event from an incoming instance of the given type.
+ *
+ * @param <IN>
+ */
+public interface FlumeEventBuilder<IN> extends Function, Serializable {
+
+	Event createFlumeEvent(IN value, RuntimeContext ctx);
+
+}

--- a/flink-connectors/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSink.java
+++ b/flink-connectors/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSink.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.flume;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+import org.apache.flume.Event;
+import org.apache.flume.EventDeliveryException;
+import org.apache.flume.api.RpcClient;
+import org.apache.flume.api.RpcClientConfigurationConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Sink for publishing data into Flume.
+ * @param <IN>
+ */
+public class FlumeSink<IN> extends RichSinkFunction<IN> {
+	private static final Logger LOG = LoggerFactory.getLogger(FlumeSink.class);
+
+	private static final int DEFAULT_MAXRETRYATTEMPTS = 3;
+	private static final long DEFAULT_WAITTIMEMS = 1000L;
+
+	private String clientType;
+	private String hostname;
+	private int port;
+	private int batchSize;
+	private int maxRetryAttempts;
+	private long waitTimeMs;
+	private List<IN> incomingList;
+	private FlumeEventBuilder eventBuilder;
+	private RpcClient client;
+
+	public FlumeSink(String clientType, String hostname, int port, FlumeEventBuilder<IN> eventBuilder) {
+		this(clientType, hostname, port, eventBuilder, RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE, DEFAULT_MAXRETRYATTEMPTS, DEFAULT_WAITTIMEMS);
+	}
+
+	public FlumeSink(String clientType, String hostname, int port, FlumeEventBuilder<IN> eventBuilder, int batchSize) {
+		this(clientType, hostname, port, eventBuilder, batchSize, DEFAULT_MAXRETRYATTEMPTS, DEFAULT_WAITTIMEMS);
+	}
+
+	public FlumeSink(String clientType, String hostname, int port, FlumeEventBuilder<IN> eventBuilder, int batchSize, int maxRetryAttempts, long waitTimeMs) {
+		this.clientType = clientType;
+		this.hostname = hostname;
+		this.port = port;
+		this.eventBuilder = eventBuilder;
+		this.batchSize = batchSize;
+		this.maxRetryAttempts = maxRetryAttempts;
+		this.waitTimeMs = waitTimeMs;
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		incomingList = new ArrayList();
+		client = FlumeUtils.getRpcClient(clientType, hostname, port, batchSize);
+	}
+
+	@Override
+	public void invoke(IN value) throws Exception {
+		int number;
+		synchronized (this) {
+			if (null != value) {
+				incomingList.add(value);
+			}
+			number = incomingList.size();
+		}
+
+		if (number == batchSize) {
+			flush();
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		FlumeUtils.destroy(client);
+	}
+
+	private void flush() throws IllegalStateException {
+		List<Event> events = new ArrayList<>();
+		List<IN>  toFlushList;
+		synchronized (this) {
+			if (incomingList.isEmpty()) {
+				return;
+			}
+			toFlushList = incomingList;
+			incomingList = new ArrayList();
+		}
+
+		for (IN value: toFlushList) {
+			Event event = this.eventBuilder.createFlumeEvent(value, getRuntimeContext());
+			events.add(event);
+		}
+
+		int retries = 0;
+		boolean flag = true;
+		while (flag) {
+			if (null != client || retries > maxRetryAttempts) {
+				flag = false;
+			}
+
+			if (retries <= maxRetryAttempts && null == client) {
+				LOG.info("Wait for {} ms before retry", waitTimeMs);
+				try {
+					Thread.sleep(waitTimeMs);
+				} catch (InterruptedException ignored) {
+
+				}
+				reconnect();
+				LOG.info("Retry attempt number {}", retries);
+				retries++;
+			}
+		}
+
+		try {
+			client.appendBatch(events);
+		} catch (EventDeliveryException e) {
+			LOG.info("Encountered exception while sending data to flume : {}", e.getMessage(), e);
+		}
+
+	}
+
+	private void reconnect() {
+		FlumeUtils.destroy(client);
+		client = null;
+		client = FlumeUtils.getRpcClient(clientType, hostname, port, batchSize);
+	}
+
+}

--- a/flink-connectors/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeUtils.java
+++ b/flink-connectors/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeUtils.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.flume;
+
+import org.apache.flume.api.RpcClient;
+import org.apache.flume.api.RpcClientConfigurationConstants;
+import org.apache.flume.api.RpcClientFactory;
+
+import java.util.Properties;
+
+/**
+ * Flume RpcClient Util.
+ */
+public class FlumeUtils {
+	private static final String CLIENT_TYPE_KEY = "client.type";
+	private static final String CLIENT_TYPE_DEFAULT_FAILOVER = "default_failover";
+	private static final String CLIENT_TYPE_DEFAULT_LOADBALANCING = "default_loadbalance";
+	private static final String DEFAULT_CLIENT_TYPE = "thrift";
+
+	public static RpcClient getRpcClient(String clientType, String hostname, Integer port, Integer batchSize) {
+		if (null == clientType) {
+			clientType = DEFAULT_CLIENT_TYPE;
+		}
+
+		Properties props;
+		RpcClient client;
+		switch(clientType.toUpperCase()) {
+			case "THRIFT":
+				client = RpcClientFactory.getThriftInstance(hostname, port, batchSize);
+				break;
+			case "DEFAULT":
+				client = RpcClientFactory.getDefaultInstance(hostname, port, batchSize);
+				break;
+			case "DEFAULT_FAILOVER":
+				props = getDefaultProperties(hostname, port, batchSize);
+				props.put(CLIENT_TYPE_KEY, CLIENT_TYPE_DEFAULT_FAILOVER);
+				client = RpcClientFactory.getInstance(props);
+				break;
+			case "DEFAULT_LOADBALANCE":
+				props = getDefaultProperties(hostname, port, batchSize);
+				props.put(CLIENT_TYPE_KEY, CLIENT_TYPE_DEFAULT_LOADBALANCING);
+				client = RpcClientFactory.getInstance(props);
+				break;
+			default:
+				throw new IllegalStateException("Unsupported client type - cannot happen");
+		}
+		return client;
+	}
+
+	public static void destroy(RpcClient client) {
+		if (null != client) {
+			client.close();
+		}
+	}
+
+	private static Properties getDefaultProperties(String hostname, Integer port, Integer batchSize) {
+		Properties props = new Properties();
+		props.setProperty(RpcClientConfigurationConstants.CONFIG_HOSTS, "h1");
+		props.setProperty(RpcClientConfigurationConstants.CONFIG_HOSTS_PREFIX + "h1",
+			hostname + ":" + port.intValue());
+		props.setProperty(RpcClientConfigurationConstants.CONFIG_BATCH_SIZE, batchSize.toString());
+		return props;
+	}
+}

--- a/flink-connectors/flink-connector-flume/src/test/java/org/apache/flink/streaming/connectors/flume/examples/FlumeSinkExample.java
+++ b/flink-connectors/flink-connector-flume/src/test/java/org/apache/flink/streaming/connectors/flume/examples/FlumeSinkExample.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.flume.examples;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.flume.FlumeEventBuilder;
+import org.apache.flink.streaming.connectors.flume.FlumeSink;
+
+import org.apache.flume.Event;
+import org.apache.flume.event.EventBuilder;
+
+import java.nio.charset.Charset;
+
+/**
+ * An example FlumeSink that sends data to Flume service.
+ */
+public class FlumeSinkExample {
+	private static String clientType = "thrift";
+	private static String hostname = "localhost";
+	private static int port = 9000;
+
+	public static void main(String[] args) throws Exception {
+		//FlumeSink send data
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		FlumeEventBuilder<String> flumeEventBuilder = new FlumeEventBuilder<String>() {
+			@Override
+			public Event createFlumeEvent(String value, RuntimeContext ctx) {
+				return EventBuilder.withBody(value, Charset.defaultCharset());
+			}
+		};
+
+		FlumeSink<String> flumeSink = new FlumeSink<>(clientType, hostname, port, flumeEventBuilder, 1, 1, 1);
+
+		// Note: parallelisms and FlumeSink batchSize
+		// if every parallelism not enough batchSize, this parallelism not word FlumeThriftService output
+		DataStreamSink<String> dataStream = env.fromElements("one", "two", "three", "four", "five")
+			.addSink(flumeSink);
+
+		env.execute();
+	}
+}

--- a/flink-connectors/flink-connector-flume/src/test/java/org/apache/flink/streaming/connectors/flume/examples/FlumeThriftService.java
+++ b/flink-connectors/flink-connector-flume/src/test/java/org/apache/flink/streaming/connectors/flume/examples/FlumeThriftService.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.flume.examples;
+
+import org.apache.flume.Channel;
+import org.apache.flume.ChannelSelector;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.flume.channel.ChannelProcessor;
+import org.apache.flume.channel.MemoryChannel;
+import org.apache.flume.channel.ReplicatingChannelSelector;
+import org.apache.flume.conf.Configurables;
+import org.apache.flume.source.ThriftSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Start Flume Source service.
+ */
+public class FlumeThriftService {
+	private static String hostname = "localhost";
+	private static int port = 9000;
+
+	public static void main(String[] args) throws Exception {
+		//Flume Source
+		ThriftSource source = new ThriftSource();
+		Channel ch = new MemoryChannel();
+		Configurables.configure(ch, new Context());
+
+		Context context = new Context();
+		context.put("port", String.valueOf(port));
+		context.put("bind", hostname);
+		Configurables.configure(source, context);
+
+		List<Channel> channels = new ArrayList<>();
+		channels.add(ch);
+		ChannelSelector rcs = new ReplicatingChannelSelector();
+		rcs.setChannels(channels);
+		source.setChannelProcessor(new ChannelProcessor(rcs));
+		source.start();
+		System.out.println("ThriftSource service start.");
+
+		while (true) {
+			Transaction transaction = ch.getTransaction();
+			transaction.begin();
+			Event event = ch.take();
+			if (null != event) {
+				System.out.println(event);
+				System.out.println(new String(event.getBody()).trim());
+			}
+			transaction.commit();
+			transaction.close();
+		}
+
+	}
+}

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -56,6 +56,7 @@ under the License.
 		<module>flink-connector-cassandra</module>
 		<module>flink-connector-filesystem</module>
 		<module>flink-connector-kafka</module>
+		<module>flink-connector-flume</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up


### PR DESCRIPTION
## What is the purpose of the change

This pull request corresponds to a [FLINK-11487](https://issues.apache.org/jira/browse/FLINK-11487)
Support for writing data to Apache Flume.

## Brief change log

- flink-connectors add flink-connector-flume module
- org.apache.flink.streaming.connectors.flume.FlumeSink<IN>  java 
- FlumeSink example

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
  
  - **Currently only examples of use are provided**
  