### PR TITLE
[FLINK-11391][shuffle] Introduce PartitionShuffleDescriptor and ShuffleDeploymentDescriptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/DefaultShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/DefaultShuffleMaster.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The default shuffle master implementation used in managing partitions globally
+ * for specific job manager.
+ */
+public class DefaultShuffleMaster implements Serializable {
+
+	private static final long serialVersionUID = 6343547936086963705L;
+
+	public DefaultShuffleMaster() {
+	}
+
+	public ShuffleDeploymentDescriptor registerPartitionProducer(PartitionShuffleDescriptor psd) {
+		checkNotNull(psd);
+
+		return new ShuffleDeploymentDescriptor(psd.getConnectionId());
+	}
+
+	@Override
+	public String toString() {
+		return "DefaultShuffleMaster []";
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/LocationType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/LocationType.java
@@ -18,14 +18,10 @@
 
 package org.apache.flink.runtime.deployment;
 
-import org.apache.flink.runtime.io.network.ConnectionID;
-
-import java.io.Serializable;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 
 /**
- * Location of a result partition from the perspective of the consuming task.
+ * Location type of a result partition from the perspective of the consuming task.
  *
  * <p>The location indicates both the instance, on which the partition is produced and the state of
  * the producing task. There are three possibilities:
@@ -45,58 +41,26 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * to have registered the partition after its state has switched to running.
  * </ol>
  */
-public class ResultPartitionLocation implements Serializable {
+public enum LocationType {
 
-	private static final long serialVersionUID = -6354238166937194463L;
-	/** The type of location for the result partition. */
-	private final LocationType locationType;
-
-	/** The connection ID of a remote result partition. */
-	private final ConnectionID connectionId;
-
-	private enum LocationType {
-		LOCAL,
-		REMOTE,
-		UNKNOWN
-	}
-
-	private ResultPartitionLocation(LocationType locationType, ConnectionID connectionId) {
-		this.locationType = checkNotNull(locationType);
-		this.connectionId = connectionId;
-	}
-
-	public static ResultPartitionLocation createRemote(ConnectionID connectionId) {
-		return new ResultPartitionLocation(LocationType.REMOTE, checkNotNull(connectionId));
-	}
-
-	public static ResultPartitionLocation createLocal() {
-		return new ResultPartitionLocation(LocationType.LOCAL, null);
-	}
-
-	public static ResultPartitionLocation createUnknown() {
-		return new ResultPartitionLocation(LocationType.UNKNOWN, null);
-	}
+	LOCAL,
+	REMOTE,
+	UNKNOWN;
 
 	// ------------------------------------------------------------------------
 
-	public boolean isLocal() {
-		return locationType == LocationType.LOCAL;
-	}
+	/**
+	 * Creates the location type based on the container IDs of producer and consumer.
+	 */
+	public static LocationType getLocationType(ResourceID producerLocation, ResourceID consumerLocation) {
+		final LocationType locationType;
 
-	public boolean isRemote() {
-		return locationType == LocationType.REMOTE;
-	}
+		if (producerLocation.equals(consumerLocation)) {
+			locationType = LocationType.LOCAL;
+		} else {
+			locationType = LocationType.REMOTE;
+		}
 
-	public boolean isUnknown() {
-		return locationType == LocationType.UNKNOWN;
-	}
-
-	public ConnectionID getConnectionId() {
-		return connectionId;
-	}
-
-	@Override
-	public String toString() {
-		return "ResultPartitionLocation [" + locationType + (isRemote() ? " [" + connectionId + "]]" : "]");
+		return locationType;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -54,16 +54,12 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 	/** The maximum parallelism. */
 	private final int maxParallelism;
 
-	/** Flag whether the result partition should send scheduleOrUpdateConsumer messages. */
-	private final boolean sendScheduleOrUpdateConsumersMessage;
-
 	public ResultPartitionDeploymentDescriptor(
 			IntermediateDataSetID resultId,
 			IntermediateResultPartitionID partitionId,
 			ResultPartitionType partitionType,
 			int numberOfSubpartitions,
-			int maxParallelism,
-			boolean lazyScheduling) {
+			int maxParallelism) {
 
 		this.resultId = checkNotNull(resultId);
 		this.partitionId = checkNotNull(partitionId);
@@ -73,7 +69,6 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		checkArgument(numberOfSubpartitions >= 1);
 		this.numberOfSubpartitions = numberOfSubpartitions;
 		this.maxParallelism = maxParallelism;
-		this.sendScheduleOrUpdateConsumersMessage = lazyScheduling;
 	}
 
 	public IntermediateDataSetID getResultId() {
@@ -96,10 +91,6 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		return maxParallelism;
 	}
 
-	public boolean sendScheduleOrUpdateConsumersMessage() {
-		return sendScheduleOrUpdateConsumersMessage;
-	}
-
 	@Override
 	public String toString() {
 		return String.format("ResultPartitionDeploymentDescriptor [result id: %s, "
@@ -110,7 +101,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 	// ------------------------------------------------------------------------
 
 	public static ResultPartitionDeploymentDescriptor from(
-			IntermediateResultPartition partition, int maxParallelism, boolean lazyScheduling) {
+			IntermediateResultPartition partition, int maxParallelism) {
 
 		final IntermediateDataSetID resultId = partition.getIntermediateResult().getId();
 		final IntermediateResultPartitionID partitionId = partition.getPartitionId();
@@ -132,6 +123,6 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		}
 
 		return new ResultPartitionDeploymentDescriptor(
-				resultId, partitionId, partitionType, numberOfSubpartitions, maxParallelism, lazyScheduling);
+				resultId, partitionId, partitionType, numberOfSubpartitions, maxParallelism);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ShuffleDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ShuffleDeploymentDescriptor.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.runtime.io.network.ConnectionID;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Deployment descriptor for shuffle specific information.
+ */
+public class ShuffleDeploymentDescriptor implements Serializable {
+
+	private static final long serialVersionUID = 6343547936086963705L;
+
+	/** The connection address of shuffle service to be used for requesting partition. */
+	private final ConnectionID connectionId;
+
+	public ShuffleDeploymentDescriptor(ConnectionID connectionId) {
+		this.connectionId = checkNotNull(connectionId);
+	}
+
+	public ConnectionID getConnectionId() {
+		return connectionId;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ShuffleDeploymentDescriptor [connection id: %s]", connectionId);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -146,6 +146,9 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	@Nullable
 	private final JobManagerTaskRestore taskRestore;
 
+	/** Flag whether the task should send scheduleOrUpdateConsumer messages. */
+	private final boolean sendScheduleOrUpdateConsumersMessage;
+
 	public TaskDeploymentDescriptor(
 		JobID jobId,
 		MaybeOffloaded<JobInformation> serializedJobInformation,
@@ -157,7 +160,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		int targetSlotNumber,
 		@Nullable JobManagerTaskRestore taskRestore,
 		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
-		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
+		boolean lazyScheduling) {
 
 		this.jobId = Preconditions.checkNotNull(jobId);
 
@@ -180,6 +184,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 		this.producedPartitions = Preconditions.checkNotNull(resultPartitionDeploymentDescriptors);
 		this.inputGates = Preconditions.checkNotNull(inputGateDeploymentDescriptors);
+
+		this.sendScheduleOrUpdateConsumersMessage = lazyScheduling;
 	}
 
 	/**
@@ -271,6 +277,10 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 	public AllocationID getAllocationId() {
 		return allocationId;
+	}
+
+	public boolean sendScheduleOrUpdateConsumersMessage() {
+		return sendScheduleOrUpdateConsumersMessage;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
+import org.apache.flink.runtime.deployment.DefaultShuffleMaster;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
@@ -614,6 +615,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	public SlotProvider getSlotProvider() {
 		return slotProvider;
+	}
+
+	public DefaultShuffleMaster getShuffleMaster() {
+		return new DefaultShuffleMaster();
 	}
 
 	public Either<SerializedValue<JobInformation>, PermanentBlobKey> getJobInformationOrBlobKey() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -794,7 +794,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		}
 	}
 
-	/**
+	/**TaskDeploymentDescriptorTest.java
 	 * Creates a task deployment descriptor to deploy a subtask to the given target slot.
 	 * TODO: This should actually be in the EXECUTION
 	 */
@@ -820,8 +820,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 				//TODO this case only exists for test, currently there has to be exactly one consumer in real jobs!
 				producedPartitions.add(ResultPartitionDeploymentDescriptor.from(
 						partition,
-						KeyGroupRangeAssignment.UPPER_BOUND_MAX_PARALLELISM,
-						lazyScheduling));
+						KeyGroupRangeAssignment.UPPER_BOUND_MAX_PARALLELISM));
 			} else {
 				Preconditions.checkState(1 == consumers.size(),
 						"Only one consumer supported in the current implementation! Found: " + consumers.size());
@@ -829,7 +828,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 				List<ExecutionEdge> consumer = consumers.get(0);
 				ExecutionJobVertex vertex = consumer.get(0).getTarget().getJobVertex();
 				int maxParallelism = vertex.getMaxParallelism();
-				producedPartitions.add(ResultPartitionDeploymentDescriptor.from(partition, maxParallelism, lazyScheduling));
+				producedPartitions.add(ResultPartitionDeploymentDescriptor.from(partition, maxParallelism));
 			}
 		}
 
@@ -892,7 +891,8 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 			targetSlot.getPhysicalSlotNumber(),
 			taskRestore,
 			producedPartitions,
-			consumedPartitions);
+			consumedPartitions,
+			lazyScheduling);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/PartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/PartitionInfo.java
@@ -20,7 +20,8 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.util.Preconditions;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 
@@ -33,16 +34,19 @@ public class PartitionInfo implements Serializable {
 
 	private static final long serialVersionUID = 1724490660830968430L;
 
-	private final IntermediateDataSetID intermediateDataSetID;
+	private final IntermediateDataSetID resultId;
 	private final InputChannelDeploymentDescriptor inputChannelDeploymentDescriptor;
 
-	public PartitionInfo(IntermediateDataSetID intermediateResultPartitionID, InputChannelDeploymentDescriptor inputChannelDeploymentDescriptor) {
-		this.intermediateDataSetID = Preconditions.checkNotNull(intermediateResultPartitionID);
-		this.inputChannelDeploymentDescriptor = Preconditions.checkNotNull(inputChannelDeploymentDescriptor);
+	public PartitionInfo(
+			IntermediateDataSetID resultId,
+			InputChannelDeploymentDescriptor inputChannelDeploymentDescriptor) {
+
+		this.resultId = checkNotNull(resultId);
+		this.inputChannelDeploymentDescriptor = checkNotNull(inputChannelDeploymentDescriptor);
 	}
 
-	public IntermediateDataSetID getIntermediateDataSetID() {
-		return intermediateDataSetID;
+	public IntermediateDataSetID getResultId() {
+		return resultId;
 	}
 
 	public InputChannelDeploymentDescriptor getInputChannelDeploymentDescriptor() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -528,6 +528,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				tdd.getProducedPartitions(),
 				tdd.getInputGates(),
 				tdd.getTargetSlotNumber(),
+				tdd.sendScheduleOrUpdateConsumersMessage(),
 				taskExecutorServices.getMemoryManager(),
 				taskExecutorServices.getIOManager(),
 				taskExecutorServices.getNetworkEnvironment(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -624,10 +624,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		if (task != null) {
 			for (final PartitionInfo partitionInfo: partitionInfos) {
-				IntermediateDataSetID intermediateResultPartitionID = partitionInfo.getIntermediateDataSetID();
-
-				final SingleInputGate singleInputGate = task.getInputGateById(intermediateResultPartitionID);
-
+				IntermediateDataSetID resultId = partitionInfo.getResultId();
+				final SingleInputGate singleInputGate = task.getInputGateById(resultId);
 				if (singleInputGate != null) {
 					// Run asynchronously because it might be blocking
 					getRpcService().execute(
@@ -647,8 +645,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 						});
 				} else {
 					return FutureUtils.completedExceptionally(
-						new PartitionException("No reader with ID " + intermediateResultPartitionID +
-							" for task " + executionAttemptID + " was found."));
+						new PartitionException("No reader with ID " + resultId + " for task " + executionAttemptID + " was found."));
 				}
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -279,6 +279,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
 		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
 		int targetSlotNumber,
+		boolean sendScheduleOrUpdateConsumersMessage,
 		MemoryManager memManager,
 		IOManager ioManager,
 		NetworkEnvironment networkEnvironment,
@@ -371,7 +372,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				networkEnvironment.getResultPartitionManager(),
 				resultPartitionConsumableNotifier,
 				ioManager,
-				desc.sendScheduleOrUpdateConsumersMessage());
+				sendScheduleOrUpdateConsumersMessage);
 
 			++counter;
 		}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1232,6 +1232,7 @@ class TaskManager(
         tdd.getProducedPartitions,
         tdd.getInputGates,
         tdd.getTargetSlotNumber,
+        tdd.sendScheduleOrUpdateConsumersMessage(),
         memoryManager,
         ioManager,
         network,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1289,7 +1289,7 @@ class TaskManager(
 
         val errors: Iterable[String] = partitionInfos.asScala.flatMap { info =>
 
-          val resultID = info.getIntermediateDataSetID
+          val resultID = info.getResultId
           val partitionInfo = info.getInputChannelDeploymentDescriptor
           val reader = task.getInputGateById(resultID)
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link ResultPartitionDeploymentDescriptor}.
@@ -50,8 +49,7 @@ public class ResultPartitionDeploymentDescriptorTest {
 						partitionId,
 						partitionType,
 						numberOfSubpartitions,
-						numberOfSubpartitions,
-						true);
+						numberOfSubpartitions);
 
 		ResultPartitionDeploymentDescriptor copy =
 				CommonTestUtils.createCopySerializable(orig);
@@ -60,6 +58,5 @@ public class ResultPartitionDeploymentDescriptorTest {
 		assertEquals(partitionId, copy.getPartitionId());
 		assertEquals(partitionType, copy.getPartitionType());
 		assertEquals(numberOfSubpartitions, copy.getNumberOfSubpartitions());
-		assertTrue(copy.sendScheduleOrUpdateConsumersMessage());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -48,7 +48,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -123,71 +122,10 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 		assertThat(actualSerializedJobInformation, is(serializedJobInformation));
 
 		try {
-			final JobID jobID = new JobID();
-			final JobVertexID vertexID = new JobVertexID();
-			final ExecutionAttemptID execId = new ExecutionAttemptID();
-			final AllocationID allocationId = new AllocationID();
-			final String jobName = "job name";
-			final String taskName = "task name";
-			final int numberOfKeyGroups = 1;
-			final int indexInSubtaskGroup = 0;
-			final int currentNumberOfSubtasks = 1;
-			final int attemptNumber = 0;
-			final Configuration jobConfiguration = new Configuration();
-			final Configuration taskConfiguration = new Configuration();
-			final Class<? extends AbstractInvokable> invokableClass = BatchTask.class;
-			final List<ResultPartitionDeploymentDescriptor> producedResults = new ArrayList<ResultPartitionDeploymentDescriptor>(0);
-			final List<InputGateDeploymentDescriptor> inputGates = new ArrayList<InputGateDeploymentDescriptor>(0);
-			final List<PermanentBlobKey> requiredJars = new ArrayList<>(0);
-			final List<URL> requiredClasspaths = new ArrayList<>(0);
-			final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
-			final SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(new JobInformation(
-				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths));
-			final SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(new TaskInformation(
-				vertexID, taskName, currentNumberOfSubtasks, numberOfKeyGroups, invokableClass.getName(), taskConfiguration));
-			final int targetSlotNumber = 47;
-			final TaskStateSnapshot taskStateHandles = new TaskStateSnapshot();
-			final JobManagerTaskRestore taskRestore = new JobManagerTaskRestore(1L, taskStateHandles);
-
-			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(
-				jobID,
-				new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobInformation),
-				new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobVertexInformation),
-				execId,
-				allocationId,
-				indexInSubtaskGroup,
-				attemptNumber,
-				targetSlotNumber,
-				taskRestore,
-				producedResults,
-				inputGates,
-				true);
-
-			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
-
-			assertFalse(orig.getSerializedJobInformation() == copy.getSerializedJobInformation());
-			assertFalse(orig.getSerializedTaskInformation() == copy.getSerializedTaskInformation());
-			assertFalse(orig.getExecutionAttemptId() == copy.getExecutionAttemptId());
-			assertFalse(orig.getTaskRestore() == copy.getTaskRestore());
-			assertFalse(orig.getProducedPartitions() == copy.getProducedPartitions());
-			assertFalse(orig.getInputGates() == copy.getInputGates());
-
-			assertEquals(orig.getSerializedJobInformation(), copy.getSerializedJobInformation());
-			assertEquals(orig.getSerializedTaskInformation(), copy.getSerializedTaskInformation());
-			assertEquals(orig.getExecutionAttemptId(), copy.getExecutionAttemptId());
-			assertEquals(orig.getAllocationId(), copy.getAllocationId());
-			assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
-			assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
-			assertEquals(orig.getTargetSlotNumber(), copy.getTargetSlotNumber());
-			assertEquals(orig.getTaskRestore().getRestoreCheckpointId(), copy.getTaskRestore().getRestoreCheckpointId());
-			assertEquals(orig.getTaskRestore().getTaskStateSnapshot(), copy.getTaskRestore().getTaskStateSnapshot());
-			assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
-			assertEquals(orig.getInputGates(), copy.getInputGates());
-			assertTrue(copy.sendScheduleOrUpdateConsumersMessage());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+			taskDeploymentDescriptor.getSerializedTaskInformation();
+			fail("Expected to fail since the task information should be offloaded.");
+		} catch (IllegalStateException expected) {
+			// expected
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -122,10 +123,71 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 		assertThat(actualSerializedJobInformation, is(serializedJobInformation));
 
 		try {
-			taskDeploymentDescriptor.getSerializedTaskInformation();
-			fail("Expected to fail since the task information should be offloaded.");
-		} catch (IllegalStateException expected) {
-			// expected
+			final JobID jobID = new JobID();
+			final JobVertexID vertexID = new JobVertexID();
+			final ExecutionAttemptID execId = new ExecutionAttemptID();
+			final AllocationID allocationId = new AllocationID();
+			final String jobName = "job name";
+			final String taskName = "task name";
+			final int numberOfKeyGroups = 1;
+			final int indexInSubtaskGroup = 0;
+			final int currentNumberOfSubtasks = 1;
+			final int attemptNumber = 0;
+			final Configuration jobConfiguration = new Configuration();
+			final Configuration taskConfiguration = new Configuration();
+			final Class<? extends AbstractInvokable> invokableClass = BatchTask.class;
+			final List<ResultPartitionDeploymentDescriptor> producedResults = new ArrayList<ResultPartitionDeploymentDescriptor>(0);
+			final List<InputGateDeploymentDescriptor> inputGates = new ArrayList<InputGateDeploymentDescriptor>(0);
+			final List<PermanentBlobKey> requiredJars = new ArrayList<>(0);
+			final List<URL> requiredClasspaths = new ArrayList<>(0);
+			final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
+			final SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(new JobInformation(
+				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths));
+			final SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(new TaskInformation(
+				vertexID, taskName, currentNumberOfSubtasks, numberOfKeyGroups, invokableClass.getName(), taskConfiguration));
+			final int targetSlotNumber = 47;
+			final TaskStateSnapshot taskStateHandles = new TaskStateSnapshot();
+			final JobManagerTaskRestore taskRestore = new JobManagerTaskRestore(1L, taskStateHandles);
+
+			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(
+				jobID,
+				new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobInformation),
+				new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobVertexInformation),
+				execId,
+				allocationId,
+				indexInSubtaskGroup,
+				attemptNumber,
+				targetSlotNumber,
+				taskRestore,
+				producedResults,
+				inputGates,
+				true);
+
+			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
+
+			assertFalse(orig.getSerializedJobInformation() == copy.getSerializedJobInformation());
+			assertFalse(orig.getSerializedTaskInformation() == copy.getSerializedTaskInformation());
+			assertFalse(orig.getExecutionAttemptId() == copy.getExecutionAttemptId());
+			assertFalse(orig.getTaskRestore() == copy.getTaskRestore());
+			assertFalse(orig.getProducedPartitions() == copy.getProducedPartitions());
+			assertFalse(orig.getInputGates() == copy.getInputGates());
+
+			assertEquals(orig.getSerializedJobInformation(), copy.getSerializedJobInformation());
+			assertEquals(orig.getSerializedTaskInformation(), copy.getSerializedTaskInformation());
+			assertEquals(orig.getExecutionAttemptId(), copy.getExecutionAttemptId());
+			assertEquals(orig.getAllocationId(), copy.getAllocationId());
+			assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
+			assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
+			assertEquals(orig.getTargetSlotNumber(), copy.getTargetSlotNumber());
+			assertEquals(orig.getTaskRestore().getRestoreCheckpointId(), copy.getTaskRestore().getRestoreCheckpointId());
+			assertEquals(orig.getTaskRestore().getTaskStateSnapshot(), copy.getTaskRestore().getTaskStateSnapshot());
+			assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
+			assertEquals(orig.getInputGates(), copy.getInputGates());
+			assertTrue(copy.sendScheduleOrUpdateConsumersMessage());
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
@@ -142,6 +204,7 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 			targetSlotNumber,
 			taskRestore,
 			producedResults,
-			inputGates);
+			inputGates,
+			true);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -386,7 +386,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
 
 			assertEquals(1, producedPartitions.size());
 			ResultPartitionDeploymentDescriptor desc = producedPartitions.iterator().next();
-			assertEquals(mode.allowLazyDeployment(), desc.sendScheduleOrUpdateConsumersMessage());
+			assertEquals(mode.allowLazyDeployment(), tdd.sendScheduleOrUpdateConsumersMessage());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.ConnectionID;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -699,7 +699,8 @@ public class TaskExecutorTest extends TestLogger {
 				0,
 				null,
 				Collections.emptyList(),
-				Collections.emptyList());
+				Collections.emptyList(),
+				true);
 
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
 		when(libraryCacheManager.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
@@ -1103,7 +1104,8 @@ public class TaskExecutorTest extends TestLogger {
 				0,
 				null,
 				Collections.emptyList(),
-				Collections.emptyList());
+				Collections.emptyList(),
+				true);
 
 			// we have to add the job after the TaskExecutor, because otherwise the service has not
 			// been properly started. This will also offer the slots to the job master

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -257,6 +257,7 @@ public class TaskAsyncCallTest extends TestLogger {
 			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 			Collections.<InputGateDeploymentDescriptor>emptyList(),
 			0,
+			true,
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -680,7 +680,7 @@ public class TaskManagerTest extends TestLogger {
 				IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 
 				List<ResultPartitionDeploymentDescriptor> irpdd = new ArrayList<ResultPartitionDeploymentDescriptor>();
-				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, 1, true));
+				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, 1));
 
 				InputGateDeploymentDescriptor ircdd =
 						new InputGateDeploymentDescriptor(
@@ -829,7 +829,7 @@ public class TaskManagerTest extends TestLogger {
 				IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 
 				List<ResultPartitionDeploymentDescriptor> irpdd = new ArrayList<ResultPartitionDeploymentDescriptor>();
-				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, 1, true));
+				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, 1));
 
 				InputGateDeploymentDescriptor ircdd =
 						new InputGateDeploymentDescriptor(
@@ -1583,8 +1583,7 @@ public class TaskManagerTest extends TestLogger {
 				new IntermediateResultPartitionID(),
 				ResultPartitionType.PIPELINED,
 				1,
-				1,
-				true);
+				1);
 
 			final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
 				"TestTask", 1, 0, 1, 0, new Configuration(), new Configuration(),
@@ -2178,7 +2177,8 @@ public class TaskManagerTest extends TestLogger {
 			targetSlotNumber,
 			null,
 			producedPartitions,
-			inputGates);
+			inputGates,
+			true);
 
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -1052,6 +1052,7 @@ public class TaskTest extends TestLogger {
 				Collections.emptyList(),
 				Collections.emptyList(),
 				0,
+				true,
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				networkEnvironment,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -204,6 +204,7 @@ public class JvmExitOnFatalErrorTest {
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						0,       // targetSlotNumber
+						true,
 						memoryManager,
 						ioManager,
 						networkEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -26,7 +26,6 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -271,6 +271,7 @@ public class InterruptSensitiveRestoreTest {
 			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 			Collections.<InputGateDeploymentDescriptor>emptyList(),
 			0,
+			true,
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -159,6 +159,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 			Collections.<InputGateDeploymentDescriptor>emptyList(),
 			0,
+			true,
 			new MemoryManager(32L * 1024L, 1),
 			new IOManagerAsync(),
 			networkEnv,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -931,6 +931,7 @@ public class StreamTaskTest extends TestLogger {
 			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 			Collections.<InputGateDeploymentDescriptor>emptyList(),
 			0,
+			true,
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			network,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -237,6 +237,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
 				0,
+				true,
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				network,


### PR DESCRIPTION
## What is the purpose of the change

*This is a sub task for introducing `ShuffleMaster` component on JM side based on pluggable `ShuffleManager` architecture.*

*In the first step, we try to refactor the related information structures during deployment. So we introduce the `PartitionShuffleDescriptor (PSD)` to cover all the necessary info which might come from `ExecutionGraph` directly or registration from `TM/ShuffleService`.*

*The `ShuffleDeploymentDescriptor (SDD)` is also introduced for covering only shuffle specific info and SDD is created by `ShuffleMaster` during `registerPartitionProducer`.*

*PSD and SDD would be cached and used for generating `ResultPartitionDeploymentDescriptor (RPDD)`, `InputGateDeploymentDescriptor (IGDD)`, `InputChannelDeploymentDescriptor (ICDD)`, etc during producer/consumer task deployments. The relationship between them seems PSD+SDD = RPDD/IGDD/ICDD.*

*In addition, we remove the `ResultPartitionLocation` structure to separate the `ConnectionID` and `LocationType` info. The `ConnectionID` can be regarded as shuffle specific info which would be covered in PSD, SDD, ICDD. And `LocationType` is covered only in ICDD when both producer and consumer are deployed.*

Notes:
1. *The `DefaultShuffleMaster` here is only for interacting with the related logics, and the formal implementation would be done in a separate pr.*

2. *We might not confirm the deployment sequence of scheduler, that means it might exist the scenario of deploying consumer before producer. So we can not rely on the producer's PSD/SDD to generate IGDD/ICDD of consumer, and this part is still relying on the `ExecutionEdge`.*

## Brief change log

  - *Introduce the structure of `PSD`*
  - *Introduce the structure of `SDD`*
  - *Remove the `ResultPartitionLocation`*
  - *Refactor the related process of task deployment*
  - *Refactor the related process of `scheduleOrUpdateConsumers`*

## Verifying this change

*The related tests would be added after reviewing to confirm current refactoring make sense. *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)