### PR TITLE
[FLINK-11510] [DataStream]  Add the MultiFieldSumAggregator to support KeyedStream.sum(int[] positionToSums )

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -41,6 +41,7 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
+import org.apache.flink.streaming.api.functions.aggregation.MultiFieldSumAggregator;
 import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
 import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
 import org.apache.flink.streaming.api.functions.query.QueryableAppendingStateOperator;
@@ -732,6 +733,22 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	}
 
 	/**
+	 * Applies an aggregation that gives a rolling sum of the data stream at the
+	 * given position grouped by the given key. An independent aggregate is kept
+	 * per key.
+	 *
+	 * @param positionToSums
+	 *            An Array of the field position in the data points to sum. This is applicable to
+	 *            Tuple types, basic and primitive array types, Scala case classes,
+	 *            and primitive types (which is considered as having one field).
+	 * @return The transformed DataStream.
+	 */
+	public SingleOutputStreamOperator<T> sum(int[] positionToSums ) {
+		return aggregate(new MultiFieldSumAggregator<>(positionToSums, getType(), getExecutionConfig()));
+	}
+
+
+	/**
 	 * Applies an aggregation that gives the current sum of the data
 	 * stream at the given field by the given key. An independent
 	 * aggregate is kept per key.
@@ -747,6 +764,25 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 */
 	public SingleOutputStreamOperator<T> sum(String field) {
 		return aggregate(new SumAggregator<>(field, getType(), getExecutionConfig()));
+	}
+
+	/**
+	 * Applies an aggregation that gives the current sum of the data
+	 * stream at the given fields by the given key. An independent
+	 * aggregate is kept per key.
+	 *
+	 * @param fields
+	 * 			  An Array of the field name in the data points to sum.
+	 *            In case of a POJO, Scala case class, or Tuple type, the
+	 *            name of the (public) field on which to perform the aggregation.
+	 *            Additionally, a dot can be used to drill down into nested
+	 *            objects, as in {@code "field1.fieldxy" }.
+	 *            Furthermore "*" can be specified in case of a basic type
+	 *            (which is considered as having only one field).
+	 * @return The transformed DataStream.
+	 */
+	public SingleOutputStreamOperator<T> sum(String[] fields) {
+		return aggregate(new MultiFieldSumAggregator<>(fields, getType(), getExecutionConfig()));
 	}
 
 	/**


### PR DESCRIPTION



## What is the purpose of the change

* The goal is to implement a KeyedStream API to sum with multi field as
[https://issues.apache.org/jira/browse/FLINK-11510](https://issues.apache.org/jira/browse/FLINK-11510)

## Brief change log
- add the class:
  -  MultiFieldSumAggregator 
- add  function in KeyedStream:
  - public SingleOutputStreamOperator<T> sum(int[] positionToSums ) 
  - public SingleOutputStreamOperator<T> sum(String[] fields)
- add unit test in follow ut
  - DataStreamTest
  - AggregationFunctionTest


## Verifying this change


This change added tests and can be verified as follows:
  - *Added integration tests for end-to-end deployment with small data collection*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *yes* 
     - org.apache.flink.streaming.api.datastream.KeyedStream
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented?  not documented
