### PR TITLE
[FLINK-10944] Increase slot request timout for MiniClusterResource

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -125,6 +125,10 @@ public class MiniClusterResource extends ExternalResource {
 			configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
 		}
 
+		if (!configuration.contains(JobManagerOptions.SLOT_REQUEST_TIMEOUT)) {
+			configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 10L * 60L * 1000L);
+		}
+
 		// set rest and rpc port to 0 to avoid clashes with concurrent MiniClusters
 		configuration.setInteger(JobManagerOptions.PORT, 0);
 		configuration.setInteger(RestOptions.PORT, 0);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
@@ -212,6 +213,8 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 		// the default network buffers size (10% of heap max =~ 150MB) seems to much for this test case
 		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(80L << 20)); // 80 MB
 		config.setString(AkkaOptions.FRAMESIZE, String.valueOf(MAX_MEM_STATE_SIZE) + "b");
+
+		config.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 600_000L);
 
 		if (zkServer != null) {
 			config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");


### PR DESCRIPTION
 Before, tests were sometimes timing out on Travis with missing slots.

@zentol This has two commits, only one of them should go in in the end. The Jira issue is specifically about `EventTimeWindowCheckpointingITCase` (https://issues.apache.org/jira/browse/FLINK-10944) but I think that's not relevant. The other tests can fail/timeout with the same problem. That's why I'm proposing to increase the timeout for all tests that use `MiniClusterResource`. What do you think?