### PR TITLE
[FLINK-11584][docs] Add space in self-closing linebreak tag

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/description/HtmlFormatter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/description/HtmlFormatter.java
@@ -32,7 +32,7 @@ public class HtmlFormatter extends Formatter {
 
 	@Override
 	protected void formatLineBreak(StringBuilder state) {
-		state.append("<br/>");
+		state.append("<br />");
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/configuration/description/DescriptionHtmlTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/description/DescriptionHtmlTest.java
@@ -93,7 +93,7 @@ public class DescriptionHtmlTest {
 		String formattedDescription = new HtmlFormatter().format(description);
 
 		assertEquals(
-			"This is first line.<br/>This is second line.",
+			"This is first line.<br />This is second line.",
 			formattedDescription);
 	}
 

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
@@ -171,6 +171,7 @@ public class ConfigOptionsDocsCompletenessITCase {
 
 	private static Collection<DocumentedOption> parseDocumentedOptionsFromFile(Path file) throws IOException {
 		Document document = Jsoup.parse(file.toFile(), StandardCharsets.UTF_8.name());
+		document.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
 		document.outputSettings().prettyPrint(false);
 		return document.getElementsByTag("table").stream()
 			.map(element -> element.getElementsByTag("tbody").get(0))


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

2 issues are being addressed here:
* The configuration docs completeness test was parsing the document using html syntax, which has no support for self-closing tags. As a result the comparison of descriptions that contained linebreaks always failed, since we expected a self-closing tag (`<br/>`) but were returned something else (`<br>`).
* Jsoup (which we use for parsing html) always adds a space in self-closing tags, (i.e., `<br />` instead of `<br/>`). Functionally these behave the same, and since the rest of our documentation also includes a space I have modified the `HtmlFormatter` accordingly.
