### PR TITLE
[FLINK-11453][DataStream] Support SliceStream with forwardable pane info using slice assigner, operator and stream

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SlicedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SlicedStream.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.windowing.assigners.SliceAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.evictors.Evictor;
+import org.apache.flink.streaming.api.windowing.slicing.Slice;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.IterableSliceOperator;
+import org.apache.flink.streaming.runtime.operators.windowing.SliceOperator;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@code SlicedStream} represents a data stream where elements are grouped by key, and
+ * for each key, the stream of elements is split into zero or one window based on a
+ * {@link SliceAssigner}. Window emission is triggered based on a {@link Trigger}.
+ *
+ * <p>The windows are conceptually evaluated for each key individually, meaning they can trigger
+ * at different points for each key. These windows elements are assigned to are called slices.
+ *
+ * <p>Note that the {@code SlicedStream} is purely and API construct, during runtime the
+ * {@code SlicedStream} will be collapsed together with the {@code KeyedStream} and the operation
+ * over the window into one single operation.
+ *
+ * @param <T> The type of elements in the stream.
+ * @param <K> The type of the key by which elements are grouped.
+ * @param <W> The type of {@code Window} that the {@code SliceAssigner} assigns the elements to.
+ */
+@Public
+public class SlicedStream<T, K, W extends Window> extends WindowedStream<T, K, W> {
+
+	/**
+	 * Side output {@code OutputTag} for late data. If no tag is set late data will simply be
+	 * dropped.
+ 	 */
+	private OutputTag<T> lateDataOutputTag;
+
+	private SliceAssigner<? super T, W> sliceAssigner;
+
+	@PublicEvolving
+	public SlicedStream(KeyedStream<T, K> input,
+						SliceAssigner<? super T, W> sliceAssigner) {
+		super(input, sliceAssigner);
+		this.sliceAssigner = sliceAssigner;
+		this.trigger = sliceAssigner.getDefaultTrigger(input.getExecutionEnvironment());
+	}
+
+	/**
+	 * Sets the {@code Trigger} that should be used to trigger window emission.
+	 */
+	@PublicEvolving
+	public SlicedStream<T, K, W> trigger(Trigger<? super T, ? super W> trigger) {
+		super.trigger(trigger);
+		return this;
+	}
+
+	/**
+	 * Sets the time by which elements are allowed to be late. Elements that
+	 * arrive behind the watermark by more than the specified time will be dropped.
+	 * By default, the allowed lateness is {@code 0L}.
+	 *
+	 * <p>Setting an allowed lateness is only valid for event-time windows.
+	 */
+	@PublicEvolving
+	public SlicedStream<T, K, W> allowedLateness(Time lateness) {
+		super.allowedLateness(lateness);
+		return this;
+	}
+
+	/**
+	 * Send late arriving data to the side output identified by the given {@link OutputTag}. Data
+	 * is considered late after the watermark has passed the end of the window plus the allowed
+	 * lateness set using {@link #allowedLateness(Time)}.
+	 *
+	 * <p>You can get the stream of late data using
+	 * {@link SingleOutputStreamOperator#getSideOutput(OutputTag)} on the
+	 * {@link SingleOutputStreamOperator} resulting from the windowed operation
+	 * with the same {@link OutputTag}.
+	 */
+	@PublicEvolving
+	public SlicedStream<T, K, W> sideOutputLateData(OutputTag<T> outputTag) {
+		Preconditions.checkNotNull(outputTag, "Side output tag must not be null.");
+		this.lateDataOutputTag = input.getExecutionEnvironment().clean(outputTag);
+		return this;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Operations on the keyed windows
+	// ------------------------------------------------------------------------
+	/**
+	 * Applies a reduce function to the sliced stream, each of the window for each key are applied
+	 * individually. The output of this reduce function can be re-interpreted as a keyed stream.
+	 *
+	 * @param reduceFunction The reduce function.
+	 * @return The data stream that is the result of applying the reduce function to the window.
+	 */
+	public SingleOutputStreamOperator<Slice<T, K, W>> reduceToSlice(
+		ReduceFunction<T> reduceFunction) {
+
+		TypeInformation<Slice<T, K, W>> resultType = getSliceTypeInfo(input.getType(),
+			input.getKeyType(),
+			sliceAssigner.getWindowType());
+
+		return reduceToSlice(reduceFunction, resultType);
+	}
+
+	/**
+	 * Applies a reduce function to the sliced stream.
+	 *
+	 * @param reduceFunction The reduce function.
+	 * @param resultType The type information for the slice result type
+	 * @return The data stream that is the result of applying the reduce function to the window.
+	 */
+	private SingleOutputStreamOperator<Slice<T, K, W>> reduceToSlice(
+		ReduceFunction<T> reduceFunction,
+		TypeInformation<Slice<T, K, W>> resultType) {
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of reduce can not be a RichFunction.");
+		}
+
+		//clean the closures
+		reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
+
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, reduceFunction, null);
+		KeySelector<T, K> keySel = input.getKeySelector();
+
+		ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
+			reduceFunction,
+			input.getType().createSerializer(getExecutionEnvironment().getConfig()));
+
+		OneInputStreamOperator<T, Slice<T, K, W>> operator =
+			new SliceOperator<>(sliceAssigner,
+				sliceAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
+				keySel,
+				input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
+				stateDesc,
+				trigger,
+				allowedLateness,
+				lateDataOutputTag);
+
+		return input.transform(opName, resultType, operator);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Aggregation Function
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies the given aggregation function to each window. The aggregation function is called for
+	 * each element, aggregating values incrementally and keeping the state to one accumulator
+	 * per key and window. The output of the window function can be re-interpreted as a keyed stream.
+	 *
+	 * @param function The aggregation function.
+	 * @return The data stream that is the result of applying the aggregate function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 */
+	@PublicEvolving
+	public <ACC> SingleOutputStreamOperator<Slice<ACC, K, W>> aggregateToSlice(AggregateFunction<T, ACC, ?> function) {
+		checkNotNull(function, "function");
+
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
+		}
+		TypeInformation<ACC> accumulatorType = TypeExtractor.getAggregateFunctionAccumulatorType(
+				function, input.getType(), null, false);
+
+		return aggregateToSlice(function, accumulatorType);
+	}
+
+	/**
+	 * Applies the given aggregation function to each window.
+	 *
+	 * @param function The aggregation function.
+	 * @param accumulatorType The type information of the accumulator result.
+	 * @return The data stream that is the result of applying the aggregate function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 */
+	@PublicEvolving
+	public <ACC> SingleOutputStreamOperator<Slice<ACC, K, W>> aggregateToSlice(
+		AggregateFunction<T, ACC, ?> function,
+		TypeInformation<ACC> accumulatorType) {
+		checkNotNull(function, "function");
+
+		if (function instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregation function cannot be a RichFunction.");
+		}
+
+		AggregateFunction<T, ACC, ACC> wrappedFunction = wrapSlicedStreamAggregateFunction(function);
+
+		TypeInformation<Slice<ACC, K, W>> resultType = getSliceTypeInfo(accumulatorType,
+			input.getKeyType(),
+			sliceAssigner.getWindowType());
+
+		return aggregateToSlice(wrappedFunction, accumulatorType, resultType);
+	}
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function can
+	 * be re-interpreted as a keyed stream.
+	 *
+	 * <p>Arriving data is incrementally aggregated using the given aggregate function. This means
+	 * that the window function typically has only a single value to process when called.
+	 *
+	 * @param aggregateFunction The aggregation function that is used for incremental aggregation.
+	 * @param accumulatorType Type information for the internal accumulator type of the aggregation function
+	 * @param resultType Type information for the slice result type
+	 *
+	 * @return The data stream that is the result of applying the window function to the window.
+	 *
+	 * @param <ACC> The type of the AggregateFunction's accumulator
+	 */
+	@PublicEvolving
+	private <ACC> SingleOutputStreamOperator<Slice<ACC, K, W>> aggregateToSlice(
+			AggregateFunction<T, ACC, ACC> aggregateFunction,
+			TypeInformation<ACC> accumulatorType,
+			TypeInformation<Slice<ACC, K, W>> resultType) {
+
+		checkNotNull(aggregateFunction, "aggregateFunction");
+		checkNotNull(accumulatorType, "accumulatorType");
+
+		if (aggregateFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("This aggregate function cannot be a RichFunction.");
+		}
+
+		//clean the closures
+		aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
+
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, aggregateFunction, null);
+		KeySelector<T, K> keySel = input.getKeySelector();
+
+		AggregatingStateDescriptor<T, ACC, ACC> stateDesc = new AggregatingStateDescriptor<>("window-contents",
+				aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
+
+		OneInputStreamOperator<T, Slice<ACC, K, W>> operator = new SliceOperator<>(sliceAssigner,
+			sliceAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
+			keySel,
+			input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
+			stateDesc,
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+
+		return input.transform(opName, resultType, operator);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Window Function - Slice into iterable objects
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Applies the given window function to each window. The window function is called for each
+	 * evaluation of the window for each key individually. The output of the window function can
+	 * be re-interpreted as a keyed stream.
+	 *
+	 * <p>Note that this function requires that all data in the windows is buffered until the window
+	 * is evaluated, as the function provides no means of incremental aggregation. The result is
+	 * directly forwarded to downstream operators. This is especially useful if multiple window
+	 * functions or multiple overlapping windows are applied toward this same slice multiple times.
+	 *
+	 * @return The data stream that is the iterable result of the buffering operation.
+	 */
+	public SingleOutputStreamOperator<Slice<List<T>, K, W>> applyToSlice() {
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, null, null);
+
+		TypeInformation<List<T>> contentType = Types.LIST(input.getType());
+		TypeInformation<Slice<List<T>, K, W>> resultType = getSliceTypeInfo(contentType,
+			input.getKeyType(),
+			sliceAssigner.getWindowType());
+
+		KeySelector<T, K> keySel = input.getKeySelector();
+
+		ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
+			input.getType().createSerializer(getExecutionEnvironment().getConfig()));
+
+		IterableSliceOperator<K, T, W> operator = new IterableSliceOperator<>(sliceAssigner,
+			sliceAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
+			keySel,
+			input.getKeyType().createSerializer(getExecutionEnvironment().getConfig()),
+			stateDesc,
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+
+		return input.transform(opName, resultType, operator);
+	}
+
+	private static String generateOperatorName(
+		WindowAssigner<?, ?> assigner,
+		Trigger<?, ?> trigger,
+		@Nullable Evictor<?, ?> evictor,
+		@Nullable Function function1,
+		@Nullable Function function2) {
+		return "Window(" +
+			assigner + ", " +
+			trigger.getClass().getSimpleName() + ", " +
+			(evictor == null ? "" : (evictor.getClass().getSimpleName() + ", ")) +
+			(function1 == null ? "" : (", " + generateFunctionName(function1))) +
+			(function2 == null ? "" : (", " + generateFunctionName(function2))) +
+			")";
+	}
+
+	public StreamExecutionEnvironment getExecutionEnvironment() {
+		return input.getExecutionEnvironment();
+	}
+
+	public TypeInformation<T> getInputType() {
+		return input.getType();
+	}
+
+	private <R> KeySelector<Slice<R, K, W>, K> getSliceToKeySelector(TypeInformation<R> contentType) {
+		return (KeySelector<Slice<R, K, W>, K>) rkwSlice -> rkwSlice.getKey();
+	}
+
+	private <ACC> AggregateFunction<T, ACC, ACC> wrapSlicedStreamAggregateFunction(AggregateFunction<T, ACC, ?> function) {
+		return new AggregateFunction<T, ACC, ACC>() {
+			@Override
+			public ACC createAccumulator() {
+				return function.createAccumulator();
+			}
+
+			@Override
+			public ACC add(T value, ACC accumulator) {
+				return function.add(value, accumulator);
+			}
+
+			@Override
+			public ACC getResult(ACC accumulator) {
+				return accumulator;
+			}
+
+			@Override
+			public ACC merge(ACC a, ACC b) {
+				return function.merge(a, b);
+			}
+		};
+	}
+
+	<C> TupleTypeInfo<Slice<C, K, W>> getSliceTypeInfo(
+		TypeInformation<C> contentType,
+		TypeInformation<K> keyType,
+		TypeInformation<W> windowType) {
+		return new TupleTypeInfo<>(contentType, keyType, windowType);
+	}
+
+	// -------------------- Testing Methods --------------------
+
+	@VisibleForTesting
+	long getAllowedLateness() {
+		return allowedLateness;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -102,25 +102,25 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class WindowedStream<T, K, W extends Window> {
 
 	/** The keyed data stream that is windowed by this stream. */
-	private final KeyedStream<T, K> input;
+	protected final KeyedStream<T, K> input;
 
 	/** The window assigner. */
-	private final WindowAssigner<? super T, W> windowAssigner;
+	protected final WindowAssigner<? super T, W> windowAssigner;
 
 	/** The trigger that is used for window evaluation/emission. */
-	private Trigger<? super T, ? super W> trigger;
+	protected Trigger<? super T, ? super W> trigger;
 
 	/** The evictor that is used for evicting elements before window evaluation. */
-	private Evictor<? super T, ? super W> evictor;
+	protected Evictor<? super T, ? super W> evictor;
 
 	/** The user-specified allowed lateness. */
-	private long allowedLateness = 0L;
+	protected long allowedLateness = 0L;
 
 	/**
 	 * Side output {@code OutputTag} for late data. If no tag is set late data will simply be
 	 * dropped.
  	 */
-	private OutputTag<T> lateDataOutputTag;
+	protected OutputTag<T> lateDataOutputTag;
 
 	@PublicEvolving
 	public WindowedStream(KeyedStream<T, K> input,
@@ -1303,7 +1303,7 @@ public class WindowedStream<T, K, W extends Window> {
 		return input.transform(opName, resultType, operator);
 	}
 
-	private static String generateFunctionName(Function function) {
+	protected static String generateFunctionName(Function function) {
 		Class<? extends Function> functionClass = function.getClass();
 		if (functionClass.isAnonymousClass()) {
 			// getSimpleName returns an empty String for anonymous classes

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SliceAssigner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SliceAssigner.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A {@code SliceAssigner} assigns zero or one unique {@link Window Windows} to an element.
+ *
+ * <p>It specifies the type of window that are guaranteed to be non-overlapping.
+ *
+ * @param <T> The type of elements that this SliceAssigner can assign windows to.
+ * @param <W> The type of {@code Window} that this assigner assigns.
+ */
+@PublicEvolving
+public abstract class SliceAssigner<T, W extends Window> extends WindowAssigner<T, W> {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Returns zero or one unique window that should be assigned to the element.
+	 *
+	 * @param element The element to which windows should be assigned.
+	 * @param timestamp The timestamp of the element.
+	 * @param context The {@link WindowAssignerContext} in which the assigner operates.
+	 */
+	public abstract W assignSlice(T element, long timestamp, WindowAssignerContext context);
+
+	@Override
+	public Collection<W> assignWindows(T element, long timestamp, WindowAssignerContext context) {
+		return Collections.singleton(assignSlice(element, timestamp, context));
+	}
+
+	public abstract TypeInformation<W> getWindowType();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeSlices.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeSlices.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+/**
+ * A {@link SliceAssigner} that slices elements into windows based on the timestamp of the
+ * elements. Windows cannot overlap.
+ */
+@PublicEvolving
+public class TumblingEventTimeSlices extends SliceAssigner<Object, TimeWindow> {
+	private static final long serialVersionUID = 1L;
+
+	private final long size;
+
+	private final long offset;
+
+	protected TumblingEventTimeSlices(long size, long offset) {
+		if (offset < 0 || offset >= size) {
+			throw new IllegalArgumentException("TumblingEventTimeSlices parameters must satisfy 0 <= offset < size");
+		}
+
+		this.size = size;
+		this.offset = offset;
+	}
+
+	@Override
+	public TimeWindow assignSlice(Object element, long timestamp, WindowAssignerContext context) {
+		if (timestamp > Long.MIN_VALUE) {
+			// Long.MIN_VALUE is currently assigned when no timestamp is present
+			long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, size);
+			return new TimeWindow(start, start + size);
+		} else {
+			throw new RuntimeException("Record has Long.MIN_VALUE timestamp (= no timestamp marker). " +
+				"Is the time characteristic set to 'ProcessingTime', or did you forget to call " +
+				"'DataStream.assignTimestampsAndWatermarks(...)'?");
+		}
+	}
+
+	@Override
+	public TypeInformation<TimeWindow> getWindowType() {
+		return TypeInformation.of(TimeWindow.class);
+	}
+
+	@Override
+	public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+		return EventTimeTrigger.create();
+	}
+
+	@Override
+	public String toString() {
+		return "TumblingEventTimeSlices(" + size + ")";
+	}
+
+	/**
+	 * Creates a new {@code TumblingEventTimeSlices} {@link SliceAssigner} that assigns
+	 * elements to time window based on the element timestamp.
+	 *
+	 * @param size The size of the generated windows.
+	 * @return The time policy.
+	 */
+	public static TumblingEventTimeSlices of(Time size) {
+		return new TumblingEventTimeSlices(size.toMilliseconds(), 0);
+	}
+
+	/**
+	 * Creates a new {@code TumblingEventTime Slices} {@link SliceAssigner} that assigns
+	 * elements to time window based on the element timestamp and offset.
+	 *
+	 * @param size The size of the generated windows.
+	 * @param offset The offset which window start would be shifted by.
+	 * @return The time policy.
+	 */
+	public static TumblingEventTimeSlices of(Time size, Time offset) {
+		return new TumblingEventTimeSlices(size.toMilliseconds(), offset.toMilliseconds());
+	}
+
+	@Override
+	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new TimeWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return true;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeSlices.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeSlices.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+/**
+ * A {@link SliceAssigner} that sliceselements into window based on the current
+ * system time of the machine the operation is running on. Windows cannot overlap.
+ */
+public class TumblingProcessingTimeSlices extends SliceAssigner<Object, TimeWindow> {
+	private static final long serialVersionUID = 1L;
+
+	private final long size;
+
+	private final long offset;
+
+	private TumblingProcessingTimeSlices(long size, long offset) {
+		if (offset < 0 || offset >= size) {
+			throw new IllegalArgumentException("TumblingProcessingTimeSlices parameters must satisfy  0 <= offset < size");
+		}
+
+		this.size = size;
+		this.offset = offset;
+	}
+
+	@Override
+	public TimeWindow assignSlice(Object element, long timestamp, WindowAssignerContext context) {
+		final long now = context.getCurrentProcessingTime();
+		long start = TimeWindow.getWindowStartWithOffset(now, offset, size);
+		return new TimeWindow(start, start + size);
+	}
+
+	@Override
+	public TypeInformation<TimeWindow> getWindowType() {
+		return TypeInformation.of(TimeWindow.class);
+	}
+
+	public long getSize() {
+		return size;
+	}
+
+	@Override
+	public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+		return ProcessingTimeTrigger.create();
+	}
+
+	@Override
+	public String toString() {
+		return "TumblingProcessingTimeSlices(" + size + ")";
+	}
+
+	/**
+	 * Creates a new {@code TumblingProcessingTimeSlices} {@link SliceAssigner} that assigns
+	 * elements to time window based on the element timestamp.
+	 *
+	 * @param size The size of the generated windows.
+	 * @return The time policy.
+	 */
+	public static TumblingProcessingTimeSlices of(Time size) {
+		return new TumblingProcessingTimeSlices(size.toMilliseconds(), 0);
+	}
+
+	/**
+	 * Creates a new {@code TumblingProcessingTimeSlices} {@link SliceAssigner} that assigns
+	 * elements to time window based on the element timestamp and offset.
+	 *
+	 * @param size The size of the generated windows.
+	 * @param offset The offset which window start would be shifted by.
+	 * @return The time policy.
+	 */
+	public static TumblingProcessingTimeSlices of(Time size, Time offset) {
+		return new TumblingProcessingTimeSlices(size.toMilliseconds(), offset.toMilliseconds());
+	}
+
+	@Override
+	public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+		return new TimeWindow.Serializer();
+	}
+
+	@Override
+	public boolean isEventTime() {
+		return false;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/slicing/Slice.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/slicing/Slice.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.slicing;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+
+/**
+ * Output type of a process result from sliced stream.
+ *
+ * <p>A slice is defined by its contents shared key and window
+ * This slice container also contains the combined contents
+ *
+ * @param <T> type of contents contains within the slice
+ * @param <K> key type of the elements
+ * @param <W> window type of the slice
+ */
+public class Slice<T, K, W extends Window> extends Tuple3<T, K, W> {
+
+	public Slice() {
+		super();
+	}
+
+	public Slice(T content, K key, W window) {
+		super(content, key, window);
+	}
+
+	public T getContent() {
+		return super.f0;
+	}
+
+	public void setContent(T content) {
+		super.f0 = content;
+	}
+
+	public W getWindow() {
+		return super.f2;
+	}
+
+	public void setWindow(W window) {
+		super.f2 = window;
+	}
+
+	public K getKey() {
+		return super.f1;
+	}
+
+	public void setKey(K key) {
+		super.f1 = key;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/IterableSliceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/IterableSliceOperator.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.SliceAssigner;
+import org.apache.flink.streaming.api.windowing.slicing.Slice;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
+import org.apache.flink.util.OutputTag;
+
+import java.util.List;
+
+/**
+ * An operator that implements the logic for windowing based on a {@link SliceAssigner} and
+ * {@link Trigger}.
+ *
+ * <p>Unlike {@link WindowOperator}, each element arrived at the slice operator only gets
+ * assigned to zero or one unique window segments.
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <IN> The type of the incoming elements.
+ */
+@Internal
+public class IterableSliceOperator<K, IN, W extends Window>
+	extends WindowOperator<K, IN, Iterable<IN>, Slice<List<IN>, K, W>, W> {
+
+	/**
+	 * Creates a new {@code IterableSliceOperator} based on the given policies and user functions.
+	 */
+	public IterableSliceOperator(
+		SliceAssigner<? super IN, W> sliceAssigner,
+		TypeSerializer<W> windowSerializer,
+		KeySelector<IN, K> keySelector,
+		TypeSerializer<K> keySerializer,
+		StateDescriptor<? extends ListState<IN>, ?> windowStateDescriptor,
+		Trigger<? super IN, ? super W> trigger,
+		long allowedLateness,
+		OutputTag<IN> lateDataOutputTag) {
+		this(sliceAssigner,
+			windowSerializer,
+			keySelector,
+			keySerializer,
+			windowStateDescriptor,
+			new InternalSingleValueWindowFunction<>(
+				(WindowFunction<Iterable<IN>, Slice<List<IN>, K, W>, K, W>) (key, window, input, out) -> {
+					for (Iterable<IN> val : input) {
+						out.collect(new Slice<>((List<IN>) val, key, window));
+					}
+				}),
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+	}
+
+	IterableSliceOperator(
+		SliceAssigner<? super IN, W> sliceAssigner,
+		TypeSerializer<W> windowSerializer,
+		KeySelector<IN, K> keySelector,
+		TypeSerializer<K> keySerializer,
+		StateDescriptor<? extends AppendingState<IN, Iterable<IN>>, ?> windowStateDescriptor,
+		InternalWindowFunction<Iterable<IN>, Slice<List<IN>, K, W>, K, W> windowFunction,
+		Trigger<? super IN, ? super W> trigger,
+		long allowedLateness,
+		OutputTag<IN> lateDataOutputTag) {
+		super(sliceAssigner,
+			windowSerializer,
+			keySelector,
+			keySerializer,
+			windowStateDescriptor,
+			windowFunction,
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/SliceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/SliceOperator.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.AppendingState;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.SliceAssigner;
+import org.apache.flink.streaming.api.windowing.slicing.Slice;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalSingleValueWindowFunction;
+import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * An operator that implements the logic for windowing based on a {@link SliceAssigner} and
+ * {@link Trigger}.
+ *
+ * <p>Unlike {@link WindowOperator}, each element arrived at the slice operator only gets
+ * assigned to zero or one unique window segments.
+ *
+ * @param <K> The type of key returned by the {@code KeySelector}.
+ * @param <IN> The type of the incoming elements.
+ * @param <ACC> The type of elements emitted by the window {@code StateDescriptor}
+ * @param <W> The type of {@code Window} that the {@code WindowAssigner} assigns.
+ */
+@Internal
+public class SliceOperator<K, IN, ACC, W extends Window>
+	extends WindowOperator<K, IN, ACC, Slice<ACC, K, W>, W> {
+
+	/**
+	 * Creates a new {@code WindowOperator} based on the given policies and user functions.
+	 */
+	public SliceOperator(
+		SliceAssigner<? super IN, W> sliceAssigner,
+		TypeSerializer<W> windowSerializer,
+		KeySelector<IN, K> keySelector,
+		TypeSerializer<K> keySerializer,
+		StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor,
+		Trigger<? super IN, ? super W> trigger,
+		long allowedLateness,
+		OutputTag<IN> lateDataOutputTag) {
+		this(sliceAssigner,
+			windowSerializer,
+			keySelector,
+			keySerializer,
+			windowStateDescriptor,
+			new InternalSingleValueWindowFunction<>(
+				(WindowFunction<ACC, Slice<ACC, K, W>, K, W>) (key, window, input, out) -> {
+					for (ACC val : input) {
+						out.collect(new Slice<>(val, key, window));
+					}
+				}),
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+	}
+
+	SliceOperator(
+		SliceAssigner<? super IN, W> sliceAssigner,
+		TypeSerializer<W> windowSerializer,
+		KeySelector<IN, K> keySelector,
+		TypeSerializer<K> keySerializer,
+		StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor,
+		InternalWindowFunction<ACC, Slice<ACC, K, W>, K, W> windowFunction,
+		Trigger<? super IN, ? super W> trigger,
+		long allowedLateness,
+		OutputTag<IN> lateDataOutputTag) {
+		super(sliceAssigner,
+			windowSerializer,
+			keySelector,
+			keySerializer,
+			windowStateDescriptor,
+			windowFunction,
+			trigger,
+			allowedLateness,
+			lateDataOutputTag);
+
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SliceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SliceOperatorTest.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.SliceAssigner;
+import org.apache.flink.streaming.api.windowing.slicing.Slice;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for {@link SliceOperator}.
+ */
+@SuppressWarnings("serial")
+public class SliceOperatorTest extends TestLogger {
+
+	private static final TypeInformation<Tuple2<String, Integer>> STRING_INT_TUPLE =
+		TypeInformation.of(new TypeHint<Tuple2<String, Integer>>(){});
+
+	// For counting if close() is called the correct number of times on the SumReducer
+	private static AtomicInteger closeCalled = new AtomicInteger(0);
+
+	// late arriving event OutputTag<StreamRecord<IN>>
+	private static final OutputTag<Tuple2<String, Integer>> lateOutputTag = new OutputTag<Tuple2<String, Integer>>("late-output") {};
+
+	private static <OUT> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, OUT> createTestHarness(OneInputStreamOperator<Tuple2<String, Integer>, OUT> operator) throws Exception {
+		return new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+	}
+
+	private void testEventTimeSlicing(OneInputStreamOperator<Tuple2<String, Integer>, Slice<Tuple2<String, Integer>, String, TimeWindow>> operator) throws Exception {
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Slice<Tuple2<String, Integer>, String, TimeWindow>> testHarness =
+			createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 3999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 3000));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 0));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1998));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
+
+		testHarness.processWatermark(new Watermark(999));
+		expectedOutput.add(new Watermark(999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(1999));
+		expectedOutput.add(new Watermark(1999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0L);
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+		testHarness.close();
+
+		testHarness = createTestHarness(operator);
+		expectedOutput.clear();
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark(new Watermark(2999));
+		expectedOutput.add(new StreamRecord<>(new Slice<>(new Tuple2<>("key1", 3), "key1", new TimeWindow(0, 3000)), 2999));
+		expectedOutput.add(new StreamRecord<>(new Slice<>(new Tuple2<>("key2", 3), "key2", new TimeWindow(0, 3000)), 2999));
+		expectedOutput.add(new Watermark(2999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(3999));
+		expectedOutput.add(new Watermark(3999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(4999));
+		expectedOutput.add(new Watermark(4999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(5999));
+		expectedOutput.add(new StreamRecord<>(new Slice<>(new Tuple2<>("key2", 2), "key2", new TimeWindow(3000, 6000)), 5999));
+		expectedOutput.add(new Watermark(5999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		// those don't have any effect...
+		testHarness.processWatermark(new Watermark(6999));
+		testHarness.processWatermark(new Watermark(7999));
+		expectedOutput.add(new Watermark(6999));
+		expectedOutput.add(new Watermark(7999));
+
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		testHarness.close();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testEventTimeSlicingReduce() throws Exception {
+		closeCalled.set(0);
+
+		final int windowSize = 3;
+
+		ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc = new ReducingStateDescriptor<>("window-contents",
+			new SumReducer(),
+			STRING_INT_TUPLE.createSerializer(new ExecutionConfig()));
+
+		SliceOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, TimeWindow> operator = new SliceOperator<>(
+			new TumbleSliceAssigner(Time.of(windowSize, TimeUnit.SECONDS).toMilliseconds(), 0L),
+			new TimeWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			EventTimeTrigger.create(),
+			0,
+			null /* late data output tag */);
+		testEventTimeSlicing(operator);
+	}
+
+	private void testEventTimeSlicingIterable(OneInputStreamOperator<Tuple2<String, Integer>, Slice<Iterable<Tuple2<String, Integer>>, String, TimeWindow>> operator) throws Exception {
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Slice<Iterable<Tuple2<String, Integer>>, String, TimeWindow>> testHarness =
+			createTestHarness(operator);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		// add elements out-of-order
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 3999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 3000));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 0));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1998));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
+
+		testHarness.processWatermark(new Watermark(999));
+		expectedOutput.add(new Watermark(999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(1999));
+		expectedOutput.add(new Watermark(1999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+
+		// do a snapshot, close and restore again
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0L);
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple2ResultSortComparator());
+		testHarness.close();
+
+		testHarness = createTestHarness(operator);
+		expectedOutput.clear();
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+
+		testHarness.processWatermark(new Watermark(2999));
+		expectedOutput.add(new StreamRecord<>(new Slice<>(Arrays.asList(
+			new Tuple2<>("key1", 1), new Tuple2<>("key1", 1), new Tuple2<>("key1", 1)), "key1", new TimeWindow(0, 3000)), 2999));
+		expectedOutput.add(new StreamRecord<>(new Slice<>(Arrays.asList(
+			new Tuple2<>("key2", 1), new Tuple2<>("key2", 1), new Tuple2<>("key2", 1)), "key2", new TimeWindow(0, 3000)), 2999));
+		expectedOutput.add(new Watermark(2999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new IterableTuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(3999));
+		expectedOutput.add(new Watermark(3999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new IterableTuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(4999));
+		expectedOutput.add(new Watermark(4999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new IterableTuple2ResultSortComparator());
+
+		testHarness.processWatermark(new Watermark(5999));
+		expectedOutput.add(new StreamRecord<>(new Slice<>(Arrays.asList(
+			new Tuple2<>("key2", 1), new Tuple2<>("key2", 1)), "key2", new TimeWindow(3000, 6000)), 5999));
+		expectedOutput.add(new Watermark(5999));
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new IterableTuple2ResultSortComparator());
+
+		// those don't have any effect...
+		testHarness.processWatermark(new Watermark(6999));
+		testHarness.processWatermark(new Watermark(7999));
+		expectedOutput.add(new Watermark(6999));
+		expectedOutput.add(new Watermark(7999));
+
+		TestHarnessUtil.assertObjectOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new IterableTuple2ResultSortComparator());
+
+		testHarness.close();
+	}
+
+	@Test
+	public void testEventTimeSlicingIterable() throws Exception {
+		closeCalled.set(0);
+
+		final int windowSize = 3;
+
+		ListStateDescriptor<Tuple2<String, Integer>> stateDesc = new ListStateDescriptor<>("window-contents",
+			STRING_INT_TUPLE.createSerializer(new ExecutionConfig()));
+
+		SliceOperator<String, Tuple2<String, Integer>, Iterable<Tuple2<String, Integer>>, TimeWindow> operator = new SliceOperator<>(
+			new TumbleSliceAssigner(Time.of(windowSize, TimeUnit.SECONDS).toMilliseconds(), 0L),
+			new TimeWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			EventTimeTrigger.create(),
+			0,
+			null /* late data output tag */);
+
+		testEventTimeSlicingIterable(operator);
+	}
+
+	// ------------------------------------------------------------------------
+	//  UDFs
+	// ------------------------------------------------------------------------
+
+	private static class SumReducer implements ReduceFunction<Tuple2<String, Integer>> {
+		private static final long serialVersionUID = 1L;
+		@Override
+		public Tuple2<String, Integer> reduce(
+			Tuple2<String, Integer> value1,
+			Tuple2<String, Integer> value2) throws Exception {
+			return new Tuple2<>(value2.f0, value1.f1 + value2.f1);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static class IterableTuple2ResultSortComparator implements Comparator<Object>, Serializable {
+		private static RawTuple2ResultSortComparator cmp = new RawTuple2ResultSortComparator();
+		@Override
+		public int compare(Object o1, Object o2) {
+			if (o1 instanceof Watermark || o2 instanceof Watermark) {
+				return 0;
+			} else {
+				StreamRecord<Slice<Iterable<Tuple2<String, Integer>>, String, TimeWindow>> sr0 = (StreamRecord<Slice<Iterable<Tuple2<String, Integer>>, String, TimeWindow>>) o1;
+				StreamRecord<Slice<Iterable<Tuple2<String, Integer>>, String, TimeWindow>> sr1 = (StreamRecord<Slice<Iterable<Tuple2<String, Integer>>, String, TimeWindow>>) o2;
+				Tuple2<String, Integer>[] arr0 = toArray(sr0.getValue().getContent());
+				Tuple2<String, Integer>[] arr1 = toArray(sr1.getValue().getContent());
+				for (int i = 0; i < Math.min(arr0.length, arr1.length); i++) {
+					int val = cmp.compare(arr0[i], arr1[i]);
+					if (val != 0) {
+						return val;
+					}
+				}
+				if (arr0.length > arr1.length) {
+					return cmp.compare(arr0[arr1.length], null);
+				} else if (arr1.length > arr0.length) {
+					return cmp.compare(null, arr1[arr0.length]);
+				} else {
+					return 0;
+				}
+			}
+		}
+
+		private static Tuple2<String, Integer>[] toArray(Iterable<Tuple2<String, Integer>> itr) {
+			ArrayList<Tuple2<String, Integer>> ret = new ArrayList<>();
+			for (Tuple2<String, Integer> t : itr) {
+				ret.add(t);
+			}
+			ret.sort(cmp);
+			return ret.toArray(new Tuple2[0]);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static class Tuple2ResultSortComparator implements Comparator<Object>, Serializable {
+		@Override
+		public int compare(Object o1, Object o2) {
+			if (o1 instanceof Watermark || o2 instanceof Watermark) {
+				return 0;
+			} else {
+				StreamRecord<Slice<Tuple2<String, Integer>, String, TimeWindow>> sr0 = (StreamRecord<Slice<Tuple2<String, Integer>, String, TimeWindow>>) o1;
+				StreamRecord<Slice<Tuple2<String, Integer>, String, TimeWindow>> sr1 = (StreamRecord<Slice<Tuple2<String, Integer>, String, TimeWindow>>) o2;
+				if (sr0.getTimestamp() != sr1.getTimestamp()) {
+					return (int) (sr0.getTimestamp() - sr1.getTimestamp());
+				}
+				int comp0 = sr0.getValue().getContent().f0.compareTo(sr1.getValue().getContent().f0);
+				if (comp0 != 0) {
+					return comp0;
+				}
+				int comp1 = sr0.getValue().getContent().f1.compareTo(sr1.getValue().getContent().f1);
+				if (comp1 != 0) {
+					return comp1;
+				}
+				int comp2 = sr0.getValue().getKey().compareTo(sr1.getValue().getKey());
+				if (comp2 != 0) {
+					return comp2;
+				}
+				long comp3 = sr0.getValue().getWindow().getStart() - sr1.getValue().getWindow().getStart();
+				if (comp3 != 0) {
+					return new Long(comp3).intValue();
+				}
+				long comp4 = sr0.getValue().getWindow().getEnd() - sr1.getValue().getWindow().getEnd();
+				return new Long(comp4).intValue();
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static class RawTuple2ResultSortComparator implements Comparator<Object>, Serializable {
+		@Override
+		public int compare(Object o1, Object o2) {
+			if (o1 instanceof Tuple2 && o2 instanceof Tuple2) {
+				int comp = ((Tuple2<String, Integer>) o1).f0.compareTo(((Tuple2<String, Integer>) o2).f0);
+				if (comp != 0) {
+					return comp;
+				} else {
+					return ((Tuple2<String, Integer>) o1).f1.compareTo(((Tuple2<String, Integer>) o2).f1);
+				}
+			} else {
+				return 0;
+			}
+		}
+	}
+
+	private static class TupleKeySelector implements KeySelector<Tuple2<String, Integer>, String> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String getKey(Tuple2<String, Integer> value) throws Exception {
+			return value.f0;
+		}
+	}
+
+	private class TumbleSliceAssigner extends SliceAssigner<Object, TimeWindow> {
+
+		private long size;
+		private long offset;
+
+		protected TumbleSliceAssigner(long size, long offset) {
+			this.size = size;
+			this.offset = offset;
+		}
+
+		@Override
+		public TimeWindow assignSlice(Object element, long timestamp, WindowAssignerContext context) {
+			if (timestamp > Long.MIN_VALUE) {
+				// Long.MIN_VALUE is currently assigned when no timestamp is present
+				long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, size);
+				return new TimeWindow(start, start + size);
+			} else {
+				throw new RuntimeException("Record has Long.MIN_VALUE timestamp (= no timestamp marker). " +
+					"Is the time characteristic set to 'ProcessingTime', or did you forget to call " +
+					"'DataStream.assignTimestampsAndWatermarks(...)'?");
+			}
+		}
+
+		@Override
+		public TypeInformation<TimeWindow> getWindowType() {
+			return TypeInformation.of(TimeWindow.class);
+		}
+
+		@Override
+		public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+			return EventTimeTrigger.create();
+		}
+
+		@Override
+		public String toString() {
+			return "TumblingSliceWindow(" + size + ")";
+		}
+
+		@Override
+		public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+			return new TimeWindow.Serializer();
+		}
+
+		@Override
+		public boolean isEventTime() {
+			return true;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestHarnessUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestHarnessUtil.java
@@ -25,6 +25,7 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.junit.Assert;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -122,6 +123,62 @@ public class TestHarnessUtil {
 			} else if (elem instanceof StreamRecord) {
 				boolean dataIsOnTime = highestWatermark < ((StreamRecord) elem).getTimestamp();
 				Assert.assertTrue("Late data was emitted after join", dataIsOnTime);
+			}
+		}
+	}
+
+	/**
+	 * Compare the two queues containing operator/task output by converting them to an array first.
+	 */
+	public static void assertObjectOutputEqualsSorted(String message, Iterable<Object> expected, Iterable<Object> actual, Comparator<Object> comparator) {
+		assertEquals(Iterables.size(expected), Iterables.size(actual));
+
+		// first, compare only watermarks, their position should be deterministic
+		Iterator<Object> exIt = expected.iterator();
+		Iterator<Object> actIt = actual.iterator();
+		while (exIt.hasNext()) {
+			Object nextEx = exIt.next();
+			Object nextAct = actIt.next();
+			if (nextEx instanceof Watermark) {
+				assertEquals(nextEx, nextAct);
+			}
+		}
+
+		List<Object> expectedRecords = new ArrayList<>();
+		List<Object> actualRecords = new ArrayList<>();
+
+		for (Object ex: expected) {
+			if (ex instanceof StreamRecord) {
+				expectedRecords.add(ex);
+			}
+		}
+
+		for (Object act: actual) {
+			if (act instanceof StreamRecord) {
+				actualRecords.add(act);
+			}
+		}
+
+		Object[] sortedExpected = expectedRecords.toArray();
+		Object[] sortedActual = actualRecords.toArray();
+
+		Arrays.sort(sortedExpected, comparator);
+		Arrays.sort(sortedActual, comparator);
+
+		assertObjectArrayEquals(message, sortedExpected, sortedActual, comparator);
+
+	}
+
+	public static void assertObjectArrayEquals(String message, Object[] sortedExpected, Object[] sortedActual, Comparator<Object> comparator) {
+		if (sortedExpected != sortedActual && !Arrays.deepEquals(new Object[]{sortedExpected}, new Object[]{sortedActual})) {
+			String header = message == null ? "" : message + ": ";
+			int expectedsLength = sortedExpected.length;
+			Assert.assertEquals(message, expectedsLength, sortedActual.length);
+
+			for (int i = 0; i < expectedsLength; ++i) {
+				Object expected = Array.get(sortedExpected, i);
+				Object actual = Array.get(sortedActual, i);
+				Assert.assertEquals(message, 0, comparator.compare(expected, actual));
 			}
 		}
 	}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SlicedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SlicedStream.scala
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import java.util.{List => JList}
+
+import org.apache.flink.annotation.{Public, PublicEvolving}
+import org.apache.flink.api.common.functions.{AggregateFunction, ReduceFunction}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.datastream.{SlicedStream => JavaSStream}
+import org.apache.flink.streaming.api.scala.function.util._
+import org.apache.flink.streaming.api.windowing.evictors.Evictor
+import org.apache.flink.streaming.api.windowing.slicing.Slice
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.streaming.api.windowing.triggers.Trigger
+import org.apache.flink.streaming.api.windowing.windows.Window
+
+
+/**
+ * A [[SlicedStream]] represents a [[WindowedStream]] with non-overlapping windows.
+ *
+ * @tparam T The type of elements in the stream.
+ * @tparam K The type of the key by which elements are grouped.
+ * @tparam W The type of [[Window]] that the
+ *           [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]]
+ *           assigns the elements to.
+ */
+@Public
+class SlicedStream[T, K, W <: Window](javaStream: JavaSStream[T, K, W]) {
+
+  /**
+    * Sets the allowed lateness to a user-specified value.
+    * If not explicitly set, the allowed lateness is [[0L]].
+    * Setting the allowed lateness is only valid for event-time windows.
+    * If a value different than 0 is provided with a processing-time
+    * [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]],
+    * then an exception is thrown.
+    */
+  @PublicEvolving
+  def allowedLateness(lateness: Time): SlicedStream[T, K, W] = {
+    javaStream.allowedLateness(lateness)
+    this
+  }
+
+  /**
+   * Send late arriving data to the side output identified by the given [[OutputTag]]. Data
+   * is considered late after the watermark has passed the end of the window plus the allowed
+   * lateness set using [[allowedLateness(Time)]].
+   *
+   * You can get the stream of late data using [[DataStream.getSideOutput()]] on the [[DataStream]]
+   * resulting from the windowed operation with the same [[OutputTag]].
+   */
+  @PublicEvolving
+  def sideOutputLateData(outputTag: OutputTag[T]): SlicedStream[T, K, W] = {
+    javaStream.sideOutputLateData(outputTag)
+    this
+  }
+
+  /**
+   * Sets the [[Trigger]] that should be used to trigger window emission.
+   */
+  @PublicEvolving
+  def trigger(trigger: Trigger[_ >: T, _ >: W]): SlicedStream[T, K, W] = {
+    javaStream.trigger(trigger)
+    this
+  }
+
+  /**
+   * Sets the [[Evictor]] that should be used to evict elements from a window before emission.
+   *
+   * Note: When using an evictor window performance will degrade significantly, since
+   * pre-aggregation of window results cannot be used.
+   */
+  @PublicEvolving
+  def evictor(evictor: Evictor[_ >: T, _ >: W]): SlicedStream[T, K, W] = {
+    javaStream.evictor(evictor)
+    this
+  }
+
+  // ------------------------------------------------------------------------
+  //  Operations on the keyed windows
+  // ------------------------------------------------------------------------
+
+  // --------------------------- reduce() -----------------------------------
+
+  /**
+   * Applies a reduce function to the window. The window function is called for each evaluation
+   * of the window for each key individually. The output of the reduce function can be
+   * re-interpreted as a keyed stream.
+   *
+   * @param function The reduce function.
+   * @return The data stream that is the result of applying the reduce function to the window.
+   */
+  def reduceToSlice(function: ReduceFunction[T]): DataStream[Slice[T, K, W]] = {
+    asScalaStream(javaStream.reduceToSlice(clean(function)))
+  }
+
+  /**
+   * Applies a reduce function to the window. The window function is called for each evaluation
+   * of the window for each key individually. The output of the reduce function can be
+   * re-interpreted as a keyed stream.
+   *
+   * @param function The reduce function.
+   * @return The data stream that is the result of applying the reduce function to the window.
+   */
+  def reduceToSlice(function: (T, T) => T): DataStream[Slice[T, K, W]] = {
+    if (function == null) {
+      throw new NullPointerException("Reduce function must not be null.")
+    }
+    val cleanFun = clean(function)
+    val reducer = new ScalaReduceFunction[T](cleanFun)
+    reduceToSlice(reducer)
+  }
+
+  // -------------------------- aggregate() ---------------------------------
+
+  /**
+   * Applies the given aggregation function to each window and key. The aggregation function
+   * is called for each element, aggregating values incrementally and keeping the state to
+   * one accumulator per key and window. The output of the reduce function can be
+   * re-interpreted as a keyed stream.
+   *
+   * @param aggregateFunction The aggregation function.
+   * @return The data stream that is the result of applying the aggregate function to the window.
+   */
+  @PublicEvolving
+  def aggregateToSlice[ACC: TypeInformation](
+      aggregateFunction: AggregateFunction[T, ACC, _]): DataStream[Slice[ACC, K, W]] = {
+
+    val accumulatorType: TypeInformation[ACC] = implicitly[TypeInformation[ACC]]
+
+    asScalaStream(javaStream.aggregateToSlice(clean(aggregateFunction), accumulatorType))
+  }
+
+  // ---------------------------- apply() -------------------------------------
+
+  /**
+    * Applied the given input stream by aggregating each individual element into an iterable
+    * collection for downstream processing.
+    *
+    * @return The data stream that is the iterable result of the buffering operation.
+    */
+  def applyToSlice(): DataStream[Slice[JList[T], K, W]] = {
+    asScalaStream(javaStream.applyToSlice())
+  }
+
+  // ------------------------------------------------------------------------
+  //  Utilities
+  // ------------------------------------------------------------------------
+
+  /**
+   * Returns a "closure-cleaned" version of the given function. Cleans only if closure cleaning
+   * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]].
+   */
+  private[flink] def clean[F <: AnyRef](f: F): F = {
+    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaClean(f)
+  }
+
+  /**
+   * Gets the output type.
+   */
+  private def getInputType(): TypeInformation[T] = javaStream.getInputType
+}

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/SliceTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/SliceTranslationTest.scala
@@ -1,0 +1,478 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import java.util.{List => JList}
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.functions._
+import org.apache.flink.api.common.state.{AggregatingStateDescriptor, ListStateDescriptor, ReducingStateDescriptor}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.streaming.api.operators.{OneInputStreamOperator, OutputTypeConfigurable}
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.streaming.api.windowing.assigners._
+import org.apache.flink.streaming.api.windowing.slicing.Slice
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.streaming.api.windowing.triggers.{CountTrigger, EventTimeTrigger, ProcessingTimeTrigger, Trigger}
+import org.apache.flink.streaming.api.windowing.windows.{TimeWindow, Window}
+import org.apache.flink.streaming.runtime.operators.windowing._
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+  * These tests verify that the api calls on [[SlicedStream]] instantiate the correct
+  * [[SliceOperator]].
+  */
+class SliceTranslationTest {
+
+  // --------------------------------------------------------------------------
+  //  rich function tests
+  // --------------------------------------------------------------------------
+
+  /**
+    * .reduce() does not support [[RichReduceFunction]], since the reduce function is used
+    * internally in a [[org.apache.flink.api.common.state.ReducingState]].
+    */
+  @Test(expected = classOf[UnsupportedOperationException])
+  def testReduceWithRichReducerFails() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+
+    source
+      .keyBy(0)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .reduceToSlice(new RichReduceFunction[(String, Int)] {
+        override def reduce(value1: (String, Int), value2: (String, Int)) = null
+      })
+
+    fail("exception was not thrown")
+  }
+
+  /**
+   * .reduce() does not support [[RichReduceFunction]], since the reduce function is used
+   * internally in a [[org.apache.flink.api.common.state.ReducingState]].
+   */
+  @Test(expected = classOf[UnsupportedOperationException])
+  def testAggregateWithRichFunctionFails() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+
+    source
+      .keyBy(0)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .aggregateToSlice(new DummyRichAggregator())
+
+    fail("exception was not thrown")
+  }
+
+  // --------------------------------------------------------------------------
+  //  reduceToSlice() tests
+  // --------------------------------------------------------------------------
+
+  @Test
+  def testReduceEventTime() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice: DataStream[Slice[(String, Int), String, TimeWindow]] = source
+      .keyBy(_._1)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .reduceToSlice(new DummyReducer)
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[OneInputTransformation[(String, Int), Slice[(String, Int), String, TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[SliceOperator[_, _, _, _ <: Window]])
+
+    val sliceOperator = operator
+      .asInstanceOf[SliceOperator[String, (String, Int), (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
+
+    processElementAndEnsureOutput[String, (String, Int), Slice[(String, Int), String, TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  @Test
+  def testReduceProcessingTime() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingProcessingTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .reduceToSlice(new DummyReducer)
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[OneInputTransformation[(String, Int), Slice[(String, Int), String, TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[SliceOperator[_, _, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[SliceOperator[String, (String, Int), (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
+
+    processElementAndEnsureOutput[String, (String, Int), Slice[(String, Int), String, TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  @Test
+  def testReduceEventTimeWithScalaFunction() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .reduceToSlice((x, _) => x)
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[OneInputTransformation[(String, Int), Slice[(String, Int), String, TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[SliceOperator[_, _, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[SliceOperator[String, (String, Int), (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
+
+    processElementAndEnsureOutput[String, (String, Int), Slice[(String, Int), String, TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  // --------------------------------------------------------------------------
+  //  aggregate() tests
+  // --------------------------------------------------------------------------
+
+  @Test
+  def testAggregateEventTime() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .aggregateToSlice(new DummyAggregator())
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[OneInputTransformation[(String, Int), Slice[(String, Int), String, TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[SliceOperator[_, _, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[SliceOperator[String, (String, Int), (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
+
+    processElementAndEnsureOutput[String, (String, Int), Slice[(String, Int), String, TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  @Test
+  def testAggregateProcessingTime() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingProcessingTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .aggregateToSlice(new DummyAggregator())
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[OneInputTransformation[(String, Int), Slice[(String, Int), String, TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[SliceOperator[_, _, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[SliceOperator[String, (String, Int), (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
+
+    processElementAndEnsureOutput[String, (String, Int), Slice[(String, Int), String, TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  // --------------------------------------------------------------------------
+  //  apply() tests
+  // --------------------------------------------------------------------------
+
+  @Test
+  def testApplyEventTime() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .applyToSlice()
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[
+          OneInputTransformation[(String, Int),
+          Slice[JList[(String, Int)],
+          String,
+          TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[IterableSliceOperator[_, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[IterableSliceOperator[String, (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
+
+    processElementAndEnsureOutput[
+        String,
+        (String, Int),
+        Slice[JList[(String, Int)],
+        String,
+        TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  @Test
+  def testApplyProcessingTime() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingProcessingTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .applyToSlice()
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[
+          OneInputTransformation[(String, Int),
+          Slice[JList[(String, Int)],
+          String,
+          TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[IterableSliceOperator[_, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[IterableSliceOperator[String, (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
+
+    processElementAndEnsureOutput[
+        String,
+        (String, Int),
+        Slice[JList[(String, Int)],
+        String,
+        TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  // --------------------------------------------------------------------------
+  //  custom trigger test
+  // --------------------------------------------------------------------------
+
+  @Test
+  def testReduceWithCustomTrigger() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .trigger(CountTrigger.of(1))
+      .reduceToSlice(new DummyReducer)
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[OneInputTransformation[(String, Int), Slice[(String, Int), String, TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[SliceOperator[_, _, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[SliceOperator[String, (String, Int), (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
+
+    processElementAndEnsureOutput[String, (String, Int), Slice[(String, Int), String, TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  @Test
+  def testApplyWithCustomTrigger() {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime)
+
+    val source = env.fromElements(("hello", 1), ("hello", 2))
+
+    val slice = source
+      .keyBy(_._1)
+      .slice(TumblingEventTimeSlices.of(Time.seconds(1), Time.milliseconds(100)))
+      .trigger(CountTrigger.of(1))
+      .applyToSlice()
+
+    val transform = slice
+      .javaStream
+      .getTransformation
+      .asInstanceOf[
+          OneInputTransformation[(String, Int),
+          Slice[JList[(String, Int)],
+          String,
+          TimeWindow]]]
+
+    val operator = transform.getOperator
+    assertTrue(operator.isInstanceOf[IterableSliceOperator[_, _, TimeWindow]])
+
+    val sliceOperator = operator
+      .asInstanceOf[IterableSliceOperator[String, (String, Int), TimeWindow]]
+
+    assertTrue(sliceOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(sliceOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeSlices])
+    assertTrue(sliceOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
+
+    processElementAndEnsureOutput[
+        String,
+        (String, Int),
+        Slice[JList[(String, Int)],
+        String,
+        TimeWindow]](
+      sliceOperator,
+      sliceOperator.getKeySelector,
+      BasicTypeInfo.STRING_TYPE_INFO,
+      ("hello", 1))
+  }
+
+  /**
+    * Ensure that we get some output from the given operator when pushing in an element and
+    * setting watermark and processing time to `Long.MaxValue`.
+    */
+  @throws[Exception]
+  private def processElementAndEnsureOutput[K, IN, OUT](
+      operator: OneInputStreamOperator[IN, OUT],
+      keySelector: KeySelector[IN, K],
+      keyType: TypeInformation[K],
+      element: IN) {
+    val testHarness =
+      new KeyedOneInputStreamOperatorTestHarness[K, IN, OUT](operator, keySelector, keyType)
+
+    if (operator.isInstanceOf[OutputTypeConfigurable[String]]) {
+      // use a dummy type since window functions just need the ExecutionConfig
+      // this is also only needed for Fold, which we're getting rid off soon.
+      operator.asInstanceOf[OutputTypeConfigurable[String]]
+        .setOutputType(BasicTypeInfo.STRING_TYPE_INFO, new ExecutionConfig)
+    }
+    testHarness.open()
+
+    testHarness.setProcessingTime(0)
+    testHarness.processWatermark(Long.MinValue)
+
+    testHarness.processElement(new StreamRecord[IN](element, 0))
+
+    // provoke any processing-time/event-time triggers
+    testHarness.setProcessingTime(Long.MaxValue)
+    testHarness.processWatermark(Long.MaxValue)
+
+    // we at least get the two watermarks and should also see an output element
+    assertTrue(testHarness.getOutput.size >= 3)
+
+    testHarness.close()
+  }
+}


### PR DESCRIPTION


## What is the purpose of the change

This PR introduces a new `SlicedStream` abstract operation, which creates a resulting stream of the intermediate results buffered in the internal state of `WindowedOperator`. 
It creates a `Slice` data type as a result to contain all necessary information of a pane slice.
With this API. further processing is possible for operations:
```
val slicedStream: slicedStream = inputStream
  .keyBy("key")
  .sliceWindow(Time.seconds(5L)) 
  .aggregate(aggFunc)
val resultStream = slicedStream
    .window(Time.seconds(5000L))
    .aggregate(aggFunc)
```
Is possible to create much more efficient window operation, where elements won't have to be duplicated into all overlapping windows.

## Brief change log

  - Added `SliceAssigner` that assigns elements into zero or one window (a.k.a. the "slice")
  - Modified `KeyedStream` and `WindowedStream` API to incorporate the creation of `SlicedStream`
  - Added `SlicedStream` concept that can emit slicing results.
  - Created special operators `SliceOperator` and `IterableSliceOperator` to process the intermediate results.
  - Added in TumblingEvent/ProcessingTimeSliceAssigner as an example.


## Verifying this change

- This change is already covered by multiple tests for backward compatibility 
- This change added tests and can be verified as follows:
  - Added integration tests for end-to-end processing for reduce, aggregation, and general apply
  - Added translation tests in scala for verifying `SlicedStream` API conversion chained with `KeyedStream`.
  - Added integration tests specifically tested serialization and deserialization to/from state snapshot.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not yet, await review
