### PR TITLE
[FLINK-8297] [flink-rocksdb] A plan store elements of ListState as multiple key-values in rocksdb

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/LargeListStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/LargeListStateDescriptor.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link StateDescriptor} for {@link ListState}. This can be used to create state where the type
+ * is a list that can be appended and iterated over.
+ *
+ * <p>Using {@code ListState} is typically more efficient than manually maintaining a list in a
+ * {@link ValueState}, because the backing implementation can support efficient appends, rather than
+ * replacing the full list on write.
+ *
+ * <p>To create keyed list state (on a KeyedStream), use
+ * {@link org.apache.flink.api.common.functions.RuntimeContext#getListState(ListStateDescriptor)}.
+ *
+ * @param <T> The type of the values that can be added to the list state.
+ */
+@PublicEvolving
+public class LargeListStateDescriptor<T> extends StateDescriptor<ListState<T>, Map<Long, List<T>>> {
+	private static final long serialVersionUID = 2L;
+
+	/**
+	 * Creates a new {@code LargeListStateDescriptor} with the given name and list element type.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #LargeListStateDescriptor(String, TypeInformation)} constructor.
+	 *
+	 * @param name             The (unique) name for the state.
+	 * @param elementTypeClass The type of the elements in the state.
+	 */
+	public LargeListStateDescriptor(String name, Class<T> elementTypeClass) {
+		super(name, new MapTypeInfo<>(BasicTypeInfo.LONG_TYPE_INFO, new ListTypeInfo<T>(elementTypeClass)), null);
+	}
+
+	/**
+	 * Creates a new {@code LargeListStateDescriptor} with the given name and list element type.
+	 *
+	 * @param name            The (unique) name for the state.
+	 * @param elementTypeInfo The type of the elements in the state.
+	 */
+	public LargeListStateDescriptor(String name, TypeInformation<T> elementTypeInfo) {
+		super(name, new MapTypeInfo<>(BasicTypeInfo.LONG_TYPE_INFO, new ListTypeInfo<T>(elementTypeInfo)), null);
+	}
+
+	/**
+	 * Creates a new {@code LargeListStateDescriptor} with the given name and list element type.
+	 *
+	 * @param name           The (unique) name for the state.
+	 * @param typeSerializer The type serializer for the list values.
+	 */
+	public LargeListStateDescriptor(String name, TypeSerializer<T> typeSerializer) {
+		super(name, new MapSerializer<>(LongSerializer.INSTANCE, new ListSerializer<>(typeSerializer)), null);
+	}
+
+	/**
+	 * Gets the serializer for the elements contained in the list.
+	 *
+	 * @return The serializer for the elements in the list.
+	 */
+	public TypeSerializer<T> getElementSerializer() {
+		// call getSerializer() here to get the initialization check and proper error message
+		final TypeSerializer<Map<Long, List<T>>> rawSerializer = getSerializer();
+		if (!(rawSerializer instanceof MapSerializer)) {
+			throw new IllegalStateException();
+		}
+
+		return ((ListSerializer<T>) ((MapSerializer<Long, List<T>>) rawSerializer).getValueSerializer()).getElementSerializer();
+	}
+
+	@Override
+	public Type getType() {
+		return Type.LIST;
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/serialization/KvStateSerializer.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/serialization/KvStateSerializer.java
@@ -236,6 +236,30 @@ public final class KvStateSerializer {
 	}
 
 	/**
+	 * Serializes the iterable values with the given serializer.
+	 *
+	 * @param values      Value of type T to serialize
+	 * @param serializer Serializer for T
+	 * @param <T>        Type of the value
+	 * @return Serialized values
+	 * @throws IOException On failure during serialization
+	 */
+	public static <T> byte[] serializeIterator(Iterable<T> values, TypeSerializer<T> serializer) throws IOException {
+		if (values != null) {
+			// Serialize
+			DataOutputSerializer dos = new DataOutputSerializer(32);
+			for (T value : values) {
+				serializer.serialize(value, dos);
+				// Align with org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer.deserializeList
+				dos.write(',');
+			}
+			return dos.getCopyOfBuffer();
+		} else {
+			return null;
+		}
+	}
+
+	/**
 	 * Deserializes all kv pairs with the given serializer.
 	 *
 	 * @param serializedValue Serialized value of type Map&lt;UK, UV&gt;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotTransformer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotTransformer.java
@@ -47,6 +47,16 @@ public interface StateSnapshotTransformer<T> {
 	@Nullable
 	T filterOrTransform(@Nullable T value);
 
+	/**
+	 * Should we keep this saved value as raw.
+	 * @param key non-serialized form of key
+	 * @param value non-serialized form of value
+	 * @return keep or not
+	 */
+	default boolean keepRaw(@Nullable T key, @Nullable T value) {
+		return false;
+	}
+
 	/** Collection state specific transformer which says how to transform entries of the collection. */
 	interface CollectionStateSnapshotTransformer<T> extends StateSnapshotTransformer<T> {
 		enum TransformStrategy {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalLargeListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalLargeListState.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.internal;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.flink.api.common.state.ListState;
+
+/**
+ * The peer to the {@link ListState} in the internal state type hierarchy.
+ * 
+ * <p>See {@link InternalKvState} for a description of the internal state hierarchy.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <T> The type of elements in the list
+ */
+public interface InternalLargeListState<K, N, T> extends InternalMergingState<K, N, T, Map<Long, List<T>>, Iterable<T>>, ListState<T> {
+
+	/**
+	 * Updates the operator state accessible by {@link #get()} by updating existing values to
+	 * to the given list of values. The next time {@link #get()} is called (for the same state
+	 * partition) the returned state will represent the updated list.
+	 *
+	 * If `null` or an empty list is passed in, the state value will be null
+	 *
+	 * @param values The new values for the state.
+	 *
+	 * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+	 */
+	void update(List<T> values) throws Exception;
+
+	/**
+	 * Updates the operator state accessible by {@link #get()} by adding the given values
+	 * to existing list of values. The next time {@link #get()} is called (for the same state
+	 * partition) the returned state will represent the updated list.
+	 *
+	 * If `null` or an empty list is passed in, the state value remains unchanged
+	 *
+	 * @param values The new values to be added to the state.
+	 *
+	 * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+	 */
+	void addAll(List<T> values) throws Exception;
+
+	/**
+	 * Returns the current value for the state. When the state is not
+	 * partitioned the returned value is the same for all inputs in a given
+	 * operator instance. If state partitioning is applied, the value returned
+	 * depends on the current operator input, as the operator maintains an
+	 * independent state for each partition.
+	 *
+	 * <p><b>NOTE TO IMPLEMENTERS:</b> if the state is empty, then this method
+	 * should return {@code null}.
+	 *
+	 * @param forward The flag forward/backward scan the large list state.
+	 *
+	 * @return The operator state value corresponding to the current input or {@code null}
+	 * if the state is empty.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	Iterable<T> get(boolean forward) throws Exception;
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBMapState.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for {@link State} implementations that store state in a RocksDB database.
+ *
+ * <p>{@link RocksDBStateBackend} must ensure that we set the
+ * {@link org.rocksdb.StringAppendOperator} on the column family that we use for our state since
+ * we use the {@code merge()} call.
+ *
+ * @param <K>  The type of the key.
+ * @param <N>  The type of the namespace.
+ * @param <UK> The type of the keys in the map state.
+ * @param <UV> The type of the user values.
+ * @param <SV> The type of the user values in the map state value part.
+ */
+abstract class AbstractRocksDBMapState<K, N, UK, UV, SV>
+	extends AbstractRocksDBState<K, N, Map<UK, SV>> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractRocksDBMapState.class);
+
+	/**
+	 * Creates a new {@code AbstractRocksDBMapState}.
+	 *
+	 * @param columnFamily        The RocksDB column family that this state is associated to.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param saveSerializer      The serializer for the state.
+	 * @param defaultValue        The default value for the state.
+	 * @param backend             The backend for which this state is bind to.
+	 */
+	protected AbstractRocksDBMapState(
+		ColumnFamilyHandle columnFamily,
+		TypeSerializer<N> namespaceSerializer,
+		TypeSerializer<Map<UK, SV>> saveSerializer,
+		Map<UK, SV> defaultValue,
+		RocksDBKeyedStateBackend<K> backend) {
+		super(columnFamily, namespaceSerializer, saveSerializer, defaultValue, backend);
+	}
+
+	@Override
+	public TypeSerializer<K> getKeySerializer() {
+		return backend.getKeySerializer();
+	}
+
+	@Override
+	public TypeSerializer<N> getNamespaceSerializer() {
+		return namespaceSerializer;
+	}
+
+	@Override
+	public TypeSerializer<Map<UK, SV>> getValueSerializer() {
+		return valueSerializer;
+	}
+
+	@Override
+	public void clear() {
+		try {
+			try (RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(backend.db, columnFamily);
+				WriteBatch writeBatch = new WriteBatch(128)) {
+
+				final byte[] keyPrefixBytes = serializeCurrentKeyWithGroupAndNamespace();
+				iterator.seek(keyPrefixBytes);
+
+				while (iterator.isValid()) {
+					byte[] keyBytes = iterator.key();
+					if (startWithKeyPrefix(keyPrefixBytes, keyBytes)) {
+						writeBatch.remove(columnFamily, keyBytes);
+					} else {
+						break;
+					}
+					iterator.next();
+				}
+
+				backend.db.write(writeOptions, writeBatch);
+			}
+		} catch (Exception e) {
+			LOG.warn("Error while cleaning the state.", e);
+		}
+	}
+
+	private boolean startWithKeyPrefix(byte[] keyPrefixBytes, byte[] rawKeyBytes) {
+		if (rawKeyBytes.length < keyPrefixBytes.length) {
+			return false;
+		}
+
+		for (int i = keyPrefixBytes.length; --i >= backend.getKeyGroupPrefixBytes(); ) {
+			if (rawKeyBytes[i] != keyPrefixBytes[i]) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Internal Classes
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A map entry in AbstractRocksDBMapState.
+	 */
+	public class RocksDBBaseMapEntry implements Map.Entry<UK, UV> {
+
+		protected final RocksDB db;
+
+		/**
+		 * The raw bytes of the key stored in RocksDB. Each user key is stored in RocksDB
+		 * with the format #KeyGroup#Key#Namespace#UserKey.
+		 */
+		private final byte[] rawKeyBytes;
+
+		/**
+		 * The raw bytes of the value stored in RocksDB.
+		 */
+		private byte[] rawValueBytes;
+
+		/**
+		 * True if the entry has been deleted.
+		 */
+		protected boolean deleted;
+
+		/**
+		 * The user key and value. The deserialization is performed lazily, i.e. the key
+		 * and the value is deserialized only when they are accessed.
+		 */
+		protected UK userKey;
+
+		protected UV userValue;
+
+		/**
+		 * The offset of User Key offset in raw key bytes.
+		 */
+		private final int userKeyOffset;
+
+		RocksDBBaseMapEntry(
+			@Nonnull final RocksDB db,
+			@Nonnegative final int userKeyOffset,
+			@Nonnull final byte[] rawKeyBytes,
+			@Nonnull final byte[] rawValueBytes) {
+			this.db = db;
+
+			this.userKeyOffset = userKeyOffset;
+
+			this.rawKeyBytes = rawKeyBytes;
+			this.rawValueBytes = rawValueBytes;
+			this.deleted = false;
+		}
+
+		public byte[] getRawKeyBytes() {
+			return rawKeyBytes;
+		}
+
+		public byte[] getRawValueBytes() {
+			return rawValueBytes;
+		}
+
+		public int getUserKeyOffset() {
+			return userKeyOffset;
+		}
+
+		public boolean isDeleted() {
+			return deleted;
+		}
+
+		public void remove() {
+			throw new UnsupportedOperationException("remove");
+		}
+
+		@Override
+		public UK getKey() {
+			throw new UnsupportedOperationException("getKey");
+		}
+
+		@Override
+		public UV setValue(UV value) {
+			throw new UnsupportedOperationException("setValue");
+		}
+
+		public UV getValue() {
+			if (deleted) {
+				return null;
+			} else {
+				return userValue;
+			}
+		}
+	}
+
+	/**
+	 * An auxiliary utility to scan all entries under the given key.
+	 */
+	protected abstract class RocksDBKVIterator<T> implements Iterator<T> {
+		private static final int CACHE_SIZE_LIMIT = 128;
+
+		/**
+		 * The db where data resides.
+		 */
+		private final RocksDB db;
+
+		/**
+		 * The prefix bytes of the key being accessed. All entries under the same key
+		 * have the same prefix, hence we can stop iterating once coming across an
+		 * entry with a different prefix.
+		 */
+		@Nonnull
+		protected final byte[] metaKeyBytes;
+
+		/**
+		 * True if all entries have been accessed or the iterator has come across an
+		 * entry with a different prefix.
+		 */
+		private boolean expired = false;
+
+		/**
+		 * A in-memory cache for the entries in the rocksdb.
+		 */
+		protected ArrayList<RocksDBBaseMapEntry> cacheEntries = new ArrayList<>();
+
+		/**
+		 * The entry pointing to the current position which is last returned by calling {@link #nextEntry()}.
+		 */
+		protected RocksDBBaseMapEntry currentEntry;
+		protected int cacheIndex = 0;
+
+		RocksDBKVIterator(
+			final RocksDB db,
+			final byte[] keyPrefixBytes) {
+
+			this.db = db;
+			this.metaKeyBytes = keyPrefixBytes;
+		}
+
+		@Override
+		public boolean hasNext() {
+			loadCache();
+
+			return (cacheIndex < cacheEntries.size());
+		}
+
+		@Override
+		public void remove() {
+			if (currentEntry == null || currentEntry.isDeleted()) {
+				throw new IllegalStateException("The remove operation must be called after a valid next operation.");
+			}
+
+			currentEntry.remove();
+		}
+
+		final RocksDBBaseMapEntry nextEntry() {
+			loadCache();
+
+			if (cacheIndex == cacheEntries.size()) {
+				if (!expired) {
+					throw new IllegalStateException();
+				}
+
+				return null;
+			}
+
+			this.currentEntry = cacheEntries.get(cacheIndex);
+			cacheIndex++;
+
+			return currentEntry;
+		}
+
+		protected abstract List<RocksDBBaseMapEntry> deserializeKV(
+			@Nonnull final RocksDB db,
+			@Nonnegative final int userKeyOffset,
+			@Nonnull final byte[] rawKeyBytes,
+			@Nonnull final byte[] rawValueBytes);
+
+		protected boolean isEndOfIterator(RocksIteratorWrapper iterator) {
+			return !iterator.isValid() || !startWithKeyPrefix(metaKeyBytes, iterator.key());
+		}
+
+		protected void cacheSeek(RocksIteratorWrapper iterator) {
+			/*
+			 * The iteration starts from the prefix bytes at the first loading. After #nextEntry() is called,
+			 * the currentEntry points to the last returned entry, and at that time, we will start
+			 * the iterating from currentEntry if reloading cache is needed.
+			 */
+			byte[] startBytes = (currentEntry == null ? metaKeyBytes : currentEntry.rawKeyBytes);
+
+			cacheEntries.clear();
+			cacheIndex = 0;
+
+			iterator.seek(startBytes);
+		}
+
+		protected void cacheNext(RocksIteratorWrapper iterator) {
+			iterator.next();
+		}
+
+		private void loadCache() {
+			if (cacheIndex > cacheEntries.size()) {
+				throw new IllegalStateException();
+			}
+
+			// Load cache entries only when the cache is empty and there still exist unread entries
+			if (cacheIndex < cacheEntries.size() || expired) {
+				return;
+			}
+
+			// use try-with-resources to ensure RocksIterator can be release even some runtime exception
+			// occurred in the below code block.
+			try (RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(db, columnFamily)) {
+
+				cacheSeek(iterator);
+
+				/*
+				 * If the entry pointing to the current position is not removed, it will be the first entry in the
+				 * new iterating. Skip it to avoid redundant access in such cases.
+				 */
+				if (currentEntry != null && !currentEntry.deleted) {
+					cacheNext(iterator);
+				}
+
+				while (true) {
+					if (isEndOfIterator(iterator)) {
+						expired = true;
+						break;
+					}
+
+					if (cacheEntries.size() >= CACHE_SIZE_LIMIT) {
+						break;
+					}
+
+					cacheEntries.addAll(deserializeKV(db,
+						metaKeyBytes.length,
+						iterator.key(),
+						iterator.value()));
+
+					cacheNext(iterator);
+				}
+			}
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -163,6 +163,15 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 		return sharedKeyNamespaceSerializer.buildCompositeKeyNamespace(currentNamespace, namespaceSerializer);
 	}
 
+	byte[] serializeCurrentKeyWithGroupAndNamespacePlusUserSuffix(byte[] userSuffix, int off, int len) {
+		return sharedKeyNamespaceSerializer.buildCompositeKeyNamespaceUserSuffix(
+			currentNamespace,
+			namespaceSerializer,
+			userSuffix,
+			off,
+			len);
+	}
+
 	byte[] serializeValue(V value) throws IOException {
 		return serializeValue(value, valueSerializer);
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.AggregatingStateDescriptor;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.LargeListStateDescriptor;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ReducingStateDescriptor;
@@ -154,7 +155,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			Tuple2.of(MapStateDescriptor.class, (StateFactory) RocksDBMapState::create),
 			Tuple2.of(AggregatingStateDescriptor.class, (StateFactory) RocksDBAggregatingState::create),
 			Tuple2.of(ReducingStateDescriptor.class, (StateFactory) RocksDBReducingState::create),
-			Tuple2.of(FoldingStateDescriptor.class, (StateFactory) RocksDBFoldingState::create)
+			Tuple2.of(FoldingStateDescriptor.class, (StateFactory) RocksDBFoldingState::create),
+			Tuple2.of(LargeListStateDescriptor.class, (StateFactory) RocksDBLargeListState::create)
 		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
 
 	private interface StateFactory {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBLargeListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBLargeListState.java
@@ -1,0 +1,669 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.internal.InternalLargeListState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StateMigrationException;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.state.StateSnapshotTransformer.CollectionStateSnapshotTransformer.TransformStrategy.STOP_ON_FIRST_INCLUDED;
+
+/**
+ * {@link ListState} implementation that stores state in RocksDB.
+ *
+ * <p>{@link RocksDBStateBackend} must ensure that we set the
+ * {@link org.rocksdb.StringAppendOperator} on the column family that we use for our state since
+ * we use the {@code merge()} call.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the values in the list state.
+ */
+class RocksDBLargeListState<K, N, V>
+	extends AbstractRocksDBMapState<K, N, Long, V, List<V>>
+	implements InternalLargeListState<K, N, V> {
+
+	private final TypeSerializer<Long> keySerializer;
+
+	/**
+	 * Serializer for the values.
+	 */
+	private final TypeSerializer<V> elementSerializer;
+
+	/**
+	 * Separator of StringAppendTestOperator in RocksDB.
+	 */
+	private static final byte DELIMITER = ',';
+
+	/**
+	 * Creates a new {@code RocksDBLargeListState}.
+	 *
+	 * @param columnFamily        The RocksDB column family that this state is associated to.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param valueSerializer     The serializer for the state.
+	 * @param defaultValue        The default value for the state.
+	 * @param backend             The backend for which this state is bind to.
+	 */
+	private RocksDBLargeListState(
+		ColumnFamilyHandle columnFamily,
+		TypeSerializer<N> namespaceSerializer,
+		TypeSerializer<Map<Long, List<V>>> valueSerializer,
+		Map<Long, List<V>> defaultValue,
+		RocksDBKeyedStateBackend<K> backend) {
+
+		super(columnFamily,
+			namespaceSerializer,
+			valueSerializer,
+			defaultValue,
+			backend);
+
+		Preconditions.checkState(valueSerializer instanceof MapSerializer, "Unexpected serializer type.");
+
+		this.elementSerializer = ((ListSerializer) ((MapSerializer) valueSerializer).getValueSerializer()).getElementSerializer();
+		this.keySerializer = LongSerializer.INSTANCE;
+	}
+
+	@Override
+	public Map<Long, List<V>> getInternal() throws Exception {
+		final byte[] prefixBytes = serializeCurrentKeyWithGroupAndNamespace();
+
+		Map<Long, List<V>> map = new HashMap<>();
+
+		new RocksDBElementIterator<Map.Entry<Long, V>>(backend.db, prefixBytes) {
+			@Override
+			public Map.Entry<Long, V> next() {
+				return nextEntry();
+			}
+		}.forEachRemaining(entry -> {
+			List list;
+			if (map.containsKey(entry.getKey())) {
+				list = map.get(entry.getKey());
+			} else {
+				list = new ArrayList();
+				map.put(entry.getKey(), list);
+			}
+			list.add(entry.getValue());
+		});
+
+		return map;
+	}
+
+	@Override
+	public Iterable<V> get() throws Exception {
+		return get(true);
+	}
+
+	@Override
+	public Iterable<V> get(boolean forward) throws Exception {
+		final byte[] prefixBytes = serializeCurrentKeyWithGroupAndNamespace();
+		byte[] lexMaxKey = backend.db.get(columnFamily, prefixBytes);
+		if (lexMaxKey == null) {
+			return null;
+		} else {
+			return () -> new RocksDBElementIterator<V>(
+				backend.db,
+				prefixBytes,
+				forward) {
+				@Override
+				public V next() {
+					RocksDBBaseMapEntry entry = nextEntry();
+					return (entry == null ? null : entry.getValue());
+				}
+			};
+		}
+	}
+
+	private List<V> deserializeList(
+		byte[] valueBytes) {
+		if (valueBytes == null) {
+			return null;
+		}
+
+		dataInputView.setBuffer(valueBytes);
+
+		List<V> result = new ArrayList<>();
+		V next;
+		while ((next = deserializeNextElement(dataInputView, elementSerializer)) != null) {
+			result.add(next);
+		}
+		return result;
+	}
+
+	private static <V> V deserializeNextElement(DataInputDeserializer in, TypeSerializer<V> elementSerializer) {
+		try {
+			if (in.available() > 0) {
+				V element = elementSerializer.deserialize(in);
+				if (in.available() > 0) {
+					in.readByte();
+				}
+				return element;
+			}
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Unexpected list element deserialization failure");
+		}
+		return null;
+	}
+
+	@Override
+	public void add(V value) {
+		Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
+
+		try {
+			long key;
+			if (value instanceof StreamRecord<?>) {
+				StreamRecord<?> record = ((StreamRecord) value);
+				if (record.hasTimestamp()) {
+					key = record.getTimestamp();
+				} else {
+					key = System.currentTimeMillis();
+				}
+			} else {
+				key = System.currentTimeMillis();
+			}
+			// match lexicographically
+			key = key - Long.MIN_VALUE;
+			byte[] rawKeyBytes = serializeCurrentKeyWithGroupAndNamespacePlusUserKey(key, keySerializer);
+
+			backend.db.merge(
+				columnFamily,
+				writeOptions,
+				rawKeyBytes,
+				serializeValue(value, elementSerializer));
+
+			compareAndSwapMeta(rawKeyBytes);
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
+		}
+	}
+
+	private void compareAndSwapMeta(byte[] bytes) {
+		try {
+			// We could cache lexicographically max key in somewhere to speed up.
+			byte[] lexMaxKey = backend.db.get(columnFamily, serializeCurrentKeyWithGroupAndNamespace());
+			if (lexMaxKey == null ||
+				compareLongKeyByteArray(lexMaxKey, bytes) < 0) {
+				lexMaxKey = bytes;
+				backend.db.put(
+					columnFamily,
+					writeOptions,
+					serializeCurrentKeyWithGroupAndNamespace(),
+					lexMaxKey);
+			}
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
+		}
+	}
+
+	private int compareLongKeyByteArray(byte[] bytes1, byte[] bytes2) {
+		Preconditions.checkNotNull(bytes1, "You cannot compare null");
+		Preconditions.checkNotNull(bytes2, "You cannot compare null");
+		Preconditions.checkArgument(bytes1.length == bytes2.length,
+			"Only compare the equal length byte array");
+
+		int ret = 0;
+		for (int i = 0; i < bytes1.length; i++) {
+			ret = Integer.compare(Byte.toUnsignedInt(bytes1[i]), Byte.toUnsignedInt(bytes2[i]));
+			if (ret != 0) {
+				return ret;
+			}
+		}
+		return ret;
+	}
+
+	@Override
+	public void mergeNamespaces(N target, Collection<N> sources) {
+		if (sources == null || sources.isEmpty()) {
+			return;
+		}
+		byte[] lexMaxKey = null;
+		byte[] tarLexMaxKey = null;
+		try {
+			tarLexMaxKey = backend.db.get(columnFamily, serializeCurrentKeyWithGroupAndNamespace());
+			lexMaxKey = tarLexMaxKey;
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+		}
+
+		for (N source : sources) {
+			if (source != null) {
+
+				setCurrentNamespace(source);
+				byte[] prefixBytes = serializeCurrentKeyWithGroupAndNamespace();
+				try {
+					byte[] currLexMaxKey = backend.db.get(columnFamily, prefixBytes);
+					if (currLexMaxKey == null) {
+						continue;
+					} else if (lexMaxKey == null || compareLongKeyByteArray(lexMaxKey, currLexMaxKey) < 0) {
+						lexMaxKey = currLexMaxKey;
+					}
+				} catch (Exception e) {
+					throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+				}
+				Iterator<RocksDBBaseMapEntry> iterator = new RocksDBElementBytesIterator<RocksDBBaseMapEntry>(
+					backend.db,
+					prefixBytes) {
+					@Override
+					public RocksDBBaseMapEntry next() {
+						return nextEntry();
+					}
+				};
+				for (; iterator.hasNext(); ) {
+					try {
+						RocksDBBaseMapEntry entry = iterator.next();
+						byte[] sourceKey = entry.getRawKeyBytes();
+						int keyOffset = entry.getUserKeyOffset();
+						byte[] valueBytes = entry.getRawValueBytes();
+						backend.db.delete(columnFamily, writeOptions, sourceKey);
+						if (valueBytes != null) {
+							setCurrentNamespace(target);
+							final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespacePlusUserSuffix(
+								sourceKey,
+								keyOffset,
+								sourceKey.length - keyOffset);
+							backend.db.merge(columnFamily, writeOptions, targetKey, valueBytes);
+						}
+					} catch (Exception e) {
+						throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+					}
+				}
+				try {
+					setCurrentNamespace(source);
+					backend.db.delete(columnFamily, writeOptions, serializeCurrentKeyWithGroupAndNamespace());
+				} catch (Exception e) {
+					throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+				}
+			}
+			try {
+				if (lexMaxKey != null) {
+					if (tarLexMaxKey == null ||
+						compareLongKeyByteArray(tarLexMaxKey, lexMaxKey) < 0) {
+						setCurrentNamespace(target);
+						backend.db.put(
+							columnFamily,
+							writeOptions,
+							serializeCurrentKeyWithGroupAndNamespace(),
+							lexMaxKey);
+					}
+				}
+			} catch (Exception e) {
+				throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+			}
+		}
+	}
+
+	@Override
+	public void update(List<V> valueToStore) throws IOException, RocksDBException {
+		updateInternal(ImmutableMap.of(0L, valueToStore));
+	}
+
+	@Override
+	public void updateInternal(Map<Long, List<V>> valueToStore) throws IOException, RocksDBException {
+		Preconditions.checkNotNull(valueToStore, "Map of values to add cannot be null.");
+
+		clear();
+
+		for (List<V> values : valueToStore.values()) {
+			for (V v : values) {
+				add(v);
+			}
+		}
+	}
+
+	@Override
+	public void addAll(List<V> values) {
+		Preconditions.checkNotNull(values, "List of values to add cannot be null.");
+
+		for (V v : values) {
+			add(v);
+		}
+	}
+
+	@Override
+	public void migrateSerializedValue(
+		DataInputDeserializer serializedOldValueInput,
+		DataOutputSerializer serializedMigratedValueOutput,
+		TypeSerializer<Map<Long, List<V>>> priorSerializer,
+		TypeSerializer<Map<Long, List<V>>> newSerializer) throws StateMigrationException {
+		Preconditions.checkArgument(priorSerializer instanceof MapSerializer);
+		Preconditions.checkArgument(newSerializer instanceof MapSerializer);
+
+		TypeSerializer<V> priorElementSerializer =
+			((ListSerializer<V>) ((MapSerializer) priorSerializer).getValueSerializer()).getElementSerializer();
+
+		TypeSerializer<V> newElementSerializer =
+			((ListSerializer<V>) ((MapSerializer) newSerializer).getValueSerializer()).getElementSerializer();
+
+		try {
+			while (serializedOldValueInput.available() > 0) {
+				V element = deserializeNextElement(serializedOldValueInput, priorElementSerializer);
+				newElementSerializer.serialize(element, serializedMigratedValueOutput);
+				if (serializedOldValueInput.available() > 0) {
+					serializedMigratedValueOutput.write(DELIMITER);
+				}
+			}
+		} catch (Exception e) {
+			throw new StateMigrationException("Error while trying to migrate RocksDB list state.", e);
+		}
+	}
+
+	@Override
+	public byte[] getSerializedValue(
+		byte[] serializedKeyAndNamespace,
+		TypeSerializer<K> safeKeySerializer,
+		TypeSerializer<N> safeNamespaceSerializer,
+		TypeSerializer<Map<Long, List<V>>> safeValueSerializer) throws Exception {
+
+		Preconditions.checkNotNull(serializedKeyAndNamespace);
+		Preconditions.checkNotNull(safeKeySerializer);
+		Preconditions.checkNotNull(safeNamespaceSerializer);
+		Preconditions.checkNotNull(safeValueSerializer);
+
+		//TODO make KvStateSerializer key-group aware to save this round trip and key-group computation
+		Tuple2<K, N> keyAndNamespace = KvStateSerializer.deserializeKeyAndNamespace(
+			serializedKeyAndNamespace, safeKeySerializer, safeNamespaceSerializer);
+
+		int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(keyAndNamespace.f0, backend.getNumberOfKeyGroups());
+
+		RocksDBSerializedCompositeKeyBuilder<K> keyBuilder =
+			new RocksDBSerializedCompositeKeyBuilder<>(
+				safeKeySerializer,
+				backend.getKeyGroupPrefixBytes(),
+				32);
+
+		keyBuilder.setKeyAndKeyGroup(keyAndNamespace.f0, keyGroup);
+
+		final byte[] keyPrefixBytes = keyBuilder.buildCompositeKeyNamespace(keyAndNamespace.f1, namespaceSerializer);
+
+		final TypeSerializer<V> dupUserValueSerializer =
+			((ListSerializer) ((MapSerializer<Long, List<V>>) safeValueSerializer).getValueSerializer()).getElementSerializer();
+
+		final Iterator<V> iterator = new RocksDBElementIterator<V>(
+			backend.db,
+			keyPrefixBytes) {
+			@Override
+			public V next() {
+				RocksDBBaseMapEntry entry = nextEntry();
+				return (entry == null ? null : entry.getValue());
+			}
+		};
+
+		// Return null to make the behavior consistent with other backends
+		if (!iterator.hasNext()) {
+			return null;
+		}
+
+		return KvStateSerializer.serializeIterator(() -> iterator, dupUserValueSerializer);
+	}
+
+	protected class RocksDBValue extends RocksDBBaseMapEntry {
+
+		RocksDBValue(
+			@Nonnull RocksDB db,
+			int userKeyOffset,
+			@Nonnull byte[] rawKeyBytes,
+			@Nonnull byte[] rawValueBytes,
+			V v) {
+			super(db, userKeyOffset, rawKeyBytes, rawValueBytes);
+			super.userValue = v;
+		}
+	}
+
+	protected abstract class RocksDBElementIterator<T> extends RocksDBKVIterator<T> {
+
+		/**
+		 * Rocksdb has lexicographically order.
+		 */
+		private boolean forward;
+
+		RocksDBElementIterator(
+			RocksDB db,
+			byte[] keyPrefixBytes) {
+			this(db, keyPrefixBytes, true);
+		}
+
+		RocksDBElementIterator(
+			RocksDB db,
+			byte[] keyPrefixBytes,
+			boolean forward) {
+			super(db, keyPrefixBytes);
+			this.forward = forward;
+		}
+
+		@Override
+		protected List<RocksDBBaseMapEntry> deserializeKV(
+			@Nonnull RocksDB db,
+			int userKeyOffset,
+			@Nonnull byte[] rawKeyBytes,
+			@Nonnull byte[] rawValueBytes) {
+			List<V> list = deserializeList(rawValueBytes);
+			if (!forward) {
+				Collections.reverse(list);
+			}
+			return list.stream().map((V v) ->
+				new RocksDBValue(db, userKeyOffset, rawKeyBytes, rawValueBytes, v)
+			).collect(Collectors.toList());
+		}
+
+		@Override
+		protected boolean isEndOfIterator(RocksIteratorWrapper iterator) {
+			if (forward) {
+				return super.isEndOfIterator(iterator);
+			} else {
+				return !iterator.isValid() || Arrays.equals(metaKeyBytes, iterator.key());
+			}
+		}
+
+		@Override
+		protected void cacheSeek(RocksIteratorWrapper iterator) {
+			if (currentEntry == null) {
+				iterator.seek(metaKeyBytes);
+				if (iterator.isValid()) {
+					if (forward) {
+						// skip the meta info
+						iterator.next();
+					} else {
+						if (!Arrays.equals(iterator.key(), metaKeyBytes)) {
+							throw new FlinkRuntimeException("Failed to find the upper bound key in meta line");
+						} else {
+							// get the lexicographically max key from meta info
+							iterator.seek(iterator.value());
+						}
+					}
+				}
+			} else {
+				super.cacheSeek(iterator);
+			}
+		}
+
+		@Override
+		protected void cacheNext(RocksIteratorWrapper iterator) {
+			if (forward) {
+				iterator.next();
+			} else {
+				iterator.prev();
+			}
+		}
+	}
+
+	protected abstract class RocksDBElementBytesIterator<T> extends RocksDBKVIterator<T> {
+
+		RocksDBElementBytesIterator(RocksDB db,
+									byte[] prefixBytes) {
+			super(db, prefixBytes);
+		}
+
+		@Override
+		protected List<RocksDBBaseMapEntry> deserializeKV(
+			@Nonnull RocksDB db,
+			int userKeyOffset,
+			@Nonnull byte[] rawKeyBytes,
+			@Nonnull byte[] rawValueBytes) {
+			return ImmutableList.of(
+				new RocksDBBaseMapEntry(
+					db,
+					userKeyOffset,
+					rawKeyBytes,
+					rawValueBytes));
+		}
+
+		@Override
+		protected void cacheSeek(RocksIteratorWrapper iterator) {
+			super.cacheSeek(iterator);
+			if (currentEntry == null && iterator.isValid()) {
+				// skip the meta info
+				iterator.next();
+			}
+		}
+
+	}
+
+	@SuppressWarnings("unchecked")
+	static <E, K, N, SV, S extends State, IS extends S> IS create(
+		StateDescriptor<S, SV> stateDesc,
+		Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult,
+		RocksDBKeyedStateBackend<K> backend) {
+		return (IS) new RocksDBLargeListState<>(
+			registerResult.f0,
+			registerResult.f1.getNamespaceSerializer(),
+			(TypeSerializer<Map<Long, List<E>>>) registerResult.f1.getStateSerializer(),
+			(Map<Long, List<E>>) stateDesc.getDefaultValue(),
+			backend);
+	}
+
+	static class StateSnapshotTransformerWrapper<T> implements StateSnapshotTransformer<byte[]> {
+		private final StateSnapshotTransformer<T> elementTransformer;
+		private final TypeSerializer<T> elementSerializer;
+		private final DataOutputSerializer out = new DataOutputSerializer(128);
+		private final CollectionStateSnapshotTransformer.TransformStrategy transformStrategy;
+
+		StateSnapshotTransformerWrapper(StateSnapshotTransformer<T> elementTransformer, TypeSerializer<T> elementSerializer) {
+			this.elementTransformer = elementTransformer;
+			this.elementSerializer = elementSerializer;
+			this.transformStrategy = elementTransformer instanceof CollectionStateSnapshotTransformer ?
+				((CollectionStateSnapshotTransformer) elementTransformer).getFilterStrategy() :
+				CollectionStateSnapshotTransformer.TransformStrategy.TRANSFORM_ALL;
+		}
+
+		@Override
+		@Nullable
+		public byte[] filterOrTransform(@Nullable byte[] value) {
+			if (value == null) {
+				return null;
+			}
+			List<T> result = new ArrayList<>();
+			DataInputDeserializer in = new DataInputDeserializer(value);
+			T next;
+			int prevPosition = 0;
+			while ((next = deserializeNextElement(in, elementSerializer)) != null) {
+				T transformedElement = elementTransformer.filterOrTransform(next);
+				if (transformedElement != null) {
+					if (transformStrategy == STOP_ON_FIRST_INCLUDED) {
+						return Arrays.copyOfRange(value, prevPosition, value.length);
+					} else {
+						result.add(transformedElement);
+					}
+				}
+				prevPosition = in.getPosition();
+			}
+			try {
+				return result.isEmpty() ? null : serializeValueList(result, elementSerializer, DELIMITER);
+			} catch (IOException e) {
+				throw new FlinkRuntimeException("Failed to serialize transformed list", e);
+			}
+		}
+
+		@Override
+		public boolean keepRaw(@Nullable byte[] key, @Nullable byte[] value) {
+			// Work around fix the value 'max lexicographically key' cannot be deserialize issue.
+			if (key == null || value == null) {
+				return false;
+			}
+			if (key.length >= value.length) {
+				return false;
+			}
+
+			for (int i = 0; i < key.length; i++) {
+				if (key[i] != value[i]) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		byte[] serializeValueList(
+			List<T> valueList,
+			TypeSerializer<T> elementSerializer,
+			byte delimiter) throws IOException {
+
+			out.clear();
+			boolean first = true;
+
+			for (T value : valueList) {
+				Preconditions.checkNotNull(value, "You cannot add null to a value list.");
+
+				if (first) {
+					first = false;
+				} else {
+					out.write(delimiter);
+				}
+				elementSerializer.serialize(value, out);
+			}
+
+			return out.getCopyOfBuffer();
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSerializedCompositeKeyBuilder.java
@@ -122,6 +122,36 @@ class RocksDBSerializedCompositeKeyBuilder<K> {
 
 	/**
 	 * Returns a serialized composite key, from the key and key-group provided in a previous call to
+	 * {@link #setKeyAndKeyGroup(Object, int)} and the given namespace, followed by the given user-suffix.
+	 *
+	 * @param namespace           the namespace to concatenate for the serialized composite key bytes.
+	 * @param namespaceSerializer the serializer to obtain the serialized form of the namespace.
+	 * @param <N>                 the type of the namespace.
+	 * @param userSuffix		  the user-suffix to concatenate for the serialized composite key.
+	 * @param off		 		  the start offset of user-suffix.
+	 * @param len				  the len of user-suffix.
+	 * @return the bytes for the serialized composite key of key-group, key, namespace.
+	 */
+	@Nonnull
+	public <N> byte[] buildCompositeKeyNamespaceUserSuffix(
+		@Nonnull N namespace,
+		@Nonnull TypeSerializer<N> namespaceSerializer,
+		@Nonnull byte[] userSuffix,
+		@Nonnull int off,
+		@Nonnull int len) {
+		try {
+			serializeNamespace(namespace, namespaceSerializer);
+			keyOutView.write(userSuffix, off, len);
+			final byte[] result = keyOutView.getCopyOfBuffer();
+			resetToKey();
+			return result;
+		} catch (IOException shouldNeverHappen) {
+			throw new FlinkRuntimeException(shouldNeverHappen);
+		}
+	}
+
+	/**
+	 * Returns a serialized composite key, from the key and key-group provided in a previous call to
 	 * {@link #setKeyAndKeyGroup(Object, int)} and the given namespace, folloed by the given user-key.
 	 *
 	 * @param namespace           the namespace to concatenate for the serialized composite key bytes.

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
@@ -67,8 +67,13 @@ public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {
 	}
 
 	private void filterOrTransform(@Nonnull Runnable advance) {
-		while (isValid() && (current = stateSnapshotTransformer.filterOrTransform(super.value())) == null) {
+		if (isValid() && stateSnapshotTransformer.keepRaw(super.key(), super.value())) {
+			current = super.value();
 			advance.run();
+		} else {
+			while (isValid() && (current = stateSnapshotTransformer.filterOrTransform(super.value())) == null) {
+				advance.run();
+			}
 		}
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -506,6 +506,22 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		}
 	}
 
+	@Test
+	@Override
+	public void testLargeListState() throws Exception {
+		super.testLargeListState();
+		super.testLargeLargeListStateDefaultValue();
+		super.testLargeListStateAddAllNull();
+		super.testLargeListStateAddAllNullEntries();
+		super.testLargeListStateAddNull();
+		super.testLargeListStateAPIs();
+		super.testLargeListStateMerging();
+		super.testLargeListStateRestoreWithWrongSerializers();
+		super.testLargeListStateUpdateNull();
+		super.testLargeListStateUpdateNullEntries();
+		super.testLargeListStateNonConcurrentSnapshotTransformerAccess();
+	}
+
 	private void checkRemove(IncrementalKeyedStateHandle remove, SharedStateRegistry registry) throws Exception {
 		for (StateHandleID id : remove.getSharedState().keySet()) {
 			verify(registry, times(0)).unregisterReference(


### PR DESCRIPTION
## What is the purpose of the change

Enable storing lists not fitting to memory per single key.


## Brief change log

Ref from PR #5185.
I draft RocksDBLargeListState, it inherit AbstractRocksDBMapState which is similar RocksDBMapState.
Dual to AbstractRocksDBMapState and RocksDBListState implement the same interface InternalKvState, and they meet an java generics conflict. So I create an new interface InternalLargeListState, I think we can refine the interface hierarchy to resolve this issue.

RocksDBLargeListState store values to KV structure. 
I store the lexicographically max key as KV value in the default key(#KeyGroup#Key#Namespace).
If the value is instance of StreamRecord(We can involve TtlValue), we treat its timestamp as a part of key, and itself as value. 
**It will sort elements by timestamp instead of insertion order, but I think its behavior is acceptable.** 
Otherwise, treat current timestamp(maybe proc time) as a part of key, and itself as value.

The rocksdb store structure.
```
-----------Key-------------------       --------------------Value---------
#KeyGroup#Key#Namespace                 #KeyGroup#Key#Namespace#ts3 (max lexicographically key)  
#KeyGroup#Key#Namespace#ts1		value1,value2,value3  
#KeyGroup#Key#Namespace#ts2		value4  
#KeyGroup#Key#Namespace#ts3		value5,value6  
```

Advantage: 
1. We can seek to the lexicographically max key, then reverse iterate the list. 
2. We can iterate the values with the event time / proc time, it good at monotonous scenario. Like TimeEvictor.
3. We could make RocksDBListState and RocksDBMapState also inherit AbstractRocksDBMapState.

Disadvantage:
1. We couldn't simple replace RocksDBListState as RocksDBLargeListState, because of the above interface's generics conflict.
2. It will add 8 bytes cost to store extended timestamp in key part. 
3. For the timestamp base elements, it will sort elements by timestamp instead of insertion order. This behavior is not align with others ListState.
4. If the values has the same timestamp, the behavior almost same as RocksDBListState. I have a solution for this, but have not implement it yet. We can add order suffix for each timestamp. Like below.

```
-----------Key---------------------       --------------------Value---------
#KeyGroup#Key#Namespace             #KeyGroup#Key#Namespace#ts3#2 (Max lexicographically key)
#KeyGroup#Key#Namespace#ts1           3 (The values' count which has the same timestamp ts1)
#KeyGroup#Key#Namespace#ts1#1       value1
#KeyGroup#Key#Namespace#ts1#2       value2
#KeyGroup#Key#Namespace#ts1#3       value3
#KeyGroup#Key#Namespace#ts2           1
#KeyGroup#Key#Namespace#ts2#1       value4
#KeyGroup#Key#Namespace#ts3           2
#KeyGroup#Key#Namespace#ts3#1       value5
#KeyGroup#Key#Namespace#ts3#2       value6
```

I have try to add a murmur3 hash in the key part to resolve timestamp conflict, but it will crash the element order.

## Verifying this change

This change added tests and can be verified as follows:

  - Added test in KVStateRequestSerializerRocksDBTest, the behavior is same as KVStateRequestSerializerRocksDBTest#testListSerialization
  - Because of the class reference issue, added test in RocksDBStateBackendTest, but implement them in StateBackendTestBase. The test behavior ref from StateBackendTestBase.testListState**

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs