### PR TITLE
[FLINK-11553] Create an empty fencing tokens queue instead of using null in DispatcherHATest.testFailingRecoveryIsAFatalError

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
@@ -62,6 +62,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -78,7 +79,6 @@ import static org.junit.Assert.assertThat;
  * Tests the HA behaviour of the {@link Dispatcher}.
  */
 public class DispatcherHATest extends TestLogger {
-
 	private static final DispatcherId NULL_FENCING_TOKEN = DispatcherId.fromUuid(new UUID(0L, 0L));
 
 	private static final Time timeout = Time.seconds(10L);
@@ -297,14 +297,14 @@ public class DispatcherHATest extends TestLogger {
 	private HATestingDispatcher createDispatcher(HighAvailabilityServices haServices) throws Exception {
 		return createDispatcher(
 			haServices,
-			null,
+			new LinkedList<>(),
 			createTestingJobManagerRunnerFactory());
 	}
 
 	@Nonnull
 	private HATestingDispatcher createDispatcher(
 		HighAvailabilityServices highAvailabilityServices,
-		@Nullable Queue<DispatcherId> fencingTokens,
+		@Nonnull Queue<DispatcherId> fencingTokens,
 		JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
 		final Configuration configuration = new Configuration();
 
@@ -326,7 +326,7 @@ public class DispatcherHATest extends TestLogger {
 	}
 
 	@Nonnull
-	public static JobGraph createNonEmptyJobGraph() {
+	static JobGraph createNonEmptyJobGraph() {
 		final JobVertex noOpVertex = new JobVertex("NoOp vertex");
 		noOpVertex.setInvokableClass(NoOpInvokable.class);
 		final JobGraph jobGraph = new JobGraph(noOpVertex);
@@ -396,8 +396,6 @@ public class DispatcherHATest extends TestLogger {
 		@Nonnull
 		private final OneShotLatch proceedGetJobIdsLatch;
 
-		private boolean isStarted = false;
-
 		private BlockingSubmittedJobGraphStore(@Nonnull SubmittedJobGraph submittedJobGraph, @Nonnull OneShotLatch enterGetJobIdsLatch, @Nonnull OneShotLatch proceedGetJobIdsLatch) {
 			this.submittedJobGraph = submittedJobGraph;
 			this.enterGetJobIdsLatch = enterGetJobIdsLatch;
@@ -405,35 +403,33 @@ public class DispatcherHATest extends TestLogger {
 		}
 
 		@Override
-		public void start(SubmittedJobGraphListener jobGraphListener) throws Exception {
-			isStarted = true;
+		public void start(SubmittedJobGraphListener jobGraphListener) {
 		}
 
 		@Override
-		public void stop() throws Exception {
-			isStarted = false;
+		public void stop() {
 		}
 
 		@Nullable
 		@Override
-		public SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception {
+		public SubmittedJobGraph recoverJobGraph(JobID jobId) {
 			Preconditions.checkArgument(jobId.equals(submittedJobGraph.getJobId()));
 
 			return submittedJobGraph;
 		}
 
 		@Override
-		public void putJobGraph(SubmittedJobGraph jobGraph) throws Exception {
+		public void putJobGraph(SubmittedJobGraph jobGraph) {
 			throw new UnsupportedOperationException("Should not be called.");
 		}
 
 		@Override
-		public void removeJobGraph(JobID jobId) throws Exception {
+		public void removeJobGraph(JobID jobId) {
 			throw new UnsupportedOperationException("Should not be called.");
 		}
 
 		@Override
-		public void releaseJobGraph(JobID jobId) throws Exception {}
+		public void releaseJobGraph(JobID jobId) {}
 
 		@Override
 		public Collection<JobID> getJobIds() throws Exception {
@@ -453,12 +449,12 @@ public class DispatcherHATest extends TestLogger {
 		}
 
 		@Override
-		public void start(SubmittedJobGraphListener jobGraphListener) throws Exception {
+		public void start(SubmittedJobGraphListener jobGraphListener) {
 
 		}
 
 		@Override
-		public void stop() throws Exception {
+		public void stop() {
 
 		}
 
@@ -469,22 +465,22 @@ public class DispatcherHATest extends TestLogger {
 		}
 
 		@Override
-		public void putJobGraph(SubmittedJobGraph jobGraph) throws Exception {
+		public void putJobGraph(SubmittedJobGraph jobGraph) {
 
 		}
 
 		@Override
-		public void removeJobGraph(JobID jobId) throws Exception {
+		public void removeJobGraph(JobID jobId) {
 
 		}
 
 		@Override
-		public void releaseJobGraph(JobID jobId) throws Exception {
+		public void releaseJobGraph(JobID jobId) {
 
 		}
 
 		@Override
-		public Collection<JobID> getJobIds() throws Exception {
+		public Collection<JobID> getJobIds() {
 			return Collections.singleton(jobId);
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

DispatcherHATest.testFailingRecoveryIsAFatalError fails because it tries to instantiate HATestingDispatcher with fencingTokens = null which is annotated as @Nonnull.
The PR suggests to create an empty fencing tokens queue instead of using null.

## Brief change log

  - fix DispatcherHATest.createDispatcher
  - small style fixes in DispatcherHATest

## Verifying this change

run DispatcherHATest locally, e.g. in IDE Idea

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
