### PR TITLE
[FLINK-11522][table] Deprecate ExternalCatalogTable.builder()

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -149,7 +149,10 @@ object ExternalCatalogTable {
     *
     * @param connectorDescriptor Connector descriptor describing the external system
     * @return External catalog builder
+    *
+    * @deprecated This method will be removed in 1.9 and may be added back after the catalog rework.
     */
+  @Deprecated
   def builder(connectorDescriptor: ConnectorDescriptor): ExternalCatalogTableBuilder = {
     new ExternalCatalogTableBuilder(connectorDescriptor)
   }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request deprecates the method ExternalCatalogTable.builder() in 1.8*

## Brief change log

  - *Deprecate the method ExternalCatalogTable.builder() in 1.8*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
