### PR TITLE
[FLINK-11521] Make RetryingRegistration configurable

### DIFF
--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -1,0 +1,31 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>cluster.registration.error-delay</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>The pause made after an registration attempt caused an exception (other than timeout) in milliseconds.</td>
+        </tr>
+        <tr>
+            <td><h5>cluster.registration.initial-timeout</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Initial registration timeout between cluster components in milliseconds.</td>
+        </tr>
+        <tr>
+            <td><h5>cluster.registration.max-timeout</h5></td>
+            <td style="word-wrap: break-word;">30000</td>
+            <td>Maximum registration timeout between cluster components in milliseconds.</td>
+        </tr>
+        <tr>
+            <td><h5>cluster.registration.refused-registration-delay</h5></td>
+            <td style="word-wrap: break-word;">30000</td>
+            <td>The pause made after the registration attempt was refused in milliseconds.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -70,6 +70,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/task_manager_configuration.html %}
 
+### Distributed Coordination
+
+{% include generated/cluster_configuration.html %}
+
 ### Distributed Coordination (via Akka)
 
 {% include generated/akka_configuration.html %}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Options which control the cluster behaviour.
+ */
+@PublicEvolving
+public class ClusterOptions {
+
+	public static final ConfigOption<Long> INITIAL_REGISTRATION_TIMEOUT = ConfigOptions
+		.key("cluster.registration.initial-timeout")
+		.defaultValue(100L)
+		.withDescription("Initial registration timeout between cluster components in milliseconds.");
+
+	public static final ConfigOption<Long> MAX_REGISTRATION_TIMEOUT = ConfigOptions
+		.key("cluster.registration.max-timeout")
+		.defaultValue(30000L)
+		.withDescription("Maximum registration timeout between cluster components in milliseconds.");
+
+	public static final ConfigOption<Long> ERROR_REGISTRATION_DELAY = ConfigOptions
+		.key("cluster.registration.error-delay")
+		.defaultValue(10000L)
+		.withDescription("The pause made after an registration attempt caused an exception (other than timeout) in milliseconds.");
+
+	public static final ConfigOption<Long> REFUSED_REGISTRATION_DELAY = ConfigOptions
+		.key("cluster.registration.refused-registration-delay")
+		.defaultValue(30000L)
+		.withDescription("The pause made after the registration attempt was refused in milliseconds.");
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1566,8 +1566,14 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		@Override
 		protected RetryingRegistration<ResourceManagerId, ResourceManagerGateway, JobMasterRegistrationSuccess> generateRegistration() {
 			return new RetryingRegistration<ResourceManagerId, ResourceManagerGateway, JobMasterRegistrationSuccess>(
-					log, getRpcService(), "ResourceManager", ResourceManagerGateway.class,
-					getTargetAddress(), getTargetLeaderId()) {
+				log,
+				getRpcService(),
+				"ResourceManager",
+				ResourceManagerGateway.class,
+				getTargetAddress(),
+				getTargetLeaderId(),
+				jobMasterConfiguration.getRetryingRegistrationConfiguration()) {
+
 				@Override
 				protected CompletableFuture<RegistrationResponse> invokeRegistration(
 						ResourceManagerGateway gateway, ResourceManagerId fencingToken, long timeoutMillis) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -36,16 +37,20 @@ public class JobMasterConfiguration {
 
 	private final String tmpDirectory;
 
+	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
+
 	private final Configuration configuration;
 
 	public JobMasterConfiguration(
 			Time rpcTimeout,
 			Time slotRequestTimeout,
 			String tmpDirectory,
+			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 			Configuration configuration) {
 		this.rpcTimeout = Preconditions.checkNotNull(rpcTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.tmpDirectory = Preconditions.checkNotNull(tmpDirectory);
+		this.retryingRegistrationConfiguration = retryingRegistrationConfiguration;
 		this.configuration = Preconditions.checkNotNull(configuration);
 	}
 
@@ -61,6 +66,10 @@ public class JobMasterConfiguration {
 		return tmpDirectory;
 	}
 
+	public RetryingRegistrationConfiguration getRetryingRegistrationConfiguration() {
+		return retryingRegistrationConfiguration;
+	}
+
 	public Configuration getConfiguration() {
 		return configuration;
 	}
@@ -73,10 +82,13 @@ public class JobMasterConfiguration {
 
 		final String tmpDirectory = ConfigurationUtils.parseTempDirectories(configuration)[0];
 
+		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
+
 		return new JobMasterConfiguration(
 			rpcTimeout,
 			slotRequestTimeout,
 			tmpDirectory,
+			retryingRegistrationConfiguration,
 			configuration);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 
@@ -52,22 +51,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class RetryingRegistration<F extends Serializable, G extends RpcGateway, S extends RegistrationResponse.Success> {
 
 	// ------------------------------------------------------------------------
-	//  default configuration values
-	// ------------------------------------------------------------------------
-
-	/** Default value for the initial registration timeout (milliseconds). */
-	private static final long INITIAL_REGISTRATION_TIMEOUT_MILLIS = 100;
-
-	/** Default value for the maximum registration timeout, after exponential back-off (milliseconds). */
-	private static final long MAX_REGISTRATION_TIMEOUT_MILLIS = 30000;
-
-	/** The pause (milliseconds) made after an registration attempt caused an exception (other than timeout). */
-	private static final long ERROR_REGISTRATION_DELAY_MILLIS = 10000;
-
-	/** The pause (milliseconds) made after the registration attempt was refused. */
-	private static final long REFUSED_REGISTRATION_DELAY_MILLIS = 30000;
-
-	// ------------------------------------------------------------------------
 	// Fields
 	// ------------------------------------------------------------------------
 
@@ -85,13 +68,7 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 
 	private final CompletableFuture<Tuple2<G, S>> completionFuture;
 
-	private final long initialRegistrationTimeout;
-
-	private final long maxRegistrationTimeout;
-
-	private final long delayOnError;
-
-	private final long delayOnRefusedRegistration;
+	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
 
 	private volatile boolean canceled;
 
@@ -104,9 +81,14 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 			Class<G> targetType,
 			String targetAddress,
 			F fencingToken) {
-		this(log, rpcService, targetName, targetType, targetAddress, fencingToken,
-				INITIAL_REGISTRATION_TIMEOUT_MILLIS, MAX_REGISTRATION_TIMEOUT_MILLIS,
-				ERROR_REGISTRATION_DELAY_MILLIS, REFUSED_REGISTRATION_DELAY_MILLIS);
+		this(
+			log,
+			rpcService,
+			targetName,
+			targetType,
+			targetAddress,
+			fencingToken,
+			RetryingRegistrationConfiguration.defaultConfiguration());
 	}
 
 	public RetryingRegistration(
@@ -116,15 +98,7 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 			Class<G> targetType,
 			String targetAddress,
 			F fencingToken,
-			long initialRegistrationTimeout,
-			long maxRegistrationTimeout,
-			long delayOnError,
-			long delayOnRefusedRegistration) {
-
-		checkArgument(initialRegistrationTimeout > 0, "initial registration timeout must be greater than zero");
-		checkArgument(maxRegistrationTimeout > 0, "maximum registration timeout must be greater than zero");
-		checkArgument(delayOnError >= 0, "delay on error must be non-negative");
-		checkArgument(delayOnRefusedRegistration >= 0, "delay on refused registration must be non-negative");
+			RetryingRegistrationConfiguration retryingRegistrationConfiguration) {
 
 		this.log = checkNotNull(log);
 		this.rpcService = checkNotNull(rpcService);
@@ -132,10 +106,7 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 		this.targetType = checkNotNull(targetType);
 		this.targetAddress = checkNotNull(targetAddress);
 		this.fencingToken = checkNotNull(fencingToken);
-		this.initialRegistrationTimeout = initialRegistrationTimeout;
-		this.maxRegistrationTimeout = maxRegistrationTimeout;
-		this.delayOnError = delayOnError;
-		this.delayOnRefusedRegistration = delayOnRefusedRegistration;
+		this.retryingRegistrationConfiguration = checkNotNull(retryingRegistrationConfiguration);
 
 		this.completionFuture = new CompletableFuture<>();
 	}
@@ -199,7 +170,7 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 			CompletableFuture<Void> resourceManagerAcceptFuture = resourceManagerFuture.thenAcceptAsync(
 				(G result) -> {
 					log.info("Resolved {} address, beginning registration", targetName);
-					register(result, 1, initialRegistrationTimeout);
+					register(result, 1, retryingRegistrationConfiguration.getInitialRegistrationTimeoutMillis());
 				},
 				rpcService.getExecutor());
 
@@ -213,18 +184,18 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 								"Could not resolve {} address {}, retrying in {} ms.",
 								targetName,
 								targetAddress,
-								delayOnError,
+								retryingRegistrationConfiguration.getErrorDelayMillis(),
 								strippedFailure);
 						} else {
 							log.info(
 								"Could not resolve {} address {}, retrying in {} ms: {}.",
 								targetName,
 								targetAddress,
-								delayOnError,
+								retryingRegistrationConfiguration.getErrorDelayMillis(),
 								strippedFailure.getMessage());
 						}
 
-						startRegistrationLater(delayOnError);
+						startRegistrationLater(retryingRegistrationConfiguration.getErrorDelayMillis());
 					}
 				},
 				rpcService.getExecutor());
@@ -268,8 +239,8 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 								log.error("Received unknown response to registration attempt: {}", result);
 							}
 
-							log.info("Pausing and re-attempting registration in {} ms", delayOnRefusedRegistration);
-							registerLater(gateway, 1, initialRegistrationTimeout, delayOnRefusedRegistration);
+							log.info("Pausing and re-attempting registration in {} ms", retryingRegistrationConfiguration.getRefusedDelayMillis());
+							registerLater(gateway, 1, retryingRegistrationConfiguration.getInitialRegistrationTimeoutMillis(), retryingRegistrationConfiguration.getRefusedDelayMillis());
 						}
 					}
 				},
@@ -288,15 +259,15 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 									targetName, targetAddress, attempt, timeoutMillis);
 							}
 
-							long newTimeoutMillis = Math.min(2 * timeoutMillis, maxRegistrationTimeout);
+							long newTimeoutMillis = Math.min(2 * timeoutMillis, retryingRegistrationConfiguration.getMaxRegistrationTimeoutMillis());
 							register(gateway, attempt + 1, newTimeoutMillis);
 						}
 						else {
 							// a serious failure occurred. we still should not give up, but keep trying
 							log.error("Registration at {} failed due to an error", targetName, failure);
-							log.info("Pausing and re-attempting registration in {} ms", delayOnError);
+							log.info("Pausing and re-attempting registration in {} ms", retryingRegistrationConfiguration.getErrorDelayMillis());
 
-							registerLater(gateway, 1, initialRegistrationTimeout, delayOnError);
+							registerLater(gateway, 1, retryingRegistrationConfiguration.getInitialRegistrationTimeoutMillis(), retryingRegistrationConfiguration.getErrorDelayMillis());
 						}
 					}
 				},

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistrationConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistrationConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.registration;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Configuration for the cluster components.
+ */
+public class RetryingRegistrationConfiguration {
+
+	private final long initialRegistrationTimeoutMillis;
+
+	private final long maxRegistrationTimeoutMillis;
+
+	private final long errorDelayMillis;
+
+	private final long refusedDelayMillis;
+
+	public RetryingRegistrationConfiguration(
+			long initialRegistrationTimeoutMillis,
+			long maxRegistrationTimeoutMillis,
+			long errorDelayMillis,
+			long refusedDelayMillis) {
+		checkArgument(initialRegistrationTimeoutMillis > 0, "initial registration timeout must be greater than zero");
+		checkArgument(maxRegistrationTimeoutMillis > 0, "maximum registration timeout must be greater than zero");
+		checkArgument(errorDelayMillis >= 0, "delay on error must be non-negative");
+		checkArgument(refusedDelayMillis >= 0, "delay on refused registration must be non-negative");
+
+		this.initialRegistrationTimeoutMillis = initialRegistrationTimeoutMillis;
+		this.maxRegistrationTimeoutMillis = maxRegistrationTimeoutMillis;
+		this.errorDelayMillis = errorDelayMillis;
+		this.refusedDelayMillis = refusedDelayMillis;
+	}
+
+	public long getInitialRegistrationTimeoutMillis() {
+		return initialRegistrationTimeoutMillis;
+	}
+
+	public long getMaxRegistrationTimeoutMillis() {
+		return maxRegistrationTimeoutMillis;
+	}
+
+	public long getErrorDelayMillis() {
+		return errorDelayMillis;
+	}
+
+	public long getRefusedDelayMillis() {
+		return refusedDelayMillis;
+	}
+
+	public static RetryingRegistrationConfiguration fromConfiguration(final Configuration configuration) {
+		long initialRegistrationTimeoutMillis = configuration.getLong(ClusterOptions.INITIAL_REGISTRATION_TIMEOUT);
+		long maxRegistrationTimeoutMillis = configuration.getLong(ClusterOptions.MAX_REGISTRATION_TIMEOUT);
+		long errorDelayMillis = configuration.getLong(ClusterOptions.ERROR_REGISTRATION_DELAY);
+		long refusedDelayMillis = configuration.getLong(ClusterOptions.REFUSED_REGISTRATION_DELAY);
+
+		return new RetryingRegistrationConfiguration(
+			initialRegistrationTimeoutMillis,
+			maxRegistrationTimeoutMillis,
+			errorDelayMillis,
+			refusedDelayMillis);
+	}
+
+	public static RetryingRegistrationConfiguration defaultConfiguration() {
+		return fromConfiguration(new Configuration());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -921,6 +921,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				getRpcService(),
 				getAddress(),
 				getResourceID(),
+				taskManagerConfiguration.getRetryingRegistrationConfiguration(),
 				taskManagerLocation.dataPort(),
 				hardwareDescription,
 				resourceManagerAddress.getAddress(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.registration.RegisteredRpcConnection;
 import org.apache.flink.runtime.registration.RegistrationConnectionListener;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.registration.RetryingRegistration;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -48,6 +49,8 @@ public class TaskExecutorToResourceManagerConnection
 
 	private final ResourceID taskManagerResourceId;
 
+	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
+
 	private final int dataPort;
 
 	private final HardwareDescription hardwareDescription;
@@ -59,6 +62,7 @@ public class TaskExecutorToResourceManagerConnection
 			RpcService rpcService,
 			String taskManagerAddress,
 			ResourceID taskManagerResourceId,
+			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 			int dataPort,
 			HardwareDescription hardwareDescription,
 			String resourceManagerAddress,
@@ -71,6 +75,7 @@ public class TaskExecutorToResourceManagerConnection
 		this.rpcService = checkNotNull(rpcService);
 		this.taskManagerAddress = checkNotNull(taskManagerAddress);
 		this.taskManagerResourceId = checkNotNull(taskManagerResourceId);
+		this.retryingRegistrationConfiguration = checkNotNull(retryingRegistrationConfiguration);
 		this.dataPort = dataPort;
 		this.hardwareDescription = checkNotNull(hardwareDescription);
 		this.registrationListener = checkNotNull(registrationListener);
@@ -83,6 +88,7 @@ public class TaskExecutorToResourceManagerConnection
 			rpcService,
 			getTargetAddress(),
 			getTargetLeaderId(),
+			retryingRegistrationConfiguration,
 			taskManagerAddress,
 			taskManagerResourceId,
 			dataPort,
@@ -124,12 +130,13 @@ public class TaskExecutorToResourceManagerConnection
 				RpcService rpcService,
 				String targetAddress,
 				ResourceManagerId resourceManagerId,
+				RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 				String taskExecutorAddress,
 				ResourceID resourceID,
 				int dataPort,
 				HardwareDescription hardwareDescription) {
 
-			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, resourceManagerId);
+			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, resourceManagerId, retryingRegistrationConfiguration);
 			this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
 			this.resourceID = checkNotNull(resourceID);
 			this.dataPort = dataPort;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.util.Preconditions;
 
@@ -73,20 +74,23 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 	@Nullable
 	private final String taskManagerStdoutPath;
 
+	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
+
 	public TaskManagerConfiguration(
-		int numberSlots,
-		String[] tmpDirectories,
-		Time timeout,
-		@Nullable Time maxRegistrationDuration,
-		Time initialRegistrationPause,
-		Time maxRegistrationPause,
-		Time refusedRegistrationPause,
-		Configuration configuration,
-		boolean exitJvmOnOutOfMemory,
-		FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder,
-		String[] alwaysParentFirstLoaderPatterns,
-		@Nullable String taskManagerLogPath,
-		@Nullable String taskManagerStdoutPath) {
+			int numberSlots,
+			String[] tmpDirectories,
+			Time timeout,
+			@Nullable Time maxRegistrationDuration,
+			Time initialRegistrationPause,
+			Time maxRegistrationPause,
+			Time refusedRegistrationPause,
+			Configuration configuration,
+			boolean exitJvmOnOutOfMemory,
+			FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder,
+			String[] alwaysParentFirstLoaderPatterns,
+			@Nullable String taskManagerLogPath,
+			@Nullable String taskManagerStdoutPath,
+			RetryingRegistrationConfiguration retryingRegistrationConfiguration) {
 
 		this.numberSlots = numberSlots;
 		this.tmpDirectories = Preconditions.checkNotNull(tmpDirectories);
@@ -101,6 +105,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		this.alwaysParentFirstLoaderPatterns = alwaysParentFirstLoaderPatterns;
 		this.taskManagerLogPath = taskManagerLogPath;
 		this.taskManagerStdoutPath = taskManagerStdoutPath;
+		this.retryingRegistrationConfiguration = retryingRegistrationConfiguration;
 	}
 
 	public int getNumberSlots() {
@@ -160,6 +165,10 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 	@Nullable
 	public String getTaskManagerStdoutPath() {
 		return taskManagerStdoutPath;
+	}
+
+	public RetryingRegistrationConfiguration getRetryingRegistrationConfiguration() {
+		return retryingRegistrationConfiguration;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -263,6 +272,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			taskManagerStdoutPath = null;
 		}
 
+		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
+
 		return new TaskManagerConfiguration(
 			numberSlots,
 			tmpDirPaths,
@@ -276,6 +287,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			FlinkUserCodeClassLoaders.ResolveOrder.fromString(classLoaderResolveOrder),
 			alwaysParentFirstLoaderPatterns,
 			taskManagerLogPath,
-			taskManagerStdoutPath);
+			taskManagerStdoutPath,
+			retryingRegistrationConfiguration);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -257,7 +257,7 @@ public class TaskManagerServices {
 
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
+		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, taskManagerServicesConfiguration.getRetryingRegistrationConfiguration());
 
 		final String[] stateRootDirectoryStrings = taskManagerServicesConfiguration.getLocalRecoveryStateRootDirectories();
 
@@ -429,7 +429,6 @@ public class TaskManagerServices {
 			int numProxyServerQueryThreads = qsConfig.numProxyQueryThreads() == 0 ?
 				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numProxyQueryThreads();
 
-
 			kvClientProxy = QueryableStateUtils.createKvStateClientProxy(
 				taskManagerServicesConfiguration.getTaskManagerAddress(),
 				qsConfig.getProxyPortRange(),
@@ -501,7 +500,6 @@ public class TaskManagerServices {
 			float networkBufFraction = config.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
 			long networkBufMin = MemorySize.parse(config.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN)).getBytes();
 			long networkBufMax = MemorySize.parse(config.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX)).getBytes();
-
 
 			TaskManagerServicesConfiguration
 				.checkNetworkBufferConfig(segmentSize, networkBufFraction, networkBufMin, networkBufMax);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.NetUtils;
@@ -40,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
@@ -87,6 +89,8 @@ public class TaskManagerServicesConfiguration {
 
 	private final boolean localRecoveryEnabled;
 
+	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
+
 	private Optional<Time> systemResourceMetricsProbingInterval;
 
 	public TaskManagerServicesConfiguration(
@@ -102,6 +106,7 @@ public class TaskManagerServicesConfiguration {
 			boolean preAllocateMemory,
 			float memoryFraction,
 			long timerServiceShutdownTimeout,
+			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 			Optional<Time> systemResourceMetricsProbingInterval) {
 
 		this.taskManagerAddress = checkNotNull(taskManagerAddress);
@@ -120,6 +125,7 @@ public class TaskManagerServicesConfiguration {
 		checkArgument(timerServiceShutdownTimeout >= 0L, "The timer " +
 			"service shutdown timeout must be greater or equal to 0.");
 		this.timerServiceShutdownTimeout = timerServiceShutdownTimeout;
+		this.retryingRegistrationConfiguration = checkNotNull(retryingRegistrationConfiguration);
 
 		this.systemResourceMetricsProbingInterval = checkNotNull(systemResourceMetricsProbingInterval);
 	}
@@ -190,6 +196,10 @@ public class TaskManagerServicesConfiguration {
 
 	public Optional<Time> getSystemResourceMetricsProbingInterval() {
 		return systemResourceMetricsProbingInterval;
+	}
+
+	public RetryingRegistrationConfiguration getRetryingRegistrationConfiguration() {
+		return retryingRegistrationConfiguration;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -277,6 +287,8 @@ public class TaskManagerServicesConfiguration {
 
 		long timerServiceShutdownTimeout = AkkaUtils.getTimeout(configuration).toMillis();
 
+		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
+
 		return new TaskManagerServicesConfiguration(
 			remoteAddress,
 			tmpDirs,
@@ -290,6 +302,7 @@ public class TaskManagerServicesConfiguration {
 			preAllocateMemory,
 			memoryFraction,
 			timerServiceShutdownTimeout,
+			retryingRegistrationConfiguration,
 			ConfigurationUtils.getSystemResourceMetricsProbingInterval(configuration));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.registration;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link RetryingRegistrationConfiguration}.
+ */
+public class RetryingRegistrationConfigurationTest extends TestLogger {
+
+	@Test
+	public void testConfigurationParsing() {
+		final Configuration configuration = new Configuration();
+
+		final long initialRegistrationTimeout = 1L;
+		final long maxRegistrationTimeout = 2L;
+		final long refusedRegistrationDelay = 3L;
+		final long errorRegistrationDelay = 4L;
+
+		configuration.setLong(ClusterOptions.INITIAL_REGISTRATION_TIMEOUT, initialRegistrationTimeout);
+		configuration.setLong(ClusterOptions.MAX_REGISTRATION_TIMEOUT, maxRegistrationTimeout);
+		configuration.setLong(ClusterOptions.REFUSED_REGISTRATION_DELAY, refusedRegistrationDelay);
+		configuration.setLong(ClusterOptions.ERROR_REGISTRATION_DELAY, errorRegistrationDelay);
+
+		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
+
+		assertThat(retryingRegistrationConfiguration.getInitialRegistrationTimeoutMillis(), is(initialRegistrationTimeout));
+		assertThat(retryingRegistrationConfiguration.getMaxRegistrationTimeoutMillis(), is(maxRegistrationTimeout));
+		assertThat(retryingRegistrationConfiguration.getRefusedDelayMillis(), is(refusedRegistrationDelay));
+		assertThat(retryingRegistrationConfiguration.getErrorDelayMillis(), is(errorRegistrationDelay));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -195,10 +195,11 @@ public class RetryingRegistrationTest extends TestLogger {
 				rpcService,
 				testEndpointAddress,
 				leaderId,
-				initialTimeout,
-				1000L,
-				15000L, // make sure that we timeout in case of an error
-				15000L);
+				new RetryingRegistrationConfiguration(
+					initialTimeout,
+					1000L,
+					15000L, // make sure that we timeout in case of an error
+					15000L));
 
 			long started = System.nanoTime();
 			registration.startRegistration();
@@ -346,26 +347,25 @@ public class RetryingRegistrationTest extends TestLogger {
 		static final long MAX_TIMEOUT = 200;
 		static final long DELAY_ON_ERROR = 200;
 		static final long DELAY_ON_DECLINE = 200;
+		static final RetryingRegistrationConfiguration RETRYING_REGISTRATION_CONFIGURATION = new RetryingRegistrationConfiguration(
+			INITIAL_TIMEOUT,
+			MAX_TIMEOUT,
+			DELAY_ON_ERROR,
+			DELAY_ON_DECLINE);
 
 		public TestRetryingRegistration(RpcService rpc, String targetAddress, UUID leaderId) {
 			this(
 				rpc,
 				targetAddress,
 				leaderId,
-				INITIAL_TIMEOUT,
-				MAX_TIMEOUT,
-				DELAY_ON_ERROR,
-				DELAY_ON_DECLINE);
+				RETRYING_REGISTRATION_CONFIGURATION);
 		}
 
 		public TestRetryingRegistration(
 				RpcService rpc,
 				String targetAddress,
 				UUID leaderId,
-				long initialTimeout,
-				long maxTimeout,
-				long delayOnError,
-				long delayOnDecline) {
+				RetryingRegistrationConfiguration retryingRegistrationConfiguration) {
 			super(
 				LoggerFactory.getLogger(RetryingRegistrationTest.class),
 				rpc,
@@ -373,10 +373,7 @@ public class RetryingRegistrationTest extends TestLogger {
 				TestRegistrationGateway.class,
 				targetAddress,
 				leaderId,
-				initialTimeout,
-				maxTimeout,
-				delayOnError,
-				delayOnDecline);
+				retryingRegistrationConfiguration);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.util.TestLogger;
 
@@ -110,6 +111,7 @@ public class NetworkBufferCalculationTest extends TestLogger {
 			false,
 			managedMemoryFraction,
 			0,
+			RetryingRegistrationConfiguration.defaultConfiguration(),
 			Optional.empty());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -70,6 +70,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
@@ -234,7 +235,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testHeartbeatTimeoutWithJobManager() throws Exception {
 		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(ResourceProfile.UNKNOWN), timerService);
 
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
+		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final long heartbeatInterval = 1L;
 		final long heartbeatTimeout = 3L;
@@ -794,7 +795,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testJobLeaderDetection() throws Exception {
 		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.UNKNOWN), timerService);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
+		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final String resourceManagerAddress = "rm";
 		final ResourceManagerId resourceManagerLeaderId = ResourceManagerId.generate();
@@ -896,7 +897,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testSlotAcceptance() throws Exception {
 		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(mock(ResourceProfile.class), mock(ResourceProfile.class)), timerService);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
+		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final String resourceManagerAddress = "rm";
 		final UUID resourceManagerLeaderId = UUID.randomUUID();
@@ -1002,7 +1003,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testSubmitTaskBeforeAcceptSlot() throws Exception {
 		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(mock(ResourceProfile.class), mock(ResourceProfile.class)), timerService);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
+		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 		resourceManagerLeaderRetriever.notifyListener(resourceManagerGateway.getAddress(), resourceManagerGateway.getFencingToken().toUUID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -59,7 +60,7 @@ public class TaskManagerServicesBuilder {
 		broadcastVariableManager = new BroadcastVariableManager();
 		taskSlotTable = mock(TaskSlotTable.class);
 		jobManagerTable = new JobManagerTable();
-		jobLeaderService = new JobLeaderService(taskManagerLocation);
+		jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 		taskStateManager = mock(TaskExecutorLocalStateStoresManager.class);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
@@ -125,7 +126,8 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 				new String[0],
 				null,
-				null);
+				null,
+				RetryingRegistrationConfiguration.fromConfiguration(config));
 
 			final int networkBufNum = 32;
 			// note: the network buffer memory configured here is not actually used below but set


### PR DESCRIPTION
## What is the purpose of the change

Make the timeouts of the RetryingRegistration configurable. This gives more control
over Flinks registration behaviour which is also beneficial for testing purposes.

## Verifying this change

- Covered by `RetryingRegistrationTest` and added `RetryingRegistrationConfigurationTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
