### PR TITLE
[FLINK-11544] Add jobId to JarRequestBody

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -321,6 +321,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "parallelism" : {
       "type" : "integer"
+    },
+    "jobId" : {
+      "type" : "any"
     }
   }
 }            </code>
@@ -410,6 +413,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "parallelism" : {
       "type" : "integer"
+    },
+    "jobId" : {
+      "type" : "any"
     },
     "allowNonRestoredState" : {
       "type" : "boolean"
@@ -2361,7 +2367,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "host" : {
             "type" : "string"
           },
-          "start_time" : {
+          "start-time" : {
             "type" : "integer"
           },
           "end-time" : {
@@ -2399,6 +2405,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "boolean"
               }
             }
+          },
+          "start_time" : {
+            "type" : "integer"
           }
         }
       }
@@ -3871,5 +3880,3 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     </tr>
   </tbody>
 </table>
-
-{% top %}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -31,6 +31,8 @@ import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
+import javax.annotation.Nullable;
+
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -54,7 +56,7 @@ public class PackagedProgramUtils {
 			PackagedProgram packagedProgram,
 			Configuration configuration,
 			int defaultParallelism,
-			JobID jobID) throws ProgramInvocationException {
+			@Nullable JobID jobID) throws ProgramInvocationException {
 		Thread.currentThread().setContextClassLoader(packagedProgram.getUserCodeClassLoader());
 		final Optimizer optimizer = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), configuration);
 		final FlinkPlan flinkPlan;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanRequestBody.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanRequestBody.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,7 +35,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class JarPlanRequestBody extends JarRequestBody {
 	JarPlanRequestBody() {
-		super(null, null, null, null);
+		super(null, null, null, null, null);
 	}
 
 	@JsonCreator
@@ -42,7 +43,8 @@ public class JarPlanRequestBody extends JarRequestBody {
 		@Nullable @JsonProperty(FIELD_NAME_ENTRY_CLASS) String entryClassName,
 		@Nullable @JsonProperty(FIELD_NAME_PROGRAM_ARGUMENTS) String programArguments,
 		@Nullable @JsonProperty(FIELD_NAME_PROGRAM_ARGUMENTS_LIST) List<String> programArgumentsList,
-		@Nullable @JsonProperty(FIELD_NAME_PARALLELISM) Integer parallelism) {
-		super(entryClassName, programArguments, programArgumentsList, parallelism);
+		@Nullable @JsonProperty(FIELD_NAME_PARALLELISM) Integer parallelism,
+		@Nullable @JsonProperty(FIELD_NAME_JOB_ID) JobID jobId) {
+		super(entryClassName, programArguments, programArgumentsList, parallelism, jobId);
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRequestBody.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRequestBody.java
@@ -18,12 +18,17 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.json.JobIDDeserializer;
+import org.apache.flink.runtime.rest.messages.json.JobIDSerializer;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +44,7 @@ public abstract class JarRequestBody implements RequestBody {
 	static final String FIELD_NAME_PROGRAM_ARGUMENTS = "programArgs";
 	static final String FIELD_NAME_PROGRAM_ARGUMENTS_LIST = "programArgsList";
 	static final String FIELD_NAME_PARALLELISM = "parallelism";
+	static final String FIELD_NAME_JOB_ID = "jobId";
 
 	@JsonProperty(FIELD_NAME_ENTRY_CLASS)
 	@Nullable
@@ -56,8 +62,14 @@ public abstract class JarRequestBody implements RequestBody {
 	@Nullable
 	private Integer parallelism;
 
+	@JsonProperty(FIELD_NAME_JOB_ID)
+	@JsonDeserialize(using = JobIDDeserializer.class)
+	@JsonSerialize(using = JobIDSerializer.class)
+	@Nullable
+	private JobID jobId;
+
 	JarRequestBody() {
-		this(null, null, null, null);
+		this(null, null, null, null, null);
 	}
 
 	@JsonCreator
@@ -65,11 +77,13 @@ public abstract class JarRequestBody implements RequestBody {
 		@Nullable @JsonProperty(FIELD_NAME_ENTRY_CLASS) String entryClassName,
 		@Nullable @JsonProperty(FIELD_NAME_PROGRAM_ARGUMENTS) String programArguments,
 		@Nullable @JsonProperty(FIELD_NAME_PROGRAM_ARGUMENTS_LIST) List<String> programArgumentsList,
-		@Nullable @JsonProperty(FIELD_NAME_PARALLELISM) Integer parallelism) {
+		@Nullable @JsonProperty(FIELD_NAME_PARALLELISM) Integer parallelism,
+		@Nullable @JsonProperty(FIELD_NAME_JOB_ID) JobID jobId) {
 		this.entryClassName = entryClassName;
 		this.programArguments = programArguments;
 		this.programArgumentsList = programArgumentsList;
 		this.parallelism = parallelism;
+		this.jobId = jobId;
 	}
 
 	@Nullable
@@ -94,5 +108,11 @@ public abstract class JarRequestBody implements RequestBody {
 	@JsonIgnore
 	public Integer getParallelism() {
 		return parallelism;
+	}
+
+	@Nullable
+	@JsonIgnore
+	public JobID getJobId() {
+		return jobId;
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBody.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBody.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -46,7 +47,7 @@ public class JarRunRequestBody extends JarRequestBody {
 	private String savepointPath;
 
 	public JarRunRequestBody() {
-		this(null, null, null, null, null, null);
+		this(null, null, null, null, null, null, null);
 	}
 
 	@JsonCreator
@@ -55,9 +56,10 @@ public class JarRunRequestBody extends JarRequestBody {
 			@Nullable @JsonProperty(FIELD_NAME_PROGRAM_ARGUMENTS) String programArguments,
 			@Nullable @JsonProperty(FIELD_NAME_PROGRAM_ARGUMENTS_LIST) List<String> programArgumentsList,
 			@Nullable @JsonProperty(FIELD_NAME_PARALLELISM) Integer parallelism,
+			@Nullable @JsonProperty(FIELD_NAME_JOB_ID) JobID jobId,
 			@Nullable @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE) Boolean allowNonRestoredState,
 			@Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_PATH) String savepointPath) {
-		super(entryClassName, programArguments, programArgumentsList, parallelism);
+		super(entryClassName, programArguments, programArgumentsList, parallelism, jobId);
 		this.allowNonRestoredState = allowNonRestoredState;
 		this.savepointPath = savepointPath;
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers.utils;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -69,12 +70,14 @@ public class JarHandlerUtils {
 		private final String entryClass;
 		private final List<String> programArgs;
 		private final int parallelism;
+		private final JobID jobId;
 
-		private JarHandlerContext(Path jarFile, String entryClass, List<String> programArgs, int parallelism) {
+		private JarHandlerContext(Path jarFile, String entryClass, List<String> programArgs, int parallelism, JobID jobId) {
 			this.jarFile = jarFile;
 			this.entryClass = entryClass;
 			this.programArgs = programArgs;
 			this.parallelism = parallelism;
+			this.jobId = jobId;
 		}
 
 		public static <R extends JarRequestBody> JarHandlerContext fromRequest(
@@ -100,7 +103,13 @@ public class JarHandlerUtils {
 				ExecutionConfig.PARALLELISM_DEFAULT,
 				log);
 
-			return new JarHandlerContext(jarFile, entryClass, programArgs, parallelism);
+			JobID jobId = fromRequestBodyOrQueryParameter(
+				requestBody.getJobId(),
+				() -> null, // No support via query parameter
+				null, // Delegate default job ID to actual JobGraph generation
+				log);
+
+			return new JarHandlerContext(jarFile, entryClass, programArgs, parallelism, jobId);
 		}
 
 		public JobGraph toJobGraph(Configuration configuration) {
@@ -114,7 +123,7 @@ public class JarHandlerUtils {
 					jarFile.toFile(),
 					entryClass,
 					programArgs.toArray(new String[0]));
-				return PackagedProgramUtils.createJobGraph(packagedProgram, configuration, parallelism);
+				return PackagedProgramUtils.createJobGraph(packagedProgram, configuration, parallelism, jobId);
 			} catch (final ProgramInvocationException e) {
 				throw new CompletionException(e);
 			}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -49,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,6 +58,9 @@ import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Base test class for jar request handlers. */
 public abstract class JarHandlerParameterTest
@@ -184,6 +189,25 @@ public abstract class JarHandlerParameterTest
 		}
 	}
 
+	@Test
+	public void testProvideJobId() throws Exception {
+		JobID jobId = new JobID();
+
+		HandlerRequest<REQB, M> request = createRequest(
+			getJarRequestBodyWithJobId(jobId),
+			getUnresolvedJarMessageParameters(),
+			getUnresolvedJarMessageParameters(),
+			jarWithManifest
+		);
+
+		handleRequest(request);
+
+		Optional<JobGraph> jobGraph = getLastSubmittedJobGraphAndReset();
+
+		assertThat(jobGraph.isPresent(), is(true));
+		assertThat(jobGraph.get().getJobID(), is(equalTo(jobId)));
+	}
+
 	private void testConfigurationViaJsonRequest(ProgramArgsParType programArgsParType) throws Exception {
 		handleRequest(createRequest(
 			getJarRequestBody(programArgsParType),
@@ -270,6 +294,8 @@ public abstract class JarHandlerParameterTest
 
 	abstract REQB getJarRequestBody(ProgramArgsParType programArgsParType);
 
+	abstract REQB getJarRequestBodyWithJobId(JobID jobId);
+
 	abstract void handleRequest(HandlerRequest<REQB, M> request) throws Exception;
 
 	JobGraph validateDefaultGraph() {
@@ -284,6 +310,10 @@ public abstract class JarHandlerParameterTest
 		Assert.assertArrayEquals(PROG_ARGS, ParameterProgram.actualArguments);
 		Assert.assertEquals(PARALLELISM, getExecutionConfig(jobGraph).getParallelism());
 		return jobGraph;
+	}
+
+	private static Optional<JobGraph> getLastSubmittedJobGraphAndReset() {
+		return Optional.ofNullable(LAST_SUBMITTED_JOB_GRAPH_REFERENCE.getAndSet(null));
 	}
 
 	private static ExecutionConfig getExecutionConfig(JobGraph jobGraph) {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
@@ -103,7 +103,8 @@ public class JarPlanHandlerParameterTest extends JarHandlerParameterTest<JarPlan
 			ParameterProgram.class.getCanonicalName(),
 			getProgramArgsString(programArgsParType),
 			getProgramArgsList(programArgsParType),
-			PARALLELISM);
+			PARALLELISM,
+			null);
 	}
 
 	@Override

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandlerParameterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -105,6 +106,11 @@ public class JarPlanHandlerParameterTest extends JarHandlerParameterTest<JarPlan
 			getProgramArgsList(programArgsParType),
 			PARALLELISM,
 			null);
+	}
+
+	@Override
+	JarPlanRequestBody getJarRequestBodyWithJobId(JobID jobId) {
+		return new JarPlanRequestBody(null, null, null, null, jobId);
 	}
 
 	@Override

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -121,10 +122,15 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 			getProgramArgsString(programArgsParType),
 			getProgramArgsList(programArgsParType),
 			PARALLELISM,
+			null,
 			ALLOW_NON_RESTORED_STATE_QUERY,
-			RESTORE_PATH,
-			null
+			RESTORE_PATH
 		);
+	}
+
+	@Override
+	JarRunRequestBody getJarRequestBodyWithJobId(JobID jobId) {
+		return new JarRunRequestBody(null, null, null, null, jobId, null, null);
 	}
 
 	@Override

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -122,7 +122,8 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 			getProgramArgsList(programArgsParType),
 			PARALLELISM,
 			ALLOW_NON_RESTORED_STATE_QUERY,
-			RESTORE_PATH
+			RESTORE_PATH,
+			null
 		);
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBodyTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBodyTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
 
 import java.util.Arrays;
@@ -41,6 +42,7 @@ public class JarRunRequestBodyTest extends RestRequestMarshallingTestBase<JarRun
 			"world",
 			Arrays.asList("boo", "far"),
 			4,
+			new JobID(),
 			true,
 			"foo/bar"
 		);
@@ -54,6 +56,7 @@ public class JarRunRequestBodyTest extends RestRequestMarshallingTestBase<JarRun
 		assertEquals(expected.getProgramArguments(), actual.getProgramArguments());
 		assertEquals(expected.getProgramArgumentsList(), actual.getProgramArgumentsList());
 		assertEquals(expected.getParallelism(), actual.getParallelism());
+		assertEquals(expected.getJobId(), actual.getJobId());
 		assertEquals(expected.getAllowNonRestoredState(), actual.getAllowNonRestoredState());
 		assertEquals(expected.getSavepointPath(), actual.getSavepointPath());
 	}


### PR DESCRIPTION
## What is the purpose of the change

- This PR adds the optional `jobId` entry to `JarRequestBody`
  * If specified, users manually set the job ID of a job when submitting a JAr
  * If not specified, we keep the current behavior

## Brief change log

- Add `jobId` to `JarRequestBody`
- Parse `jobId` when generating `JobGraph`

## Verifying this change

- This change added unit tests for added functionality
- If you want to manually verify this change, you can follow these steps:
  1. Build this branch
  2. Upload `examples/streaming/TopSpeedWindowing.jar` via web UI
  3. Get `$jarId` from `/v1/jars` endpoint
  4. Execute `curl -X POST -d '{}' http://localhost:8081/v1/jars/$jarId/run` (expected: random job ID)
  5. Execute `curl -X POST -d '{"jobId": "4\. fd72014d4c864993a2e5a9287b4a9c5d"}' http://localhost:8081/v1/jars/$jarId/run` (expected: job ID `fd72014d4c864993a2e5a9287b4a9c5d`)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (adds new field in request body of a v1 REST API endpoint)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

- I didn't add any documentation as I assume that the REST API docs are auto generated (@zentol please correct me if I'm wrong)
