### PR TITLE
 [FLINK-11535][table] Include table-api-java in SQL Client jar

### DIFF
--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -68,9 +68,22 @@ under the License.
 		<!-- Table ecosystem -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
@@ -162,6 +175,7 @@ under the License.
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.flink:flink-table-common</include>
+									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-table-api-java-bridge_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/BatchQueryConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/BatchQueryConfig.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 /**
  * The {@link BatchQueryConfig} holds parameters to configure the behavior of batch queries.
  */
+@PublicEvolving
 public class BatchQueryConfig implements QueryConfig {
 
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StreamQueryConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StreamQueryConfig.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.time.Time;
 
 /**
  * The {@link StreamQueryConfig} holds parameters to configure the behavior of streaming queries.
  */
+@PublicEvolving
 public class StreamQueryConfig implements QueryConfig {
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Explicitly adds `flink-table-common` and `flink-table-api-java` to the SQL Client `pom.xml`.


## Brief change log

- Dependencies updated


## Verifying this change

Run SQL Client end-to-end test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
