### PR TITLE
[hotfix] [javadocs] Correct outdated doc for TaskSlotTable.start()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -112,7 +112,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	}
 
 	/**
-	 * Start the task slot table with the given slot actions and slot timeout value.
+	 * Start the task slot table with the given slot actions.
 	 *
 	 * @param initialSlotActions to use for slot actions
 	 */
@@ -182,7 +182,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 	/**
 	 * Allocate the slot with the given index for the given job and allocation id. Returns true if
-	 * the slot could be allocated. Otherwise it returns false;
+	 * the slot could be allocated. Otherwise it returns false.
 	 *
 	 * @param index of the task slot to allocate
 	 * @param jobId to allocate the task slot for


### PR DESCRIPTION
Correct outdated doc for `TaskSlotTable.start()`.