### PR TITLE
[FLINK-11545] [container] Add job-id arg to StandaloneJobClusterEntryPoint

### DIFF
--- a/flink-container/kubernetes/README.md
+++ b/flink-container/kubernetes/README.md
@@ -38,6 +38,12 @@ At last, you should start the task manager deployment:
 
 `FLINK_IMAGE_NAME=<IMAGE_NAME> FLINK_JOB_PARALLELISM=<PARALLELISM> envsubst < task-manager-deployment.yaml.template | kubectl create -f -`
 
+### Additional command line arguments
+
+You can provide the following additional command line arguments to the cluster entrypoint:
+
+- `--job-id <job id>`: Manually set a Flink job ID for the job (default: `00000000000000000000000000000000`)
+
 ## Resuming from a savepoint
 
 In order to resume from a savepoint, one needs to pass the savepoint path to the cluster entrypoint.

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.container.entrypoint;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -46,8 +45,6 @@ public class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	@Nonnull
 	private final String[] programArguments;
 
-	public static final JobID FIXED_JOB_ID = new JobID(0, 0);
-
 	public ClassPathJobGraphRetriever(
 			@Nonnull String jobClassName,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
@@ -66,7 +63,7 @@ public class ClassPathJobGraphRetriever implements JobGraphRetriever {
 				packagedProgram,
 				configuration,
 				defaultParallelism,
-				FIXED_JOB_ID);
+				StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID);
 			jobGraph.setAllowQueuedScheduling(true);
 			jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
 

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -30,14 +31,19 @@ import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nonnull;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * {@link JobGraphRetriever} which creates the {@link JobGraph} from a class
  * on the class path.
  */
-public class ClassPathJobGraphRetriever implements JobGraphRetriever {
+class ClassPathJobGraphRetriever implements JobGraphRetriever {
 
 	@Nonnull
 	private final String jobClassName;
+
+	@Nonnull
+	private final JobID jobId;
 
 	@Nonnull
 	private final SavepointRestoreSettings savepointRestoreSettings;
@@ -45,13 +51,15 @@ public class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	@Nonnull
 	private final String[] programArguments;
 
-	public ClassPathJobGraphRetriever(
+	ClassPathJobGraphRetriever(
 			@Nonnull String jobClassName,
+			@Nonnull JobID jobId,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
 			@Nonnull String[] programArguments) {
-		this.jobClassName = jobClassName;
-		this.savepointRestoreSettings = savepointRestoreSettings;
-		this.programArguments = programArguments;
+		this.jobClassName = requireNonNull(jobClassName, "jobClassName");
+		this.jobId = requireNonNull(jobId, "jobId");
+		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
+		this.programArguments = requireNonNull(programArguments, "programArguments");
 	}
 
 	@Override
@@ -63,7 +71,7 @@ public class ClassPathJobGraphRetriever implements JobGraphRetriever {
 				packagedProgram,
 				configuration,
 				defaultParallelism,
-				StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID);
+				jobId);
 			jobGraph.setAllowQueuedScheduling(true);
 			jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
 

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.entrypoint.EntrypointClusterConfiguration;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
@@ -25,6 +26,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Configuration for the {@link StandaloneJobClusterEntryPoint}.
@@ -37,10 +40,22 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 	@Nonnull
 	private final SavepointRestoreSettings savepointRestoreSettings;
 
-	public StandaloneJobClusterConfiguration(@Nonnull String configDir, @Nonnull Properties dynamicProperties, @Nonnull String[] args, @Nullable String hostname, int restPort, @Nonnull String jobClassName, @Nonnull SavepointRestoreSettings savepointRestoreSettings) {
+	@Nonnull
+	private final JobID jobId;
+
+	StandaloneJobClusterConfiguration(
+			@Nonnull String configDir,
+			@Nonnull Properties dynamicProperties,
+			@Nonnull String[] args,
+			@Nullable String hostname,
+			int restPort,
+			@Nonnull String jobClassName,
+			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
+			@Nonnull JobID jobId) {
 		super(configDir, dynamicProperties, args, hostname, restPort);
-		this.jobClassName = jobClassName;
-		this.savepointRestoreSettings = savepointRestoreSettings;
+		this.jobClassName = requireNonNull(jobClassName, "jobClassName");
+		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
+		this.jobId = requireNonNull(jobId, "jobId");
 	}
 
 	@Nonnull
@@ -49,7 +64,12 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 	}
 
 	@Nonnull
-	public SavepointRestoreSettings getSavepointRestoreSettings() {
+	SavepointRestoreSettings getSavepointRestoreSettings() {
 		return savepointRestoreSettings;
+	}
+
+	@Nonnull
+	JobID getJobId() {
+		return jobId;
 	}
 }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -79,6 +80,7 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 			hostname,
 			restPort,
 			jobClassName,
-			savepointRestoreSettings);
+			savepointRestoreSettings,
+			new JobID());
 	}
 }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
@@ -42,6 +42,8 @@ import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST
  */
 public class StandaloneJobClusterConfigurationParserFactory implements ParserResultFactory<StandaloneJobClusterConfiguration> {
 
+	static final JobID DEFAULT_JOB_ID = new JobID(0, 0);
+
 	private static final Option JOB_CLASS_NAME_OPTION = Option.builder("j")
 		.longOpt("job-classname")
 		.required(true)
@@ -50,12 +52,21 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 		.desc("Class name of the job to run.")
 		.build();
 
+	private static final Option JOB_ID_OPTION = Option.builder("jid")
+		.longOpt("job-id")
+		.required(false)
+		.hasArg(true)
+		.argName("job id")
+		.desc("Job ID of the job to run.")
+		.build();
+
 	@Override
 	public Options getOptions() {
 		final Options options = new Options();
 		options.addOption(CONFIG_DIR_OPTION);
 		options.addOption(REST_PORT_OPTION);
 		options.addOption(JOB_CLASS_NAME_OPTION);
+		options.addOption(JOB_ID_OPTION);
 		options.addOption(DYNAMIC_PROPERTY_OPTION);
 		options.addOption(CliFrontendParser.SAVEPOINT_PATH_OPTION);
 		options.addOption(CliFrontendParser.SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
@@ -72,6 +83,7 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 		final String hostname = commandLine.getOptionValue(HOST_OPTION.getOpt());
 		final String jobClassName = commandLine.getOptionValue(JOB_CLASS_NAME_OPTION.getOpt());
 		final SavepointRestoreSettings savepointRestoreSettings = CliFrontendParser.createSavepointRestoreSettings(commandLine);
+		final JobID jobId = getJobId(commandLine);
 
 		return new StandaloneJobClusterConfiguration(
 			configDir,
@@ -81,6 +93,14 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 			restPort,
 			jobClassName,
 			savepointRestoreSettings,
-			new JobID());
+			jobId);
+	}
+
+	private static JobID getJobId(CommandLine commandLine) {
+		String jobId = commandLine.getOptionValue(JOB_ID_OPTION.getOpt());
+		if (jobId == null) {
+			return DEFAULT_JOB_ID;
+		}
+		return JobID.fromHexString(jobId);
 	}
 }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
@@ -45,18 +46,23 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 	private final String jobClassName;
 
 	@Nonnull
+	private final JobID jobId;
+
+	@Nonnull
 	private final SavepointRestoreSettings savepointRestoreSettings;
 
 	@Nonnull
 	private final String[] programArguments;
 
-	StandaloneJobClusterEntryPoint(
+	private StandaloneJobClusterEntryPoint(
 			Configuration configuration,
 			@Nonnull String jobClassName,
+			@Nonnull JobID jobId,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
 			@Nonnull String[] programArguments) {
 		super(configuration);
 		this.jobClassName = requireNonNull(jobClassName, "jobClassName");
+		this.jobId = requireNonNull(jobId, "jobId");
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
 		this.programArguments = requireNonNull(programArguments, "programArguments");
 	}
@@ -65,7 +71,7 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 	protected DispatcherResourceManagerComponentFactory<?> createDispatcherResourceManagerComponentFactory(Configuration configuration) {
 		return new JobDispatcherResourceManagerComponentFactory(
 			StandaloneResourceManagerFactory.INSTANCE,
-			new ClassPathJobGraphRetriever(jobClassName, savepointRestoreSettings, programArguments));
+			new ClassPathJobGraphRetriever(jobClassName, jobId, savepointRestoreSettings, programArguments));
 	}
 
 	public static void main(String[] args) {
@@ -92,6 +98,7 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 		StandaloneJobClusterEntryPoint entrypoint = new StandaloneJobClusterEntryPoint(
 			configuration,
 			clusterConfiguration.getJobClassName(),
+			clusterConfiguration.getJobId(),
 			clusterConfiguration.getSavepointRestoreSettings(),
 			clusterConfiguration.getArgs());
 

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -21,7 +21,6 @@ package org.apache.flink.container.entrypoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
-import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.JobDispatcherResourceManagerComponentFactory;
@@ -85,7 +84,7 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 
 		try {
 			clusterConfiguration = commandLineParser.parse(args);
-		} catch (FlinkParseException e) {
+		} catch (Exception e) {
 			LOG.error("Could not parse command line arguments {}.", args, e);
 			commandLineParser.printHelp(StandaloneJobClusterEntryPoint.class.getSimpleName());
 			System.exit(1);

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.util.SignalHandler;
 
 import javax.annotation.Nonnull;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link JobClusterEntrypoint} which is started with a job in a predefined
@@ -41,13 +41,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 
-	private final String[] programArguments;
-
 	@Nonnull
 	private final String jobClassName;
 
 	@Nonnull
 	private final SavepointRestoreSettings savepointRestoreSettings;
+
+	@Nonnull
+	private final String[] programArguments;
 
 	StandaloneJobClusterEntryPoint(
 			Configuration configuration,
@@ -55,9 +56,9 @@ public final class StandaloneJobClusterEntryPoint extends JobClusterEntrypoint {
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
 			@Nonnull String[] programArguments) {
 		super(configuration);
-		this.programArguments = checkNotNull(programArguments);
-		this.jobClassName = checkNotNull(jobClassName);
-		this.savepointRestoreSettings = savepointRestoreSettings;
+		this.jobClassName = requireNonNull(jobClassName, "jobClassName");
+		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
+		this.programArguments = requireNonNull(programArguments, "programArguments");
 	}
 
 	@Override

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -37,16 +38,18 @@ import static org.junit.Assert.assertThat;
  */
 public class ClassPathJobGraphRetrieverTest extends TestLogger {
 
-	public static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
+	private static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
 
 	@Test
 	public void testJobGraphRetrieval() throws FlinkException {
 		final int parallelism = 42;
 		final Configuration configuration = new Configuration();
 		configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+		final JobID jobId = new JobID();
 
 		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
 			TestJob.class.getCanonicalName(),
+			jobId,
 			SavepointRestoreSettings.none(),
 			PROGRAM_ARGUMENTS);
 
@@ -54,22 +57,24 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 
 		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName() + "-suffix")));
 		assertThat(jobGraph.getMaximumParallelism(), is(parallelism));
-		assertEquals(jobGraph.getJobID(), StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID);
+		assertEquals(jobGraph.getJobID(), jobId);
 	}
 
 	@Test
 	public void testSavepointRestoreSettings() throws FlinkException {
 		final Configuration configuration = new Configuration();
 		final SavepointRestoreSettings savepointRestoreSettings = SavepointRestoreSettings.forPath("foobar", true);
+		final JobID jobId = new JobID();
 
 		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
 			TestJob.class.getCanonicalName(),
+			jobId,
 			savepointRestoreSettings,
 			PROGRAM_ARGUMENTS);
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
 		assertThat(jobGraph.getSavepointRestoreSettings(), is(equalTo(savepointRestoreSettings)));
-		assertEquals(jobGraph.getJobID(), StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID);
+		assertEquals(jobGraph.getJobID(), jobId);
 	}
 }

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
@@ -54,7 +54,7 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 
 		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName() + "-suffix")));
 		assertThat(jobGraph.getMaximumParallelism(), is(parallelism));
-		assertEquals(jobGraph.getJobID(), ClassPathJobGraphRetriever.FIXED_JOB_ID);
+		assertEquals(jobGraph.getJobID(), StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID);
 	}
 
 	@Test
@@ -70,6 +70,6 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
 		assertThat(jobGraph.getSavepointRestoreSettings(), is(equalTo(savepointRestoreSettings)));
-		assertEquals(jobGraph.getJobID(), ClassPathJobGraphRetriever.FIXED_JOB_ID);
+		assertEquals(jobGraph.getJobID(), StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID);
 	}
 }

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -27,11 +28,14 @@ import org.junit.Test;
 
 import java.util.Properties;
 
+import static org.apache.flink.container.entrypoint.StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID;
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link StandaloneJobClusterConfigurationParserFactory}.
@@ -63,6 +67,8 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 		assertThat(clusterConfiguration.getArgs(), arrayContaining(arg1, arg2));
 
 		assertThat(clusterConfiguration.getSavepointRestoreSettings(), is(equalTo(SavepointRestoreSettings.none())));
+
+		assertThat(clusterConfiguration.getJobId(), is(equalTo(DEFAULT_JOB_ID)));
 	}
 
 	@Test
@@ -97,4 +103,54 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 		assertThat(savepointRestoreSettings.getRestorePath(), is(equalTo(restorePath)));
 		assertThat(savepointRestoreSettings.allowNonRestoredState(), is(true));
 	}
+
+	@Test
+	public void testSetJobIdManually() throws FlinkParseException {
+		final JobID jobId = new JobID();
+		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", jobId.toString()};
+
+		final StandaloneJobClusterConfiguration standaloneJobClusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(standaloneJobClusterConfiguration.getJobId(), is(equalTo(jobId)));
+	}
+
+	@Test
+	public void testInvalidJobIdThrows() throws FlinkParseException {
+		final String invalidJobId = "0xINVALID";
+		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", invalidJobId};
+
+		try {
+			commandLineParser.parse(args);
+			fail("Did not throw expected FlinkParseException");
+		} catch (IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString(invalidJobId));
+		}
+	}
+
+	@Test
+	public void testShortOptions() throws FlinkParseException {
+		final String configDir = "/foo/bar";
+		final String jobClassName = "foobar";
+		final JobID jobId = new JobID();
+		final String savepointRestorePath = "s3://foo/bar";
+
+		final String[] args = {
+			"-c", configDir,
+			"-j", jobClassName,
+			"-jid", jobId.toString(),
+			"-s", savepointRestorePath,
+			"-n"};
+
+		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+
+		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
+		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(jobClassName)));
+		assertThat(clusterConfiguration.getJobId(), is(equalTo(jobId)));
+
+		final SavepointRestoreSettings savepointRestoreSettings = clusterConfiguration.getSavepointRestoreSettings();
+		assertThat(savepointRestoreSettings.restoreSavepoint(), is(true));
+		assertThat(savepointRestoreSettings.getRestorePath(), is(equalTo(savepointRestorePath)));
+		assertThat(savepointRestoreSettings.allowNonRestoredState(), is(true));
+	}
+
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobID.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobID.java
@@ -108,7 +108,8 @@ public final class JobID extends AbstractID {
 		try {
 			return new JobID(StringUtils.hexStringToByte(hexString));
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Cannot parse JobID from \"" + hexString + "\".", e);
+			throw new IllegalArgumentException("Cannot parse JobID from \"" + hexString + "\". The expected format is " +
+				"[0-9a-fA-F]{32}, e.g. fd72014d4c864993a2e5a9287b4a9c5d.", e);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

- This PR adds the optional `--job-id` command line argument to the `StandaloneJobClusterEntryPoint`
  - If specified, users manually set the job ID of the job
  - If not specified, the job ID of the job is all zeros (current behavior)

## Brief change log

- Parse job ID option in `StandaloneJobClusterConfigurationParserFactory` 
- Provide job ID in `ClassPathJobGraphRetriever` constructor
- Catch `Throwable` when parsing command line args as a safety net and have a good error message in the logs

## Verifying this change

- This change added unit tests for added functionality
- If you want to manually verify this change, you can follow these steps:
  1. Build this branch
  2. Copy `examples/streaming/TopSpeedWindowing.jar` to `lib`
  3. Execute `bin/standalone-job.sh start --job-classname org.apache.flink.streaming.examples.windowing.TopSpeedWindowing` (expected: job ID is all zeros)
  4. Execute `bin/standalone-job.sh start --job-classname org.apache.flink.streaming.examples.windowing.TopSpeedWindowing --job-id fd72014d4c864993a2e5a9287b4a9c5d` (expected: job ID fd72014d4c864993a2e5a9287b4a9c5d)
  5. Execute `bin/standalone-job.sh start --job-classname org.apache.flink.streaming.examples.windowing.TopSpeedWindowing --job-id INVALID_JOB_ID` (expected: logs with error message)

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (it adds a new command line argument which is part of the extended API)
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Added note about new command line arg in `flink-container/kubernetes/README.md`
