### PR TITLE
[FLINK-11515][client] Port ClientTest

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -99,12 +99,12 @@ public class ClientTest extends TestLogger {
 	 */
 	@Test
 	public void testDetachedMode() throws Exception{
-		final ClusterClient<?> out = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
-		out.setDetached(true);
+		final ClusterClient<?> clusterClient = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
+		clusterClient.setDetached(true);
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestExecuteTwice.class);
-			out.run(prg, 1);
+			clusterClient.run(prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -114,7 +114,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestEager.class);
-			out.run(prg, 1);
+			clusterClient.run(prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -124,7 +124,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetRuntime.class);
-			out.run(prg, 1);
+			clusterClient.run(prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -134,7 +134,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetJobID.class);
-			out.run(prg, 1);
+			clusterClient.run(prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -144,7 +144,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetAccumulator.class);
-			out.run(prg, 1);
+			clusterClient.run(prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -154,7 +154,7 @@ public class ClientTest extends TestLogger {
 
 		try {
 			PackagedProgram prg = new PackagedProgram(TestGetAllAccumulator.class);
-			out.run(prg, 1);
+			clusterClient.run(prg, 1);
 			fail(FAIL_MESSAGE);
 		} catch (ProgramInvocationException e) {
 			assertEquals(
@@ -168,9 +168,9 @@ public class ClientTest extends TestLogger {
 	 */
 	@Test
 	public void shouldSubmitToJobClient() throws Exception {
-		final ClusterClient<?> out = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
-		out.setDetached(true);
-		JobSubmissionResult result = out.run(program.getPlanWithJars(), 1);
+		final ClusterClient<?> clusterClient = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
+		clusterClient.setDetached(true);
+		JobSubmissionResult result = clusterClient.run(program.getPlanWithJars(), 1);
 
 		assertNotNull(result);
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -182,58 +182,46 @@ public class ClientTest extends TestLogger {
 	 * the program is submitted through a client.
 	 */
 	@Test
-	public void tryLocalExecution() {
-		try {
-			PackagedProgram packagedProgramMock = mock(PackagedProgram.class);
-			when(packagedProgramMock.isUsingInteractiveMode()).thenReturn(true);
-			doAnswer(new Answer<Void>() {
-				@Override
-				public Void answer(InvocationOnMock invocation) throws Throwable {
-					ExecutionEnvironment.createLocalEnvironment();
-					return null;
-				}
-			}).when(packagedProgramMock).invokeInteractiveModeForExecution();
+	public void tryLocalExecution() throws ProgramInvocationException, ProgramMissingJobException {
+		PackagedProgram packagedProgramMock = mock(PackagedProgram.class);
+		when(packagedProgramMock.isUsingInteractiveMode()).thenReturn(true);
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				ExecutionEnvironment.createLocalEnvironment();
+				return null;
+			}
+		}).when(packagedProgramMock).invokeInteractiveModeForExecution();
 
-			try {
-				final ClusterClient<?> client = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
-				client.setDetached(true);
-				client.run(packagedProgramMock, 1);
-				fail("Creating the local execution environment should not be possible");
-			}
-			catch (InvalidProgramException e) {
-				// that is what we want
-			}
+		try {
+			final ClusterClient<?> client = new MiniClusterClient(new Configuration(), MINI_CLUSTER_RESOURCE.getMiniCluster());
+			client.setDetached(true);
+			client.run(packagedProgramMock, 1);
+			fail("Creating the local execution environment should not be possible");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (InvalidProgramException e) {
+			// that is what we want
 		}
 	}
 
 	@Test
-	public void testGetExecutionPlan() {
-		try {
-			PackagedProgram prg = new PackagedProgram(TestOptimizerPlan.class, "/dev/random", "/tmp");
-			assertNotNull(prg.getPreviewPlan());
+	public void testGetExecutionPlan() throws ProgramInvocationException {
+		PackagedProgram prg = new PackagedProgram(TestOptimizerPlan.class, "/dev/random", "/tmp");
+		assertNotNull(prg.getPreviewPlan());
 
-			Optimizer optimizer = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), config);
-			OptimizedPlan op = (OptimizedPlan) ClusterClient.getOptimizedPlan(optimizer, prg, 1);
-			assertNotNull(op);
+		Optimizer optimizer = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), config);
+		OptimizedPlan op = (OptimizedPlan) ClusterClient.getOptimizedPlan(optimizer, prg, 1);
+		assertNotNull(op);
 
-			PlanJSONDumpGenerator dumper = new PlanJSONDumpGenerator();
-			assertNotNull(dumper.getOptimizerPlanAsJSON(op));
+		PlanJSONDumpGenerator dumper = new PlanJSONDumpGenerator();
+		assertNotNull(dumper.getOptimizerPlanAsJSON(op));
 
-			// test HTML escaping
-			PlanJSONDumpGenerator dumper2 = new PlanJSONDumpGenerator();
-			dumper2.setEncodeForHTML(true);
-			String htmlEscaped = dumper2.getOptimizerPlanAsJSON(op);
+		// test HTML escaping
+		PlanJSONDumpGenerator dumper2 = new PlanJSONDumpGenerator();
+		dumper2.setEncodeForHTML(true);
+		String htmlEscaped = dumper2.getOptimizerPlanAsJSON(op);
 
-			assertEquals(-1, htmlEscaped.indexOf('\\'));
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		assertEquals(-1, htmlEscaped.indexOf('\\'));
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the `ClientTest` to not rely on legacy code.


## Brief change log

* replace actor system with a `MiniClusterResource`
* replace StandaloneClusterClient with MiniClusterClient
* move `shouldSubmitToJobClientFails()` to `RestClusterClientTest`
