### PR TITLE
[hotfix][doc] Fix docs of checkpoints in iterative jobs

### DIFF
--- a/docs/dev/stream/state/checkpointing.md
+++ b/docs/dev/stream/state/checkpointing.md
@@ -153,7 +153,7 @@ See [state backends]({{ site.baseurl }}/ops/state/state_backends.html) for more 
 
 ## State Checkpoints in Iterative Jobs
 
-Flink currently only provides processing guarantees for jobs without iterations. Enabling checkpointing on an iterative job causes an exception. In order to force checkpointing on an iterative program the user needs to set a special flag when enabling checkpointing: `env.enableCheckpointing(interval, force = true)`.
+Flink currently only provides processing guarantees for jobs without iterations. Enabling checkpointing on an iterative job causes an exception. In order to force checkpointing on an iterative program the user needs to set a special flag when enabling checkpointing: `env.enableCheckpointing(interval, CheckpointingMode.EXACTLY_ONCE, force = true)`.
 
 Please note that records in flight in the loop edges (and the state changes associated with them) will be lost during failure.
 


### PR DESCRIPTION


## What is the purpose of the change

Fix the documentation of API to enable checkpoints in iterative jobs. `env.enableCheckpointing(interval, force = true)` has not been supported after [FLINK-2407](https://issues.apache.org/jira/browse/FLINK-2407), we should fix this part of doc.


## Brief change log

  - Fix doc description.

## Verifying this change


This change is a trivial rework

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable