### PR TITLE
[FLINK-11591][core] Support legacy TypeSerializerSnapshot transformations

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link CompositeTypeSerializerSnapshot} is a convenient serializer snapshot class that can be used by
  * simple serializers which 1) delegates its serialization to multiple nested serializers, and 2) may contain
@@ -110,7 +112,7 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
 	 * @param correspondingSerializerClass the expected class of the new serializer.
 	 */
 	public CompositeTypeSerializerSnapshot(Class<S> correspondingSerializerClass) {
-		this.correspondingSerializerClass = Preconditions.checkNotNull(correspondingSerializerClass);
+		this.correspondingSerializerClass = checkNotNull(correspondingSerializerClass);
 	}
 
 	/**
@@ -120,7 +122,7 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
 	 */
 	@SuppressWarnings("unchecked")
 	public CompositeTypeSerializerSnapshot(S serializerInstance) {
-		Preconditions.checkNotNull(serializerInstance);
+		checkNotNull(serializerInstance);
 		this.nestedSerializersSnapshotDelegate = new NestedSerializersSnapshotDelegate(getNestedSerializers(serializerInstance));
 		this.correspondingSerializerClass = (Class<S>) serializerInstance.getClass();
 	}
@@ -169,6 +171,11 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
 		return constructFinalSchemaCompatibilityResult(
 			getNestedSerializers(castedNewSerializer),
 			snapshots);
+	}
+
+	@Internal
+	void setNestedSerializersSnapshotDelegate(NestedSerializersSnapshotDelegate delegate) {
+		this.nestedSerializersSnapshotDelegate = checkNotNull(delegate);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUtil.java
@@ -48,4 +48,19 @@ public class CompositeTypeSerializerUtil {
 		checkArgument(legacyNestedSnapshots.length > 0);
 		return newCompositeSnapshot.internalResolveSchemaCompatibility(newSerializer, legacyNestedSnapshots);
 	}
+
+
+	/**
+	 * Overrides the existing nested serializer's snapshots with the provided {@code nestedSnapshots}.
+	 *
+	 * @param compositeSnapshot the composite snapshot to overwrite its nested serializers.
+	 * @param nestedSnapshots the nested snapshots to overwrite with.
+	 */
+	public static void setNestedSerializersSnapshots(
+		CompositeTypeSerializerSnapshot<?, ?> compositeSnapshot,
+		TypeSerializerSnapshot<?>... nestedSnapshots) {
+
+		NestedSerializersSnapshotDelegate delegate = new NestedSerializersSnapshotDelegate(nestedSnapshots);
+		compositeSnapshot.setNestedSerializersSnapshotDelegate(delegate);
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/LegacySerializerSnapshotTransformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/LegacySerializerSnapshotTransformation.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Provide a way for {@link TypeSerializer}s to transform a legacy {@link TypeSerializerSnapshot}.
+ *
+ * <p>This interface is provided for {@link TypeSerializer}s to implement, that would like to transform an
+ * associated snapshot class during deserialization from previous Flink versions.
+ */
+@Internal
+public interface LegacySerializerSnapshotTransformation<T> {
+
+	/**
+	 * Transform a {@link TypeSerializerSnapshot} that was previously associated with {@code this} {@link TypeSerializer}.
+	 *
+	 * @param legacySnapshot the snapshot to transform
+	 * @param <U> the snapshot element type
+	 * @return a possibly transformed snapshot
+	 */
+	<U> TypeSerializerSnapshot<T> transformLegacySerializerSnapshot(TypeSerializerSnapshot<U> legacySnapshot);
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/LegacySerializerSnapshotTransformer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/LegacySerializerSnapshotTransformer.java
@@ -27,7 +27,7 @@ import org.apache.flink.annotation.Internal;
  * associated snapshot class during deserialization from previous Flink versions.
  */
 @Internal
-public interface LegacySerializerSnapshotTransformation<T> {
+public interface LegacySerializerSnapshotTransformer<T> {
 
 	/**
 	 * Transform a {@link TypeSerializerSnapshot} that was previously associated with {@code this} {@link TypeSerializer}.

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/NestedSerializersSnapshotDelegate.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/NestedSerializersSnapshotDelegate.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A NestedSerializersSnapshotDelegate represents the snapshots of multiple serializers that are used
@@ -65,8 +66,9 @@ public class NestedSerializersSnapshotDelegate {
 	/**
 	 * Constructor to create a snapshot during deserialization.
 	 */
-	private NestedSerializersSnapshotDelegate(TypeSerializerSnapshot<?>[] snapshots) {
-		this.nestedSnapshots = snapshots;
+	@Internal
+	NestedSerializersSnapshotDelegate(TypeSerializerSnapshot<?>[] snapshots) {
+		this.nestedSnapshots = checkNotNull(snapshots);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -218,7 +218,7 @@ public class TypeSerializerSerializationUtil {
 				configSnapshot = TypeSerializerSnapshotSerializationUtil.readSerializerSnapshot(
 						bufferWrapper, userCodeClassLoader, serializer);
 
-				if (serializer instanceof LegacySerializerSnapshotTransformation) {
+				if (serializer instanceof LegacySerializerSnapshotTransformer) {
 					configSnapshot = transformLegacySnapshot(serializer, configSnapshot);
 				}
 
@@ -233,7 +233,7 @@ public class TypeSerializerSerializationUtil {
 	private static <T, U> TypeSerializerSnapshot<T> transformLegacySnapshot(
 		TypeSerializer<T> serializer, TypeSerializerSnapshot<U> configSnapshot) {
 
-		LegacySerializerSnapshotTransformation<T> transformation = (LegacySerializerSnapshotTransformation<T>) serializer;
+		LegacySerializerSnapshotTransformer<T> transformation = (LegacySerializerSnapshotTransformer<T>) serializer;
 		return transformation.transformLegacySerializerSnapshot(configSnapshot);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -218,11 +218,23 @@ public class TypeSerializerSerializationUtil {
 				configSnapshot = TypeSerializerSnapshotSerializationUtil.readSerializerSnapshot(
 						bufferWrapper, userCodeClassLoader, serializer);
 
+				if (serializer instanceof LegacySerializerSnapshotTransformation) {
+					configSnapshot = transformLegacySnapshot(serializer, configSnapshot);
+				}
+
 				serializersAndConfigSnapshots.add(new Tuple2<>(serializer, configSnapshot));
 			}
 		}
 
 		return serializersAndConfigSnapshots;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T, U> TypeSerializerSnapshot<T> transformLegacySnapshot(
+		TypeSerializer<T> serializer, TypeSerializerSnapshot<U> configSnapshot) {
+
+		LegacySerializerSnapshotTransformation<T> transformation = (LegacySerializerSnapshotTransformation<T>) serializer;
+		return transformation.transformLegacySerializerSnapshot(configSnapshot);
 	}
 
 	// -----------------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
@@ -19,12 +19,11 @@
 package org.apache.flink.cep.nfa.sharedbuffer;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
+import org.apache.flink.api.common.typeutils.LegacySerializerSnapshotTransformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
-import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -95,7 +94,9 @@ public final class Lockable<T> {
 	}
 
 	/** Serializer for {@link Lockable}. */
-	public static class LockableTypeSerializer<E> extends TypeSerializer<Lockable<E>> {
+	public static class LockableTypeSerializer<E> extends TypeSerializer<Lockable<E>>
+			implements LegacySerializerSnapshotTransformation<Lockable<E>> {
+
 		private static final long serialVersionUID = 3298801058463337340L;
 		private final TypeSerializer<E> elementSerializer;
 
@@ -190,26 +191,35 @@ public final class Lockable<T> {
 			return new LockableTypeSerializerSnapshot<>(this);
 		}
 
-		/**
-		 * This cannot be removed until {@link TypeSerializerConfigSnapshot} is no longer supported.
-		 */
-		@Override
-		public CompatibilityResult<Lockable<E>> ensureCompatibility(TypeSerializerConfigSnapshot<?> configSnapshot) {
-			// backwards compatibility path
-			CompatibilityResult<E> inputCompatibilityResult = CompatibilityUtil.resolveCompatibilityResult(
-				configSnapshot.restoreSerializer(),
-				UnloadableDummyTypeSerializer.class,
-				configSnapshot,
-				elementSerializer);
-
-			return (inputCompatibilityResult.isRequiresMigration())
-				? CompatibilityResult.requiresMigration()
-				: CompatibilityResult.compatible();
-		}
-
 		@VisibleForTesting
 		TypeSerializer<E> getElementSerializer() {
 			return elementSerializer;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <U> TypeSerializerSnapshot<Lockable<E>> transformLegacySerializerSnapshot(TypeSerializerSnapshot<U> legacySnapshot) {
+			if (legacySnapshot instanceof LockableTypeSerializerSnapshot) {
+				return (TypeSerializerSnapshot<Lockable<E>>) legacySnapshot;
+			}
+			// In flink 1.6, this serializer was directly returning the elementSerializer's snapshot
+			// instead of wrapping it in a LockableTypeSerializer(Config)Snapshot.
+			// This caused state information to be written as <LockableTypeSerializer, SomeArbitrarySerializerSnapshot>,
+			// Therefore we need to preform the following transformation:
+			// 	1. set the prior serializer on the legacySnapshot to be the elementSerializer
+			// 	2. return a LockableTypeSerializerSnapshot that has the legacySnapshot as a nested snapshot.
+			if (legacySnapshot instanceof TypeSerializerConfigSnapshot) {
+				setElementSerializerAsPriorSerializer(legacySnapshot, this.elementSerializer);
+			}
+			LockableTypeSerializerSnapshot<E> lockableSnapshot = new LockableTypeSerializerSnapshot<>();
+			CompositeTypeSerializerUtil.setNestedSerializersSnapshots(lockableSnapshot, legacySnapshot);
+			return lockableSnapshot;
+		}
+
+		@SuppressWarnings("unchecked")
+		private static <U, E> void setElementSerializerAsPriorSerializer(TypeSerializerSnapshot<U> legacySnapshot, TypeSerializer<E> elementSerializer) {
+			TypeSerializerConfigSnapshot<E> elementLegacySnapshot = (TypeSerializerConfigSnapshot<E>) legacySnapshot;
+			elementLegacySnapshot.setPriorSerializer(elementSerializer);
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
@@ -20,7 +20,7 @@ package org.apache.flink.cep.nfa.sharedbuffer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
-import org.apache.flink.api.common.typeutils.LegacySerializerSnapshotTransformation;
+import org.apache.flink.api.common.typeutils.LegacySerializerSnapshotTransformer;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
@@ -95,7 +95,7 @@ public final class Lockable<T> {
 
 	/** Serializer for {@link Lockable}. */
 	public static class LockableTypeSerializer<E> extends TypeSerializer<Lockable<E>>
-			implements LegacySerializerSnapshotTransformation<Lockable<E>> {
+			implements LegacySerializerSnapshotTransformer<Lockable<E>> {
 
 		private static final long serialVersionUID = 3298801058463337340L;
 		private final TypeSerializer<E> elementSerializer;


### PR DESCRIPTION
## What is the purpose of the change
(copied from the issue description)

In 1.6 and below, the LockableTypeSerializer incorrectly returns directly the element serializer's snapshot instead of wrapping it within an independent snapshot class:

https://github.com/apache/flink/blob/release-1.6/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java#L188

This results in the fact that the the written state information for this would be `(LockableTypeSerializer, SomeArbitrarySnapshot)`.

The problem occurs when restoring this in Flink 1.7+, since compatibility checks are now performed by providing the new serializer to the snapshot, what would happen is:
`SomeArbitrarySnapshot.resolveSchemaCompatibility(newLockableTypeSerializer)`, which would not work since the arbitrary snapshot does not recognize the LockableTypeSerializer.

To fix this, we essentially need to preprocess that arbitrary snapshot when restoring from <= 1.6 version snapshots.

## Brief change log

- This PR adds an interface `LegacySerializerSnapshotTransformer` that is being respect by the `TypeSerializerSerializationUtil` that allows serializers provide custom transformation logic for their associated snapshot classes.
- Uses that interface by the `LockableTypeSerializer`.

## Verifying this change

This change is already covered by existing tests, such as `CEPMigrationTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
