### PR TITLE
[FLINK-11445][table] Deprecate static methods in TableEnvironments

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -40,7 +40,7 @@ StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironm
 
 // create a TableEnvironment
 // for batch programs use BatchTableEnvironment instead of StreamTableEnvironment
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // register a Table
 tableEnv.registerTable("table1", ...)            // or
@@ -69,7 +69,7 @@ env.execute();
 val env = StreamExecutionEnvironment.getExecutionEnvironment
 
 // create a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // register a Table
 tableEnv.registerTable("table1", ...)           // or
@@ -111,7 +111,7 @@ The `TableEnvironment` is a central concept of the Table API and SQL integration
 
 A `Table` is always bound to a specific `TableEnvironment`. It is not possible to combine tables of different TableEnvironments in the same query, e.g., to join or union them.
 
-A `TableEnvironment` is created by calling the static `TableEnvironment.getTableEnvironment()` method with a `StreamExecutionEnvironment` or an `ExecutionEnvironment` and an optional `TableConfig`. The `TableConfig` can be used to configure the `TableEnvironment` or to customize the query optimization and translation process (see [Query Optimization](#query-optimization)).
+A `TableEnvironment` is created by calling the static `BatchTableEnvironment.create()` or `StreamTableEnvironment.create()` method with a `StreamExecutionEnvironment` or an `ExecutionEnvironment` and an optional `TableConfig`. The `TableConfig` can be used to configure the `TableEnvironment` or to customize the query optimization and translation process (see [Query Optimization](#query-optimization)).
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -119,16 +119,20 @@ A `TableEnvironment` is created by calling the static `TableEnvironment.getTable
 // ***************
 // STREAMING QUERY
 // ***************
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+
 StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 // create a TableEnvironment for streaming queries
-StreamTableEnvironment sTableEnv = TableEnvironment.getTableEnvironment(sEnv);
+StreamTableEnvironment sTableEnv = StreamTableEnvironment.create(sEnv);
 
 // ***********
 // BATCH QUERY
 // ***********
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+
 ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
 // create a TableEnvironment for batch queries
-BatchTableEnvironment bTableEnv = TableEnvironment.getTableEnvironment(bEnv);
+BatchTableEnvironment bTableEnv = BatchTableEnvironment.create(bEnv);
 {% endhighlight %}
 </div>
 
@@ -137,16 +141,20 @@ BatchTableEnvironment bTableEnv = TableEnvironment.getTableEnvironment(bEnv);
 // ***************
 // STREAMING QUERY
 // ***************
+import org.apache.flink.table.api.scala.StreamTableEnvironment
+
 val sEnv = StreamExecutionEnvironment.getExecutionEnvironment
 // create a TableEnvironment for streaming queries
-val sTableEnv = TableEnvironment.getTableEnvironment(sEnv)
+val sTableEnv = StreamTableEnvironment.create(sEnv)
 
 // ***********
 // BATCH QUERY
 // ***********
+import org.apache.flink.table.api.scala.BatchTableEnvironment
+
 val bEnv = ExecutionEnvironment.getExecutionEnvironment
 // create a TableEnvironment for batch queries
-val bTableEnv = TableEnvironment.getTableEnvironment(bEnv)
+val bTableEnv = BatchTableEnvironment.create(bEnv)
 {% endhighlight %}
 </div>
 </div>
@@ -174,7 +182,7 @@ A `Table` is registered in a `TableEnvironment` as follows:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // Table is the result of a simple projection query 
 Table projTable = tableEnv.scan("X").select(...);
@@ -187,7 +195,7 @@ tableEnv.registerTable("projectedTable", projTable);
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // Table is the result of a simple projection query 
 val projTable: Table = tableEnv.scan("X").select(...)
@@ -214,7 +222,7 @@ A `TableSource` is registered in a `TableEnvironment` as follows:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // create a TableSource
 TableSource csvSource = new CsvTableSource("/path/to/file", ...);
@@ -227,7 +235,7 @@ tableEnv.registerTableSource("CsvTable", csvSource);
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // create a TableSource
 val csvSource: TableSource = new CsvTableSource("/path/to/file", ...)
@@ -252,7 +260,7 @@ A `TableSink` is registered in a `TableEnvironment` as follows:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // create a TableSink
 TableSink csvSink = new CsvTableSink("/path/to/file", ...);
@@ -269,7 +277,7 @@ tableEnv.registerTableSink("CsvSinkTable", fieldNames, fieldTypes, csvSink);
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // create a TableSink
 val csvSink: TableSink = new CsvTableSink("/path/to/file", ...)
@@ -297,7 +305,7 @@ An external catalog can be created by implementing the `ExternalCatalog` interfa
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // create an external catalog
 ExternalCatalog catalog = new InMemoryExternalCatalog();
@@ -310,7 +318,7 @@ tableEnv.registerExternalCatalog("InMemCatalog", catalog);
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // create an external catalog
 val catalog: ExternalCatalog = new InMemoryExternalCatalog
@@ -344,7 +352,7 @@ The following example shows a simple Table API aggregation query:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // register Orders table
 
@@ -364,7 +372,7 @@ Table revenue = orders
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // register Orders table
 
@@ -398,7 +406,7 @@ The following example shows how to specify a query and return the result as a `T
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // register Orders table
 
@@ -418,7 +426,7 @@ Table revenue = tableEnv.sqlQuery(
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // register Orders table
 
@@ -443,7 +451,7 @@ The following example shows how to specify an update query that inserts its resu
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // register "Orders" table
 // register "RevenueFrance" output table
@@ -464,7 +472,7 @@ tableEnv.sqlUpdate(
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // register "Orders" table
 // register "RevenueFrance" output table
@@ -512,7 +520,7 @@ The following examples shows how to emit a `Table`:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // create a TableSink
 TableSink sink = new CsvTableSink("/path/to/file", fieldDelim = "|");
@@ -534,7 +542,7 @@ result.insertInto("CsvSinkTable");
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // create a TableSink
 val sink: TableSink = new CsvTableSink("/path/to/file", fieldDelim = "|")
@@ -596,7 +604,7 @@ A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a Table
 {% highlight java %}
 // get StreamTableEnvironment
 // registration of a DataSet in a BatchTableEnvironment is equivalent
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 DataStream<Tuple2<Long, String>> stream = ...
 
@@ -612,7 +620,7 @@ tableEnv.registerDataStream("myTable2", stream, "myLong, myString");
 {% highlight scala %}
 // get TableEnvironment 
 // registration of a DataSet is equivalent
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 val stream: DataStream[(Long, String)] = ...
 
@@ -638,7 +646,7 @@ Instead of registering a `DataStream` or `DataSet` in a `TableEnvironment`, it c
 {% highlight java %}
 // get StreamTableEnvironment
 // registration of a DataSet in a BatchTableEnvironment is equivalent
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 DataStream<Tuple2<Long, String>> stream = ...
 
@@ -654,7 +662,7 @@ Table table2 = tableEnv.fromDataStream(stream, "myLong, myString");
 {% highlight scala %}
 // get TableEnvironment
 // registration of a DataSet is equivalent
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 val stream: DataStream[(Long, String)] = ...
 
@@ -694,7 +702,7 @@ There are two modes to convert a `Table` into a `DataStream`:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get StreamTableEnvironment. 
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // Table with two fields (String name, Integer age)
 Table table = ...
@@ -724,7 +732,7 @@ DataStream<Tuple2<Boolean, Row>> retractStream =
 {% highlight scala %}
 // get TableEnvironment. 
 // registration of a DataSet is equivalent
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // Table with two fields (String name, Integer age)
 val table: Table = ...
@@ -755,7 +763,7 @@ A `Table` is converted into a `DataSet` as follows:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get BatchTableEnvironment
-BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
 
 // Table with two fields (String name, Integer age)
 Table table = ...
@@ -776,7 +784,7 @@ DataSet<Tuple2<String, Integer>> dsTuple =
 {% highlight scala %}
 // get TableEnvironment 
 // registration of a DataSet is equivalent
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = BatchTableEnvironment.create(env)
 
 // Table with two fields (String name, Integer age)
 val table: Table = ...
@@ -808,7 +816,7 @@ When defining a position-based mapping, the specified names must not exist in th
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 DataStream<Tuple2<Long, Integer>> stream = ...
 
@@ -826,7 +834,7 @@ Table table = tableEnv.fromDataStream(stream, "myLong, myInt");
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 val stream: DataStream[(Long, Int)] = ...
 
@@ -852,7 +860,7 @@ If no field names are specified, the default field names and field order of the 
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 DataStream<Tuple2<Long, Integer>> stream = ...
 
@@ -873,7 +881,7 @@ Table table = tableEnv.fromDataStream(stream, "f1 as myInt, f0 as myLong");
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 val stream: DataStream[(Long, Int)] = ...
 
@@ -900,7 +908,7 @@ Flink treats primitives (`Integer`, `Double`, `String`) or generic types (types 
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 DataStream<Long> stream = ...
 
@@ -915,7 +923,7 @@ Table table = tableEnv.fromDataStream(stream, "myLong");
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 val stream: DataStream[Long] = ...
 
@@ -936,7 +944,7 @@ Flink supports Scala's built-in tuples and provides its own tuple classes for Ja
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 DataStream<Tuple2<Long, String>> stream = ...
 
@@ -960,7 +968,7 @@ Table table = tableEnv.fromDataStream(stream, "f1 as 'myString', f0 as 'myLong'"
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 val stream: DataStream[(Long, String)] = ...
 
@@ -1006,7 +1014,7 @@ When converting a POJO `DataStream` or `DataSet` into a `Table` without specifyi
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // Person is a POJO with fields "name" and "age"
 DataStream<Person> stream = ...
@@ -1028,7 +1036,7 @@ Table table = tableEnv.fromDataStream(stream, "name as myName");
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // Person is a POJO with field names "name" and "age"
 val stream: DataStream[Person] = ...
@@ -1056,7 +1064,7 @@ The `Row` data type supports an arbitrary number of fields and fields with `null
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // DataStream of Row with two fields "name" and "age" specified in `RowTypeInfo`
 DataStream<Row> stream = ...
@@ -1081,7 +1089,7 @@ Table table = tableEnv.fromDataStream(stream, "name as myName");
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 // get a TableEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // DataStream of Row with two fields "name" and "age" specified in `RowTypeInfo`
 val stream: DataStream[Row] = ...
@@ -1129,7 +1137,7 @@ The following code shows an example and the corresponding output:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
 DataStream<Tuple2<Integer, String>> stream1 = env.fromElements(new Tuple2<>(1, "hello"));
 DataStream<Tuple2<Integer, String>> stream2 = env.fromElements(new Tuple2<>(1, "hello"));
@@ -1148,7 +1156,7 @@ System.out.println(explanation);
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tEnv = TableEnvironment.getTableEnvironment(env)
+val tEnv = StreamTableEnvironment.create(env)
 
 val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
 val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -42,7 +42,7 @@ The following examples show how to specify a SQL queries on registered and inlin
 <div data-lang="java" markdown="1">
 {% highlight java %}
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // ingest a DataStream from an external source
 DataStream<Tuple3<Long, String, Integer>> ds = env.addSource(...);
@@ -74,7 +74,7 @@ tableEnv.sqlUpdate(
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // read a DataStream from an external source
 val ds: DataStream[(Long, String, Integer)] = env.addSource(...)
@@ -861,7 +861,7 @@ The following examples show how to specify SQL queries with group windows on str
 <div data-lang="java" markdown="1">
 {% highlight java %}
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // ingest a DataStream from an external source
 DataStream<Tuple3<Long, String, Integer>> ds = env.addSource(...);
@@ -898,7 +898,7 @@ Table result4 = tableEnv.sqlQuery(
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // read a DataStream from an external source
 val ds: DataStream[(Long, String, Int)] = env.addSource(...)

--- a/docs/dev/table/streaming/query_configuration.md
+++ b/docs/dev/table/streaming/query_configuration.md
@@ -30,7 +30,7 @@ Flink's Table API and SQL interface provide parameters to tune the accuracy and 
 <div data-lang="java" markdown="1">
 {% highlight java %}
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 
 // obtain query configuration from TableEnvironment
 StreamQueryConfig qConfig = tableEnv.queryConfig();
@@ -61,7 +61,7 @@ DataStream<Row> stream = tableEnv.toAppendStream(result, Row.class, qConfig);
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = StreamTableEnvironment.create(env)
 
 // obtain query configuration from TableEnvironment
 val qConfig: StreamQueryConfig = tableEnv.queryConfig

--- a/docs/dev/table/streaming/temporal_tables.md
+++ b/docs/dev/table/streaming/temporal_tables.md
@@ -128,7 +128,7 @@ import org.apache.flink.table.functions.TemporalTableFunction;
 
 // Get the stream and table environments.
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
 // Provide a static data set of the rates history table.
 List<Tuple2<String, Long>> ratesHistoryData = new ArrayList<>();
@@ -155,7 +155,7 @@ tEnv.registerFunction("Rates", rates);                                          
 {% highlight scala %}
 // Get the stream and table environments.
 val env = StreamExecutionEnvironment.getExecutionEnvironment
-val tEnv = TableEnvironment.getTableEnvironment(env)
+val tEnv = StreamTableEnvironment.create(env)
 
 // Provide a static data set of the rates history table.
 val ratesHistoryData = new mutable.MutableList[(String, Long)]

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -46,7 +46,7 @@ The Java Table API is enabled by importing `org.apache.flink.table.api.java.*`. 
 {% highlight java %}
 // environment configuration
 ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 
 // register Orders table in table environment
 // ...
@@ -77,7 +77,7 @@ import org.apache.flink.table.api.scala._
 
 // environment configuration
 val env = ExecutionEnvironment.getExecutionEnvironment
-val tEnv = TableEnvironment.getTableEnvironment(env)
+val tEnv = BatchTableEnvironment.create(env)
 
 // register Orders table in table environment
 // ...

--- a/docs/dev/table/udfs.md
+++ b/docs/dev/table/udfs.md
@@ -63,7 +63,7 @@ public class HashCode extends ScalarFunction {
   }
 }
 
-BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
 
 // register the function
 tableEnv.registerFunction("hashCode", new HashCode(10));
@@ -85,7 +85,7 @@ class HashCode(factor: Int) extends ScalarFunction {
   }
 }
 
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = BatchTableEnvironment.create(env)
 
 // use the function in Scala Table API
 val hashCode = new HashCode(10)
@@ -164,7 +164,7 @@ public class Split extends TableFunction<Tuple2<String, Integer>> {
     }
 }
 
-BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
 Table myTable = ...         // table schema: [a: String]
 
 // Register the function.
@@ -194,7 +194,7 @@ class Split(separator: String) extends TableFunction[(String, Int)] {
   }
 }
 
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = BatchTableEnvironment.create(env)
 val myTable = ...         // table schema: [a: String]
 
 // Use the table function in the Scala Table API (Note: No registration required in Scala Table API).
@@ -703,7 +703,7 @@ public class HashCode extends ScalarFunction {
 }
 
 ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
 
 // set job parameter
 Configuration conf = new Configuration();
@@ -738,7 +738,7 @@ object hashCode extends ScalarFunction {
   }
 }
 
-val tableEnv = TableEnvironment.getTableEnvironment(env)
+val tableEnv = BatchTableEnvironment.create(env)
 
 // use the function in Scala Table API
 myTable.select('string, hashCode('string))

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -44,7 +44,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkContextUtil;
 import org.apache.flink.streaming.runtime.operators.WriteAheadSinkTestBase;
-import org.apache.flink.table.api.StreamTableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 
 import com.datastax.driver.core.Cluster;
@@ -454,7 +454,7 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 	public void testCassandraTableSink() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(4);
-		StreamTableEnvironment tEnv = StreamTableEnvironment.getTableEnvironment(env);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
 		DataStreamSource<Row> source = env.fromCollection(rowCollection);
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -30,7 +30,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -145,7 +144,7 @@ public class HBaseConnectorITCase extends HBaseTestingClusterAutostarter {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(4);
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, new TableConfig());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, new TableConfig());
 		HBaseTableSource hbaseTable = new HBaseTableSource(getConf(), TEST_TABLE);
 		hbaseTable.addColumn(FAMILY1, F1COL1, Integer.class);
 		hbaseTable.addColumn(FAMILY2, F2COL1, String.class);
@@ -186,7 +185,7 @@ public class HBaseConnectorITCase extends HBaseTestingClusterAutostarter {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(4);
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, new TableConfig());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, new TableConfig());
 		HBaseTableSource hbaseTable = new HBaseTableSource(getConf(), TEST_TABLE);
 		hbaseTable.addColumn(FAMILY1, F1COL1, Integer.class);
 		hbaseTable.addColumn(FAMILY2, F2COL1, String.class);
@@ -225,7 +224,7 @@ public class HBaseConnectorITCase extends HBaseTestingClusterAutostarter {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(4);
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, new TableConfig());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, new TableConfig());
 		HBaseTableSource hbaseTable = new HBaseTableSource(getConf(), TEST_TABLE);
 		// shuffle order of column registration
 		hbaseTable.addColumn(FAMILY2, F2COL1, String.class);
@@ -260,7 +259,7 @@ public class HBaseConnectorITCase extends HBaseTestingClusterAutostarter {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(4);
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, new TableConfig());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, new TableConfig());
 		// fetch row2 from the table till the end
 		HBaseTableSource hbaseTable = new HBaseTableSource(getConf(), TEST_TABLE);
 		hbaseTable.addColumn(FAMILY2, F2COL1, byte[].class);

--- a/flink-connectors/flink-orc/src/test/java/org/apache/flink/orc/OrcTableSourceITCase.java
+++ b/flink-connectors/flink-orc/src/test/java/org/apache/flink/orc/OrcTableSourceITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.orc;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
 import org.apache.flink.types.Row;
@@ -49,7 +48,7 @@ public class OrcTableSourceITCase extends MultipleProgramsTestBase {
 	public void testFullScan() throws Exception {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 
 		OrcTableSource orc = OrcTableSource.builder()
 			.path(getPath(TEST_FILE_FLAT))
@@ -84,7 +83,7 @@ public class OrcTableSourceITCase extends MultipleProgramsTestBase {
 	public void testScanWithProjectionAndFilter() throws Exception {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 
 		OrcTableSource orc = OrcTableSource.builder()
 			.path(getPath(TEST_FILE_FLAT))

--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -38,7 +38,6 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.sources.DefinedFieldMapping;
@@ -88,7 +87,7 @@ public class StreamSQLTestProgram {
 		sEnv.enableCheckpointing(4000);
 		sEnv.getConfig().setAutoWatermarkInterval(1000);
 
-		StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(sEnv);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(sEnv);
 
 		tEnv.registerTableSource("table1", new GeneratorTableSource(10, 100, 60, 0));
 		tEnv.registerTableSource("table2", new GeneratorTableSource(5, 0.2f, 60, 5));

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.examples.java;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 
 import java.util.Arrays;
@@ -45,7 +44,7 @@ public class StreamSQLExample {
 
 		// set up execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
 		DataStream<Order> orderA = env.fromCollection(Arrays.asList(
 			new Order(1L, "beer", 3),

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountSQL.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountSQL.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.examples.java;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 
 /**
@@ -42,7 +41,7 @@ public class WordCountSQL {
 
 		// set up execution environment
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 
 		DataSet<WC> input = env.fromElements(
 			new WC("Hello", 1),

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountTable.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountTable.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.examples.java;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 
 /**
@@ -39,7 +38,7 @@ public class WordCountTable {
 
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env);
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
 
 		DataSet<WC> input = env.fromElements(
 				new WC("Hello", 1),

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -19,7 +19,6 @@ package org.apache.flink.table.examples.scala
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 
 /**
@@ -41,7 +40,7 @@ object StreamSQLExample {
 
     // set up execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val orderA: DataStream[Order] = env.fromCollection(Seq(
       Order(1L, "beer", 3),

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamTableExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamTableExample.scala
@@ -19,7 +19,6 @@ package org.apache.flink.table.examples.scala
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 
 /**
@@ -39,7 +38,7 @@ object StreamTableExample {
 
     // set up execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val orderA = env.fromCollection(Seq(
       Order(1L, "beer", 3),

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/TPCHQuery3Table.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/TPCHQuery3Table.scala
@@ -18,7 +18,6 @@
 package org.apache.flink.table.examples.scala
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 
 /**
@@ -84,7 +83,7 @@ object TPCHQuery3Table {
 
     // get execution environment
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val lineitems = getLineitemDataSet(env)
       .toTable(tEnv, 'id, 'extdPrice, 'discount, 'shipDate)

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountSQL.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountSQL.scala
@@ -18,7 +18,6 @@
 package org.apache.flink.table.examples.scala
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 
 /**
@@ -40,7 +39,7 @@ object WordCountSQL {
 
     // set up execution environment
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val input = env.fromElements(WC("hello", 1), WC("hello", 1), WC("ciao", 1))
 

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountTable.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountTable.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.examples.scala
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 
 /**
@@ -40,7 +39,7 @@ object WordCountTable {
 
     // set up execution environment
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val input = env.fromElements(WC("hello", 1), WC("hello", 1), WC("ciao", 1))
     val expr = input.toTable(tEnv)

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
@@ -28,7 +28,6 @@ import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.formats.avro.utils.AvroKryoSerializerUtils;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -150,7 +149,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.getConfig().registerTypeWithKryoSerializer(LocalDate.class, AvroKryoSerializerUtils.JodaLocalDateSerializer.class);
 		env.getConfig().registerTypeWithKryoSerializer(LocalTime.class, AvroKryoSerializerUtils.JodaLocalTimeSerializer.class);
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
 		Table result = t.select("*");
@@ -177,7 +176,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 	@Test
 	public void testAvroStringAccess() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
 		Table result = t.select("name");
@@ -191,7 +190,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 	@Test
 	public void testAvroObjectAccess() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
 		Table result = t
@@ -206,7 +205,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 	@Test
 	public void testAvroToAvro() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
 		Table result = t.select("*");

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
@@ -23,7 +23,6 @@ import java.io.{BufferedReader, File, FileOutputStream}
 import org.apache.flink.api.java.{JarHelper, ScalaShellRemoteEnvironment, ScalaShellRemoteStreamEnvironment}
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala.{BatchTableEnvironment, StreamTableEnvironment}
 import org.apache.flink.util.AbstractID
 
@@ -100,8 +99,8 @@ class FlinkILoop(
     ) = {
     val scalaBenv = new ExecutionEnvironment(remoteBenv)
     val scalaSenv = new StreamExecutionEnvironment(remoteSenv)
-    val scalaBTEnv = TableEnvironment.getTableEnvironment(scalaBenv)
-    val scalaSTEnv = TableEnvironment.getTableEnvironment(scalaSenv)
+    val scalaBTEnv = BatchTableEnvironment.create(scalaBenv)
+    val scalaSTEnv = StreamTableEnvironment.create(scalaSenv)
     (scalaBenv,scalaSenv,scalaBTEnv,scalaSTEnv)
   }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -275,11 +275,11 @@ public class ExecutionContext<T> {
 			if (mergedEnv.getExecution().isStreamingExecution()) {
 				streamExecEnv = createStreamExecutionEnvironment();
 				execEnv = null;
-				tableEnv = TableEnvironment.getTableEnvironment(streamExecEnv);
+				tableEnv = StreamTableEnvironment.create(streamExecEnv);
 			} else if (mergedEnv.getExecution().isBatchExecution()) {
 				streamExecEnv = null;
 				execEnv = createExecutionEnvironment();
-				tableEnv = TableEnvironment.getTableEnvironment(execEnv);
+				tableEnv = BatchTableEnvironment.create(execEnv);
 			} else {
 				throw new SqlExecutionException("Unsupported execution type specified.");
 			}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -1258,6 +1258,7 @@ object TableEnvironment {
     *
     * @param executionEnvironment The Java batch ExecutionEnvironment.
     */
+  @Deprecated
   def getTableEnvironment(executionEnvironment: JavaBatchExecEnv): JavaBatchTableEnv = {
     new JavaBatchTableEnv(executionEnvironment, new TableConfig())
   }
@@ -1268,6 +1269,7 @@ object TableEnvironment {
     * @param executionEnvironment The Java batch ExecutionEnvironment.
     * @param tableConfig The TableConfig for the new TableEnvironment.
     */
+  @Deprecated
   def getTableEnvironment(
     executionEnvironment: JavaBatchExecEnv,
     tableConfig: TableConfig): JavaBatchTableEnv = {
@@ -1280,6 +1282,7 @@ object TableEnvironment {
     *
     * @param executionEnvironment The Scala batch ExecutionEnvironment.
     */
+  @deprecated("This method will be removed. Use BatchTableEnvironment.create() instead.", "1.8.0")
   def getTableEnvironment(executionEnvironment: ScalaBatchExecEnv): ScalaBatchTableEnv = {
     new ScalaBatchTableEnv(executionEnvironment, new TableConfig())
   }
@@ -1291,6 +1294,7 @@ object TableEnvironment {
     * @param executionEnvironment The Scala batch ExecutionEnvironment.
     * @param tableConfig The TableConfig for the new TableEnvironment.
     */
+  @deprecated("This method will be removed. Use BatchTableEnvironment.create() instead.", "1.8.0")
   def getTableEnvironment(
     executionEnvironment: ScalaBatchExecEnv,
     tableConfig: TableConfig): ScalaBatchTableEnv = {
@@ -1303,6 +1307,7 @@ object TableEnvironment {
     *
     * @param executionEnvironment The Java StreamExecutionEnvironment.
     */
+  @Deprecated
   def getTableEnvironment(executionEnvironment: JavaStreamExecEnv): JavaStreamTableEnv = {
     new JavaStreamTableEnv(executionEnvironment, new TableConfig())
   }
@@ -1313,6 +1318,7 @@ object TableEnvironment {
     * @param executionEnvironment The Java StreamExecutionEnvironment.
     * @param tableConfig The TableConfig for the new TableEnvironment.
     */
+  @Deprecated
   def getTableEnvironment(
     executionEnvironment: JavaStreamExecEnv,
     tableConfig: TableConfig): JavaStreamTableEnv = {
@@ -1325,6 +1331,7 @@ object TableEnvironment {
     *
     * @param executionEnvironment The Scala StreamExecutionEnvironment.
     */
+  @deprecated("This method will be removed. Use StreamTableEnvironment.create() instead.", "1.8.0")
   def getTableEnvironment(executionEnvironment: ScalaStreamExecEnv): ScalaStreamTableEnv = {
     new ScalaStreamTableEnv(executionEnvironment, new TableConfig())
   }
@@ -1335,6 +1342,7 @@ object TableEnvironment {
     * @param executionEnvironment The Scala StreamExecutionEnvironment.
     * @param tableConfig The TableConfig for the new TableEnvironment.
     */
+  @deprecated("This method will be removed. Use StreamTableEnvironment.create() instead.", "1.8.0")
   def getTableEnvironment(
     executionEnvironment: ScalaStreamExecEnv,
     tableConfig: TableConfig): ScalaStreamTableEnv = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/BatchTableEnvironment.scala
@@ -40,7 +40,7 @@ import org.apache.flink.table.functions.{AggregateFunction, TableFunction}
   * @param execEnv The Java batch [[ExecutionEnvironment]] of the TableEnvironment.
   * @param config The configuration of the TableEnvironment.
   */
-class BatchTableEnvironment(
+class BatchTableEnvironment @Deprecated() (
     execEnv: ExecutionEnvironment,
     config: TableConfig)
   extends org.apache.flink.table.api.BatchTableEnvironment(execEnv, config) {
@@ -245,5 +245,31 @@ class BatchTableEnvironment(
       .asInstanceOf[TypeInformation[ACC]]
 
     registerAggregateFunctionInternal[T, ACC](name, f)
+  }
+}
+
+object BatchTableEnvironment {
+
+  /**
+    * Returns a [[BatchTableEnvironment]] for a Java [[ExecutionEnvironment]].
+    *
+    * @param executionEnvironment The Java batch ExecutionEnvironment.
+    */
+  def create(executionEnvironment: ExecutionEnvironment): BatchTableEnvironment = {
+    new BatchTableEnvironment(executionEnvironment, new TableConfig())
+  }
+
+  /**
+    * Returns a [[BatchTableEnvironment]] for a Java [[ExecutionEnvironment]] and a given
+    * [[TableConfig]].
+    *
+    * @param executionEnvironment The Java batch ExecutionEnvironment.
+    * @param tableConfig The TableConfig for the new TableEnvironment.
+    */
+  def create(
+    executionEnvironment: ExecutionEnvironment,
+    tableConfig: TableConfig): BatchTableEnvironment = {
+
+    new BatchTableEnvironment(executionEnvironment, tableConfig)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
@@ -42,7 +42,7 @@ import _root_.java.lang.{Boolean => JBool}
   * @param execEnv The Java [[StreamExecutionEnvironment]] of the TableEnvironment.
   * @param config The configuration of the TableEnvironment.
   */
-class StreamTableEnvironment(
+class StreamTableEnvironment @Deprecated() (
     execEnv: StreamExecutionEnvironment,
     config: TableConfig)
   extends org.apache.flink.table.api.StreamTableEnvironment(execEnv, config) {
@@ -378,5 +378,32 @@ class StreamTableEnvironment(
       .asInstanceOf[TypeInformation[ACC]]
 
     registerAggregateFunctionInternal[T, ACC](name, f)
+  }
+}
+
+object StreamTableEnvironment {
+
+  /**
+    * Returns a [[StreamTableEnvironment]] for a Java [[StreamExecutionEnvironment]].
+    *
+    * @param executionEnvironment The Java StreamExecutionEnvironment.
+    */
+  def create(executionEnvironment: StreamExecutionEnvironment):
+  StreamTableEnvironment = {
+    new StreamTableEnvironment(executionEnvironment, new TableConfig())
+  }
+
+  /**
+    * Returns a [[StreamTableEnvironment]] for a Java [[StreamExecutionEnvironment]] and a given
+    * [[TableConfig]].
+    *
+    * @param executionEnvironment The Java StreamExecutionEnvironment.
+    * @param tableConfig The TableConfig for the new TableEnvironment.
+    */
+  def create(
+    executionEnvironment: StreamExecutionEnvironment,
+    tableConfig: TableConfig): StreamTableEnvironment = {
+
+    new StreamTableEnvironment(executionEnvironment, tableConfig)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
@@ -41,7 +41,7 @@ import _root_.scala.reflect.ClassTag
   * @param execEnv The Scala batch [[ExecutionEnvironment]] of the TableEnvironment.
   * @param config The configuration of the TableEnvironment.
   */
-class BatchTableEnvironment(
+class BatchTableEnvironment @deprecated("Don't construct directly, use create method", "1.8.0") (
     execEnv: ExecutionEnvironment,
     config: TableConfig)
   extends org.apache.flink.table.api.BatchTableEnvironment(execEnv.getJavaEnv, config) {
@@ -184,5 +184,31 @@ class BatchTableEnvironment(
       f: AggregateFunction[T, ACC])
   : Unit = {
     registerAggregateFunctionInternal[T, ACC](name, f)
+  }
+}
+
+object BatchTableEnvironment {
+
+  /**
+    * Returns a [[BatchTableEnvironment]] for a Scala [[ExecutionEnvironment]].
+    *
+    * @param executionEnvironment The Scala batch ExecutionEnvironment.
+    */
+  def create(executionEnvironment: ExecutionEnvironment): BatchTableEnvironment = {
+    new BatchTableEnvironment(executionEnvironment, new TableConfig())
+  }
+
+  /**
+    * Returns a [[BatchTableEnvironment]] for a Scala [[ExecutionEnvironment]] and a given
+    * [[TableConfig]].
+    *
+    * @param executionEnvironment The Scala batch ExecutionEnvironment.
+    * @param tableConfig The TableConfig for the new TableEnvironment.
+    */
+  def create(
+    executionEnvironment: ExecutionEnvironment,
+    tableConfig: TableConfig): BatchTableEnvironment = {
+
+    new BatchTableEnvironment(executionEnvironment, tableConfig)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
@@ -40,7 +40,7 @@ import org.apache.flink.streaming.api.scala.asScalaStream
   * @param execEnv The Scala [[StreamExecutionEnvironment]] of the TableEnvironment.
   * @param config The configuration of the TableEnvironment.
   */
-class StreamTableEnvironment(
+class StreamTableEnvironment @deprecated("Don't construct directly, use create method", "1.8.0") (
     execEnv: StreamExecutionEnvironment,
     config: TableConfig)
   extends org.apache.flink.table.api.StreamTableEnvironment(
@@ -230,5 +230,30 @@ class StreamTableEnvironment(
       f: AggregateFunction[T, ACC])
   : Unit = {
     registerAggregateFunctionInternal[T, ACC](name, f)
+  }
+}
+
+object StreamTableEnvironment {
+
+  /**
+    * Returns a [[StreamTableEnvironment]] for a Scala stream [[StreamExecutionEnvironment]].
+    *
+    * @param executionEnvironment The Scala StreamExecutionEnvironment.
+    */
+  def create(executionEnvironment: StreamExecutionEnvironment): StreamTableEnvironment = {
+    new StreamTableEnvironment(executionEnvironment, new TableConfig())
+  }
+
+  /**
+    * Returns a [[StreamTableEnvironment]] for a Scala stream [[StreamExecutionEnvironment]].
+    *
+    * @param executionEnvironment The Scala StreamExecutionEnvironment.
+    * @param tableConfig The TableConfig for the new TableEnvironment.
+    */
+  def create(
+    executionEnvironment: StreamExecutionEnvironment,
+    tableConfig: TableConfig): StreamTableEnvironment = {
+
+    new StreamTableEnvironment(executionEnvironment, tableConfig)
   }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/JavaTableSourceITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/JavaTableSourceITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.batch;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.runtime.utils.CommonTestData;
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase;
@@ -48,7 +47,7 @@ public class JavaTableSourceITCase extends TableProgramsCollectionTestBase {
 	public void testBatchTableSourceTableAPI() throws Exception {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 		BatchTableSource csvTable = CommonTestData.getCsvTableSource();
 
 		tableEnv.registerTableSource("persons", csvTable);
@@ -74,7 +73,7 @@ public class JavaTableSourceITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testBatchTableSourceSQL() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 		BatchTableSource csvTable = CommonTestData.getCsvTableSource();
 
 		tableEnv.registerTableSource("persons", csvTable);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/GroupingSetsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/GroupingSetsITCase.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.operators.MapOperator;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase;
 import org.apache.flink.test.operators.util.CollectionDataSets;
@@ -59,7 +58,7 @@ public class GroupingSetsITCase extends TableProgramsClusterTestBase {
 	@Before
 	public void setupTables() {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		tableEnv = TableEnvironment.getTableEnvironment(env, new TableConfig());
+		tableEnv = BatchTableEnvironment.create(env, new TableConfig());
 
 		DataSet<Tuple3<Integer, Long, String>> dataSet = CollectionDataSets.get3TupleDataSet(env);
 		tableEnv.registerDataSet(TABLE_NAME, dataSet);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -28,7 +28,6 @@ import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.java.typeutils.MapTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase;
 import org.apache.flink.test.operators.util.CollectionDataSets;
@@ -56,7 +55,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testValues() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		String sqlQuery = "VALUES (1, 'Test', TRUE, DATE '1944-02-24', 12.4444444444444445)," +
 			"(2, 'Hello', TRUE, DATE '1944-02-24', 12.666666665)," +
@@ -76,7 +75,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testSelectFromTable() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table in = tableEnv.fromDataSet(ds, "a,b,c");
@@ -100,7 +99,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testFilterFromDataSet() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		tableEnv.registerDataSet("DataSetTable", ds, "x, y, z");
@@ -117,7 +116,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testAggregation() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		tableEnv.registerDataSet("AggTable", ds, "x, y, z");
@@ -134,7 +133,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testJoin() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
@@ -154,7 +153,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 	@Test
 	public void testMap() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<Tuple2<Integer, Map<String, String>>> rows = new ArrayList<>();
 		rows.add(new Tuple2<>(1, Collections.singletonMap("foo", "bar")));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.calcite.CalciteConfig;
@@ -75,7 +74,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	public void testSimpleRegister() throws Exception {
 		final String tableName = "MyTable";
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		tableEnv.registerDataSet(tableName, ds);
@@ -95,7 +94,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	public void testRegisterWithFields() throws Exception {
 		final String tableName = "MyTable";
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		tableEnv.registerDataSet(tableName, ds, "a, b, c");
@@ -118,7 +117,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testRegisterExistingDatasetTable() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		tableEnv.registerDataSet("MyTable", ds);
@@ -131,7 +130,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testScanUnregisteredTable() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. No table registered under that name.
 		tableEnv.scan("nonRegisteredTable");
@@ -141,7 +140,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	public void testTableRegister() throws Exception {
 		final String tableName = "MyTable";
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);
@@ -159,7 +158,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testIllegalName() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);
@@ -170,8 +169,8 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testRegisterTableFromOtherEnv() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv1 = TableEnvironment.getTableEnvironment(env, config());
-		BatchTableEnvironment tableEnv2 = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv1 = BatchTableEnvironment.create(env, config());
+		BatchTableEnvironment tableEnv2 = BatchTableEnvironment.create(env, config());
 
 		Table t = tableEnv1.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
 		// Must fail. Table is bound to different TableEnvironment.
@@ -181,7 +180,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromTupleByPosition() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		Table table = tableEnv
 			.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c")
@@ -202,7 +201,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromTupleByName() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		Table table = tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "f2");
 
@@ -221,7 +220,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromAndToTuple() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		Table table = tableEnv
 			.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c")
@@ -248,7 +247,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromTupleToPojo() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<Tuple4<String, Integer, Double, String>> data = new ArrayList<>();
 		data.add(new Tuple4<>("Rofl", 1, 1.0, "Hi"));
@@ -268,7 +267,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromPojo() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<SmallPojo> data = new ArrayList<>();
 		data.add(new SmallPojo("Peter", 28, 4000.00, "Sales", new Integer[] {42}));
@@ -296,7 +295,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testFromNonAtomicAndNonComposite() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<Either<String, Integer>> data = new ArrayList<>();
 		data.add(new Either.Left<>("Hello"));
@@ -324,7 +323,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromPojoProjected() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<SmallPojo> data = new ArrayList<>();
 		data.add(new SmallPojo("Peter", 28, 4000.00, "Sales", new Integer[] {42}));
@@ -347,7 +346,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromPrivateFieldsPojo() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<PrivateSmallPojo> data = new ArrayList<>();
 		data.add(new PrivateSmallPojo("Peter", 28, 4000.00, "Sales"));
@@ -374,7 +373,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromAndToPojo() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<SmallPojo> data = new ArrayList<>();
 		data.add(new SmallPojo("Peter", 28, 4000.00, "Sales", new Integer[] {42}));
@@ -402,7 +401,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsFromAndToPrivateFieldPojo() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<PrivateSmallPojo> data = new ArrayList<>();
 		data.add(new PrivateSmallPojo("Peter", 28, 4000.00, "Sales"));
@@ -429,7 +428,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test
 	public void testAsWithPojoAndGenericTypes() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		List<PojoWithGeneric> data = new ArrayList<>();
 		data.add(new PojoWithGeneric("Peter", 28, new HashMap<String, String>(), new ArrayList<String>()));
@@ -461,7 +460,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testGenericRow() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// use null value the enforce GenericType
 		DataSet<Row> dataSet = env.fromElements(Row.of(1, 2L, "Hello", null));
@@ -475,7 +474,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testGenericRowWithAlias() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// use null value the enforce GenericType
 		DataSet<Row> dataSet = env.fromElements(Row.of((Integer) null));
@@ -489,7 +488,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testAsWithToManyFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. Too many field names specified.
 		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c, d");
@@ -498,7 +497,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testAsWithAmbiguousFields() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. Specified field names are not unique.
 		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, b");
@@ -507,7 +506,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testAsWithNonFieldReference1() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. as() does only allow field name expressions
 		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a + 1, b, c");
@@ -516,7 +515,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testAsWithNonFieldReference2() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. as() does only allow field name expressions
 		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a as foo, b,  c");
@@ -525,7 +524,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testNonStaticClassInput() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail since class is not static
 		tableEnv.fromDataSet(env.fromElements(new MyNonStatic()), "name");
@@ -534,7 +533,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testNonStaticClassOutput() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail since class is not static
 		Table t = tableEnv.fromDataSet(env.fromElements(1, 2, 3), "number");
@@ -544,7 +543,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 	@Test(expected = TableException.class)
 	public void testCustomCalciteConfig() {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		CalciteConfig cc = new CalciteConfigBuilder()
 				.replaceLogicalOptRuleSet(RuleSets.ofList())

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.runtime.utils.JavaStreamTestData;
 import org.apache.flink.table.runtime.utils.StreamITCase;
@@ -46,7 +45,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 	@Test
 	public void testRowRegisterRowWithNames() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 		StreamITCase.clear();
 
 		List<Row> data = new ArrayList<>();
@@ -85,7 +84,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 	@Test
 	public void testSelect() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 		StreamITCase.clear();
 
 		DataStream<Tuple3<Integer, Long, String>> ds = JavaStreamTestData.getSmall3TupleDataSet(env);
@@ -110,7 +109,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 	@Test
 	public void testFilter() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 		StreamITCase.clear();
 
 		DataStream<Tuple5<Integer, Long, Integer, String, Long>> ds = JavaStreamTestData.get5TupleDataStream(env);
@@ -135,7 +134,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 	@Test
 	public void testUnion() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 		StreamITCase.clear();
 
 		DataStream<Tuple3<Integer, Long, String>> ds1 = JavaStreamTestData.getSmall3TupleDataSet(env);

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/ExternalCatalogInsertTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/ExternalCatalogInsertTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.api
 
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.java.StreamTableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData
 import org.apache.flink.table.utils.TableTestBase
@@ -29,9 +30,9 @@ import org.junit.Test
   * Test for inserting into tables from external catalog.
   */
 class ExternalCatalogInsertTest extends TableTestBase {
-  private val tableBatchEnv = TableEnvironment.getTableEnvironment(
+  private val tableBatchEnv = BatchTableEnvironment.create(
     ExecutionEnvironment.getExecutionEnvironment)
-  private val tableStreamEnv = TableEnvironment.getTableEnvironment(
+  private val tableStreamEnv = StreamTableEnvironment.create(
     StreamExecutionEnvironment.getExecutionEnvironment)
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.api.batch
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.test.util.MultipleProgramsTestBase
 import org.junit.Assert.assertEquals
@@ -33,7 +32,7 @@ class ExplainTest
   @Test
   def testFilterWithoutExtended(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env.fromElements((1, "hello"))
       .toTable(tEnv, 'a, 'b)
@@ -48,7 +47,7 @@ class ExplainTest
   @Test
   def testFilterWithExtended(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env.fromElements((1, "hello"))
       .toTable(tEnv, 'a, 'b)
@@ -63,7 +62,7 @@ class ExplainTest
   @Test
   def testJoinWithoutExtended(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'c, 'd)
@@ -78,7 +77,7 @@ class ExplainTest
   @Test
   def testJoinWithExtended(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'c, 'd)
@@ -93,7 +92,7 @@ class ExplainTest
   @Test
   def testUnionWithoutExtended(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
@@ -108,7 +107,7 @@ class ExplainTest
   @Test
   def testUnionWithExtended(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/JoinValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.batch.table.validation
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, TableException, ValidationException}
+import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.types.Row
 import org.junit._
@@ -121,8 +121,8 @@ class JoinValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testJoinTablesFromDifferentEnvs(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = BatchTableEnvironment.create(env)
+    val tEnv2 = BatchTableEnvironment.create(env)
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
     val in1 = tEnv1.fromDataSet(ds1, 'a, 'b, 'c)
@@ -135,8 +135,8 @@ class JoinValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testJoinTablesFromDifferentEnvsJava() {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = BatchTableEnvironment.create(env)
+    val tEnv2 = BatchTableEnvironment.create(env)
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
     val in1 = tEnv1.fromDataSet(ds1, 'a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/SetOperatorsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/SetOperatorsValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.batch.table.validation
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, ValidationException}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.utils.TableTestBase
 import org.junit._
 
@@ -51,8 +51,8 @@ class SetOperatorsValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testUnionTablesFromDifferentEnvs(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = BatchTableEnvironment.create(env)
+    val tEnv2 = BatchTableEnvironment.create(env)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv1, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv2, 'a, 'b, 'c)
@@ -75,8 +75,8 @@ class SetOperatorsValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testMinusAllTablesFromDifferentEnvs(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = BatchTableEnvironment.create(env)
+    val tEnv2 = BatchTableEnvironment.create(env)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv1, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv2, 'a, 'b, 'c)
@@ -99,8 +99,8 @@ class SetOperatorsValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testIntersectTablesFromDifferentEnvs(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = BatchTableEnvironment.create(env)
+    val tEnv2 = BatchTableEnvironment.create(env)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv1, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv2, 'a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.api.stream
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.test.util.AbstractTestBase
 import org.junit.Assert.assertEquals
@@ -33,7 +32,7 @@ class ExplainTest extends AbstractTestBase {
   @Test
   def testFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val table = env.fromElements((1, "hello"))
       .toTable(tEnv, 'a, 'b)
@@ -50,7 +49,7 @@ class ExplainTest extends AbstractTestBase {
   @Test
   def testUnion(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JStreamExecEnv}
 import org.apache.flink.table.api.java.{StreamTableEnvironment => JStreamTableEnv}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.utils.TableTestUtil.{binaryNode, streamTableNode, term, unaryNode}
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
@@ -175,7 +175,7 @@ class StreamTableEnvironmentTest extends TableTestBase {
 
     val jStreamExecEnv = mock(classOf[JStreamExecEnv])
     when(jStreamExecEnv.getStreamTimeCharacteristic).thenReturn(TimeCharacteristic.EventTime)
-    val jTEnv = TableEnvironment.getTableEnvironment(jStreamExecEnv)
+    val jTEnv = JStreamTableEnv.create(jStreamExecEnv)
 
     val sType = new TupleTypeInfo(Types.LONG, Types.INT, Types.STRING, Types.INT, Types.LONG)
       .asInstanceOf[TupleTypeInfo[JTuple5[JLong, JInt, String, JInt, JLong]]]

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentValidationTest.scala
@@ -22,7 +22,7 @@ import java.math.BigDecimal
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{TableEnvironment, TableException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.stream.TimeAttributesITCase.TimestampWithEqualWatermark
 import org.apache.flink.table.utils.TableTestBase
@@ -128,7 +128,7 @@ class StreamTableEnvironmentValidationTest extends TableTestBase {
   def testInvalidTimeCharacteristicByPosition(): Unit = {
     val data = List((1L, 1, 1d, 1f, new BigDecimal("1"), "Hi"))
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val stream = env
       .fromCollection(data)
       .assignTimestampsAndWatermarks(new TimestampWithEqualWatermark())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/InsertIntoValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.stream.sql.validation
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types, ValidationException}
+import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.runtime.utils.StreamTestData
 import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
 import org.junit.Test
@@ -31,7 +31,7 @@ class InsertIntoValidationTest {
   @Test(expected = classOf[ValidationException])
   def testInconsistentLengthInsert(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
@@ -50,7 +50,7 @@ class InsertIntoValidationTest {
   @Test(expected = classOf[ValidationException])
   def testUnmatchedTypesInsert(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
@@ -69,7 +69,7 @@ class InsertIntoValidationTest {
   @Test(expected = classOf[ValidationException])
   def testUnsupportedPartialInsert(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/InsertIntoValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.stream.table.validation
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types, ValidationException}
+import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.runtime.utils.StreamTestData
 import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
 import org.junit.Test
@@ -31,7 +31,7 @@ class InsertIntoValidationTest {
   @Test(expected = classOf[ValidationException])
   def testInconsistentLengthInsert(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)
@@ -50,7 +50,7 @@ class InsertIntoValidationTest {
   @Test(expected = classOf[ValidationException])
   def testUnmatchedTypesInsert(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("sourceTable", t)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.stream.table.validation.JoinValidationTest.WithoutEqualsHashCode
-import org.apache.flink.table.api.{TableEnvironment, TableException, ValidationException}
+import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.runtime.utils.StreamTestData
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.types.Row
@@ -36,7 +36,7 @@ class JoinValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testInvalidStateTypes(): Unit = {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
-    val tenv = TableEnvironment.getTableEnvironment(env)
+    val tenv = StreamTableEnvironment.create(env)
     val ds = env.fromElements(new WithoutEqualsHashCode) // no equals/hashCode
     val t = tenv.fromDataStream(ds)
 
@@ -205,8 +205,8 @@ class JoinValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testJoinTablesFromDifferentEnvs(): Unit = {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = StreamTableEnvironment.create(env)
+    val tEnv2 = StreamTableEnvironment.create(env)
     val ds1 = StreamTestData.get3TupleDataStream(env)
     val ds2 = StreamTestData.get5TupleDataStream(env)
     val in1 = tEnv1.fromDataStream(ds1, 'a, 'b, 'c)
@@ -219,8 +219,8 @@ class JoinValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testJoinTablesFromDifferentEnvsJava() {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = StreamTableEnvironment.create(env)
+    val tEnv2 = StreamTableEnvironment.create(env)
     val ds1 = StreamTestData.get3TupleDataStream(env)
     val ds2 = StreamTestData.get5TupleDataStream(env)
     val in1 = tEnv1.fromDataStream(ds1, 'a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/SetOperatorsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/SetOperatorsValidationTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.stream.table.validation
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, ValidationException}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.types.Row
@@ -35,7 +35,7 @@ class SetOperatorsValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testUnionFieldsNameNotOverlap1(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -53,7 +53,7 @@ class SetOperatorsValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testUnionFieldsNameNotOverlap2(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -72,8 +72,8 @@ class SetOperatorsValidationTest extends TableTestBase {
   @Test(expected = classOf[ValidationException])
   def testUnionTablesFromDifferentEnv(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = StreamTableEnvironment.create(env)
+    val tEnv2 = StreamTableEnvironment.create(env)
 
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv1, 'a, 'b, 'c)
     val ds2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv2, 'a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSinkValidationTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.api.stream.table.validation
 
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{TableEnvironment, TableException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.stream.table.{TestAppendSink, TestUpsertSink}
 import org.apache.flink.table.runtime.utils.StreamTestData
@@ -32,7 +32,7 @@ class TableSinkValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testAppendSinkOnUpdatingTable(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'id, 'num, 'text)
     tEnv.registerTableSink("testSink", new TestAppendSink)
@@ -49,7 +49,7 @@ class TableSinkValidationTest extends TableTestBase {
   def testUpsertSinkOnUpdatingTableWithoutFullKey(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -68,7 +68,7 @@ class TableSinkValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testAppendSinkOnLeftJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val ds1 = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.api.stream.table.validation
 
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, ValidationException}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.runtime.utils.StreamTestData
 import org.apache.flink.test.util.AbstractTestBase
 import org.junit.Test
@@ -30,14 +30,14 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testSort(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).orderBy('_1.desc)
   }
 
   @Test(expected = classOf[ValidationException])
   def testJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.join(t2)
@@ -46,7 +46,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testUnion(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.union(t2)
@@ -55,7 +55,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testIntersect(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.intersect(t2)
@@ -64,7 +64,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testIntersectAll(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.intersectAll(t2)
@@ -73,7 +73,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testMinus(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.minus(t2)
@@ -82,7 +82,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testMinusAll(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.minusAll(t2)
@@ -91,7 +91,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testOffset(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.offset(5)
   }
@@ -99,7 +99,7 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   @Test(expected = classOf[ValidationException])
   def testFetch(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
     t1.fetch(5)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableEnvironmentValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableEnvironmentValidationTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.TableEnvironmentTest.{CClass, PojoClass}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, TableException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.runtime.types.CRowTypeInfo
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.types.Row
@@ -35,7 +35,7 @@ import org.junit._
 class TableEnvironmentValidationTest extends TableTestBase {
 
   private val env = ExecutionEnvironment.getExecutionEnvironment
-  private val tEnv = TableEnvironment.getTableEnvironment(env)
+  private val tEnv = BatchTableEnvironment.create(env)
 
   val tupleType = new TupleTypeInfo(
     INT_TYPE_INFO,
@@ -113,7 +113,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testRegisterExistingDataSet(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env)
     tEnv.registerDataSet("MyTable", ds1)
@@ -125,7 +125,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testScanUnregisteredTable(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     // Must fail. No table registered under that name.
     tEnv.scan("someTable")
   }
@@ -133,7 +133,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testRegisterExistingTable(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val t1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("MyTable", t1)
@@ -145,8 +145,8 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testRegisterTableFromOtherEnv(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv1 = TableEnvironment.getTableEnvironment(env)
-    val tEnv2 = TableEnvironment.getTableEnvironment(env)
+    val tEnv1 = BatchTableEnvironment.create(env)
+    val tEnv2 = BatchTableEnvironment.create(env)
 
     val t1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv1)
     // Must fail. Table is bound to different TableEnvironment.
@@ -156,7 +156,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testToTableWithToManyFields(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     CollectionDataSets.get3TupleDataSet(env)
       // Must fail. Number of fields does not match.
@@ -166,7 +166,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testToTableWithAmbiguousFields(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     CollectionDataSets.get3TupleDataSet(env)
       // Must fail. Field names not unique.
@@ -176,7 +176,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testToTableWithNonFieldReference1(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     // Must fail. as() can only have field references
     CollectionDataSets.get3TupleDataSet(env)
@@ -186,7 +186,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testToTableWithNonFieldReference2(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     // Must fail. as() can only have field references
     CollectionDataSets.get3TupleDataSet(env)
@@ -196,7 +196,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testGenericRow() {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
+    val tableEnv = BatchTableEnvironment.create(env)
 
     // use null value the enforce GenericType
     val dataSet = env.fromElements(Row.of(null))
@@ -210,7 +210,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
   @Test(expected = classOf[TableException])
   def testGenericRowWithAlias() {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
+    val tableEnv = BatchTableEnvironment.create(env)
 
     // use null value the enforce GenericType
     val dataSet = env.fromElements(Row.of(null))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableSourceValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableSourceValidationTest.scala
@@ -25,7 +25,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{TableEnvironment, TableSchema, Types, ValidationException}
+import org.apache.flink.table.api.scala.StreamTableEnvironment
+import org.apache.flink.table.api.{TableSchema, Types, ValidationException}
 import org.apache.flink.table.sources._
 import org.apache.flink.table.sources.tsextractors.ExistingField
 import org.apache.flink.table.sources.wmstrategies.AscendingTimestamps
@@ -40,7 +41,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount", "value"),
@@ -59,7 +60,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount"),
@@ -78,7 +79,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount"),
@@ -96,7 +97,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount"),
@@ -114,7 +115,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount", "ptime"),
@@ -133,7 +134,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount", "rtime"),
@@ -153,7 +154,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount", "time"),
@@ -174,7 +175,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val schema = new TableSchema(
       Array("id", "name", "amount", "rtime"),
@@ -203,7 +204,7 @@ class TableSourceValidationTest {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val fieldNames = Array("id", "name", "amount")
     val rowType = new RowTypeInfo(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
@@ -21,12 +21,10 @@ package org.apache.flink.table.expressions.utils
 import java.util
 import java.util.concurrent.Future
 
-import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.hep.{HepMatchOrder, HepPlanner, HepProgramBuilder}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.`type`.SqlTypeName._
-import org.apache.calcite.sql2rel.RelDecorrelator
 import org.apache.calcite.tools.{Programs, RelBuilder}
 import org.apache.flink.api.common.TaskInfo
 import org.apache.flink.api.common.accumulators.Accumulator
@@ -39,12 +37,12 @@ import org.apache.flink.api.java.{DataSet => JDataSet}
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.fs.Path
+import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv}
 import org.apache.flink.table.api.{BatchTableEnvironment, TableConfig, TableEnvironment}
 import org.apache.flink.table.calcite.FlinkPlannerImpl
 import org.apache.flink.table.codegen.{Compiler, FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 import org.apache.flink.table.functions.ScalarFunction
-import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.dataset.{DataSetCalc, DataSetScan}
 import org.apache.flink.table.plan.rules.FlinkRuleSets
 import org.apache.flink.types.Row
@@ -90,7 +88,7 @@ abstract class ExpressionTestBase {
     when(jDataSetMock.getType).thenReturn(typeInfo)
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = ScalaBatchTableEnv.create(env)
     tEnv.registerDataSet(tableName, dataSetMock)
     functions.foreach(f => tEnv.registerFunction(f._1, f._2))
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.cep.pattern.Pattern
 import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableConfig, TableEnvironment}
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.calcite.FlinkPlannerImpl
 import org.apache.flink.table.plan.nodes.datastream.{DataStreamMatch, DataStreamScan}
 import org.apache.flink.types.Row
@@ -60,7 +60,7 @@ abstract class PatternTranslatorTestBase extends TestLogger{
     when(jDataStreamMock.getType).thenReturn(typeInfo)
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.registerDataStream(tableName, dataStreamMock, 'f0, 'proctime.proctime)
 
     // prepare RelBuilder

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.batch.sql
 import org.apache.calcite.runtime.SqlFunctions.{internalToTimestamp => toTimestamp}
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvgWithMergeAndReset
@@ -45,7 +44,7 @@ class AggregateITCase(
   def testAggregationTypes(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT sum(_1), min(_1), max(_1), count(_1), avg(_1) FROM MyTable"
 
@@ -63,7 +62,7 @@ class AggregateITCase(
   def testTableAggregation(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT sum(_1) FROM MyTable"
 
@@ -81,7 +80,7 @@ class AggregateITCase(
   def testDataSetAggregation(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT sum(_1) FROM MyTable"
 
@@ -99,7 +98,7 @@ class AggregateITCase(
   def testAggregationDataTypes(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT avg(a), avg(b), avg(c), avg(d), avg(e), avg(f), count(g), " +
       "min(g), min('Ciao'), max(g), max('Ciao'), sum(CAST(f AS DECIMAL)) FROM MyTable"
@@ -120,7 +119,7 @@ class AggregateITCase(
   def testTableProjection(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT avg(a), sum(a), count(a), avg(b), sum(b) " +
       "FROM MyTable"
@@ -139,7 +138,7 @@ class AggregateITCase(
   def testTableAggregationWithArithmetic(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT avg(a + 2) + 2, count(b) + 5 " +
       "FROM MyTable"
@@ -158,7 +157,7 @@ class AggregateITCase(
   def testAggregationWithTwoCount(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT count(_1), count(_2) FROM MyTable"
 
@@ -177,7 +176,7 @@ class AggregateITCase(
   def testAggregationAfterProjection(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT avg(a), sum(b), count(c) FROM " +
       "(SELECT _1 as a, _2 as b, _3 as c FROM MyTable)"
@@ -198,7 +197,7 @@ class AggregateITCase(
   def testDistinctAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT sum(_1) as a, count(distinct _3) as b FROM MyTable"
 
@@ -216,7 +215,7 @@ class AggregateITCase(
   def testGroupedDistinctAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT _2, avg(distinct _1) as a, count(_3) as b FROM MyTable GROUP BY _2"
 
@@ -235,7 +234,7 @@ class AggregateITCase(
   def testGroupingSetAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery =
       "SELECT _2, _3, avg(_1) as a, GROUP_ID() as g FROM MyTable GROUP BY GROUPING SETS (_2, _3)"
@@ -262,7 +261,7 @@ class AggregateITCase(
   def testAggregateEmptyDataSets(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val myAgg = new NonMergableCount
     tEnv.registerFunction("myAgg", myAgg)
 
@@ -310,7 +309,7 @@ class AggregateITCase(
   def testTumbleWindowAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.registerFunction("countFun", new CountAggFunction)
     tEnv.registerFunction("wAvgWithMergeAndReset", new WeightedAvgWithMergeAndReset)
 
@@ -341,7 +340,7 @@ class AggregateITCase(
   def testTumbleWindowAggregateWithCollect(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery =
       "SELECT b, COLLECT(b)" +
@@ -369,7 +368,7 @@ class AggregateITCase(
   @Test
   def testTumbleWindowAggregateWithCollectUnnest(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // create timestamps
@@ -397,7 +396,7 @@ class AggregateITCase(
   @Test
   def testTumbleWindowWithProperties(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery =
       "SELECT b, COUNT(a), " +
@@ -433,7 +432,7 @@ class AggregateITCase(
   def testHopWindowAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.registerFunction("countFun", new CountAggFunction)
     tEnv.registerFunction("wAvgWithMergeAndReset", new WeightedAvgWithMergeAndReset)
 
@@ -464,7 +463,7 @@ class AggregateITCase(
   def testHopWindowWithProperties(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery =
       "SELECT b, COUNT(a), " +
@@ -506,7 +505,7 @@ class AggregateITCase(
   def testSessionWindowAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.registerFunction("countFun", new CountAggFunction)
     tEnv.registerFunction("wAvgWithMergeAndReset", new WeightedAvgWithMergeAndReset)
 
@@ -535,7 +534,7 @@ class AggregateITCase(
   def testSessionWindowWithProperties(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery =
       "SELECT COUNT(a), " +
@@ -563,7 +562,7 @@ class AggregateITCase(
   @Test
   def testMultipleDistinctWithDiffParams(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlWithNull = "SELECT a, " +
       " CASE WHEN b = 2 THEN null ELSE b END AS b, " +

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -24,7 +24,7 @@ import java.util
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, ValidationException}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.expressions.utils.SplitUDF
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.runtime.batch.table.OldHashCode
@@ -48,7 +48,7 @@ class CalcITCase(
   def testSelectStarFromTable(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable"
 
@@ -72,7 +72,7 @@ class CalcITCase(
   def testSelectStarFromNestedTable(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable"
 
@@ -91,7 +91,7 @@ class CalcITCase(
   def testSelectStarFromDataSet(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable"
 
@@ -115,7 +115,7 @@ class CalcITCase(
   def testSimpleSelectAll(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT a, b, c FROM MyTable"
 
@@ -139,7 +139,7 @@ class CalcITCase(
   def testSelectWithNaming(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT `1-_./Ü`, b FROM (SELECT _1 as `1-_./Ü`, _2 as b FROM MyTable)"
 
@@ -160,7 +160,7 @@ class CalcITCase(
   def testInvalidFields(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT a, foo FROM MyTable"
 
@@ -174,7 +174,7 @@ class CalcITCase(
   def testAllRejectingFilter(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE false"
 
@@ -192,7 +192,7 @@ class CalcITCase(
   def testAllPassingFilter(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE true"
 
@@ -215,7 +215,7 @@ class CalcITCase(
   def testFilterOnString(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE c LIKE '%world%'"
 
@@ -233,7 +233,7 @@ class CalcITCase(
   def testFilterOnInteger(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE MOD(a,2)=0"
 
@@ -254,7 +254,7 @@ class CalcITCase(
   def testDisjunctivePredicate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE a < 2 OR a > 20 OR a IN(3,4,5)"
 
@@ -273,7 +273,7 @@ class CalcITCase(
   def testFilterWithAnd(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE MOD(a,2)<>0 AND MOD(b,2)=0 AND b NOT IN(1,2,3)"
 
@@ -291,7 +291,7 @@ class CalcITCase(
   @Test
   def testAdvancedDataTypes(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT a, b, c, DATE '1984-07-12', TIME '14:34:24', " +
       "TIMESTAMP '1984-07-12 14:34:24' FROM MyTable"
@@ -313,7 +313,7 @@ class CalcITCase(
   @Test
   def testValueConstructor(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT (a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable " +
       "WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')"
@@ -339,7 +339,7 @@ class CalcITCase(
   @Test
   def testUserDefinedScalarFunction(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     tEnv.registerFunction("hashCode", OldHashCode)
     tEnv.registerFunction("hashCode", MyHashCode)
@@ -363,7 +363,7 @@ class CalcITCase(
 
     val env = ExecutionEnvironment.getExecutionEnvironment
 
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val splitUDF0 = new SplitUDF(deterministic = true)
     val splitUDF1 = new SplitUDF(deterministic = false)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/JoinITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.batch.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -41,7 +40,7 @@ class JoinITCase(
   @Test
   def testInnerJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e"
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
@@ -60,7 +59,7 @@ class JoinITCase(
   def testInnerJoinWithFilter(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND b < 2"
 
@@ -80,7 +79,7 @@ class JoinITCase(
   def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6 AND h < b"
 
@@ -100,7 +99,7 @@ class JoinITCase(
   def testInnerJoinWithMultipleKeys(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE a = d AND b = h"
 
@@ -121,7 +120,7 @@ class JoinITCase(
   def testInnerJoinWithAlias(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery =
       "SELECT Table5.c, T.`1-_./Ü` FROM (SELECT a, b, c AS `1-_./Ü` FROM Table3) AS T, Table5 " +
@@ -143,7 +142,7 @@ class JoinITCase(
   def testInnerJoinWithAggregation(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT COUNT(g), COUNT(b) FROM Table3, Table5 WHERE a = d"
 
@@ -163,7 +162,7 @@ class JoinITCase(
   def testInnerJoinWithAggregation2(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT COUNT(b), COUNT(g) FROM Table3, Table5 WHERE a = d"
 
@@ -183,7 +182,7 @@ class JoinITCase(
   def testFullOuterJoin(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val sqlQuery = "SELECT c, g FROM Table3 FULL OUTER JOIN Table5 ON b = e"
@@ -206,7 +205,7 @@ class JoinITCase(
   def testLeftOuterJoin(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val sqlQuery = "SELECT c, g FROM Table5 LEFT OUTER JOIN Table3 ON b = e"
@@ -228,7 +227,7 @@ class JoinITCase(
   def testRightOuterJoin(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e"
@@ -249,7 +248,7 @@ class JoinITCase(
   @Test
   def testCrossJoinWithLeftSingleRowInput(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a1, 'a2, 'a3)
     tEnv.registerTable("A", table)
@@ -266,7 +265,7 @@ class JoinITCase(
   @Test
   def testCrossJoinWithRightSingleRowInput(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a1, 'a2, 'a3)
     tEnv.registerTable("A", table)
@@ -283,7 +282,7 @@ class JoinITCase(
   @Test
   def testCrossJoinWithEmptySingleRowInput(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a1, 'a2, 'a3)
     tEnv.registerTable("A", table)
@@ -296,7 +295,7 @@ class JoinITCase(
   @Test
   def testLeftNullRightJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt " +
       "FROM (SELECT cnt FROM (SELECT COUNT(*) AS cnt FROM B) WHERE cnt < 0) RIGHT JOIN A ON a < cnt"
@@ -324,7 +323,7 @@ class JoinITCase(
   @Test
   def testLeftSingleRightJoinEqualPredicate(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt = a"
 
@@ -348,7 +347,7 @@ class JoinITCase(
   @Test
   def testLeftSingleRightJoinNotEqualPredicate(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt > a"
 
@@ -372,7 +371,7 @@ class JoinITCase(
   @Test
   def testRightNullLeftJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt " +
       "FROM A LEFT JOIN (SELECT cnt FROM (SELECT COUNT(*) AS cnt FROM B) WHERE cnt < 0) ON cnt > a"
@@ -395,7 +394,7 @@ class JoinITCase(
   @Test
   def testRightSingleLeftJoinEqualPredicate(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) ON cnt = a"
 
@@ -420,7 +419,7 @@ class JoinITCase(
   @Test
   def testRightSingleLeftJoinNotEqualPredicate(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) ON cnt < a"
 
@@ -445,7 +444,7 @@ class JoinITCase(
   @Test
   def testRightSingleLeftJoinTwoFields(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery =
       "SELECT a, cnt, cnt2 " +
       "FROM t1 LEFT JOIN (SELECT COUNT(*) AS cnt,COUNT(*) AS cnt2 FROM t2 ) AS x ON a = cnt"
@@ -471,7 +470,7 @@ class JoinITCase(
   def testCrossWithUnnest(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val data = List(
       (1, 1L, Array("Hi", "w")),
@@ -493,7 +492,7 @@ class JoinITCase(
   @Test
   def testJoinWithUnnestOfTuple(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val data = List(
       (1, Array((12, "45.6"), (2, "45.612"))),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.batch.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -43,7 +42,7 @@ class SetOperatorsITCase(
   def testUnionAll(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM t1 UNION ALL (SELECT f FROM t2)"
 
@@ -63,7 +62,7 @@ class SetOperatorsITCase(
   def testUnion(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM t1 UNION (SELECT f FROM t2)"
 
@@ -83,7 +82,7 @@ class SetOperatorsITCase(
   def testUnionWithFilter(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM (" +
       "SELECT * FROM t1 UNION ALL (SELECT a, b, c FROM t2))" +
@@ -105,7 +104,7 @@ class SetOperatorsITCase(
   def testUnionWithAggregation(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT count(c) FROM (" +
       "SELECT * FROM t1 UNION ALL (SELECT a, b, c FROM t2))"
@@ -125,7 +124,7 @@ class SetOperatorsITCase(
   @Test
   def testValuesWithCast(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "VALUES (1, cast(1 as BIGINT) )," +
       "(2, cast(2 as BIGINT))," +
@@ -142,7 +141,7 @@ class SetOperatorsITCase(
   def testExcept(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM t1 EXCEPT (SELECT c FROM t2)"
 
@@ -163,7 +162,7 @@ class SetOperatorsITCase(
   // calcite sql parser doesn't support EXCEPT ALL
   def testExceptAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM t1 EXCEPT ALL SELECT c FROM t2"
 
@@ -188,7 +187,7 @@ class SetOperatorsITCase(
   def testExceptWithFilter(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM (" +
       "SELECT * FROM t1 EXCEPT (SELECT a, b, c FROM t2))" +
@@ -209,7 +208,7 @@ class SetOperatorsITCase(
   @Test
   def testIntersect(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM t1 INTERSECT SELECT c FROM t2"
 
@@ -236,7 +235,7 @@ class SetOperatorsITCase(
   // calcite sql parser doesn't support INTERSECT ALL
   def testIntersectAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM t1 INTERSECT ALL SELECT c FROM t2"
 
@@ -260,7 +259,7 @@ class SetOperatorsITCase(
   @Test
   def testIntersectWithFilter(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT c FROM ((SELECT * FROM t1) INTERSECT (SELECT * FROM t2)) WHERE a > 1"
 
@@ -280,7 +279,7 @@ class SetOperatorsITCase(
   @Test
   def testInWithFilter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
@@ -297,7 +296,7 @@ class SetOperatorsITCase(
   @Test
   def testInWithProjection(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SortITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.batch.sql
 
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.api.scala.{ExecutionEnvironment, _}
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.SortTestUtils._
 import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase
@@ -50,7 +49,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByMultipleFieldsWithSql(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable ORDER BY _1 DESC, _2 DESC"
 
@@ -87,7 +86,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByWithOffset(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable ORDER BY _1 DESC OFFSET 2 ROWS"
 
@@ -118,7 +117,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByWithOffsetAndFetch(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable ORDER BY _1 OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY"
 
@@ -149,7 +148,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByLimit(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT * FROM MyTable ORDER BY _2, _1 LIMIT 5"
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.batch.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -43,7 +42,7 @@ class TableEnvironmentITCase(
   def testSQLTable(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
@@ -61,7 +60,7 @@ class TableEnvironmentITCase(
   def testTableSQLTable(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val t1 = ds.filter('a > 9)
@@ -81,7 +80,7 @@ class TableEnvironmentITCase(
   def testMultipleSQLQueries(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     tEnv.registerTable("MyTable", t)
@@ -101,7 +100,7 @@ class TableEnvironmentITCase(
   @Test
   def testSelectWithCompositeType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val sqlQuery = "SELECT MyTable.a2, MyTable.a1._2 FROM MyTable"
 
@@ -119,7 +118,7 @@ class TableEnvironmentITCase(
   @Test
   def testInsertIntoMemoryTable(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.batch.sql
 
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{CommonTestData, TableProgramsCollectionTestBase}
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -41,7 +40,7 @@ class TableSourceITCase(
     val csvTable = CommonTestData.getCsvTableSource
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     tEnv.registerTableSource("csvTable", csvTable)
     val results = tEnv.sqlQuery(
@@ -62,7 +61,7 @@ class TableSourceITCase(
   @Test
   def testNested(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val nestedTable = CommonTestData.getNestedTableSource
 
     tableEnv.registerTableSource("NestedPersons", nestedTable)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
@@ -22,7 +22,7 @@ import java.math.BigDecimal
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinctWithMergeAndReset, WeightedAvgWithMergeAndReset}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
@@ -46,7 +46,7 @@ class AggregationsITCase(
   @Test
   def testAggregationWithCaseClass(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val inputTable = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv, 'a, 'b)
     tEnv.registerDataSet("MyTable", inputTable)
@@ -64,7 +64,7 @@ class AggregationsITCase(
   def testAggregationTypes(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
       .select('_1.sum, '_1.sum0, '_1.min, '_1.max, '_1.count, '_1.avg)
@@ -78,7 +78,7 @@ class AggregationsITCase(
   def testWorkingAggregationDataTypes(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = env.fromElements(
       (1: Byte, 1: Short, 1, 1L, 1.0f, 1.0d, "Hello"),
@@ -94,7 +94,7 @@ class AggregationsITCase(
   def testProjection(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = env.fromElements(
       (1: Byte, 1: Short),
@@ -110,7 +110,7 @@ class AggregationsITCase(
   def testAggregationWithArithmetic(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = env.fromElements((1f, "Hello"), (2f, "Ciao")).toTable(tEnv)
       .select(('_1 + 2).avg + 2, '_2.count + 5)
@@ -124,7 +124,7 @@ class AggregationsITCase(
   def testAggregationWithTwoCount(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = env.fromElements((1f, "Hello"), (2f, "Ciao")).toTable(tEnv)
       .select('_1.count, '_2.count)
@@ -138,7 +138,7 @@ class AggregationsITCase(
   def testAggregationAfterProjection(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = env.fromElements(
       (1: Byte, 1: Short, 1, 1L, 1.0f, 1.0d, "Hello"),
@@ -155,7 +155,7 @@ class AggregationsITCase(
   def testSQLStyleAggregations(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .select(
@@ -175,7 +175,7 @@ class AggregationsITCase(
   def testPojoAggregation(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val input = env.fromElements(
       WC("hello", 1),
@@ -198,7 +198,7 @@ class AggregationsITCase(
   @Test
   def testDistinct(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val distinct = ds.select('b).distinct()
@@ -211,7 +211,7 @@ class AggregationsITCase(
   @Test
   def testDistinctAfterAggregate(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
     val distinct = ds.groupBy('a, 'e).select('e).distinct()
@@ -225,7 +225,7 @@ class AggregationsITCase(
   def testGroupedAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val countFun = new CountAggFunction
     val wAvgFun = new WeightedAvgWithMergeAndReset
     val countDistinct = new CountDistinctWithMergeAndReset
@@ -244,7 +244,7 @@ class AggregationsITCase(
   def testGroupingKeyForwardIfNotUsed(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .groupBy('b)
@@ -259,7 +259,7 @@ class AggregationsITCase(
   def testGroupNoAggregation(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env)
       .toTable(tEnv, 'a, 'b, 'c)
@@ -276,7 +276,7 @@ class AggregationsITCase(
   def testAggregateEmptyDataSets(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val myAgg = new NonMergableCount
 
@@ -301,7 +301,7 @@ class AggregationsITCase(
     // This uses very long keys to force serialized comparison.
     // With short keys, the normalized key is sufficient.
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = env.fromElements(
       ("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhaa", 1, 2),
@@ -326,7 +326,7 @@ class AggregationsITCase(
   def testGroupedAggregateWithConstant1(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .select('a, 4 as 'four, 'b)
@@ -345,7 +345,7 @@ class AggregationsITCase(
   def testGroupedAggregateWithConstant2(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .select('b, 4 as 'four, 'a)
@@ -361,7 +361,7 @@ class AggregationsITCase(
   def testGroupedAggregateWithExpression(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
       .groupBy('e, 'b % 3)
@@ -377,7 +377,7 @@ class AggregationsITCase(
   def testGroupedAggregateWithFilter(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .groupBy('b)
@@ -392,7 +392,7 @@ class AggregationsITCase(
   @Test
   def testAnalyticAggregation(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv =BatchTableEnvironment.create(env)
     val ds = env.fromElements(
       (1: Byte, 1: Short, 1, 1L, 1.0f, 1.0d, BigDecimal.ONE),
       (2: Byte, 2: Short, 2, 2L, 2.0f, 2.0d, new BigDecimal(2))).toTable(tEnv)
@@ -422,7 +422,7 @@ class AggregationsITCase(
   def testComplexAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val top10Fun = new Top10
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
@@ -443,7 +443,7 @@ class AggregationsITCase(
   @Test
   def testCollect(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .groupBy('b)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
@@ -24,7 +24,6 @@ import java.util
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.Types._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.Literal
@@ -51,7 +50,7 @@ class CalcITCase(
   @Test
   def testSimpleSelectAll(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).select('_1, '_2, '_3)
 
@@ -68,7 +67,7 @@ class CalcITCase(
   @Test
   def testSimpleSelectAllWithAs(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c).select('a, 'b, 'c)
 
@@ -85,7 +84,7 @@ class CalcITCase(
   @Test
   def testSimpleSelectWithNaming(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
       .select('_1 as 'a, '_2 as 'b, '_1 as 'c)
@@ -101,7 +100,7 @@ class CalcITCase(
   @Test
   def testSimpleSelectRenameAll(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
       .select('_1 as 'a, '_2 as 'b, '_3 as 'c)
@@ -117,7 +116,7 @@ class CalcITCase(
   @Test
   def testSelectStar(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv, 'a, 'b).select('*)
 
@@ -130,7 +129,7 @@ class CalcITCase(
   @Test
   def testAllRejectingFilter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
@@ -144,7 +143,7 @@ class CalcITCase(
   @Test
   def testAllPassingFilter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
@@ -162,7 +161,7 @@ class CalcITCase(
   @Test
   def testFilterOnStringTupleField(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val filterDs = ds.filter( 'c.like("%world%") )
@@ -175,7 +174,7 @@ class CalcITCase(
   @Test
   def testFilterOnIntegerTupleField(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
@@ -192,7 +191,7 @@ class CalcITCase(
   @Test
   def testNotEquals(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
@@ -208,7 +207,7 @@ class CalcITCase(
   @Test
   def testDisjunctivePredicate(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
@@ -221,7 +220,7 @@ class CalcITCase(
   @Test
   def testConsecutiveFilters(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
@@ -236,7 +235,7 @@ class CalcITCase(
   @Test
   def testFilterBasicType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.getStringDataSet(env)
 
@@ -250,7 +249,7 @@ class CalcITCase(
   @Test
   def testFilterOnCustomType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.getCustomTypeDataSet(env)
     val filterDs = ds.toTable(tEnv, 'myInt as 'i, 'myLong as 'l, 'myString as 's)
@@ -264,7 +263,7 @@ class CalcITCase(
   @Test
   def testSimpleCalc(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
         .select('_1, '_2, '_3)
@@ -280,7 +279,7 @@ class CalcITCase(
   @Test
   def testCalcWithTwoFilters(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
         .select('_1, '_2, '_3)
@@ -297,7 +296,7 @@ class CalcITCase(
   @Test
   def testCalcWithAggregation(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
         .select('_1, '_2, '_3)
@@ -314,7 +313,7 @@ class CalcITCase(
   @Test
   def testCalcJoin(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -330,7 +329,7 @@ class CalcITCase(
   @Test
   def testAdvancedDataTypes(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setDecimalContext(new MathContext(30))
 
     val t = env
@@ -355,7 +354,7 @@ class CalcITCase(
   @Test
   def testUserDefinedScalarFunction() {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     tableEnv.registerFunction("hashCode", OldHashCode)
     tableEnv.registerFunction("hashCode", HashCode)
     val table = env.fromElements("a", "b", "c").toTable(tableEnv, 'text)
@@ -369,7 +368,7 @@ class CalcITCase(
   def testNumericAutocastInArithmetic() {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
+    val tableEnv = BatchTableEnvironment.create(env)
 
     val table = env.fromElements(
       (1.toByte, 1.toShort, 1, 1L, 1.0f, 1.0d, 1L, 1001.1)).toTable(tableEnv)
@@ -384,7 +383,7 @@ class CalcITCase(
   @Test
   def testNumericAutocastInComparison() {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
+    val tableEnv = BatchTableEnvironment.create(env)
 
     val table = env.fromElements(
       (1.toByte, 1.toShort, 1, 1L, 1.0f, 1.0d),
@@ -400,7 +399,7 @@ class CalcITCase(
   @Test
   def testCasting() {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
+    val tableEnv = BatchTableEnvironment.create(env)
     val table = env.fromElements((1, 0.0, 1L, true)).toTable(tableEnv)
       .select(
         // * -> String
@@ -423,7 +422,7 @@ class CalcITCase(
   @Test
   def testCastFromString() {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
+    val tableEnv = BatchTableEnvironment.create(env)
     val table = env.fromElements(("1", "true", "2.0")).toTable(tableEnv)
       .select('_1.cast(BYTE), '_1.cast(SHORT), '_1.cast(INT), '_1.cast(LONG),
         '_3.cast(DOUBLE), '_3.cast(FLOAT), '_2.cast(BOOLEAN))
@@ -436,7 +435,7 @@ class CalcITCase(
   @Test
   def testUserDefinedScalarFunctionWithParameter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     tEnv.registerFunction("RichFunc2", new RichFunc2)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("string.value" -> "ABC"))
 
@@ -458,7 +457,7 @@ class CalcITCase(
     val filePath = UserDefinedFunctionTestUtils.writeCacheFile("test_words", words)
     val env = ExecutionEnvironment.getExecutionEnvironment
     env.registerCachedFile(filePath, "words")
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     tEnv.registerFunction("RichFunc3", new RichFunc3)
 
     val ds = CollectionDataSets.getSmall3TupleDataSet(env)
@@ -476,7 +475,7 @@ class CalcITCase(
   @Test
   def testValueConstructor(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val rowValue = ("foo", 12, Timestamp.valueOf("1984-07-12 14:34:24"))
 
@@ -504,7 +503,7 @@ class CalcITCase(
   @Test
   def testMultipleUserDefinedScalarFunctions(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     tEnv.registerFunction("RichFunc1", new RichFunc1)
     tEnv.registerFunction("RichFunc2", new RichFunc2)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("string.value" -> "Abc"))
@@ -525,7 +524,7 @@ class CalcITCase(
   @Test
   def testScalarFunctionConstructorWithParams(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
 
     val data = new mutable.MutableList[(Int, Long, String)]
     data.+=((1, 1L, "Jack#22"))
@@ -558,7 +557,7 @@ class CalcITCase(
 
     val env = ExecutionEnvironment.getExecutionEnvironment
 
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val splitUDF0 = new SplitUDF(deterministic = true)
     val splitUDF1 = new SplitUDF(deterministic = false)
@@ -582,7 +581,7 @@ class CalcITCase(
   @Test
   def testSplitFieldsOnCustomType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)  // splits fields
 
     val ds = CollectionDataSets.getCustomTypeDataSet(env)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -23,7 +23,7 @@ import java.sql.{Date, Timestamp}
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types, ValidationException}
+import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.expressions.utils.{Func1, Func18, Func20, RichFunc2}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -49,7 +49,7 @@ class CorrelateITCase(
   @Test
   def testCrossJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val func1 = new TableFunc1
@@ -70,7 +70,7 @@ class CorrelateITCase(
   @Test
   def testLeftOuterJoinWithoutPredicates(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val func2 = new TableFunc2
@@ -84,7 +84,7 @@ class CorrelateITCase(
   @Test
   def testLeftOuterJoinWithSplit(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     tableEnv.getConfig.setMaxGeneratedCodeLength(1) // split every field
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
@@ -102,7 +102,7 @@ class CorrelateITCase(
   @Test (expected = classOf[ValidationException])
   def testLeftOuterJoinWithPredicates(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val func2 = new TableFunc2
@@ -118,7 +118,7 @@ class CorrelateITCase(
   @Test
   def testWithFilter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
@@ -136,7 +136,7 @@ class CorrelateITCase(
   @Test
   def testCustomReturnType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func2 = new TableFunc2
 
@@ -154,7 +154,7 @@ class CorrelateITCase(
   @Test
   def testHierarchyType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val hierarchy = new HierarchyTableFunction
@@ -172,7 +172,7 @@ class CorrelateITCase(
   @Test
   def testPojoType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val pojo = new PojoTableFunc()
@@ -190,7 +190,7 @@ class CorrelateITCase(
   @Test
   def testUserDefinedTableFunctionWithScalarFunction(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func1 = new TableFunc1
 
@@ -208,7 +208,7 @@ class CorrelateITCase(
   @Test
   def testUserDefinedTableFunctionWithScalarFunctionInCondition(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
@@ -226,7 +226,7 @@ class CorrelateITCase(
   @Test
   def testLongAndTemporalTypes(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func0 = new JavaTableFunc0
 
@@ -247,7 +247,7 @@ class CorrelateITCase(
   @Test
   def testByteShortFloatArguments(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val tFunc = new TableFunc4
 
@@ -268,7 +268,7 @@ class CorrelateITCase(
   @Test
   def testUserDefinedTableFunctionWithParameter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     val richTableFunc1 = new RichTableFunc1
     tEnv.registerFunction("RichTableFunc1", richTableFunc1)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("word_separator" -> "#"))
@@ -286,7 +286,7 @@ class CorrelateITCase(
   @Test
   def testUserDefinedTableFunctionWithScalarFunctionWithParameters(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     val richTableFunc1 = new RichTableFunc1
     tEnv.registerFunction("RichTableFunc1", richTableFunc1)
     val richFunc2 = new RichFunc2
@@ -308,7 +308,7 @@ class CorrelateITCase(
   @Test
   def testTableFunctionConstructorWithParams(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func30 = new TableFunc3(null)
     val func31 = new TableFunc3("OneConf_")
@@ -334,7 +334,7 @@ class CorrelateITCase(
   @Test
   def testTableFunctionWithVariableArguments(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val varArgsFunc0 = new VarArgsFunc0
     tableEnv.registerFunction("VarArgsFunc0", varArgsFunc0)
 
@@ -370,7 +370,7 @@ class CorrelateITCase(
   @Test
   def testTableFunctionCollectorOpenClose(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     val t = testData(env).toTable(tableEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
     val func20 = new Func20

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/GroupWindowITCase.scala
@@ -22,7 +22,6 @@ import java.math.BigDecimal
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
@@ -52,7 +51,7 @@ class GroupWindowITCase(
   @Test(expected = classOf[UnsupportedOperationException])
   def testAllEventTimeTumblingWindowOverCount(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -69,7 +68,7 @@ class GroupWindowITCase(
   @Test
   def testEventTimeTumblingGroupWindowOverCount(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -92,7 +91,7 @@ class GroupWindowITCase(
   @Test
   def testEventTimeTumblingGroupWindowOverTime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -119,7 +118,7 @@ class GroupWindowITCase(
   @Test
   def testAllEventTimeTumblingWindowOverTime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -142,7 +141,7 @@ class GroupWindowITCase(
   @Test
   def testEventTimeSessionGroupWindow(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -166,7 +165,7 @@ class GroupWindowITCase(
   @Test
   def testAllEventTimeSessionGroupWindow(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     val table = env
       .fromCollection(data)
       .toTable(tEnv, 'long, 'int, 'double, 'float, 'bigdec, 'string)
@@ -187,7 +186,7 @@ class GroupWindowITCase(
   @Test
   def testMultiGroupWindow(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -219,7 +218,7 @@ class GroupWindowITCase(
   @Test(expected = classOf[UnsupportedOperationException])
   def testAllEventTimeSlidingGroupWindowOverCount(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val table = env
       .fromCollection(data)
@@ -237,7 +236,7 @@ class GroupWindowITCase(
   def testAllEventTimeSlidingGroupWindowOverTime(): Unit = {
     // please keep this test in sync with the DataStream variant
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env
       .fromCollection(data)
@@ -267,7 +266,7 @@ class GroupWindowITCase(
   def testEventTimeSlidingGroupWindowOverTimeOverlappingFullPane(): Unit = {
     // please keep this test in sync with the DataStream variant
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env
       .fromCollection(data)
@@ -300,7 +299,7 @@ class GroupWindowITCase(
   def testEventTimeSlidingGroupWindowOverTimeOverlappingSplitPane(): Unit = {
     // please keep this test in sync with the DataStream variant
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env
       .fromCollection(data)
@@ -329,7 +328,7 @@ class GroupWindowITCase(
   def testEventTimeSlidingGroupWindowOverTimeNonOverlappingFullPane(): Unit = {
     // please keep this test in sync with the DataStream variant
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env
       .fromCollection(data)
@@ -353,7 +352,7 @@ class GroupWindowITCase(
   def testEventTimeSlidingGroupWindowOverTimeNonOverlappingSplitPane(): Unit = {
     // please keep this test in sync with the DataStream variant
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val table = env
       .fromCollection(data)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/JoinITCase.scala
@@ -23,7 +23,6 @@ import java.lang.Iterable
 import org.apache.flink.api.common.functions.MapPartitionFunction
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.Literal
 import org.apache.flink.table.expressions.utils.Func20
@@ -49,7 +48,7 @@ class JoinITCase(
   @Test
   def testInnerJoin(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -70,7 +69,7 @@ class JoinITCase(
   def testInnerJoinWithFilter(): Unit = {
 
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
@@ -85,7 +84,7 @@ class JoinITCase(
   @Test
   def testInnerJoinWithJoinFilter(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -101,7 +100,7 @@ class JoinITCase(
   @Test
   def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -116,7 +115,7 @@ class JoinITCase(
   @Test
   def testInnerJoinWithMultipleKeys(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = addNullKey3Tuples(
       CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
@@ -134,9 +133,9 @@ class JoinITCase(
   @Test
   def testInnerJoinWithAggregation(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     // use different table env in order to let tmp table ids are the same
-    val tEnv2 = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv2 = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -151,7 +150,7 @@ class JoinITCase(
   @Test
   def testInnerJoinWithGroupedAggregation(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -169,7 +168,7 @@ class JoinITCase(
   @Test
   def testInnerJoinPushThroughJoin(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -189,7 +188,7 @@ class JoinITCase(
   @Test
   def testInnerJoinWithDisjunctivePred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -206,7 +205,7 @@ class JoinITCase(
   @Test
   def testInnerJoinWithExpressionPreds(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -225,7 +224,7 @@ class JoinITCase(
   @Test
   def testLeftJoinWithMultipleKeys(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -250,7 +249,7 @@ class JoinITCase(
   @Test
   def testLeftJoinWithNonEquiJoinPred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -275,7 +274,7 @@ class JoinITCase(
   @Test
   def testLeftJoinWithLeftLocalPred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -300,7 +299,7 @@ class JoinITCase(
   @Test
   def testRightJoinWithMultipleKeys(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -322,7 +321,7 @@ class JoinITCase(
   @Test
   def testRightJoinWithNonEquiJoinPred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey5Tuples(
@@ -347,7 +346,7 @@ class JoinITCase(
   @Test
   def testRightJoinWithLeftLocalPred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey5Tuples(
@@ -372,7 +371,7 @@ class JoinITCase(
   @Test
   def testFullOuterJoinWithMultipleKeys(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -399,7 +398,7 @@ class JoinITCase(
   @Test
   def testFullJoinWithNonEquiJoinPred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -428,7 +427,7 @@ class JoinITCase(
   @Test
   def testFullJoinWithLeftLocalPred(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     tEnv.getConfig.setNullCheck(true)
 
     val ds1 = addNullKey3Tuples(
@@ -460,7 +459,7 @@ class JoinITCase(
   @Test
   def testUDTFJoinOnTuples(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val data = List("hi#world", "how#are#you")
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/SetOperatorsITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.batch.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -42,7 +41,7 @@ class SetOperatorsITCase(
   @Test
   def testUnionAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f)
@@ -57,7 +56,7 @@ class SetOperatorsITCase(
   @Test
   def testUnion(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f)
@@ -72,7 +71,7 @@ class SetOperatorsITCase(
   @Test
   def testTernaryUnionAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
@@ -90,7 +89,7 @@ class SetOperatorsITCase(
   @Test
   def testTernaryUnion(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
@@ -106,7 +105,7 @@ class SetOperatorsITCase(
   @Test
   def testMinusAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = env.fromElements((1, 1L, "Hi")).toTable(tEnv, 'a, 'b, 'c)
@@ -125,7 +124,7 @@ class SetOperatorsITCase(
   @Test
   def testMinus(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = env.fromElements((1, 1L, "Hi")).toTable(tEnv, 'a, 'b, 'c)
@@ -141,7 +140,7 @@ class SetOperatorsITCase(
   @Test
   def testMinusDifferentFieldNames(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = env.fromElements((1, 1L, "Hi")).toTable(tEnv, 'd, 'e, 'f)
@@ -157,7 +156,7 @@ class SetOperatorsITCase(
   @Test
   def testIntersect(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val data = new mutable.MutableList[(Int, Long, String)]
@@ -178,7 +177,7 @@ class SetOperatorsITCase(
   @Test
   def testIntersectAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val data1 = new mutable.MutableList[Int]
     data1 += (1, 1, 1, 2, 2)
@@ -197,7 +196,7 @@ class SetOperatorsITCase(
   @Test
   def testIntersectWithDifferentFieldNames(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'e, 'f, 'g)
@@ -212,7 +211,7 @@ class SetOperatorsITCase(
   @Test
   def testIntersectWithScalarExpression(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
       .select('a + 1, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/SortITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.batch.table
 
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.api.scala.{ExecutionEnvironment, _}
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.SortTestUtils._
 import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase
@@ -50,7 +49,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByDesc(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val t = ds.toTable(tEnv).orderBy('_1.desc)
@@ -78,7 +77,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByAsc(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val t = ds.toTable(tEnv).orderBy('_1.asc)
@@ -106,7 +105,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByMultipleFieldsDifferentDirections(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val t = ds.toTable(tEnv).orderBy('_2.asc, '_1.desc)
@@ -140,7 +139,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByOffset(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val t = ds.toTable(tEnv).orderBy('_1.asc).offset(3)
@@ -168,7 +167,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByOffsetAndFetch(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val t = ds.toTable(tEnv).orderBy('_1.desc).offset(3).fetch(5)
@@ -196,7 +195,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
   @Test
   def testOrderByFetch(): Unit = {
     val env = getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val t = ds.toTable(tEnv).orderBy('_1.asc).fetch(5)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableEnvironmentITCase.scala
@@ -22,7 +22,6 @@ import java.util
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.runtime.utils.{TableProgramsCollectionTestBase, TableProgramsTestBase}
@@ -46,7 +45,7 @@ class TableEnvironmentITCase(
 
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     tEnv.registerDataSet(tableName, ds)
@@ -67,7 +66,7 @@ class TableEnvironmentITCase(
 
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     tEnv.registerDataSet(tableName, ds, 'a, 'b, 'c) // new alias
@@ -85,7 +84,7 @@ class TableEnvironmentITCase(
 
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
     tEnv.registerDataSet(tableName, ds, '_3, '_1, '_2) // new order
@@ -103,7 +102,7 @@ class TableEnvironmentITCase(
 
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     tEnv.registerTable(tableName, t)
@@ -122,7 +121,7 @@ class TableEnvironmentITCase(
   @Test
   def testToTable(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val t = CollectionDataSets.get3TupleDataSet(env)
       .toTable(tEnv, 'a, 'b, 'c)
@@ -141,7 +140,7 @@ class TableEnvironmentITCase(
   @Test
   def testToTableFromCaseClass(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val data = List(
       SomeCaseClass("Peter", 28, 4000.00, "Sales"),
@@ -163,7 +162,7 @@ class TableEnvironmentITCase(
   @Test
   def testToTableFromAndToCaseClass(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     val data = List(
       SomeCaseClass("Peter", 28, 4000.00, "Sales"),
@@ -185,7 +184,7 @@ class TableEnvironmentITCase(
   @Test
   def testInsertIntoMemoryTable(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSinkITCase.scala
@@ -23,7 +23,7 @@ import java.io.File
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.api.scala.{ExecutionEnvironment, _}
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -46,7 +46,7 @@ class TableSinkITCase(
     val path = tmpFile.toURI.toString
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
     env.setParallelism(4)
 
     tEnv.registerTableSink(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
 import org.apache.flink.api.java.{DataSet, ExecutionEnvironment => JExecEnv}
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, TableException, TableSchema, Types}
+import org.apache.flink.table.api.{TableException, TableSchema, Types}
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.runtime.utils.{CommonTestData, TableProgramsCollectionTestBase}
 import org.apache.flink.table.sources.BatchTableSource
@@ -48,7 +48,7 @@ class TableSourceITCase(
   @Test(expected = classOf[TableException])
   def testInvalidDatastreamType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val tableSource = new BatchTableSource[Row]() {
       private val fieldNames: Array[String] = Array("name", "id", "value")
@@ -77,7 +77,7 @@ class TableSourceITCase(
     val csvTable = CommonTestData.getCsvTableSource
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tEnv = BatchTableEnvironment.create(env, config)
 
     tEnv.registerTableSource("csvTable", csvTable)
 
@@ -100,7 +100,7 @@ class TableSourceITCase(
   def testTableSourceWithFilterable(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
     tableEnv.registerTableSource(tableName, TestFilterableTableSource())
     val results = tableEnv
       .scan(tableName)
@@ -117,7 +117,7 @@ class TableSourceITCase(
   def testRowtimeRowTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -151,7 +151,7 @@ class TableSourceITCase(
   def testProctimeRowTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -187,7 +187,7 @@ class TableSourceITCase(
   def testRowtimeProctimeRowTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -223,7 +223,7 @@ class TableSourceITCase(
   def testRowtimeAsTimestampRowTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", toTimestamp(1L), new JInt(10)),
@@ -256,7 +256,7 @@ class TableSourceITCase(
   def testTableSourceWithFilterableDate(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
 
     val rowTypeInfo = new RowTypeInfo(
       Array[TypeInformation[_]](BasicTypeInfo.INT_TYPE_INFO, SqlTimeTypeInfo.DATE),
@@ -288,7 +288,7 @@ class TableSourceITCase(
   def testRowtimeLongTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(new JLong(1L), new JLong(2L), new JLong(2L), new JLong(2001L), new JLong(4001L))
 
@@ -315,7 +315,7 @@ class TableSourceITCase(
   def testProctimeStringTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq("Mary", "Peter", "Bob", "Liz")
 
@@ -338,7 +338,7 @@ class TableSourceITCase(
   def testRowtimeProctimeLongTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(new JLong(1L), new JLong(2L), new JLong(2L), new JLong(2001L), new JLong(4001L))
 
@@ -368,7 +368,7 @@ class TableSourceITCase(
   def testFieldMappingTableSource(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -401,7 +401,7 @@ class TableSourceITCase(
   @Test
   def testProjectWithoutRowtimeProctime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
@@ -436,7 +436,7 @@ class TableSourceITCase(
   @Test
   def testProjectWithoutProctime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
@@ -471,7 +471,7 @@ class TableSourceITCase(
   @Test
   def testProjectWithoutRowtime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
@@ -507,7 +507,7 @@ class TableSourceITCase(
   @Test
   def testProjectOnlyProctime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
@@ -539,7 +539,7 @@ class TableSourceITCase(
   @Test
   def testProjectOnlyRowtime(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
@@ -574,7 +574,7 @@ class TableSourceITCase(
   @Test
   def testProjectWithMapping(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JLong(1), new JInt(1), "Mary", new JLong(10)),
@@ -611,7 +611,7 @@ class TableSourceITCase(
   def testNestedProject(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = BatchTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JLong(1),
@@ -680,7 +680,7 @@ class TableSourceITCase(
   def testTableSourceWithFilterableTime(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
 
     val rowTypeInfo = new RowTypeInfo(
       Array[TypeInformation[_]](BasicTypeInfo.INT_TYPE_INFO, SqlTimeTypeInfo.TIME),
@@ -713,7 +713,7 @@ class TableSourceITCase(
   def testTableSourceWithFilterableTimestamp(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val tableEnv = BatchTableEnvironment.create(env, config)
 
     val rowTypeInfo = new RowTypeInfo(
       Array[TypeInformation[_]](BasicTypeInfo.INT_TYPE_INFO, SqlTimeTypeInfo.TIMESTAMP),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/AggFunctionHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/AggFunctionHarnessTest.scala
@@ -27,7 +27,6 @@ import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.dataview.MapView
 import org.apache.flink.table.dataview.StateMapView
 import org.apache.flink.table.runtime.aggregate.GroupAggProcessFunction
@@ -46,7 +45,7 @@ class AggFunctionHarnessTest extends HarnessTestBase {
   @Test
   def testCollectAggregate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(JInt, String)]
     val t = env.fromCollection(data).toTable(tEnv, 'a, 'b)
@@ -111,7 +110,7 @@ class AggFunctionHarnessTest extends HarnessTestBase {
   @Test
   def testMinMaxAggFunctionWithRetract(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(JInt, JInt, String)]
     val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
@@ -27,7 +27,6 @@ import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.harness.HarnessTestBase._
 import org.apache.flink.table.runtime.types.CRow
@@ -186,7 +185,7 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
   @Test
   def testDistinctAggregateWithRetract(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(JLong, JInt)]
     val t = env.fromCollection(data).toTable(tEnv, 'a, 'b)
@@ -274,7 +273,7 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
   @Test
   def testDistinctAggregateWithDifferentArgumentOrder(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(JLong, JLong, JLong)]
     val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/MatchHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/MatchHarnessTest.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.types.Row
@@ -39,7 +38,7 @@ class MatchHarnessTest extends HarnessTestBase {
   @Test
   def testAccessingProctime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = new mutable.MutableList[(Int, String)]
     val t = env.fromCollection(data).toTable(tEnv, 'id, 'name, 'proctime.proctime)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/TimeAttributesITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/TimeAttributesITCase.scala
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, TableSchema, Types}
+import org.apache.flink.table.api.{TableSchema, Types}
 import org.apache.flink.table.expressions.{ExpressionParser, TimeIntervalUnit}
 import org.apache.flink.table.plan.TimeIndicatorConversionTest.TableFunc
 import org.apache.flink.table.runtime.stream.TimeAttributesITCase.{AtomicTimestampWithEqualWatermark, TestPojo, TimestampWithEqualWatermark, TimestampWithEqualWatermarkPojo}
@@ -62,7 +62,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testAtomicType1(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -94,7 +94,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testAtomicType2(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -126,7 +126,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testCalcMaterialization(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -156,7 +156,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testCalcMaterialization2(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -183,7 +183,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testTableSink(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     tEnv.registerTableSink(
@@ -217,7 +217,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testTableFunction(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -255,7 +255,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testWindowAfterTableFunction(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -286,7 +286,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testUnion(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -323,7 +323,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testWindowWithAggregationOnRowtimeSql(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -352,7 +352,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testMultiWindow(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -385,7 +385,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testMultiWindowSqlNoAggregation(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -424,7 +424,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testMultiWindowSqlWithAggregation(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -463,7 +463,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testMultiWindowSqlWithAggregation2(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -502,7 +502,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testCalcMaterializationWithPojoType(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -532,7 +532,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testPojoSupport(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val p1 = new TestPojo
@@ -596,7 +596,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     StreamITCase.clear
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val rows = Seq(
       Row.of(new JInt(1), "A", new JLong(1000L)),
@@ -638,7 +638,7 @@ class TimeAttributesITCase extends AbstractTestBase {
   def testSqlWindowRowtime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -668,7 +668,7 @@ class TimeAttributesITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(String, Timestamp, Int)]

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/InsertIntoITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/InsertIntoITCase.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.runtime.stream.table.{RowCollector, TestRetractSink, TestUpsertSink}
 import org.apache.flink.table.runtime.utils.{StreamTestData, StreamingWithStateTestBase}
 import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
@@ -40,7 +40,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     val input = StreamTestData.get3TupleDataStream(env)
@@ -77,7 +77,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -117,7 +117,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -164,7 +164,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -210,7 +210,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -260,7 +260,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -311,7 +311,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -360,7 +360,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.expressions.Null
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
 import org.apache.flink.types.Row
@@ -42,7 +42,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testProcessTimeInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(1)
@@ -85,7 +85,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testProcessTimeInnerJoinWithOtherConditions(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(2)
@@ -134,7 +134,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -193,7 +193,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeInnerJoinWithEquiTimeAttrs(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -240,7 +240,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeInnerJoinWithOtherConditions(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -303,7 +303,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeInnerJoinWithOtherTimeCondition(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -358,7 +358,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeInnerJoinWithWindowAggregateOnFirstTime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -413,7 +413,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeInnerJoinWithWindowAggregateOnSecondTime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -467,7 +467,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testProcTimeLeftOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(1)
@@ -507,7 +507,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeLeftOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -572,7 +572,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeLeftOuterJoinNegativeWindowSize(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -621,7 +621,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testProcTimeRightOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(1)
@@ -661,7 +661,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeRightOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -722,7 +722,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeRightOuterJoinNegativeWindowSize(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -771,7 +771,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testProcTimeFullOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(1)
@@ -811,7 +811,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeFullOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -875,7 +875,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeFullOuterJoinNegativeWindowSize(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     StreamITCase.clear
@@ -927,7 +927,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testNonWindowInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
 
@@ -981,7 +981,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e"
@@ -1003,7 +1003,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1026,7 +1026,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1049,7 +1049,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithMultipleKeys(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1074,7 +1074,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithAlias(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1100,7 +1100,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithAggregation(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
@@ -1124,7 +1124,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testLeftJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1150,7 +1150,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRightJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1176,7 +1176,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testLeftSingleRightJoinEqualPredicate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -1202,7 +1202,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testFullOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.stream.sql
 
 import java.sql.Timestamp
-import java.time.{ZoneId, ZonedDateTime}
 import java.util.TimeZone
 
 import org.apache.flink.api.common.time.Time
@@ -28,7 +27,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableConfig, TableEnvironment, Types}
+import org.apache.flink.table.api.{TableConfig, Types}
 import org.apache.flink.table.functions.{AggregateFunction, FunctionContext, ScalarFunction}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvg
 import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
@@ -45,7 +44,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testSimplePattern(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, String)]
@@ -92,7 +91,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testSimplePatternWithNulls(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, String, String)]
@@ -142,7 +141,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     env.setParallelism(1)
     val tableConfig = new TableConfig
     tableConfig.setMaxGeneratedCodeLength(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env, tableConfig)
+    val tEnv = StreamTableEnvironment.create(env, tableConfig)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, String, String, String)]
@@ -196,7 +195,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = Seq(
@@ -255,7 +254,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(String, Long, Int, Int)]
@@ -317,7 +316,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(String, Long, Int, Int)]
@@ -372,7 +371,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testLogicalOffsets(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(String, Long, Int, Int)]
@@ -422,7 +421,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testLogicalOffsetsWithStarVariable(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, String, Long, Int)]
@@ -483,7 +482,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testLogicalOffsetOutsideOfRangeInMeasures(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(String, Long, Int, Int)]
@@ -535,7 +534,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testAggregates(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
     StreamITCase.clear
 
@@ -597,7 +596,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testAggregatesWithNullInputs(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
     StreamITCase.clear
 
@@ -653,7 +652,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testAccessingCurrentTime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, String)]
@@ -693,7 +692,7 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
   def testUserDefinedFunctions(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
     StreamITCase.clear
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/OverWindowITCase.scala
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
-import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment}
+import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.MultiArgCount
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
@@ -57,7 +57,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
 
@@ -99,7 +99,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   def testProcTimeBoundedNonPartitionedRowsOver(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     env.setParallelism(1)
     StreamITCase.clear
@@ -141,7 +141,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   def testProcTimeUnboundedPartitionedRangeOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     // for sum aggregation ensure that every time the order of each element is consistent
@@ -172,7 +172,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   def testProcTimeUnboundedPartitionedRowsOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
@@ -204,7 +204,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     // for sum aggregation ensure that every time the order of each element is consistent
@@ -234,7 +234,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   def testProcTimeUnboundedNonPartitionedRowsOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
@@ -290,7 +290,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env
@@ -355,7 +355,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env
@@ -426,7 +426,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env
@@ -489,7 +489,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env
@@ -523,7 +523,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeUnBoundedPartitionedRangeOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     env.setParallelism(1)
@@ -592,7 +592,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeUnBoundedPartitionedRowsOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     StreamITCase.testResults = mutable.MutableList()
@@ -662,7 +662,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeUnBoundedNonPartitionedRangeOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     env.setParallelism(1)
@@ -724,7 +724,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeUnBoundedNonPartitionedRowsOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
@@ -780,7 +780,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeUnBoundedPartitionedRowsOver2(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
@@ -860,7 +860,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
 
@@ -905,7 +905,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
 
@@ -967,7 +967,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     // for sum aggregation ensure that every time the order of each element is consistent
@@ -1023,7 +1023,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
 import org.apache.flink.types.Row
@@ -32,7 +31,7 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
   @Test
   def testInUncorrelatedWithConditionAndAgg(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery =
@@ -77,7 +76,7 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
   @Test
   def testInWithMultiUncorrelatedCondition(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery =
@@ -129,7 +128,7 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
   @Test
   def testNotInUncorrelated(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
 import org.apache.flink.table.runtime.stream.sql.SortITCase.StringRowSelectorSink
@@ -78,7 +78,7 @@ class SortITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env.addSource(new EventTimeSourceFunction[(Long, Int, String)](data))
@@ -112,7 +112,7 @@ class SortITCase extends StreamingWithStateTestBase {
   def testInsertIntoMemoryTableOrderBy(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     val t = StreamTestData.getSmall3TupleDataStream(env)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.api.Types
 import org.apache.flink.table.descriptors.{Rowtime, Schema}
 import org.apache.flink.table.expressions.utils.Func15
 import org.apache.flink.table.runtime.stream.sql.SqlITCase.TimestampAndWatermarkWithOffset
@@ -74,7 +74,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       .assignTimestampsAndWatermarks(
         new TimestampAndWatermarkWithOffset[(Long, Int, String)](10L))
 
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     val table = stream.toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
     tEnv.registerTable("MyTable", table)
     tEnv.registerFunction("myCount", new MultiArgCount)
@@ -106,7 +106,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
 
@@ -140,7 +140,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     StreamITCase.clear
     env.setParallelism(1)
@@ -168,7 +168,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testNonWindowedCount(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.retractedResults = mutable.ArrayBuffer()
     StreamITCase.clear
 
@@ -194,7 +194,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testRowRegister(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT * FROM MyTableRow WHERE c < 3"
@@ -227,7 +227,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testUnboundedGroupBy(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT b, COUNT(a) FROM MyTable GROUP BY b"
@@ -247,7 +247,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testDistinctGroupBy(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery =
@@ -273,7 +273,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testDistinctWithRetraction(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, Long, String)]
@@ -310,7 +310,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testUnboundedGroupByCollect(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
 
@@ -337,7 +337,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testUnboundedGroupByCollectWithObject(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
 
@@ -370,7 +370,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testSelectStar(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT * FROM MyTable"
@@ -391,7 +391,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testSelectExpressionFromTable(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT a * 2, b - 1 FROM MyTable"
@@ -411,7 +411,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testSelectExpressionWithSplitFromTable(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.getConfig.setMaxGeneratedCodeLength(1) // split every field
     StreamITCase.clear
 
@@ -433,7 +433,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testSimpleFilter(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT * FROM MyTable WHERE a = 3"
@@ -454,7 +454,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testDatastreamFilter(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT * FROM MyTable WHERE _1 = 3"
@@ -474,7 +474,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnion(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT * FROM T1 " +
@@ -501,7 +501,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnionWithFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT * FROM T1 WHERE a = 3 " +
@@ -527,7 +527,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnionTableWithDataSet(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val sqlQuery = "SELECT c FROM T1 WHERE a = 3 " +
@@ -550,7 +550,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnnestPrimitiveArrayFromTable(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = List(
@@ -581,7 +581,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnnestArrayOfArrayFromTable(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = List(
@@ -610,7 +610,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnnestObjectArrayFromTableWithFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = List(
@@ -636,7 +636,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUnnestMultiSetFromCollectResult(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
 
@@ -679,7 +679,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (7, "8", "Hello World"))
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t1 = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
@@ -707,7 +707,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testHopStartEndWithHaving(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
@@ -759,7 +759,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testWriteReadTableSourceSink(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     val desc = Schema()
@@ -796,7 +796,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUDFWithLongVarargs(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     tEnv.registerFunction("func15", Func15)
@@ -821,7 +821,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   @Test
   def testUDTFWithLongVarargs(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     tEnv.registerFunction("udtf", new JavaUserDefinedTableFunctions.JavaTableFunc1)
@@ -848,7 +848,7 @@ class SqlITCase extends StreamingWithStateTestBase {
   def testVeryBigQuery(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.getSingletonDataStream(env).toTable(tEnv).as('a, 'b, 'c)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/TableSourceITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{CommonTestData, StreamITCase}
 import org.apache.flink.test.util.AbstractTestBase
@@ -38,7 +37,7 @@ class TableSourceITCase extends AbstractTestBase {
     val csvTable = CommonTestData.getCsvTableSource
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     tEnv.registerTableSource("persons", csvTable)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
@@ -25,7 +25,6 @@ import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.windowing.time.Time
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
 import org.apache.flink.types.Row
@@ -44,7 +43,7 @@ class TemporalJoinITCase extends StreamingWithStateTestBase {
   @Test
   def testProcessTimeInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(1)
@@ -95,7 +94,7 @@ class TemporalJoinITCase extends StreamingWithStateTestBase {
   @Test
   def testEventTimeInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStateBackend(getStateBackend)
     StreamITCase.clear
     env.setParallelism(1)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/AggregateITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.StreamITCase.RetractingSink
-import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment, Types}
+import org.apache.flink.table.api.{StreamQueryConfig, Types}
 import org.apache.flink.table.expressions.Null
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, DataViewTestAgg, WeightedAvg}
 import org.apache.flink.table.runtime.utils.{JavaUserDefinedAggFunctions, StreamITCase, StreamTestData, StreamingWithStateTestBase}
@@ -45,7 +45,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDistinctUDAGG(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val testAgg = new DataViewTestAgg
@@ -65,7 +65,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDistinctUDAGGMixedWithNonDistinctUsage(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val testAgg = new WeightedAvg
@@ -85,7 +85,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDistinctAggregate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, Int, String)]
@@ -119,7 +119,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDistinctAggregateMixedWithNonDistinct(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
@@ -138,7 +138,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDistinct(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -156,7 +156,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDistinctAfterAggregate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
@@ -174,7 +174,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testNonKeyedGroupAggregate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -192,7 +192,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testGroupAggregate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -211,7 +211,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testDoubleGroupAggregation(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -232,7 +232,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testGroupAggregateWithExpression(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
@@ -254,7 +254,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testCollect(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -275,7 +275,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testGroupAggregateWithStateBackend(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, Long, String)]
@@ -313,7 +313,7 @@ class AggregateITCase extends StreamingWithStateTestBase {
   def testRemoveDuplicateRecordsWithUpsertSink(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val data = new mutable.MutableList[(Int, Long, String)]

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.Literal
 import org.apache.flink.table.expressions.utils._
@@ -38,7 +37,7 @@ class CalcITCase extends AbstractTestBase {
   def testSimpleSelectAll(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).select('_1, '_2, '_3)
 
@@ -57,7 +56,7 @@ class CalcITCase extends AbstractTestBase {
   def testSelectStar(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmallNestedTupleDataStream(env).toTable(tEnv).select('*)
 
@@ -73,7 +72,7 @@ class CalcITCase extends AbstractTestBase {
   def testSelectFirst(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).select('_1)
 
@@ -90,7 +89,7 @@ class CalcITCase extends AbstractTestBase {
 
     // verify ProjectMergeRule.
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv)
       .select('_1 as 'a, '_2 as 'b, '_1 as 'c)
@@ -111,7 +110,7 @@ class CalcITCase extends AbstractTestBase {
   def testSimpleSelectAllWithAs(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
       .select('a, 'b, 'c)
@@ -133,7 +132,7 @@ class CalcITCase extends AbstractTestBase {
      * Test simple filter
      */
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -153,7 +152,7 @@ class CalcITCase extends AbstractTestBase {
      * Test all-rejecting filter
      */
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -172,7 +171,7 @@ class CalcITCase extends AbstractTestBase {
      * Test all-passing filter
      */
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -195,7 +194,7 @@ class CalcITCase extends AbstractTestBase {
      * Test filter on Integer tuple field.
      */
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -218,7 +217,7 @@ class CalcITCase extends AbstractTestBase {
      * Test filter on Integer tuple field.
      */
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -238,7 +237,7 @@ class CalcITCase extends AbstractTestBase {
   @Test
   def testUserDefinedFunctionWithParameter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.registerFunction("RichFunc2", new RichFunc2)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("string.value" -> "ABC"))
 
@@ -260,7 +259,7 @@ class CalcITCase extends AbstractTestBase {
   @Test
   def testMultipleUserDefinedFunctions(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.registerFunction("RichFunc1", new RichFunc1)
     tEnv.registerFunction("RichFunc2", new RichFunc2)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("string.value" -> "Abc"))
@@ -283,7 +282,7 @@ class CalcITCase extends AbstractTestBase {
   @Test
   def testScalarFunctionConstructorWithParams(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
 
@@ -316,7 +315,7 @@ class CalcITCase extends AbstractTestBase {
   def testMapType(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.get3TupleDataStream(env)
       .toTable(tEnv)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -22,7 +22,7 @@ import java.lang.{Boolean => JBoolean}
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, Types, ValidationException}
+import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.expressions.utils.{Func18, Func20, RichFunc2}
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, _}
 import org.apache.flink.table.utils._
@@ -36,7 +36,7 @@ import scala.collection.mutable
 class CorrelateITCase extends AbstractTestBase {
 
   val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
-  val tEnv: StreamTableEnvironment = TableEnvironment.getTableEnvironment(env)
+  val tEnv: StreamTableEnvironment = StreamTableEnvironment.create(env)
 
   @Before
   def clear(): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment}
+import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.runtime.stream.table.GroupWindowITCase._
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, CountDistinctWithMerge, WeightedAvg, WeightedAvgWithMerge}
@@ -68,7 +68,7 @@ class GroupWindowITCase extends AbstractTestBase {
   def testProcessingTimeSlidingGroupWindowOverCount(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env.fromCollection(data)
@@ -110,7 +110,7 @@ class GroupWindowITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val countFun = new CountAggFunction
@@ -141,7 +141,7 @@ class GroupWindowITCase extends AbstractTestBase {
   def testAllProcessingTimeTumblingGroupWindowOverCount(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env.fromCollection(data)
@@ -170,7 +170,7 @@ class GroupWindowITCase extends AbstractTestBase {
   def testEventTimeTumblingWindow(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -211,7 +211,7 @@ class GroupWindowITCase extends AbstractTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env.fromCollection(data)
@@ -242,7 +242,7 @@ class GroupWindowITCase extends AbstractTestBase {
     // please keep this test in sync with the DataSet variant
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -281,7 +281,7 @@ class GroupWindowITCase extends AbstractTestBase {
     // please keep this test in sync with the DataSet variant
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -321,7 +321,7 @@ class GroupWindowITCase extends AbstractTestBase {
     // please keep this test in sync with the DataSet variant
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -358,7 +358,7 @@ class GroupWindowITCase extends AbstractTestBase {
     // please keep this test in sync with the DataSet variant
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -389,7 +389,7 @@ class GroupWindowITCase extends AbstractTestBase {
     // please keep this test in sync with the DataSet variant
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env
@@ -418,7 +418,7 @@ class GroupWindowITCase extends AbstractTestBase {
   def testEventTimeGroupWindowWithoutExplicitTimeField(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream = env

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/JoinITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{StreamQueryConfig, TableEnvironment, Types}
+import org.apache.flink.table.api.{StreamQueryConfig, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
 import org.junit.Assert._
@@ -72,7 +72,7 @@ class JoinITCase extends StreamingWithStateTestBase {
     )
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -136,7 +136,7 @@ class JoinITCase extends StreamingWithStateTestBase {
     )
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -184,7 +184,7 @@ class JoinITCase extends StreamingWithStateTestBase {
       (16L, 3, "RIGHT:Hello world"))
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
 
     val stream1 = env
@@ -219,7 +219,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -243,7 +243,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -262,7 +262,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithJoinFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -283,7 +283,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithNonEquiJoinPredicate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -303,7 +303,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithMultipleKeys(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -325,7 +325,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithAggregation(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
@@ -346,7 +346,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithGroupedAggregation(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
@@ -370,7 +370,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinPushThroughJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -395,7 +395,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithDisjunctivePred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -415,7 +415,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testInnerJoinWithExpressionPreds(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -436,7 +436,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testLeftJoinWithMultipleKeys(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -464,7 +464,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testLeftJoinWithNonEquiJoinPred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -490,7 +490,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testLeftJoinWithLeftLocalPred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -515,7 +515,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testLeftJoinWithRetractionInput(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -537,7 +537,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRightJoinWithMultipleKeys(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -560,7 +560,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRightJoinWithNonEquiJoinPred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -585,7 +585,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testRightJoinWithLeftLocalPred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -610,7 +610,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testFullOuterJoinWithMultipleKeys(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -638,7 +638,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testFullJoinWithNonEquiJoinPred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -668,7 +668,7 @@ class JoinITCase extends StreamingWithStateTestBase {
   @Test
   def testFullJoinWithLeftLocalPred(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
@@ -24,7 +24,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, CountDistinctWithRetractAndReset, WeightedAvg}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0
 import org.apache.flink.table.api.scala._
@@ -57,7 +56,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     StreamITCase.clear
     val stream = env.fromCollection(data)
@@ -103,7 +102,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.testResults = mutable.MutableList()
     StreamITCase.clear
     val stream = env.fromCollection(data)
@@ -128,7 +127,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
   @Test
   def testRowTimeUnBoundedPartitionedRangeOver(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
     StreamITCase.testResults = mutable.MutableList()
@@ -223,7 +222,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(1)
     StreamITCase.testResults = mutable.MutableList()
 
@@ -286,7 +285,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     env.setParallelism(1)
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val countDist = new CountDistinctWithRetractAndReset
@@ -350,7 +349,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setStateBackend(getStateBackend)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val countDist = new CountDistinctWithRetractAndReset

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/RetractionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/RetractionITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
 import org.apache.flink.table.utils.TableFunc0
@@ -50,7 +49,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
   @Test
   def testWordCount(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -74,7 +73,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
   @Test
   def testGroupByAndNonKeyedGroupBy(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -99,7 +98,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
   def testNonKeyedGroupByAndGroupBy(): Unit = {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 
@@ -139,7 +138,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
       (7, 8L)
     )
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
     env.setParallelism(1)
@@ -166,7 +165,7 @@ class RetractionITCase extends StreamingWithStateTestBase {
   @Test
   def testCorrelate(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
     env.setStateBackend(getStateBackend)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.stream.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
@@ -36,7 +35,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testUnion(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -56,7 +55,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testUnionWithFilter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
@@ -75,7 +74,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testUnionWithAnyType(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val s1 = env.fromElements((1, new NonPojo), (2, new NonPojo)).toTable(tEnv, 'a, 'b)
@@ -92,7 +91,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testUnionWithCompositeType(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     StreamITCase.testResults = mutable.MutableList()
     val s1 = env.fromElements((1, (1, "a")), (2, (2, "b")))
@@ -111,7 +110,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testInUncorrelated(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val dataA = Seq(
@@ -147,7 +146,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testInUncorrelatedWithConditionAndAgg(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val dataA = Seq(
@@ -187,7 +186,7 @@ class SetOperatorsITCase extends AbstractTestBase {
   @Test
   def testInWithMultiUncorrelatedCondition(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val dataA = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, TableException, Types}
+import org.apache.flink.table.api.{TableException, Types}
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
@@ -53,7 +53,7 @@ class TableSinkITCase extends AbstractTestBase {
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
     val input = StreamTestData.get3TupleDataStream(env)
@@ -89,7 +89,7 @@ class TableSinkITCase extends AbstractTestBase {
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     env.setParallelism(4)
 
     tEnv.registerTableSink(
@@ -127,7 +127,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
         .assignAscendingTimestamps(_._1.toLong)
@@ -162,7 +162,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val ds1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = StreamTestData.get5TupleDataStream(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
@@ -189,7 +189,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -227,7 +227,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -268,7 +268,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -309,7 +309,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -353,7 +353,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -398,7 +398,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -442,7 +442,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -486,7 +486,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env)
@@ -533,7 +533,7 @@ class TableSinkITCase extends AbstractTestBase {
   def testToRetractStreamRowtime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     StreamITCase.clear
 
     val t = StreamTestData.get3TupleDataStream(env)
@@ -581,7 +581,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
@@ -600,7 +600,7 @@ class TableSinkITCase extends AbstractTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment =>
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableEnvironment, TableException, TableSchema, Types}
+import org.apache.flink.table.api.{TableException, TableSchema, Types}
 import org.apache.flink.table.runtime.utils.{CommonTestData, StreamITCase}
 import org.apache.flink.table.sources.StreamTableSource
 import org.apache.flink.table.utils._
@@ -48,7 +48,7 @@ class TableSourceITCase extends AbstractTestBase {
   @Test(expected = classOf[TableException])
   def testInvalidDatastreamType(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val tableSource = new StreamTableSource[Row]() {
       private val fieldNames: Array[String] = Array("name", "id", "value")
@@ -81,7 +81,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     tEnv.registerTableSource("csvTable", csvTable)
     tEnv.scan("csvTable")
@@ -105,7 +105,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
     tEnv.registerTableSource(tableName, TestFilterableTableSource())
     tEnv.scan(tableName)
       .where("amount > 4 && price < 9")
@@ -124,7 +124,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -161,7 +161,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -200,7 +200,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -239,7 +239,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", toTimestamp(1L), new JInt(10)),
@@ -276,7 +276,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(new JLong(1L), new JLong(2L), new JLong(2L), new JLong(2001L), new JLong(4001L))
 
@@ -306,7 +306,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       "1970-01-01 00:00:00",
@@ -342,7 +342,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq("Mary", "Peter", "Bob", "Liz")
 
@@ -368,7 +368,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(new JLong(1L), new JLong(2L), new JLong(2L), new JLong(2001L), new JLong(4001L))
 
@@ -401,7 +401,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of("Mary", new JLong(1L), new JInt(10)),
@@ -437,7 +437,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
@@ -475,7 +475,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
@@ -513,7 +513,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), "Mary", new JLong(10L), new JLong(1)),
@@ -551,7 +551,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
@@ -585,7 +585,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
@@ -623,7 +623,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JLong(1), new JInt(1), "Mary", new JLong(10)),
@@ -663,7 +663,7 @@ class TableSourceITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     val data = Seq(
       Row.of(new JLong(1),
@@ -735,7 +735,7 @@ class TableSourceITCase extends AbstractTestBase {
     val tableName = "MyTable"
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
-    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val tEnv = StreamTableEnvironment.create(env)
 
     // rows with timestamps and watermarks
     val data = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -21,15 +21,16 @@ package org.apache.flink.table.utils
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.RelNode
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.{LocalEnvironment, DataSet => JDataSet, ExecutionEnvironment => JExecutionEnvironment}
+import org.apache.flink.api.java.{LocalEnvironment, DataSet => JDataSet}
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
-import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment => JStreamExecutionEnvironment}
+import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment}
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.java.{BatchTableEnvironment => JavaBatchTableEnv, StreamTableEnvironment => JavaStreamTableEnv}
+import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv, StreamTableEnvironment => ScalaStreamTableEnv}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{Table, TableEnvironment, TableSchema}
+import org.apache.flink.table.api.{Table, TableSchema}
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
 import org.junit.Assert.assertEquals
@@ -187,9 +188,9 @@ object TableTestUtil {
 
 case class BatchTableTestUtil() extends TableTestUtil {
   val javaEnv = new LocalEnvironment()
-  val javaTableEnv = TableEnvironment.getTableEnvironment(javaEnv)
+  val javaTableEnv = JavaBatchTableEnv.create(javaEnv)
   val env = new ExecutionEnvironment(javaEnv)
-  val tableEnv = TableEnvironment.getTableEnvironment(env)
+  val tableEnv = ScalaBatchTableEnv.create(env)
 
   def addTable[T: TypeInformation](
       name: String,
@@ -273,9 +274,9 @@ case class StreamTableTestUtil() extends TableTestUtil {
   val javaEnv = new LocalStreamEnvironment()
   javaEnv.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
-  val javaTableEnv = TableEnvironment.getTableEnvironment(javaEnv)
+  val javaTableEnv = JavaStreamTableEnv.create(javaEnv)
   val env = new StreamExecutionEnvironment(javaEnv)
-  val tableEnv = TableEnvironment.getTableEnvironment(env)
+  val tableEnv = ScalaStreamTableEnv.create(env)
 
   def addTable[T: TypeInformation](
       name: String,


### PR DESCRIPTION
## What is the purpose of the change

This pull request deprecates static methods in TableEnvironments and direct to the java/scala Batch/StreamTableEnvionrment.create() approach.


## Brief change log

  - Deprecated the getTableEnvironment method in TableEnvironment.
  - Deprecate the constructors of all table environments. Because of scala, deprecation messages of constructors will only be shown at compile time
  - Add create method in all 4 TableEnvironments: java/scala Batch/StreamTableEnvionrment.
  - Replace all old getTableEnvironment methods to the new create methods in all places in Flink.
  - Adapt document


## Verifying this change


This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)