### PR TITLE
[FLINK-11551][rpc] Allow RpcEndpoint to execute asynchronous stop operations

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -400,8 +400,8 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 	}
 
 	@Override
-	public CompletableFuture<Void> postStop() {
-		return stopSupportingActorsAsync().thenCompose((ignored) -> super.postStop());
+	public CompletableFuture<Void> onStop() {
+		return stopSupportingActorsAsync().thenCompose((ignored) -> super.onStop());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -542,7 +542,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 	@Override
 	public CompletableFuture<Acknowledge> shutDownCluster() {
-		shutDown();
+		closeAsync();
 		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -183,7 +183,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	//------------------------------------------------------
 
 	@Override
-	public CompletableFuture<Void> postStop() {
+	public CompletableFuture<Void> onStop() {
 		log.info("Stopping dispatcher {}.", getAddress());
 
 		final CompletableFuture<Void> allJobManagerRunnersTerminationFuture = terminateJobManagerRunnersAndGetTerminationFuture();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
@@ -235,13 +235,11 @@ public abstract class AbstractDispatcherResourceManagerComponentFactory<T extend
 			}
 
 			if (resourceManager != null) {
-				resourceManager.shutDown();
-				terminationFutures.add(resourceManager.getTerminationFuture());
+				terminationFutures.add(resourceManager.closeAsync());
 			}
 
 			if (dispatcher != null) {
-				dispatcher.shutDown();
-				terminationFutures.add(dispatcher.getTerminationFuture());
+				terminationFutures.add(dispatcher.closeAsync());
 			}
 
 			final FutureUtils.ConjunctFuture<Void> terminationFuture = FutureUtils.completeAll(terminationFutures);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -169,11 +169,9 @@ public class DispatcherResourceManagerComponent<T extends Dispatcher> implements
 			exception = ExceptionUtils.firstOrSuppressed(e, exception);
 		}
 
-		dispatcher.shutDown();
-		terminationFutures.add(dispatcher.getTerminationFuture());
+		terminationFutures.add(dispatcher.closeAsync());
 
-		resourceManager.shutDown();
-		terminationFutures.add(resourceManager.getTerminationFuture());
+		terminationFutures.add(resourceManager.closeAsync());
 
 		if (exception != null) {
 			terminationFutures.add(FutureUtils.completedExceptionally(exception));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -366,7 +366,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		suspendExecution(new FlinkException("JobManager is shutting down."));
 
 		// shut down will internally release all registered slots
-		slotPool.shutDown();
+		final CompletableFuture<Void> slotPoolTerminationFuture = slotPool.closeAsync();
 
 		final CompletableFuture<Void> disposeInternalSavepointFuture;
 
@@ -375,8 +375,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		} else {
 			disposeInternalSavepointFuture = CompletableFuture.completedFuture(null);
 		}
-
-		final CompletableFuture<Void> slotPoolTerminationFuture = slotPool.getTerminationFuture();
 
 		return FutureUtils.completeAll(Arrays.asList(disposeInternalSavepointFuture, slotPoolTerminationFuture));
 	}
@@ -1509,12 +1507,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	@Override
 	public JobMasterGateway getGateway() {
 		return getSelfGateway(JobMasterGateway.class);
-	}
-
-	@Override
-	public CompletableFuture<Void> closeAsync() {
-		shutDown();
-		return getTerminationFuture();
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -347,7 +347,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	 * Suspend the job and shutdown all other services including rpc.
 	 */
 	@Override
-	public CompletableFuture<Void> postStop() {
+	public CompletableFuture<Void> onStop() {
 		log.info("Stopping the JobMaster for job {}({}).", jobGraph.getName(), jobGraph.getJobID());
 
 		// disconnect from all registered TaskExecutors

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -217,7 +217,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 	}
 
 	@Override
-	public CompletableFuture<Void> postStop() {
+	public CompletableFuture<Void> onStop() {
 		log.info("Stopping SlotPool.");
 		// cancel all pending allocations
 		Set<AllocationID> allocationIds = pendingRequests.keySetB();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -413,8 +413,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					if (taskManagers != null) {
 						for (TaskExecutor tm : taskManagers) {
 							if (tm != null) {
-								tm.shutDown();
-								componentTerminationFutures.add(tm.getTerminationFuture());
+								componentTerminationFutures.add(tm.closeAsync());
 							}
 						}
 						taskManagers = null;
@@ -931,7 +930,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 				if (currentTaskManagers != null) {
 					// the shutDown is asynchronous
-					currentTaskManagers[index].shutDown();
+					currentTaskManagers[index].closeAsync();
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -226,7 +226,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	}
 
 	@Override
-	public CompletableFuture<Void> postStop() {
+	public CompletableFuture<Void> onStop() {
 		Exception exception = null;
 
 		taskManagerHeartbeatManager.stop();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
@@ -43,8 +43,6 @@ public class ResourceManagerRunner implements FatalErrorHandler, AutoCloseableAs
 
 	private static final Logger LOG = LoggerFactory.getLogger(ResourceManagerRunner.class);
 
-	private final Object lock = new Object();
-
 	private final ResourceManagerRuntimeServices resourceManagerRuntimeServices;
 
 	private final ResourceManager<?> resourceManager;
@@ -88,10 +86,6 @@ public class ResourceManagerRunner implements FatalErrorHandler, AutoCloseableAs
 			jobManagerMetricGroup);
 	}
 
-	public ResourceManagerGateway getResourceManageGateway() {
-		return resourceManager.getSelfGateway(ResourceManagerGateway.class);
-	}
-
 	//-------------------------------------------------------------------------------------
 	// Lifecycle management
 	//-------------------------------------------------------------------------------------
@@ -102,11 +96,7 @@ public class ResourceManagerRunner implements FatalErrorHandler, AutoCloseableAs
 
 	@Override
 	public CompletableFuture<Void> closeAsync() {
-		synchronized (lock) {
-			resourceManager.shutDown();
-
-			return resourceManager.getTerminationFuture();
-		}
+			return resourceManager.closeAsync();
 	}
 
 	//-------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -147,7 +147,9 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 * @return Future which is completed once all post stop actions are completed. If an error
 	 * occurs this future is completed exceptionally
 	 */
-	public abstract CompletableFuture<Void> postStop();
+	public CompletableFuture<Void> onStop() {
+		return CompletableFuture.completedFuture(null);
+	}
 
 	/**
 	 * Triggers the shut down of the rpc endpoint. The shut down is executed asynchronously.
@@ -157,6 +159,11 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 */
 	public final void shutDown() {
 		rpcService.stopServer(rpcServer);
+	}
+
+	public final CompletableFuture<Void> terminate() {
+		rpcService.stopServer(rpcServer);
+		return getTerminationFuture();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledFutureAdapter;
+import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -56,7 +57,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>The RPC endpoint provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Time)}
  * and the {@link #getMainThreadExecutor()} to execute code in the RPC endpoint's main thread.
  */
-public abstract class RpcEndpoint implements RpcGateway {
+public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -157,11 +158,8 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 * <p>In order to wait on the completion of the shut down, obtain the termination future
 	 * via {@link #getTerminationFuture()}} and wait on its completion.
 	 */
-	public final void shutDown() {
-		rpcService.stopServer(rpcServer);
-	}
-
-	public final CompletableFuture<Void> terminate() {
+	@Override
+	public final CompletableFuture<Void> closeAsync() {
 		rpcService.stopServer(rpcServer);
 		return getTerminationFuture();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -74,8 +74,7 @@ public class RpcUtils {
 	 * @throws TimeoutException if a timeout occurred
 	 */
 	public static void terminateRpcEndpoint(RpcEndpoint rpcEndpoint, Time timeout) throws ExecutionException, InterruptedException, TimeoutException {
-		rpcEndpoint.shutDown();
-		rpcEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		rpcEndpoint.closeAsync().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.StartStoppable;
-import org.apache.flink.runtime.rpc.akka.messages.Processing;
 import org.apache.flink.runtime.rpc.exceptions.RpcException;
 import org.apache.flink.runtime.rpc.messages.CallAsync;
 import org.apache.flink.runtime.rpc.messages.LocalRpcInvocation;
@@ -172,12 +171,12 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 
 	@Override
 	public void start() {
-		rpcEndpoint.tell(Processing.START, ActorRef.noSender());
+		rpcEndpoint.tell(ControlMessages.START, ActorRef.noSender());
 	}
 
 	@Override
 	public void stop() {
-		rpcEndpoint.tell(Processing.STOP, ActorRef.noSender());
+		rpcEndpoint.tell(ControlMessages.STOP, ActorRef.noSender());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -24,8 +24,8 @@ import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaHandshakeException;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcException;
+import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcInvalidStateException;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaUnknownMessageException;
-import org.apache.flink.runtime.rpc.akka.messages.Processing;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.runtime.rpc.messages.CallAsync;
 import org.apache.flink.runtime.rpc.messages.HandshakeSuccessMessage;
@@ -38,11 +38,15 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedValue;
 
 import akka.actor.ActorRef;
+import akka.actor.Kill;
 import akka.actor.Status;
 import akka.actor.UntypedActor;
 import akka.pattern.Patterns;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -59,7 +63,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Akka rpc actor which receives {@link LocalRpcInvocation}, {@link RunAsync} and {@link CallAsync}
- * {@link Processing} messages.
+ * {@link ControlMessages} messages.
  *
  * <p>The {@link LocalRpcInvocation} designates a rpc and is dispatched to the given {@link RpcEndpoint}
  * instance.
@@ -67,8 +71,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>The {@link RunAsync} and {@link CallAsync} messages contain executable code which is executed
  * in the context of the actor thread.
  *
- * <p>The {@link Processing} message controls the processing behaviour of the akka rpc actor. A
- * {@link Processing#START} starts processing incoming messages. A {@link Processing#STOP} message
+ * <p>The {@link ControlMessages} message controls the processing behaviour of the akka rpc actor. A
+ * {@link ControlMessages#START} starts processing incoming messages. A {@link ControlMessages#STOP} message
  * stops processing messages. All messages which arrive when the processing is stopped, will be
  * discarded.
  *
@@ -90,7 +94,11 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 
 	private final long maximumFramesize;
 
+	@Nonnull
 	private State state;
+
+	@Nullable
+	private CompletableFuture<Void> rpcEndpointTerminationFuture;
 
 	AkkaRpcActor(
 			final T rpcEndpoint,
@@ -104,29 +112,16 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 		this.terminationFuture = checkNotNull(terminationFuture);
 		this.version = version;
 		this.maximumFramesize = maximumFramesize;
-		this.state = State.STOPPED;
+		this.state = StoppedState.INSTANCE;
+		this.rpcEndpointTerminationFuture = null;
 	}
 
 	@Override
 	public void postStop() throws Exception {
-		mainThreadValidator.enterMainThread();
+		super.postStop();
 
-		try {
-			CompletableFuture<Void> postStopFuture;
-			try {
-				postStopFuture = rpcEndpoint.postStop();
-			} catch (Throwable throwable) {
-				postStopFuture = FutureUtils.completedExceptionally(throwable);
-			}
-
-			super.postStop();
-
-			// IMPORTANT: This only works if we don't use a restarting supervisor strategy. Otherwise
-			// we would complete the future and let the actor system restart the actor with a completed
-			// future.
-			// Complete the termination future so that others know that we've stopped.
-
-			postStopFuture.whenComplete(
+		if (rpcEndpointTerminationFuture != null && rpcEndpointTerminationFuture.isDone()) {
+			rpcEndpointTerminationFuture.whenComplete(
 				(Void value, Throwable throwable) -> {
 					if (throwable != null) {
 						terminationFuture.completeExceptionally(throwable);
@@ -134,20 +129,22 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 						terminationFuture.complete(null);
 					}
 				});
-		} finally {
-			mainThreadValidator.exitMainThread();
+		} else {
+			terminationFuture.completeExceptionally(
+				new AkkaRpcException(
+					String.format("RpcEndpoint %s has not been properly stopped.", rpcEndpoint.getEndpointId())));
 		}
+
+		state = state.finishTermination();
 	}
 
 	@Override
 	public void onReceive(final Object message) {
 		if (message instanceof RemoteHandshakeMessage) {
 			handleHandshakeMessage((RemoteHandshakeMessage) message);
-		} else if (message.equals(Processing.START)) {
-			state = State.STARTED;
-		} else if (message.equals(Processing.STOP)) {
-			state = State.STOPPED;
-		} else if (state == State.STARTED) {
+		} else if (message instanceof ControlMessages) {
+			handleControlMessage(((ControlMessages) message));
+		} else if (state.isRunning()) {
 			mainThreadValidator.enterMainThread();
 
 			try {
@@ -163,6 +160,28 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 			sendErrorIfSender(new AkkaRpcException(
 				String.format("Discard message, because the rpc endpoint %s has not been started yet.", rpcEndpoint.getAddress())));
 		}
+	}
+
+	private void handleControlMessage(ControlMessages controlMessage) {
+		switch (controlMessage) {
+			case START:
+				state = state.start();
+				break;
+			case STOP:
+				state = state.stop();
+				break;
+			case TERMINATE:
+				state.terminate(this);
+				break;
+			default:
+				handleUnknownControlMessage(controlMessage);
+		}
+	}
+
+	private void handleUnknownControlMessage(ControlMessages controlMessage) {
+		final String message = String.format("Received unknown control message %s. Dropping this message!", controlMessage);
+		log.warn(message);
+		sendErrorIfSender(new AkkaUnknownMessageException(message));
 	}
 
 	protected void handleRpcMessage(Object message) {
@@ -438,8 +457,115 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 		return message;
 	}
 
-	enum State {
-		STARTED,
-		STOPPED
+	// ---------------------------------------------------------------------------
+	// Internal state machine
+	// ---------------------------------------------------------------------------
+
+	interface State {
+		default State start() {
+			throw new AkkaRpcInvalidStateException(invalidStateTransitionMessage(StartedState.INSTANCE));
+		}
+
+		default State stop() {
+			throw new AkkaRpcInvalidStateException(invalidStateTransitionMessage(StoppedState.INSTANCE));
+		}
+
+		default State terminate(AkkaRpcActor<?> akkaRpcActor) {
+			throw new AkkaRpcInvalidStateException(invalidStateTransitionMessage(TerminatingState.INSTANCE));
+		}
+
+		default State finishTermination() {
+			return TerminatedState.INSTANCE;
+		}
+
+		default boolean isRunning() {
+			return false;
+		}
+
+		default String invalidStateTransitionMessage(State targetState) {
+			return String.format("AkkaRpcActor is currently in state %s and cannot go into state %s.", this, targetState);
+		}
+	}
+
+	@SuppressWarnings("Singleton")
+	enum StartedState implements State {
+		INSTANCE;
+
+		@Override
+		public State start() {
+			return INSTANCE;
+		}
+
+		@Override
+		public State stop() {
+			return StoppedState.INSTANCE;
+		}
+
+		@Override
+		public State terminate(AkkaRpcActor<?> akkaRpcActor) {
+			akkaRpcActor.mainThreadValidator.enterMainThread();
+
+			try {
+				akkaRpcActor.rpcEndpointTerminationFuture = akkaRpcActor.rpcEndpoint.onStop();
+			} catch (Throwable t) {
+				akkaRpcActor.rpcEndpointTerminationFuture = FutureUtils.completedExceptionally(
+					new AkkaRpcException(
+						String.format("Failure while stopping RpcEndpoint %s.", akkaRpcActor.rpcEndpoint.getEndpointId()),
+						t));
+			} finally {
+				akkaRpcActor.mainThreadValidator.exitMainThread();
+			}
+
+			// IMPORTANT: This only works if we don't use a restarting supervisor strategy. Otherwise
+			// we would complete the future and let the actor system restart the actor with a completed
+			// future.
+			// Complete the termination future so that others know that we've stopped.
+
+			akkaRpcActor.rpcEndpointTerminationFuture.whenComplete((ignored, throwable) -> akkaRpcActor.getSelf().tell(Kill.getInstance(), ActorRef.noSender()));
+
+			return TerminatingState.INSTANCE;
+		}
+
+		@Override
+		public boolean isRunning() {
+			return true;
+		}
+	}
+
+	@SuppressWarnings("Singleton")
+	enum StoppedState implements State {
+		INSTANCE;
+
+		@Override
+		public State start() {
+			return StartedState.INSTANCE;
+		}
+
+		@Override
+		public State stop() {
+			return INSTANCE;
+		}
+
+		@Override
+		public State terminate(AkkaRpcActor<?> akkaRpcActor) {
+			akkaRpcActor.rpcEndpointTerminationFuture = CompletableFuture.completedFuture(null);
+			akkaRpcActor.getSelf().tell(Kill.getInstance(), ActorRef.noSender());
+
+			return TerminatingState.INSTANCE;
+		}
+	}
+
+	@SuppressWarnings("Singleton")
+	enum TerminatingState implements State {
+		INSTANCE;
+
+		@Override
+		public boolean isRunning() {
+			return true;
+		}
+	}
+
+	enum TerminatedState implements State {
+		INSTANCE
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/ControlMessages.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/ControlMessages.java
@@ -16,12 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.akka;
 
 /**
- * Controls the processing behaviour of the {@link org.apache.flink.runtime.rpc.akka.AkkaRpcActor}
+ * Control messages for the {@link AkkaRpcActor}.
  */
-public enum Processing  {
-	START, // Unstashes all stashed messages and starts processing incoming messages
-	STOP // Stop processing messages and stashes all incoming messages
+public enum ControlMessages {
+	START, // Start processing incoming messages
+	STOP, // Stop processing messages and drop all newly incoming messages
+	TERMINATE, // Terminate the AkkaRpcActor
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaRpcInvalidStateException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaRpcInvalidStateException.java
@@ -16,21 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka;
+package org.apache.flink.runtime.rpc.akka.exceptions;
 
-import org.apache.flink.runtime.rpc.RpcEndpoint;
-import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.FlinkRuntimeException;
 
-import java.util.concurrent.CompletableFuture;
+/**
+ * Exception which indicates an invalid state.
+ */
+public class AkkaRpcInvalidStateException extends FlinkRuntimeException {
+	private static final long serialVersionUID = 7771345513700817242L;
 
-class TestRpcEndpoint extends RpcEndpoint {
-
-	protected TestRpcEndpoint(RpcService rpcService) {
-		super(rpcService);
+	public AkkaRpcInvalidStateException(String message) {
+		super(message);
 	}
 
-	@Override
-	public CompletableFuture<Void> postStop() {
-		return CompletableFuture.completedFuture(null);
+	public AkkaRpcInvalidStateException(Throwable cause) {
+		super(cause);
+	}
+
+	public AkkaRpcInvalidStateException(String message, Throwable cause) {
+		super(message, cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -294,7 +294,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	 * Called to shut down the TaskManager. The method closes all TaskManager services.
 	 */
 	@Override
-	public CompletableFuture<Void> postStop() {
+	public CompletableFuture<Void> onStop() {
 		log.info("Stopping TaskExecutor {}.", getAddress());
 
 		Throwable throwable = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -176,8 +176,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			if (!shutdown) {
 				shutdown = true;
 
-				taskManager.shutDown();
-				final CompletableFuture<Void> taskManagerTerminationFuture = taskManager.getTerminationFuture();
+				final CompletableFuture<Void> taskManagerTerminationFuture = taskManager.closeAsync();
 
 				final CompletableFuture<Void> serviceTerminationFuture = FutureUtils.composeAfterwards(
 					taskManagerTerminationFuture,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -107,7 +107,7 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor, Co
 		return insertRunnable(command, true);
 	}
 
-	Collection<ScheduledFuture<?>> getScheduledTasks() {
+	public Collection<ScheduledFuture<?>> getScheduledTasks() {
 		return new ArrayList<>(scheduledTasks);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -208,8 +208,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 	@After
 	public void teardown() throws Exception {
 		if (dispatcher != null) {
-			dispatcher.shutDown();
-			dispatcher.getTerminationFuture().get();
+			dispatcher.close();
 		}
 
 		if (fatalErrorHandler != null) {
@@ -294,7 +293,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 	public void testBlobServerCleanupWhenClosingDispatcher() throws Exception {
 		submitJob();
 
-		dispatcher.shutDown();
+		dispatcher.closeAsync();
 		terminationFuture.complete(null);
 		dispatcher.getTerminationFuture().get();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -680,8 +680,7 @@ public class DispatcherTest extends TestLogger {
 		submissionFuture.get();
 		assertThat(dispatcher.getNumberJobs(TIMEOUT).get(), Matchers.is(1));
 
-		dispatcher.shutDown();
-		dispatcher.getTerminationFuture().get();
+		dispatcher.close();
 
 		assertThat(submittedJobGraphStore.contains(jobGraph.getJobID()), Matchers.is(true));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ZooKeeperHADispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ZooKeeperHADispatcherTest.java
@@ -302,10 +302,10 @@ public class ZooKeeperHADispatcherTest extends TestLogger {
 				dispatcherGateway.submitJob(nonEmptyJobGraph, TIMEOUT).get();
 
 				if (dispatcher1.getAddress().equals(leaderConnectionInfo.getAddress())) {
-					dispatcher1.shutDown();
+					dispatcher1.closeAsync();
 					assertThat(jobGraphFuture2.get().getJobID(), is(equalTo(nonEmptyJobGraph.getJobID())));
 				} else {
-					dispatcher2.shutDown();
+					dispatcher2.closeAsync();
 					assertThat(jobGraphFuture1.get().getJobID(), is(equalTo(nonEmptyJobGraph.getJobID())));
 				}
 			} finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -35,6 +36,10 @@ public class TestingHeartbeatServices extends HeartbeatServices {
 		super(heartbeatInterval, heartbeatTimeout);
 
 		this.scheduledExecutorToUse = Preconditions.checkNotNull(scheduledExecutorToUse);
+	}
+
+	public TestingHeartbeatServices() {
+		this(1000L, 10000L, TestingUtils.defaultScheduledExecutor());
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolResource.java
@@ -27,8 +27,6 @@ import org.junit.rules.ExternalResource;
 
 import javax.annotation.Nonnull;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * {@link ExternalResource} which provides a {@link SlotPool}.
  */
@@ -102,8 +100,6 @@ public class SlotPoolResource extends ExternalResource {
 	}
 
 	private void terminateSlotPool() {
-		slotPool.shutDown();
-		CompletableFuture<Void> terminationFuture = slotPool.getTerminationFuture();
-		terminationFuture.join();
+		slotPool.closeAsync().join();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
@@ -268,7 +268,7 @@ public class SlotPoolTest extends TestLogger {
 			assertEquals(slot1.getTaskManagerLocation(), slot2.getTaskManagerLocation());
 			assertEquals(slot1.getPhysicalSlotNumber(), slot2.getPhysicalSlotNumber());
 		} finally {
-			slotPool.shutDown();
+			RpcUtils.terminateRpcEndpoint(slotPool, timeout);
 		}
 	}
 
@@ -336,7 +336,7 @@ public class SlotPoolTest extends TestLogger {
 			assertFalse(slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, anotherSlotOfferWithSameAllocationId).get());
 			assertFalse(slotPoolGateway.offerSlot(anotherTaskManagerLocation, taskManagerGateway, slotOffer).get());
 		} finally {
-			slotPool.shutDown();
+			RpcUtils.terminateRpcEndpoint(slotPool, timeout);
 		}
 	}
 
@@ -393,7 +393,7 @@ public class SlotPoolTest extends TestLogger {
 			Thread.sleep(10);
 			assertFalse(future2.isDone());
 		} finally {
-			slotPool.shutDown();
+			RpcUtils.terminateRpcEndpoint(slotPool, timeout);
 		}
 	}
 
@@ -577,8 +577,7 @@ public class SlotPoolTest extends TestLogger {
 			assertThat(acceptedSlotOffers, Matchers.equalTo(slotOffers));
 
 			// shut down the slot pool
-			slotPool.shutDown();
-			slotPool.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			slotPool.closeAsync().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 			// the shut down operation should have freed all registered slots
 			ArrayList<AllocationID> freedSlots = new ArrayList<>(numSlotOffers);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
-import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -40,10 +40,8 @@ import org.junit.Test;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import static org.mockito.Mockito.mock;
-
 /**
- * resourceManager HA test, including grant leadership and revoke leadership
+ * ResourceManager HA test, including grant leadership and revoke leadership.
  */
 public class ResourceManagerHATest extends TestLogger {
 
@@ -64,7 +62,7 @@ public class ResourceManagerHATest extends TestLogger {
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
 		highAvailabilityServices.setResourceManagerLeaderElectionService(leaderElectionService);
 
-		HeartbeatServices heartbeatServices = mock(HeartbeatServices.class);
+		TestingHeartbeatServices heartbeatServices = new TestingHeartbeatServices();
 
 		ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration = new ResourceManagerRuntimeServicesConfiguration(
 			Time.seconds(5L),
@@ -76,8 +74,6 @@ public class ResourceManagerHATest extends TestLogger {
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,
 			rpcService.getScheduledExecutor());
-
-		MetricRegistryImpl metricRegistry = mock(MetricRegistryImpl.class);
 
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 
@@ -91,7 +87,7 @@ public class ResourceManagerHATest extends TestLogger {
 				highAvailabilityServices,
 				heartbeatServices,
 				resourceManagerRuntimeServices.getSlotManager(),
-				metricRegistry,
+				NoOpMetricRegistry.INSTANCE,
 				resourceManagerRuntimeServices.getJobLeaderIdService(),
 				new ClusterInformation("localhost", 1234),
 				testingFatalErrorHandler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -135,7 +135,7 @@ public class AsyncCallsTest extends TestLogger {
 			// validate that no concurrent access happened
 			assertFalse("Rpc Endpoint had concurrent access", concurrentAccess.get());
 		} finally {
-			rpcEndpoint.shutDown();
+			RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
 		}
 	}
 
@@ -320,8 +320,7 @@ public class AsyncCallsTest extends TestLogger {
 
 			return result;
 		} finally {
-			fencedTestEndpoint.shutDown();
-			fencedTestEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(fencedTestEndpoint, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -367,11 +367,6 @@ public class AsyncCallsTest extends TestLogger {
 				concurrentAccess.set(true);
 			}
 		}
-
-		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
 	}
 
 	public interface FencedTestGateway extends FencedRpcGateway<UUID>, TestGateway {
@@ -450,11 +445,6 @@ public class AsyncCallsTest extends TestLogger {
 			setFencingToken(fencingToken);
 
 			return CompletableFuture.completedFuture(Acknowledge.get());
-		}
-
-		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -101,8 +101,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 			assertEquals(newFencingToken, fencedGateway.getFencingToken());
 			assertEquals(newFencingToken, fencedTestingEndpoint.getFencingToken());
 		} finally {
-			fencedTestingEndpoint.shutDown();
-			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
 		}
 	}
 
@@ -150,8 +149,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 			}
 
 		} finally {
-			fencedTestingEndpoint.shutDown();
-			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
 		}
 	}
 
@@ -197,8 +195,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenException);
 			}
 		} finally {
-			fencedTestingEndpoint.shutDown();
-			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
 		}
 	}
 
@@ -241,8 +238,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 			}
 
 		} finally {
-			fencedTestingEndpoint.shutDown();
-			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
 		}
 	}
 
@@ -277,8 +273,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 				// we should not be able to call getFencingToken on an unfenced gateway
 			}
 		} finally {
-			fencedTestingEndpoint.shutDown();
-			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -300,11 +300,6 @@ public class FencedRpcEndpointTest extends TestLogger {
 			this(rpcService, value, null);
 		}
 
-		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
-
 		protected FencedTestingEndpoint(RpcService rpcService, String value, UUID initialFencingToken) {
 			super(rpcService);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -161,11 +161,6 @@ public class RpcEndpointTest extends TestLogger {
 		public CompletableFuture<Integer> foobar() {
 			return CompletableFuture.completedFuture(foobarValue);
 		}
-
-		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
 	}
 
 	public static class ExtendedEndpoint extends BaseEndpoint implements ExtendedGateway, DifferentGateway {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -82,7 +82,7 @@ public class RpcEndpointTest extends TestLogger {
 
 			assertEquals(Integer.valueOf(expectedValue), foobar.get());
 		} finally {
-			baseEndpoint.shutDown();
+			RpcUtils.terminateRpcEndpoint(baseEndpoint, TIMEOUT);
 		}
 	}
 
@@ -102,7 +102,7 @@ public class RpcEndpointTest extends TestLogger {
 
 			fail("Expected to fail with a RuntimeException since we requested the wrong gateway type.");
 		} finally {
-			baseEndpoint.shutDown();
+			RpcUtils.terminateRpcEndpoint(baseEndpoint, TIMEOUT);
 		}
 	}
 
@@ -131,7 +131,7 @@ public class RpcEndpointTest extends TestLogger {
 			assertEquals(Integer.valueOf(barfoo), extendedGateway.barfoo().get());
 			assertEquals(foo, differentGateway.foo().get());
 		} finally {
-			endpoint.shutDown();
+			RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
@@ -145,11 +145,6 @@ public class RpcSSLAuthITCase extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
-
-		@Override
 		public CompletableFuture<String> foo() {
 			return CompletableFuture.completedFuture("bar");
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rpc.akka;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -170,7 +171,7 @@ public class AkkaRpcActorOversizedResponseMessageTest extends TestLogger {
 		String messageSync() throws RpcException;
 	}
 
-	static class MessageRpcEndpoint extends TestRpcEndpoint implements MessageRpcGateway {
+	static class MessageRpcEndpoint extends RpcEndpoint implements MessageRpcGateway {
 
 		@Nonnull
 		private final String message;
@@ -189,6 +190,5 @@ public class AkkaRpcActorOversizedResponseMessageTest extends TestLogger {
 		public String messageSync() throws RpcException {
 			return message;
 		}
-
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -162,7 +162,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		assertFalse(terminationFuture.isDone());
 
 		CompletableFuture.runAsync(
-			() -> rpcEndpoint.shutDown(),
+			rpcEndpoint::shutDown,
 			akkaRpcService.getExecutor());
 
 		// wait until the rpc endpoint has terminated
@@ -208,12 +208,12 @@ public class AkkaRpcActorTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that exception thrown in the postStop method are returned by the termination
+	 * Tests that exception thrown in the onStop method are returned by the termination
 	 * future.
 	 */
 	@Test
-	public void testPostStopExceptionPropagation() throws Exception {
-		FailingPostStopEndpoint rpcEndpoint = new FailingPostStopEndpoint(akkaRpcService, "FailingPostStopEndpoint");
+	public void testOnStopExceptionPropagation() throws Exception {
+		FailingOnStopEndpoint rpcEndpoint = new FailingOnStopEndpoint(akkaRpcService, "FailingOnStopEndpoint");
 		rpcEndpoint.start();
 
 		rpcEndpoint.shutDown();
@@ -223,15 +223,15 @@ public class AkkaRpcActorTest extends TestLogger {
 		try {
 			terminationFuture.get();
 		} catch (ExecutionException e) {
-			assertTrue(e.getCause() instanceof FailingPostStopEndpoint.PostStopException);
+			assertTrue(e.getCause() instanceof FailingOnStopEndpoint.OnStopException);
 		}
 	}
 
 	/**
-	 * Checks that the postStop callback is executed within the main thread.
+	 * Checks that the onStop callback is executed within the main thread.
 	 */
 	@Test
-	public void testPostStopExecutedByMainThread() throws Exception {
+	public void testOnStopExecutedByMainThread() throws Exception {
 		SimpleRpcEndpoint simpleRpcEndpoint = new SimpleRpcEndpoint(akkaRpcService, "SimpleRpcEndpoint");
 		simpleRpcEndpoint.start();
 
@@ -239,7 +239,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		CompletableFuture<Void> terminationFuture = simpleRpcEndpoint.getTerminationFuture();
 
-		// check that we executed the postStop method in the main thread, otherwise an exception
+		// check that we executed the onStop method in the main thread, otherwise an exception
 		// would be thrown here.
 		terminationFuture.get();
 	}
@@ -274,9 +274,9 @@ public class AkkaRpcActorTest extends TestLogger {
 	 * post stop action has completed.
 	 */
 	@Test
-	public void testActorTerminationWithAsynchronousPostStopAction() throws Exception {
-		final CompletableFuture<Void> postStopFuture = new CompletableFuture<>();
-		final AsynchronousPostStopEndpoint endpoint = new AsynchronousPostStopEndpoint(akkaRpcService, postStopFuture);
+	public void testActorTerminationWithAsynchronousOnStopAction() throws Exception {
+		final CompletableFuture<Void> onStopFuture = new CompletableFuture<>();
+		final AsynchronousOnStopEndpoint endpoint = new AsynchronousOnStopEndpoint(akkaRpcService, onStopFuture);
 
 		try {
 			endpoint.start();
@@ -287,9 +287,28 @@ public class AkkaRpcActorTest extends TestLogger {
 
 			assertFalse(terminationFuture.isDone());
 
-			postStopFuture.complete(null);
+			onStopFuture.complete(null);
 
-			// the postStopFuture completion should allow the endpoint to terminate
+			// the onStopFuture completion should allow the endpoint to terminate
+			terminationFuture.get();
+		} finally {
+			RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+		}
+	}
+
+	/**
+	 * Tests that we can still run commands via the main thread executor when the onStop method
+	 * is called.
+	 */
+	@Test
+	public void testMainThreadExecutionOnStop() throws Exception {
+		final MainThreadExecutorOnStopEndpoint endpoint = new MainThreadExecutorOnStopEndpoint(akkaRpcService);
+
+		try {
+			endpoint.start();
+
+			CompletableFuture<Void> terminationFuture = endpoint.terminate();
+
 			terminationFuture.get();
 		} finally {
 			RpcUtils.terminateRpcEndpoint(endpoint, timeout);
@@ -304,7 +323,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		CompletableFuture<Integer> foobar();
 	}
 
-	static class DummyRpcEndpoint extends TestRpcEndpoint implements DummyRpcGateway {
+	static class DummyRpcEndpoint extends RpcEndpoint implements DummyRpcGateway {
 
 		private volatile int foobar = 42;
 
@@ -328,7 +347,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		CompletableFuture<Integer> doStuff();
 	}
 
-	private static class ExceptionalEndpoint extends TestRpcEndpoint implements ExceptionalGateway {
+	private static class ExceptionalEndpoint extends RpcEndpoint implements ExceptionalGateway {
 
 		protected ExceptionalEndpoint(RpcService rpcService) {
 			super(rpcService);
@@ -340,7 +359,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
-	private static class ExceptionalFutureEndpoint extends TestRpcEndpoint implements ExceptionalGateway {
+	private static class ExceptionalFutureEndpoint extends RpcEndpoint implements ExceptionalGateway {
 
 		protected ExceptionalFutureEndpoint(RpcService rpcService) {
 			super(rpcService);
@@ -372,32 +391,26 @@ public class AkkaRpcActorTest extends TestLogger {
 		protected SimpleRpcEndpoint(RpcService rpcService, String endpointId) {
 			super(rpcService, endpointId);
 		}
-
-		@Override
-		public CompletableFuture<Void> postStop() {
-			validateRunsInMainThread();
-			return CompletableFuture.completedFuture(null);
-		}
 	}
 
 	// ------------------------------------------------------------------------
 
-	private static class FailingPostStopEndpoint extends RpcEndpoint implements RpcGateway {
+	private static class FailingOnStopEndpoint extends RpcEndpoint implements RpcGateway {
 
-		protected FailingPostStopEndpoint(RpcService rpcService, String endpointId) {
+		protected FailingOnStopEndpoint(RpcService rpcService, String endpointId) {
 			super(rpcService, endpointId);
 		}
 
 		@Override
-		public CompletableFuture<Void> postStop() {
-			return FutureUtils.completedExceptionally(new PostStopException("Test exception."));
+		public CompletableFuture<Void> onStop() {
+			return FutureUtils.completedExceptionally(new OnStopException("Test exception."));
 		}
 
-		private static class PostStopException extends FlinkException {
+		private static class OnStopException extends FlinkException {
 
 			private static final long serialVersionUID = 6701096588415871592L;
 
-			public PostStopException(String message) {
+			public OnStopException(String message) {
 				super(message);
 			}
 		}
@@ -405,19 +418,33 @@ public class AkkaRpcActorTest extends TestLogger {
 
 	// ------------------------------------------------------------------------
 
-	private static class AsynchronousPostStopEndpoint extends RpcEndpoint {
+	static class AsynchronousOnStopEndpoint extends RpcEndpoint {
 
-		private final CompletableFuture<Void> postStopFuture;
+		private final CompletableFuture<Void> onStopFuture;
 
-		protected AsynchronousPostStopEndpoint(RpcService rpcService, CompletableFuture<Void> postStopFuture) {
+		protected AsynchronousOnStopEndpoint(RpcService rpcService, CompletableFuture<Void> onStopFuture) {
 			super(rpcService);
 
-			this.postStopFuture = Preconditions.checkNotNull(postStopFuture);
+			this.onStopFuture = Preconditions.checkNotNull(onStopFuture);
 		}
 
 		@Override
-		public CompletableFuture<Void> postStop() {
-			return postStopFuture;
+		public CompletableFuture<Void> onStop() {
+			return onStopFuture;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static class MainThreadExecutorOnStopEndpoint extends RpcEndpoint {
+
+		protected MainThreadExecutorOnStopEndpoint(RpcService rpcService) {
+			super(rpcService);
+		}
+
+		@Override
+		public CompletableFuture<Void> onStop() {
+			return CompletableFuture.runAsync(() -> {}, getMainThreadExecutor());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -23,14 +23,24 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
 import akka.actor.Terminated;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -38,8 +48,10 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -48,24 +60,33 @@ import static org.junit.Assert.fail;
  */
 public class AkkaRpcServiceTest extends TestLogger {
 
+	private static final Time TIMEOUT = Time.milliseconds(10000L);
+
 	// ------------------------------------------------------------------------
 	//  shared test members
 	// ------------------------------------------------------------------------
 
-	private static final ActorSystem ACTOR_SYSTEM = AkkaUtils.createDefaultActorSystem();
+	private static ActorSystem actorSystem;
 
-	private static final Time TIMEOUT = Time.milliseconds(10000L);
+	private static AkkaRpcService akkaRpcService;
 
-	private static final AkkaRpcService AKKA_RPC_SERVICE = new AkkaRpcService(ACTOR_SYSTEM, AkkaRpcServiceConfiguration.defaultConfiguration());
+	@BeforeClass
+	public static void setup() {
+		actorSystem = AkkaUtils.createDefaultActorSystem();
+		akkaRpcService = new AkkaRpcService(actorSystem, AkkaRpcServiceConfiguration.defaultConfiguration());
+	}
 
 	@AfterClass
 	public static void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
-		final CompletableFuture<Void> rpcTerminationFuture = AKKA_RPC_SERVICE.stopService();
-		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(ACTOR_SYSTEM.terminate());
+		final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
 
 		FutureUtils
 			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
 			.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+		actorSystem = null;
+		akkaRpcService = null;
 	}
 
 	// ------------------------------------------------------------------------
@@ -78,7 +99,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 		final long delay = 100L;
 		final long start = System.nanoTime();
 
-		ScheduledFuture<?> scheduledFuture = AKKA_RPC_SERVICE.scheduleRunnable(latch::trigger, delay, TimeUnit.MILLISECONDS);
+		ScheduledFuture<?> scheduledFuture = akkaRpcService.scheduleRunnable(latch::trigger, delay, TimeUnit.MILLISECONDS);
 
 		scheduledFuture.get();
 
@@ -95,7 +116,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	public void testExecuteRunnable() throws Exception {
 		final OneShotLatch latch = new OneShotLatch();
 
-		AKKA_RPC_SERVICE.execute(latch::trigger);
+		akkaRpcService.execute(latch::trigger);
 
 		latch.await(30L, TimeUnit.SECONDS);
 	}
@@ -109,7 +130,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 		final OneShotLatch latch = new OneShotLatch();
 		final int expected = 42;
 
-		CompletableFuture<Integer> result = AKKA_RPC_SERVICE.execute(() -> {
+		CompletableFuture<Integer> result = akkaRpcService.execute(() -> {
 			latch.trigger();
 			return expected;
 		});
@@ -122,12 +143,12 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 	@Test
 	public void testGetAddress() {
-		assertEquals(AkkaUtils.getAddress(ACTOR_SYSTEM).host().get(), AKKA_RPC_SERVICE.getAddress());
+		assertEquals(AkkaUtils.getAddress(actorSystem).host().get(), akkaRpcService.getAddress());
 	}
 
 	@Test
 	public void testGetPort() {
-		assertEquals(AkkaUtils.getAddress(ACTOR_SYSTEM).port().get(), AKKA_RPC_SERVICE.getPort());
+		assertEquals(AkkaUtils.getAddress(actorSystem).port().get(), akkaRpcService.getPort());
 	}
 
 	/**
@@ -135,15 +156,13 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 60000)
 	public void testTerminationFuture() throws Exception {
-		final ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
-		final AkkaRpcService rpcService = new AkkaRpcService(
-			actorSystem, AkkaRpcServiceConfiguration.defaultConfiguration());
+		final AkkaRpcService rpcService = startAkkaRpcService();
 
 		CompletableFuture<Void> terminationFuture = rpcService.getTerminationFuture();
 
 		assertFalse(terminationFuture.isDone());
 
-		CompletableFuture.runAsync(rpcService::stopService, actorSystem.dispatcher());
+		rpcService.stopService();
 
 		terminationFuture.get();
 	}
@@ -154,7 +173,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 60000)
 	public void testScheduledExecutorServiceSimpleSchedule() throws Exception {
-		ScheduledExecutor scheduledExecutor = AKKA_RPC_SERVICE.getScheduledExecutor();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		final OneShotLatch latch = new OneShotLatch();
 
@@ -175,7 +194,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 60000)
 	public void testScheduledExecutorServicePeriodicSchedule() throws Exception {
-		ScheduledExecutor scheduledExecutor = AKKA_RPC_SERVICE.getScheduledExecutor();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		final int tries = 4;
 		final long delay = 10L;
@@ -210,7 +229,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 60000)
 	public void testScheduledExecutorServiceWithFixedDelaySchedule() throws Exception {
-		ScheduledExecutor scheduledExecutor = AKKA_RPC_SERVICE.getScheduledExecutor();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		final int tries = 4;
 		final long delay = 10L;
@@ -244,7 +263,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test
 	public void testScheduledExecutorServiceCancelWithFixedDelay() throws InterruptedException {
-		ScheduledExecutor scheduledExecutor = AKKA_RPC_SERVICE.getScheduledExecutor();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		long delay = 10L;
 
@@ -283,6 +302,119 @@ public class AkkaRpcServiceTest extends TestLogger {
 			fail("The shouldNotBeTriggeredLatch should never be triggered.");
 		} catch (TimeoutException e) {
 			// expected
+		}
+	}
+
+	/**
+	 * Tests that the {@link AkkaRpcService} terminates all its RpcEndpoints when shutting down.
+	 */
+	@Test
+	public void testAkkaRpcServiceShutDownWithRpcEndpoints() throws Exception {
+		final AkkaRpcService akkaRpcService = startAkkaRpcService();
+
+		try {
+			final int numberActors = 5;
+
+			CompletableFuture<Void> terminationFuture = akkaRpcService.getTerminationFuture();
+
+			final Collection<CompletableFuture<Void>> onStopFutures = startStopNCountingAsynchronousOnStopEndpoints(akkaRpcService, numberActors);
+
+			for (CompletableFuture<Void> onStopFuture : onStopFutures) {
+				onStopFuture.complete(null);
+			}
+
+			terminationFuture.get();
+			assertThat(akkaRpcService.getActorSystem().isTerminated(), is(true));
+		} finally {
+			RpcUtils.terminateRpcService(akkaRpcService, TIMEOUT);
+		}
+	}
+
+	/**
+	 * Tests that {@link AkkaRpcService} terminates all its RpcEndpoints and also stops
+	 * the underlying {@link ActorSystem} if one of the RpcEndpoints fails while stopping.
+	 */
+	@Test
+	public void testAkkaRpcServiceShutDownWithFailingRpcEndpoints() throws Exception {
+		final AkkaRpcService akkaRpcService = startAkkaRpcService();
+
+		final int numberActors = 5;
+
+		CompletableFuture<Void> terminationFuture = akkaRpcService.getTerminationFuture();
+
+		final Collection<CompletableFuture<Void>> onStopFutures = startStopNCountingAsynchronousOnStopEndpoints(akkaRpcService, numberActors);
+
+		Iterator<CompletableFuture<Void>> iterator = onStopFutures.iterator();
+
+		for (int i = 0; i < numberActors - 1; i++) {
+			iterator.next().complete(null);
+		}
+
+		iterator.next().completeExceptionally(new OnStopException("onStop exception occurred."));
+
+		for (CompletableFuture<Void> onStopFuture : onStopFutures) {
+			onStopFuture.complete(null);
+		}
+
+		try {
+			terminationFuture.get();
+			fail("Expected the termination future to complete exceptionally.");
+		} catch (ExecutionException e) {
+			assertThat(ExceptionUtils.findThrowable(e, OnStopException.class).isPresent(), is(true));
+		}
+
+		assertThat(akkaRpcService.getActorSystem().isTerminated(), is(true));
+	}
+
+	private Collection<CompletableFuture<Void>> startStopNCountingAsynchronousOnStopEndpoints(AkkaRpcService akkaRpcService, int numberActors) throws Exception {
+		final Collection<CompletableFuture<Void>> onStopFutures = new ArrayList<>(numberActors);
+
+		final CountDownLatch countDownLatch = new CountDownLatch(numberActors);
+
+		for (int i = 0; i < numberActors; i++) {
+			CompletableFuture<Void> onStopFuture = new CompletableFuture<>();
+			final CountingAsynchronousOnStopEndpoint endpoint = new CountingAsynchronousOnStopEndpoint(akkaRpcService, onStopFuture, countDownLatch);
+			endpoint.start();
+			onStopFutures.add(onStopFuture);
+		}
+
+		CompletableFuture<Void> terminationFuture = akkaRpcService.stopService();
+
+		assertThat(terminationFuture.isDone(), is(false));
+		assertThat(akkaRpcService.getActorSystem().isTerminated(), is(false));
+
+		countDownLatch.await();
+
+		return onStopFutures;
+	}
+
+	@Nonnull
+	private AkkaRpcService startAkkaRpcService() {
+		final ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
+		return new AkkaRpcService(actorSystem, AkkaRpcServiceConfiguration.defaultConfiguration());
+	}
+
+	private static class CountingAsynchronousOnStopEndpoint extends AkkaRpcActorTest.AsynchronousOnStopEndpoint {
+
+		private final CountDownLatch countDownLatch;
+
+		protected CountingAsynchronousOnStopEndpoint(RpcService rpcService, CompletableFuture<Void> onStopFuture, CountDownLatch countDownLatch) {
+			super(rpcService, onStopFuture);
+			this.countDownLatch = countDownLatch;
+		}
+
+		@Override
+		public CompletableFuture<Void> onStop() {
+			countDownLatch.countDown();
+			return super.onStop();
+		}
+	}
+
+	private static class OnStopException extends FlinkException {
+		private static final long serialVersionUID = 7136609202083168954L;
+
+		public OnStopException(String message) {
+			super(message);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
-import java.util.concurrent.CompletableFuture;
-
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -68,7 +66,7 @@ public class MainThreadValidationTest extends TestLogger {
 			}
 			assertTrue("should fail with an assertion error", exceptionThrown);
 
-			testEndpoint.shutDown();
+			testEndpoint.closeAsync();
 		}
 		finally {
 			akkaRpcService.stopService().get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -30,6 +30,10 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests that the {@link AkkaRpcService} runs all RPCs in the {@link AkkaRpcActor}'s
+ * main thread.
+ */
 public class MainThreadValidationTest extends TestLogger {
 
 	@Test
@@ -80,10 +84,9 @@ public class MainThreadValidationTest extends TestLogger {
 		void someConcurrencyCriticalFunction();
 	}
 
-	@SuppressWarnings("unused")
-	public static class TestEndpoint extends RpcEndpoint implements TestGateway {
+	private static class TestEndpoint extends RpcEndpoint implements TestGateway {
 
-		public TestEndpoint(RpcService rpcService) {
+		private TestEndpoint(RpcService rpcService) {
 			super(rpcService);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -91,11 +91,6 @@ public class MainThreadValidationTest extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
-
-		@Override
 		public void someConcurrencyCriticalFunction() {
 			validateRunsInMainThread();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -191,11 +191,6 @@ public class MessageSerializationTest extends TestLogger {
 		public void foobar(Object object) throws InterruptedException {
 			queue.put(object);
 		}
-
-		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
 	}
 
 	private static class NonSerializableObject {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -645,8 +645,7 @@ public class TaskExecutorTest extends TestLogger {
 					eq(taskManagerAddress), eq(taskManagerLocation.getResourceID()), anyInt(), any(HardwareDescription.class), any(Time.class));
 		}
 		finally {
-			taskManager.shutDown();
-			taskManager.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
 		}
 	}
 
@@ -726,8 +725,7 @@ public class TaskExecutorTest extends TestLogger {
 			assertNotNull(taskManager.getResourceManagerConnection());
 		}
 		finally {
-			taskManager.shutDown();
-			taskManager.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
 		}
 	}
 
@@ -835,8 +833,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			completionFuture.get();
 		} finally {
-			taskManager.shutDown();
-			taskManager.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
 		}
 	}
 
@@ -1061,8 +1058,7 @@ public class TaskExecutorTest extends TestLogger {
 			assertFalse(taskSlotTable.tryMarkSlotActive(jobId, allocationId2));
 			assertTrue(taskSlotTable.isSlotFree(1));
 		} finally {
-			taskManager.shutDown();
-			taskManager.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
 		}
 	}
 
@@ -1198,8 +1194,7 @@ public class TaskExecutorTest extends TestLogger {
 			// wait for the task completion
 			taskInTerminalState.await();
 		} finally {
-			taskManager.shutDown();
-			taskManager.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
 		}
 	}
 
@@ -1263,8 +1258,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			assertEquals(jobMasterGateway, jobManagerConnection.getJobManagerGateway());
 		} finally {
-			taskExecutor.shutDown();
-			taskExecutor.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -62,7 +62,11 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction;
 
-	TestingTaskExecutorGateway(String address, String hostname, Consumer<ResourceID> heartbeatJobManagerConsumer, BiConsumer<JobID, Throwable> disconnectJobManagerConsumer, BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer, Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction, BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction) {
+	private final Consumer<ResourceID> heartbeatResourceManagerConsumer;
+
+	private final Consumer<Exception> disconnectResourceManagerConsumer;
+
+	TestingTaskExecutorGateway(String address, String hostname, Consumer<ResourceID> heartbeatJobManagerConsumer, BiConsumer<JobID, Throwable> disconnectJobManagerConsumer, BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer, Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction, BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction, Consumer<ResourceID> heartbeatResourceManagerConsumer, Consumer<Exception> disconnectResourceManagerConsumer) {
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
 		this.heartbeatJobManagerConsumer = Preconditions.checkNotNull(heartbeatJobManagerConsumer);
@@ -70,6 +74,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 		this.submitTaskConsumer = Preconditions.checkNotNull(submitTaskConsumer);
 		this.requestSlotFunction = Preconditions.checkNotNull(requestSlotFunction);
 		this.freeSlotFunction = Preconditions.checkNotNull(freeSlotFunction);
+		this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
+		this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
 	}
 
 	@Override
@@ -130,7 +136,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public void heartbeatFromResourceManager(ResourceID heartbeatOrigin) {
-		// noop
+		heartbeatResourceManagerConsumer.accept(heartbeatOrigin);
 	}
 
 	@Override
@@ -140,7 +146,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public void disconnectResourceManager(Exception cause) {
-		// noop
+		disconnectResourceManagerConsumer.accept(cause);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -44,6 +44,8 @@ public class TestingTaskExecutorGatewayBuilder {
 	private static final BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> NOOP_SUBMIT_TASK_CONSUMER = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> NOOP_REQUEST_SLOT_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> NOOP_FREE_SLOT_FUNCTION = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
+	private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
+	private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
 
 	private String address = "foobar:1234";
 	private String hostname = "foobar";
@@ -52,6 +54,8 @@ public class TestingTaskExecutorGatewayBuilder {
 	private BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer = NOOP_SUBMIT_TASK_CONSUMER;
 	private Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
 	private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction = NOOP_FREE_SLOT_FUNCTION;
+	private Consumer<ResourceID> heartbeatResourceManagerConsumer = NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
+	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
 		this.address = address;
@@ -88,7 +92,17 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
+	public TestingTaskExecutorGatewayBuilder setHeartbeatResourceManagerConsumer(Consumer<ResourceID> heartbeatResourceManagerConsumer) {
+		this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
+		return this;
+	}
+
+	public TestingTaskExecutorGatewayBuilder setDisconnectResourceManagerConsumer(Consumer<Exception> disconnectResourceManagerConsumer) {
+		this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
+		return this;
+	}
+
 	public TestingTaskExecutorGateway createTestingTaskExecutorGateway() {
-		return new TestingTaskExecutorGateway(address, hostname, heartbeatJobManagerConsumer, disconnectJobManagerConsumer, submitTaskConsumer, requestSlotFunction, freeSlotFunction);
+		return new TestingTaskExecutorGateway(address, hostname, heartbeatJobManagerConsumer, disconnectJobManagerConsumer, submitTaskConsumer, requestSlotFunction, freeSlotFunction, heartbeatResourceManagerConsumer, disconnectResourceManagerConsumer);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -106,10 +106,8 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 			assertEquals(dummyRpcEndpoint2.getAddress(), dummyGateway2.getAddress());
 			assertEquals(expectedValue2, dummyGateway2.foobar(TIMEOUT).get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS));
 		} finally {
-			dummyRpcEndpoint.shutDown();
-			dummyRpcEndpoint2.shutDown();
-			dummyRpcEndpoint.getTerminationFuture().get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
-			dummyRpcEndpoint2.getTerminationFuture().get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcEndpoint(dummyRpcEndpoint, TIMEOUT);
+			RpcUtils.terminateRpcEndpoint(dummyRpcEndpoint2, TIMEOUT);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -138,10 +138,5 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 		public UUID getFencingToken() {
 			return HighAvailabilityServices.DEFAULT_LEADER_ID;
 		}
-
-		@Override
-		public CompletableFuture<Void> postStop() {
-			return CompletableFuture.completedFuture(null);
-		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -248,11 +248,11 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 				dispatcherResourceManagerComponent.deregisterApplicationAndClose(ApplicationStatus.SUCCEEDED, null);
 			}
 
-			haServices.closeAndCleanupAllData();
-
 			fatalErrorHandler.rethrowError();
 
 			RpcUtils.terminateRpcService(rpcService, Time.seconds(100L));
+
+			haServices.closeAndCleanupAllData();
 		}
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -254,7 +254,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	}
 
 	@Override
-	public CompletableFuture<Void> postStop() {
+	public CompletableFuture<Void> onStop() {
 		// shut down all components
 		Throwable firstException = null;
 
@@ -274,7 +274,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			}
 		}
 
-		final CompletableFuture<Void> terminationFuture = super.postStop();
+		final CompletableFuture<Void> terminationFuture = super.onStop();
 
 		if (firstException != null) {
 			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting down YARN resource manager", firstException));

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -449,7 +449,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onShutdownRequest() {
-		shutDown();
+		closeAsync();
 	}
 
 	@Override

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
-import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -291,7 +290,6 @@ public class YarnResourceManagerTest extends TestLogger {
 		 */
 		class MockResourceManagerRuntimeServices {
 
-			private final ScheduledExecutor scheduledExecutor;
 			private final TestingHighAvailabilityServices highAvailabilityServices;
 			private final HeartbeatServices heartbeatServices;
 			private final MetricRegistry metricRegistry;
@@ -302,11 +300,10 @@ public class YarnResourceManagerTest extends TestLogger {
 			private UUID rmLeaderSessionId;
 
 			MockResourceManagerRuntimeServices() throws Exception {
-				scheduledExecutor = mock(ScheduledExecutor.class);
 				highAvailabilityServices = new TestingHighAvailabilityServices();
 				rmLeaderElectionService = new TestingLeaderElectionService();
 				highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
-				heartbeatServices = new TestingHeartbeatServices(5L, 5L, scheduledExecutor);
+				heartbeatServices = new TestingHeartbeatServices();
 				metricRegistry = NoOpMetricRegistry.INSTANCE;
 				slotManager = new SlotManager(
 						new ScheduledExecutorServiceAdapter(new DirectScheduledExecutorService()),


### PR DESCRIPTION
## What is the purpose of the change

Replace RpcEndpoin#postStop with RpcEndpoint#onStop method which can execute asynchronous
operations in the main thread executor. onStop returns a future which will terminate the
RpcEndpoint once it is completed.

The new stop semantics allow to execute complex shut down logic which requires asynchronous
operations.

## Verifying this change

- Added `AkkaRpcServiceTest#testAkkaRpcServiceShutDownWithRpcEndpoints`, `AkkaRpcServiceTest#testAkkaRpcServiceShutDownWithRpcEndpoints` and `AkkaRpcActorTest#testMainThreadExecutionOnStop`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
