### PR TITLE
[FLINK-11421][Table API & SQL] Providing more compilation options for code-generated o…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/CompilationOption.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/CompilationOption.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common;
+
+/**
+ * The option for the compiler used for compiling generated Java code.
+ */
+public enum CompilationOption {
+
+	/**
+	 * Compiling Java code by Janino.
+	 * The compilation is fast, but the generated binary code is of low quality.
+	 */
+	FAST,
+
+	/**
+	 * Compiling Java code by Java Compiler API (JCA)
+	 * The compilation is slow, but the generated binary code is of high quality.
+	 */
+	SLOW;
+
+	public static boolean inTest = false;
+
+	public static CompilationOption currentOption = FAST;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -162,6 +162,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** The default input dependency constraint to schedule tasks. */
 	private InputDependencyConstraint defaultInputDependencyConstraint = InputDependencyConstraint.ANY;
 
+	/** The option for compiling generated Java code. */
+	private CompilationOption compilationOption = CompilationOption.FAST;
+
 	// ------------------------------- User code values --------------------------------------------
 
 	private GlobalJobParameters globalJobParameters;
@@ -519,6 +522,22 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 */
 	public ExecutionMode getExecutionMode() {
 		return executionMode;
+	}
+
+	/**
+	 * Sets the option for compiling generated Java code.
+	 * @param compilationOption
+	 */
+	public void setCompilationOption(CompilationOption compilationOption) {
+		this.compilationOption = compilationOption;
+	}
+
+	/**
+	 * Gets the option for compiling generated Java code.
+	 * @return
+	 */
+	public CompilationOption getCompileOption() {
+		return this.compilationOption;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -105,6 +105,12 @@ public class CoreOptions {
 			" resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against" +
 			" the fully qualified class name. These patterns are appended to \"" + ALWAYS_PARENT_FIRST_LOADER_PATTERNS.key() + "\".");
 
+	public static final ConfigOption<String> CODEGEN_COMPILATION_OPTION = ConfigOptions
+		.key("codegen.compilation.option")
+		.defaultValue("fast")
+		.withDescription("A string indicating the option used for compiling generated code. 'fast' means compiling with Janino, " +
+			"whereas 'slow' means compiling with Java Compiler API (JCA).");
+
 	public static String[] getParentFirstLoaderPatterns(Configuration config) {
 		String base = config.getString(ALWAYS_PARENT_FIRST_LOADER_PATTERNS);
 		String append = config.getString(ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/Compiler.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/Compiler.scala
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.codegen
 
-import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.common.{CompilationOption, InvalidProgramException}
+import org.apache.flink.api.common.functions.RuntimeContext
+import org.apache.flink.streaming.util.JCACompiler
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.SimpleCompiler
 
@@ -37,5 +39,14 @@ trait Compiler[T] {
           "This is a bug. Please file an issue.", t)
     }
     compiler.getClassLoader.loadClass(name).asInstanceOf[Class[T]]
+  }
+
+  @throws(classOf[CompileException])
+  def compile(ctx: RuntimeContext, name: String, code: String): Class[T] = {
+    if (ctx.getExecutionConfig.getCompileOption == CompilationOption.FAST) {
+      compile(ctx.getUserCodeClassLoader, name, code)
+    } else {
+      JCACompiler.getInstance.getCodeClass(name, code).asInstanceOf[Class[T]]
+    }
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.functions.util.FunctionUtils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.{CodeGenFunction, ProcessFunction}
 import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.codegen.Compiler
 import org.apache.flink.table.runtime.types.CRow
@@ -40,14 +40,15 @@ class CRowOutputProcessRunner(
   extends ProcessFunction[Any, CRow]
   with ResultTypeQueryable[CRow]
   with Compiler[ProcessFunction[Any, Row]]
-  with Logging {
+  with Logging
+  with CodeGenFunction{
 
   private var function: ProcessFunction[Any, Row] = _
   private var cRowWrapper: CRowWrappingCollector = _
 
   override def open(parameters: Configuration): Unit = {
     LOG.debug(s"Compiling ProcessFunction: $name \n\n Code:\n$code")
-    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    val clazz = compile(getRuntimeContext, name, code)
     LOG.debug("Instantiating ProcessFunction.")
     function = clazz.newInstance()
     FunctionUtils.setFunctionRuntimeContext(function, getRuntimeContext)
@@ -75,4 +76,8 @@ class CRowOutputProcessRunner(
   override def close(): Unit = {
     FunctionUtils.closeFunction(function)
   }
+
+  override def getName: String = name
+
+  override def getCode: String = code
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/FlatMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/FlatMapRunner.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.functions.{FlatMapFunction, RichFlatMapFuncti
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.CodeGenFunction
 import org.apache.flink.table.codegen.Compiler
 import org.apache.flink.table.util.Logging
 import org.apache.flink.types.Row
@@ -35,7 +36,8 @@ class FlatMapRunner(
   extends RichFlatMapFunction[Row, Row]
   with ResultTypeQueryable[Row]
   with Compiler[FlatMapFunction[Row, Row]]
-  with Logging {
+  with Logging
+  with CodeGenFunction {
 
   private var function: FlatMapFunction[Row, Row] = _
 
@@ -56,4 +58,8 @@ class FlatMapRunner(
   override def close(): Unit = {
     FunctionUtils.closeFunction(function)
   }
+
+  override def getName: String = name
+
+  override def getCode: String = code
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/CodeGenFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/CodeGenFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions;
+
+/**
+ * A function based on generated Java code.
+ */
+public interface CodeGenFunction {
+
+	/**
+	 * Gets the class name of generated code.
+	 * @return
+	 */
+	String getName();
+
+	/**
+	 * Gets the generated code.
+	 * @return
+	 */
+	String getCode();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.CompilationOption;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.io.InputFormat;
@@ -28,6 +29,8 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -102,6 +105,11 @@ public class StreamGraph extends StreamingPlan {
 		this.environment = environment;
 		this.executionConfig = environment.getConfig();
 		this.checkpointConfig = environment.getCheckpointConfig();
+
+		// get compilation option
+		CompilationOption compilationOption = CompilationOption.inTest ? CompilationOption.currentOption :
+			CompilationOption.valueOf(GlobalConfiguration.loadConfiguration().getString(CoreOptions.CODEGEN_COMPILATION_OPTION).toUpperCase());
+		this.executionConfig.setCompilationOption(compilationOption);
 
 		// create an empty new stream graph.
 		clear();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/JCACompiler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/JCACompiler.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Compiler based on Java Compiler API (JCA).
+ */
+public class JCACompiler {
+
+	private static JCACompiler instance = new JCACompiler();
+
+	/**
+	 * The root path of the source/binary code.
+	 */
+	private static final String codeRoot = "codegen";
+
+	/**
+	 * A cache containing all compiled classes.
+	 * The structure is: class name -> list of (code, class)
+	 */
+	private Map<String, List<ImmutablePair<String, Class<?>>>> clazzCache = new HashMap<>();
+
+	private JCACompiler() {
+	}
+
+	public static JCACompiler getInstance() {
+		return instance;
+	}
+
+	/**
+	 * Retrieve the class file path, given the source file path.
+	 *
+	 * @param srcPath
+	 * @return
+	 */
+	private String getClassFilePath(String srcPath) {
+		File srcFile = new File(srcPath);
+		String srcName = srcFile.getName();
+		int idx = srcName.lastIndexOf('.');
+		if (idx == -1) {
+			throw new IllegalArgumentException(srcPath + " is not a valid java source file path");
+		}
+		String className = srcName.substring(0, idx) + ".class";
+		return new File(srcFile.getParentFile(), className).getAbsolutePath();
+	}
+
+	/**
+	 * Get the class name, given either the source file, or the class file path.
+	 *
+	 * @param filePath
+	 * @return
+	 */
+	private String getClassName(String filePath) {
+		File file = new File(filePath);
+		String name = file.getName();
+		int idx = name.lastIndexOf(".");
+		if (idx == -1) {
+			throw new IllegalArgumentException(filePath + " is not a valid java source/class file path");
+		}
+		return name.substring(0, idx);
+	}
+
+	/**
+	 * Load the class, given its class file path.
+	 *
+	 * @param classPath
+	 * @return
+	 */
+	private Class<?> loadClass(String classPath) {
+		try {
+			File parentDir = new File(classPath).getParentFile();
+			URL[] urls = new URL[]{ parentDir.toURI().toURL() };
+			ClassLoader cl = new URLClassLoader(urls);
+			return cl.loadClass(getClassName(classPath));
+		} catch (Exception e) {
+			String msg = "Failed to load class " + getClassName(classPath) + " from path: " + new File(classPath).getAbsolutePath();
+			throw new RuntimeException(msg, e);
+		}
+	}
+
+	/**
+	 * Compile source files, given their paths.
+	 *
+	 * @param paths
+	 */
+	public void compile(String ...paths) {
+		List<String> pathList = Arrays.stream(paths).map(p -> new File(p).getAbsolutePath()).collect(Collectors.toList());
+		String pathStr = String.join(", ", pathList);
+		try {
+			JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+			StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+			Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromStrings(pathList);
+			compiler.getTask(null, fileManager, null, null, null, compilationUnits).call();
+			fileManager.close();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to compile generated code from: " + pathStr + ", due to " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Write the source file to disk, given its class name and source code.
+	 * If the source file already exists, it will be overwritten.
+	 *
+	 * @param name
+	 * @param code
+	 * @return the path of the source file on disk.
+	 */
+	private String writeSource(String name, String code) {
+		File srcFile = new File(codeRoot, name + ".java");
+		try {
+			org.apache.commons.io.FileUtils.writeStringToFile(srcFile, code);
+		} catch (Throwable e) {
+			throw new RuntimeException("Failed to write source file for " + name + ", reason: " + e.getMessage(), e);
+		}
+		return srcFile.getAbsolutePath();
+	}
+
+	/**
+	 * Try to find a class in class cache, given its name and code.
+	 *
+	 * @param name
+	 * @param code
+	 * @return
+	 */
+	private Class<?> findClassInCache(String name, String code) {
+		List<ImmutablePair<String, Class<?>>> clazzList = clazzCache.get(name);
+		if (clazzList == null) {
+			return null;
+		}
+		for (ImmutablePair<String, Class<?>> pair : clazzList) {
+			if (pair.left.equals(code)) {
+				return pair.right;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Check if a batch of source files have all been compiled, and inserted into the cache.
+	 * @param names
+	 * @param sources
+	 * @return
+	 */
+	private boolean allCompiled(List<String> names, List<String> sources) {
+		if (names.size() != sources.size()) {
+			throw new IllegalArgumentException("Source file names and code are not of equal size.");
+		}
+
+		for (int i = 0; i < names.size(); i++) {
+			if (findClassInCache(names.get(i), sources.get(i)) == null) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Compile a number of source files in batch.
+	 * This will be much faster than compiling the files individually.
+	 * @param names
+	 * @param sources
+	 */
+	public void compileSourceInBatch(List<String> names, List<String> sources) {
+		if (allCompiled(names, sources)) {
+			return;
+		}
+
+		synchronized (clazzCache) {
+			if (!allCompiled(names, sources)) {
+				// write source files to disk
+				String[] sourcePaths = new String[names.size()];
+				for (int i = 0; i < names.size(); i++) {
+					sourcePaths[i] = writeSource(names.get(i), sources.get(i));
+				}
+
+				// compile sources
+				compile(sourcePaths);
+
+				// load classes and insert them into cache
+				for (int i = 0; i < names.size(); i++) {
+					Class<?> clazz = loadClass(getClassFilePath(sourcePaths[i]));
+					List<ImmutablePair<String, Class<?>>> clazzList = clazzCache.get(names.get(i));
+					if (clazzList == null) {
+						clazzList = new ArrayList<>();
+						clazzCache.put(names.get(i), clazzList);
+					}
+					clazzList.add(new ImmutablePair<>(sources.get(i), clazz));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Given the class name and the code, get the class.
+	 *
+	 * @param name
+	 * @param code
+	 * @return
+	 */
+	public Class<?> getCodeClass(String name, String code) {
+		Class<?> ret = findClassInCache(name, code);
+		if (ret != null) {
+			// The class is in the cache.
+			return ret;
+		}
+
+		// get the list of all classes with the same name.
+		List<ImmutablePair<String, Class<?>>> clazzList = clazzCache.get(name);
+		if (clazzList == null) {
+			synchronized (clazzCache) {
+				clazzList = clazzCache.get(name);
+				if (clazzList == null) {
+					clazzList = new ArrayList<>();
+					clazzCache.put(name, clazzList);
+				}
+			}
+		}
+
+		synchronized (clazzList) {
+			ret = findClassInCache(name, code);
+			if (ret == null) {
+				// write source file
+				String srcPath = writeSource(name, code);
+
+				// compile source
+				compile(srcPath);
+
+				// load class
+				ret = loadClass(getClassFilePath(srcPath));
+
+				// insert class to cache
+				clazzList.add(new ImmutablePair<>(code, ret));
+			}
+		}
+
+		return ret;
+	}
+}


### PR DESCRIPTION
…perators (changes for stream jobs)

## What is the purpose of the change

This is to support JIRA [FLINK-11421] Providing more compilation options for code-generated operators


## Brief change log

*The main changes include*
  - *Provide the JCA compiler to compile generated code by Java Compiler API.*
  - *Support specifying the compilation option from the configuration file (flink-conf.yaml).*
  - *The default compilation option remains the same, by Janino. So it does not affect existing jobs, unless configured specifically.*


## Verifying this change


This change is already covered by existing tests, such as *(flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SortITCase.scala)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
