### PR TITLE
[FLINK-11524] Solve race condition in EmbeddedLeaderService

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -260,6 +260,18 @@ public final class ExceptionUtils {
 	}
 
 	/**
+	 * Tries to throw the given exception if not null.
+	 *
+	 * @param e exception to throw if not null.
+	 * @throws Exception
+	 */
+	public static void tryRethrowException(@Nullable Exception e) throws Exception {
+		if (e != null) {
+			throw e;
+		}
+	}
+
+	/**
 	 * Tries to throw the given {@code Throwable} in scenarios where the signatures allows only IOExceptions
 	 * (and RuntimeException and Error). Throws this exception directly, if it is an IOException,
 	 * a RuntimeException, or an Error. Otherwise does nothing.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -244,7 +244,6 @@ public class EmbeddedLeaderService {
 				}
 				else {
 					LOG.debug("Received confirmation of leadership for a stale leadership grant. Ignoring.");
-					service.isLeader = false;
 				}
 			}
 			catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1020,7 +1020,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		startJobMasterServices();
 
-		log.info("Starting execution of job {} ({})", jobGraph.getName(), jobGraph.getJobID());
+		log.info("Starting execution of job {} ({}) under job master id {}.", jobGraph.getName(), jobGraph.getJobID(), newJobMasterId);
 
 		resetAndScheduleExecutionGraph();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -314,17 +314,21 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		CompletableFuture<RegistrationResponse> registrationResponseFuture = jobMasterGatewayFuture.thenCombineAsync(
 			jobMasterIdFuture,
-			(JobMasterGateway jobMasterGateway, JobMasterId currentJobMasterId) -> {
-				if (Objects.equals(currentJobMasterId, jobMasterId)) {
+			(JobMasterGateway jobMasterGateway, JobMasterId leadingJobMasterId) -> {
+				if (Objects.equals(leadingJobMasterId, jobMasterId)) {
 					return registerJobMasterInternal(
 						jobMasterGateway,
 						jobId,
 						jobManagerAddress,
 						jobManagerResourceId);
 				} else {
-					log.debug("The current JobMaster leader id {} did not match the received " +
-						"JobMaster id {}.", jobMasterId, currentJobMasterId);
-					return new RegistrationResponse.Decline("Job manager leader id did not match.");
+					final String declineMessage = String.format(
+						"The leading JobMaster id %s did not match the received JobMaster id %s. " +
+						"This indicates that a JobMaster leader change has happened.",
+						leadingJobMasterId,
+						jobMasterId);
+					log.debug(declineMessage);
+					return new RegistrationResponse.Decline(declineMessage);
 				}
 			},
 			getMainThreadExecutor());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -32,8 +33,13 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -164,5 +170,71 @@ public class EmbeddedHaServicesTest extends TestLogger {
 		leaderElectionService.confirmLeaderSessionID(leaderId);
 
 		verify(leaderRetrievalListener).notifyLeaderAddress(eq(address), eq(leaderId));
+	}
+
+	/**
+	 * Tests that concurrent leadership operations (granting and revoking) leadership leave the
+	 * system in a sane state.
+	 */
+	@Test
+	public void testConcurrentLeadershipOperations() throws Exception {
+		final LeaderElectionService dispatcherLeaderElectionService = embeddedHaServices.getDispatcherLeaderElectionService();
+		final ArrayBlockingQueue<UUID> offeredSessionIds = new ArrayBlockingQueue<>(2);
+		final TestingLeaderContender leaderContender = new TestingLeaderContender(offeredSessionIds);
+
+		dispatcherLeaderElectionService.start(leaderContender);
+
+		final UUID oldLeaderSessionId = offeredSessionIds.take();
+
+		assertThat(dispatcherLeaderElectionService.hasLeadership(oldLeaderSessionId), is(true));
+
+		embeddedHaServices.getDispatcherLeaderService().revokeLeadership().get();
+		assertThat(dispatcherLeaderElectionService.hasLeadership(oldLeaderSessionId), is(false));
+
+		embeddedHaServices.getDispatcherLeaderService().grantLeadership();
+		final UUID newLeaderSessionId = offeredSessionIds.take();
+
+		assertThat(dispatcherLeaderElectionService.hasLeadership(newLeaderSessionId), is(true));
+
+		dispatcherLeaderElectionService.confirmLeaderSessionID(oldLeaderSessionId);
+		dispatcherLeaderElectionService.confirmLeaderSessionID(newLeaderSessionId);
+
+		assertThat(dispatcherLeaderElectionService.hasLeadership(newLeaderSessionId), is(true));
+
+		leaderContender.tryRethrowException();
+	}
+
+	private static final class TestingLeaderContender implements LeaderContender {
+
+		private final BlockingQueue<UUID> offeredSessionIds;
+
+		private final AtomicReference<Exception> occurredException;
+
+		private TestingLeaderContender(BlockingQueue<UUID> offeredSessionIds) {
+			this.offeredSessionIds = offeredSessionIds;
+			occurredException = new AtomicReference<>(null);
+		}
+
+		@Override
+		public void grantLeadership(UUID leaderSessionID) {
+			offeredSessionIds.offer(leaderSessionID);
+		}
+
+		@Override
+		public void revokeLeadership() {}
+
+		@Override
+		public String getAddress() {
+			return "foobar";
+		}
+
+		@Override
+		public void handleError(Exception exception) {
+			occurredException.compareAndSet(null, exception);
+		}
+
+		public void tryRethrowException() throws Exception {
+			ExceptionUtils.tryRethrowException(occurredException.get());
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Using the EmbeddedHaServices it could happen that the EmbeddedLeaderService goes into an
invalid state if two grant leadership operations are executed concurrently.

The problem was that the first operation when confirming the now outdated leader session id
would set the EmbeddedLeaderElectionService#isLeader field to false as part of the stale
confirmation message handling. Consequently, all subsequent calls to
LeaderElectionService#hasLeadership(newLeaderSessionId) would return false even though the
contender would still have the leadership.

The solution is to not set the EmbeddedLeaderElectionService#isLeader to false if the
EmbeddedLeaderService encounters a stale confirmation message.

## Verifying this change

- Added `EmbeddedHaServicesTest#testConcurrentLeadershipOperations`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
