### PR TITLE
[FLINK-11568][kinesis] Don't obscure important Kinesis exceptions

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -820,18 +820,18 @@ public class KinesisDataFetcherTest extends TestLogger {
 
 	@Test
 	public void testOriginalExceptionIsPreservedWhenInterruptedDuringShutdown() throws Exception {
-		final String stream = "fakeStream";
+		String stream = "fakeStream";
 
 		Map<String, List<BlockingQueue<String>>> streamsToShardQueues = new HashMap<>();
-		final LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<>(10);
+		LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<>(10);
 		queue.put("item1");
 		streamsToShardQueues.put(stream, Collections.singletonList(queue));
 
-		final AlwaysThrowsDeserializationSchema deserializationSchema = new AlwaysThrowsDeserializationSchema();
-		final KinesisProxyInterface fakeKinesis =
+		AlwaysThrowsDeserializationSchema deserializationSchema = new AlwaysThrowsDeserializationSchema();
+		KinesisProxyInterface fakeKinesis =
 			FakeKinesisBehavioursFactory.blockingQueueGetRecords(streamsToShardQueues);
 
-		final TestableKinesisDataFetcherForShardConsumerException<String> fetcher = new TestableKinesisDataFetcherForShardConsumerException<>(
+		TestableKinesisDataFetcherForShardConsumerException<String> fetcher = new TestableKinesisDataFetcherForShardConsumerException<>(
 			Collections.singletonList(stream),
 			new TestSourceContext<>(),
 			TestUtils.getStandardProperties(),
@@ -843,7 +843,7 @@ public class KinesisDataFetcherTest extends TestLogger {
 			new HashMap<>(),
 			fakeKinesis);
 
-		final DummyFlinkKinesisConsumer<String> consumer = new DummyFlinkKinesisConsumer<>(
+		DummyFlinkKinesisConsumer<String> consumer = new DummyFlinkKinesisConsumer<>(
 			TestUtils.getStandardProperties(), fetcher, 1, 0);
 
 		CheckedThread consumerThread = new CheckedThread() {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -30,13 +30,16 @@ import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardSta
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardMetadata;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
+import org.apache.flink.streaming.connectors.kinesis.testutils.AlwaysThrowsDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory;
 import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisShardIdGenerator;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestableKinesisDataFetcher;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestableKinesisDataFetcherForShardConsumerException;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.TestLogger;
 
@@ -59,12 +62,16 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -811,4 +818,63 @@ public class KinesisDataFetcherTest extends TestLogger {
 		Assert.assertTrue("idle, no watermark", watermarks.isEmpty());
 	}
 
+	@Test
+	public void testOriginalExceptionIsPreservedWhenInterruptedDuringShutdown() throws Exception {
+		final String stream = "fakeStream";
+
+		Map<String, List<BlockingQueue<String>>> streamsToShardQueues = new HashMap<>();
+		final LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<>(10);
+		queue.put("item1");
+		streamsToShardQueues.put(stream, Collections.singletonList(queue));
+
+		final AlwaysThrowsDeserializationSchema deserializationSchema = new AlwaysThrowsDeserializationSchema();
+		final KinesisProxyInterface fakeKinesis =
+			FakeKinesisBehavioursFactory.blockingQueueGetRecords(streamsToShardQueues);
+
+		final TestableKinesisDataFetcherForShardConsumerException<String> fetcher = new TestableKinesisDataFetcherForShardConsumerException<>(
+			Collections.singletonList(stream),
+			new TestSourceContext<>(),
+			TestUtils.getStandardProperties(),
+			new KinesisDeserializationSchemaWrapper<>(deserializationSchema),
+			10,
+			2,
+			new AtomicReference<>(),
+			new LinkedList<>(),
+			new HashMap<>(),
+			fakeKinesis);
+
+		final DummyFlinkKinesisConsumer<String> consumer = new DummyFlinkKinesisConsumer<>(
+			TestUtils.getStandardProperties(), fetcher, 1, 0);
+
+		CheckedThread consumerThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				consumer.run(new TestSourceContext<>());
+			}
+		};
+		consumerThread.start();
+		fetcher.waitUntilRun();
+
+		// ShardConsumer exception (from deserializer) will result in fetcher being shut down.
+		fetcher.waitUntilShutdown(20, TimeUnit.SECONDS);
+
+		// Interrupt the thread so that KinesisDataFetcher#awaitTermination() will throw InterruptedException.
+		consumerThread.interrupt();
+
+		try {
+			consumerThread.sync();
+		} catch (InterruptedException e) {
+			fail("Expected exception from deserializer, but got InterruptedException, probably from " +
+				"KinesisDataFetcher, which obscures the cause of the failure. " + e);
+		} catch (RuntimeException e) {
+			if (!e.getMessage().equals(AlwaysThrowsDeserializationSchema.EXCEPTION_MESSAGE)) {
+				fail("Expected exception from deserializer, but got: " + e);
+			}
+		} catch (Exception e) {
+			fail("Expected exception from deserializer, but got: " + e);
+		}
+
+		assertTrue("Expected Fetcher to have been interrupted. This test didn't accomplish its goal.",
+			fetcher.wasInterrupted);
+	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/AlwaysThrowsDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/AlwaysThrowsDeserializationSchema.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.testutils;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.testutils.OneShotLatch;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class AlwaysThrowsDeserializationSchema implements DeserializationSchema<String> {
+	public static final String EXCEPTION_MESSAGE = "This method always throws an exception.";
+
+	public transient OneShotLatch isExceptionThrown = new OneShotLatch();
+
+	@Override
+	public String deserialize(final byte[] bytes) throws IOException {
+		isExceptionThrown.trigger();
+		throw new RuntimeException(EXCEPTION_MESSAGE);
+	}
+
+	@Override
+	public boolean isEndOfStream(final String s) {
+		return false;
+	}
+
+	@Override
+	public TypeInformation<String> getProducedType() {
+		return BasicTypeInfo.STRING_TYPE_INFO;
+	}
+
+	private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		this.isExceptionThrown = new OneShotLatch();
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/AlwaysThrowsDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/AlwaysThrowsDeserializationSchema.java
@@ -25,7 +25,8 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import java.io.IOException;
 
 /**
- *
+ * A DeserializationSchema which always throws an exception when the deserialize method is called. Also supports
+ * waiting on a latch until at least one exception has been thrown.
  */
 public class AlwaysThrowsDeserializationSchema implements DeserializationSchema<String> {
 	public static final String EXCEPTION_MESSAGE = "This method always throws an exception.";

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -35,8 +35,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +50,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 
 	private OneShotLatch runWaiter;
 	private OneShotLatch initialDiscoveryWaiter;
+	private OneShotLatch shutdownWaiter;
 
 	private volatile boolean running;
 
@@ -77,6 +81,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 
 		this.runWaiter = new OneShotLatch();
 		this.initialDiscoveryWaiter = new OneShotLatch();
+		this.shutdownWaiter = new OneShotLatch();
 
 		this.running = true;
 	}
@@ -91,11 +96,20 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 		runWaiter.await();
 	}
 
+	public void waitUntilShutdown(long timeout, TimeUnit timeUnit) throws Exception {
+		shutdownWaiter.await(timeout, timeUnit);
+	}
+
 	@Override
 	protected ExecutorService createShardConsumersThreadPool(String subtaskName) {
 		// this is just a dummy fetcher, so no need to create a thread pool for shard consumers
 		ExecutorService mockExecutor = mock(ExecutorService.class);
 		when(mockExecutor.isTerminated()).thenAnswer((InvocationOnMock invocation) -> !running);
+		try {
+			when(mockExecutor.awaitTermination(anyLong(), any())).thenReturn(!running);
+		} catch (InterruptedException e) {
+			// We're just trying to stub the method. Must acknowledge the checked exception.
+		}
 		return mockExecutor;
 	}
 
@@ -103,6 +117,12 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 	public void awaitTermination() throws InterruptedException {
 		this.running = false;
 		super.awaitTermination();
+	}
+
+	@Override
+	public void shutdownFetcher() {
+		super.shutdownFetcher();
+		shutdownWaiter.trigger();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcherForShardConsumerException.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcherForShardConsumerException.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kinesis.testutils;
 
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
@@ -34,7 +35,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- *
+ * Extension of the {@link KinesisDataFetcher} for testing what happens when the thread is interrupted during
+ * {@link #awaitTermination()}.
  */
 public class TestableKinesisDataFetcherForShardConsumerException<T> extends TestableKinesisDataFetcher<T> {
 	public TestableKinesisDataFetcherForShardConsumerException(final List<String> fakeStreams,
@@ -58,8 +60,7 @@ public class TestableKinesisDataFetcherForShardConsumerException<T> extends Test
 	protected ExecutorService createShardConsumersThreadPool(final String subtaskName) {
 		final ThreadFactory threadFactory =
 			new ThreadFactoryBuilder().setNameFormat("KinesisShardConsumers-%d").build();
-		final ExecutorService executorService = Executors.newSingleThreadExecutor(threadFactory);
-		return executorService;
+		return Executors.newSingleThreadExecutor(threadFactory);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcherForShardConsumerException.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcherForShardConsumerException.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.testutils;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
+
+import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ *
+ */
+public class TestableKinesisDataFetcherForShardConsumerException<T> extends TestableKinesisDataFetcher<T> {
+	public TestableKinesisDataFetcherForShardConsumerException(final List<String> fakeStreams,
+			final SourceFunction.SourceContext<T> sourceContext,
+			final Properties fakeConfiguration,
+			final KinesisDeserializationSchema<T> deserializationSchema,
+			final int fakeTotalCountOfSubtasks,
+			final int fakeIndexOfThisSubtask,
+			final AtomicReference<Throwable> thrownErrorUnderTest,
+			final LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest,
+			final HashMap<String, String> subscribedStreamsToLastDiscoveredShardIdsStateUnderTest,
+			final KinesisProxyInterface fakeKinesis) {
+		super(fakeStreams, sourceContext, fakeConfiguration, deserializationSchema, fakeTotalCountOfSubtasks,
+			fakeIndexOfThisSubtask, thrownErrorUnderTest, subscribedShardsStateUnderTest,
+			subscribedStreamsToLastDiscoveredShardIdsStateUnderTest, fakeKinesis);
+	}
+
+	public volatile boolean wasInterrupted = false;
+
+	@Override
+	protected ExecutorService createShardConsumersThreadPool(final String subtaskName) {
+		final ThreadFactory threadFactory =
+			new ThreadFactoryBuilder().setNameFormat("KinesisShardConsumers-%d").build();
+		final ExecutorService executorService = Executors.newSingleThreadExecutor(threadFactory);
+		return executorService;
+	}
+
+	@Override
+	public void awaitTermination() throws InterruptedException {
+		try {
+			// Force this method to only exit by thread getting interrupted.
+			while (true) {
+				Thread.sleep(1000);
+			}
+		} catch (InterruptedException e) {
+			wasInterrupted = true;
+			throw e;
+		}
+	}
+
+	@Override
+	protected KinesisDeserializationSchema<T> getClonedDeserializationSchema() {
+		return super.getClonedDeserializationSchema();
+	}
+}


### PR DESCRIPTION
- If KinesisDataFetcher's thread is interrupted while
blocked on awaitTermination(), the InterruptedException will not be
thrown if there's already a saved exception inside the "error" field.
Instead, the exception in the "error" field will be thrown, as usual.
- Minor change to awaitTermination() so that the lock dependency is
clear (blocks on shardConsumersExecutor.awaitTermination() instead of
sleeping itself and polling the status of
shardConsumersExecutor.isTerminated()). This allows us to reduce the
context switching back to this thread, which was previously happening
about every 50ms.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This fixes the Kinesis consumer so that exceptions thrown by the ShardConsumer are not hidden if an InterruptedException occurs.

## Brief change log

- Exceptions thrown within Kinesis code (eg. in the deserializer) now appear in the log instead of getting replaced by non-informative InterruptedException.

## Verifying this change

This change added tests and can be verified as follows:

- Added KinesisDataFetcherTest#testOriginalExceptionIsPreservedWhenInterruptedDuringShutdown which examines the exception thrown by the thread in the situation where a meaningful exception was saved, but InterruptedException was thrown while shutting down.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable