### PR TITLE
[FLINK-11512] Port CliFrontendModifyTest to new code base

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
@@ -21,9 +21,9 @@ package org.apache.flink.client.cli;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
-import org.apache.flink.client.program.StandaloneClusterClient;
+import org.apache.flink.client.deployment.StandaloneClusterId;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.messages.Acknowledge;
 
 import org.hamcrest.Matchers;
@@ -115,13 +115,12 @@ public class CliFrontendModifyTest extends CliFrontendTestBase {
 		return rescaleJobFuture.get();
 	}
 
-	private static final class TestingClusterClient extends StandaloneClusterClient {
+	private static final class TestingClusterClient extends RestClusterClient<StandaloneClusterId> {
 
 		private final CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture;
 
-		TestingClusterClient(
-			CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture, Configuration configuration) {
-			super(configuration, new TestingHighAvailabilityServices(), false);
+		TestingClusterClient(CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture, Configuration configuration) throws Exception {
+			super(configuration, StandaloneClusterId.getInstance());
 
 			this.rescaleJobFuture = rescaleJobFuture;
 		}


### PR DESCRIPTION
## What is the purpose of the change

Replace `StandaloneClusterClient` with `RestClusterClient<StandaloneClusterId>`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann @mxm 
