### PR TITLE
[FLINK-11088][Security][YARN] Allow YARN to discover pre-installed keytab files

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -111,6 +111,18 @@
             <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
         </tr>
         <tr>
+            <td><h5>yarn.security.kerberos.keytab</h5></td>
+            <td style="word-wrap: break-word;">"krb5.keytab"</td>
+            <td>String</td>
+            <td>With this configuration option, user can specify the path where kerberos keytab file will be localized to. If 'yarn.security.kerberos.require.localize.keytab' set to true, Flink will set the keytab file as YARN localize resource, path is relative to the local resource directory; If set to false, Flink will try to directly locate the keytab from the path itself.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.security.kerberos.ship-local-keytab</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>With this configuration option, user can specify whether to submit the kerberos keytab file used on the client side as a localize resource. If set to true, Flink will upload the the keytab file configured in SecurityOption('security.kerberos.login.keytab') to YARN's container localize resource bucket with the specified relative path defined in 'yarn.security.kerberos.keytab.path'.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.ship-directories</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -111,16 +111,16 @@
             <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
         </tr>
         <tr>
-            <td><h5>yarn.security.kerberos.keytab</h5></td>
+            <td><h5>yarn.security.kerberos.localized-keytab-path</h5></td>
             <td style="word-wrap: break-word;">"krb5.keytab"</td>
             <td>String</td>
-            <td>With this configuration option, user can specify the path where kerberos keytab file will be localized to. If 'yarn.security.kerberos.require.localize.keytab' set to true, Flink will set the keytab file as YARN localize resource, path is relative to the local resource directory; If set to false, Flink will try to directly locate the keytab from the path itself.</td>
+            <td>Local (on NodeManager) path where kerberos keytab file will be localized to. If yarn.security.kerberos.ship-local-keytab set to true, Flink willl ship the keytab file as a YARN local resource. In this case, the path is relative to the local resource directory. If set to false, Flink will try to directly locate the keytab from the path itself.</td>
         </tr>
         <tr>
             <td><h5>yarn.security.kerberos.ship-local-keytab</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>With this configuration option, user can specify whether to submit the kerberos keytab file used on the client side as a localize resource. If set to true, Flink will upload the the keytab file configured in SecurityOption('security.kerberos.login.keytab') to YARN's container localize resource bucket with the specified relative path defined in 'yarn.security.kerberos.keytab.path'.</td>
+            <td>When this is true Flink will ship the keytab file configured via security.kerberos.login.keytab as a localized YARN resource.</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-directories</h5></td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityConfiguration.java
@@ -140,8 +140,10 @@ public class SecurityConfiguration {
 
 			// check the keytab is readable
 			File keytabFile = new File(keytab);
-			if (!keytabFile.exists() || !keytabFile.isFile() || !keytabFile.canRead()) {
-				throw new IllegalConfigurationException("Kerberos login configuration is invalid; keytab is unreadable");
+			if (!keytabFile.exists() || !keytabFile.isFile()) {
+				throw new IllegalConfigurationException("Kerberos login configuration is invalid; keytab [" + keytab + "] doesn't exist!");
+			} else if (!keytabFile.canRead()) {
+				throw new IllegalConfigurationException("Kerberos login configuration is invalid; keytab [" + keytab + "] is unreadable!");
 			}
 		}
 	}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -108,47 +108,6 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
 	}
 
 	@Test(timeout = 60000) // timeout after a minute.
-	@Override
-	public void testDetachedMode() throws Exception {
-		runTest(() -> {
-			Map<String, String> securityProperties = new HashMap<>();
-			if (SecureTestEnvironment.getTestKeytab() != null) {
-				securityProperties.put(SecurityOptions.KERBEROS_LOGIN_KEYTAB.key(), SecureTestEnvironment.getTestKeytab());
-			}
-			if (SecureTestEnvironment.getHadoopServicePrincipal() != null) {
-				securityProperties.put(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(), SecureTestEnvironment.getHadoopServicePrincipal());
-			}
-			runDetachedModeTest(securityProperties);
-			final String[] mustHave = {"Login successful for user", "using keytab file"};
-			final boolean jobManagerRunsWithKerberos = verifyStringsInNamedLogFiles(
-				mustHave,
-				"jobmanager.log");
-			final boolean taskManagerRunsWithKerberos = verifyStringsInNamedLogFiles(
-				mustHave, "taskmanager.log");
-
-			Assert.assertThat(
-				"The JobManager and the TaskManager should both run with Kerberos.",
-				jobManagerRunsWithKerberos && taskManagerRunsWithKerberos,
-				Matchers.is(true));
-
-			final List<String> amRMTokens = Lists.newArrayList(AMRMTokenIdentifier.KIND_NAME.toString());
-			final String jobmanagerContainerId = getContainerIdByLogName("jobmanager.log");
-			final String taskmanagerContainerId = getContainerIdByLogName("taskmanager.log");
-			final boolean jobmanagerWithAmRmToken = verifyTokenKindInContainerCredentials(amRMTokens, jobmanagerContainerId);
-			final boolean taskmanagerWithAmRmToken = verifyTokenKindInContainerCredentials(amRMTokens, taskmanagerContainerId);
-
-			Assert.assertThat(
-				"The JobManager should have AMRMToken.",
-				jobmanagerWithAmRmToken,
-				Matchers.is(true));
-			Assert.assertThat(
-				"The TaskManager should not have AMRMToken.",
-				taskmanagerWithAmRmToken,
-				Matchers.is(false));
-		});
-	}
-
-	@Test(timeout = 60000) // timeout after a minute.
 	public void testDetachedModeSecureWithPreInstallKeytab() throws Exception {
 		runTest(() -> {
 			LOG.info("Starting testDetachedModeSecureWithPreInstallKeytab()");
@@ -165,33 +124,53 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
 				securityProperties.put(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(), SecureTestEnvironment.getHadoopServicePrincipal());
 			}
 			runDetachedModeTest(securityProperties);
-			final String[] mustHave = {"Login successful for user", "using keytab file"};
-			final boolean jobManagerRunsWithKerberos = verifyStringsInNamedLogFiles(
-				mustHave,
-				"jobmanager.log");
-			final boolean taskManagerRunsWithKerberos = verifyStringsInNamedLogFiles(
-				mustHave, "taskmanager.log");
-
-			Assert.assertThat(
-				"The JobManager and the TaskManager should both run with Kerberos.",
-				jobManagerRunsWithKerberos && taskManagerRunsWithKerberos,
-				Matchers.is(true));
-
-			final List<String> amRMTokens = Lists.newArrayList(AMRMTokenIdentifier.KIND_NAME.toString());
-			final String jobmanagerContainerId = getContainerIdByLogName("jobmanager.log");
-			final String taskmanagerContainerId = getContainerIdByLogName("taskmanager.log");
-			final boolean jobmanagerWithAmRmToken = verifyTokenKindInContainerCredentials(amRMTokens, jobmanagerContainerId);
-			final boolean taskmanagerWithAmRmToken = verifyTokenKindInContainerCredentials(amRMTokens, taskmanagerContainerId);
-
-			Assert.assertThat(
-				"The JobManager should have AMRMToken.",
-				jobmanagerWithAmRmToken,
-				Matchers.is(true));
-			Assert.assertThat(
-				"The TaskManager should not have AMRMToken.",
-				taskmanagerWithAmRmToken,
-				Matchers.is(false));
+			verifyResultContainsKerberosKeytab();
 		});
+	}
+
+	@Test(timeout = 60000) // timeout after a minute.
+	@Override
+	public void testDetachedMode() throws Exception {
+		runTest(() -> {
+			Map<String, String> securityProperties = new HashMap<>();
+			if (SecureTestEnvironment.getTestKeytab() != null) {
+				securityProperties.put(SecurityOptions.KERBEROS_LOGIN_KEYTAB.key(), SecureTestEnvironment.getTestKeytab());
+			}
+			if (SecureTestEnvironment.getHadoopServicePrincipal() != null) {
+				securityProperties.put(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(), SecureTestEnvironment.getHadoopServicePrincipal());
+			}
+			runDetachedModeTest(securityProperties);
+			verifyResultContainsKerberosKeytab();
+		});
+	}
+
+	private static void verifyResultContainsKerberosKeytab() throws Exception {
+		final String[] mustHave = {"Login successful for user", "using keytab file"};
+		final boolean jobManagerRunsWithKerberos = verifyStringsInNamedLogFiles(
+			mustHave,
+			"jobmanager.log");
+		final boolean taskManagerRunsWithKerberos = verifyStringsInNamedLogFiles(
+			mustHave, "taskmanager.log");
+
+		Assert.assertThat(
+			"The JobManager and the TaskManager should both run with Kerberos.",
+			jobManagerRunsWithKerberos && taskManagerRunsWithKerberos,
+			Matchers.is(true));
+
+		final List<String> amRMTokens = Lists.newArrayList(AMRMTokenIdentifier.KIND_NAME.toString());
+		final String jobmanagerContainerId = getContainerIdByLogName("jobmanager.log");
+		final String taskmanagerContainerId = getContainerIdByLogName("taskmanager.log");
+		final boolean jobmanagerWithAmRmToken = verifyTokenKindInContainerCredentials(amRMTokens, jobmanagerContainerId);
+		final boolean taskmanagerWithAmRmToken = verifyTokenKindInContainerCredentials(amRMTokens, taskmanagerContainerId);
+
+		Assert.assertThat(
+			"The JobManager should have AMRMToken.",
+			jobmanagerWithAmRmToken,
+			Matchers.is(true));
+		Assert.assertThat(
+			"The TaskManager should not have AMRMToken.",
+			taskmanagerWithAmRmToken,
+			Matchers.is(false));
 	}
 
 	/* For secure cluster testing, it is enough to run only one test and override below test methods

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -368,10 +368,7 @@ public final class Utils {
 	 */
 	public static String resolveKeytabPath(String workingDir, String keytabPath) {
 		String keytab = null;
-		if (keytabPath == null) { // keytab not exist
-			LOG.info("keytab path isn't configured!");
-			keytab = null;
-		} else {
+		if (keytabPath != null) {
 			File f;
 			f = new File(keytabPath);
 			if (f.exists()) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -71,9 +71,6 @@ public final class Utils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
-	/** Keytab file is default as a localize resource to YARN container. */
-	public static final Boolean DEFAULT_KEYTAB_LOCALIZE = true;
-
 	/** Keytab file name populated in YARN container. */
 	public static final String DEFAULT_KEYTAB_FILE = "krb5.keytab";
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -360,6 +360,40 @@ public final class Utils {
 	}
 
 	/**
+	 * Resolve keytab path either as absolute path or relative to working directory.
+	 *
+	 * @param workingDir current working directory
+	 * @param keytabPath configured keytab path.
+	 * @return resolved keytab path, or null if not found.
+	 */
+	public static String resolveKeytabPath(String workingDir, String keytabPath) {
+		String keytab = null;
+		if (keytabPath == null) { // keytab not exist
+			LOG.info("keytab path isn't configured!");
+			keytab = null;
+		} else {
+			File f;
+			f = new File(keytabPath);
+			if (f.exists()) {
+				keytab = f.getAbsolutePath();
+				LOG.info("Resolved keytab path: {}", keytab);
+			} else {
+				// try using relative paths, this is the case when the keytab was shipped
+				// as a local resource
+				f = new File(workingDir, keytabPath);
+				if (f.exists()) {
+					keytab = f.getAbsolutePath();
+					LOG.info("Resolved keytab path: {}", keytab);
+				} else {
+					LOG.warn("Could not resolve keytab path with: {}", keytabPath);
+					keytab = null;
+				}
+			}
+		}
+		return keytab;
+	}
+
+	/**
 	 * Private constructor to prevent instantiation.
 	 */
 	private Utils() {
@@ -600,5 +634,4 @@ public final class Utils {
 			throw new RuntimeException(String.format(message, values));
 		}
 	}
-
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -903,9 +903,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		String localizedKeytabPath = null;
 		String keytab = configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB);
 		if (keytab != null) {
-			boolean	requireLocalizedKeytab = flinkConfiguration.getBoolean(YarnConfigOptions.SHIP_LOCAL_KEYTAB);
+			boolean	localizeKeytab = flinkConfiguration.getBoolean(YarnConfigOptions.SHIP_LOCAL_KEYTAB);
 			localizedKeytabPath = flinkConfiguration.getString(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);
-			if (requireLocalizedKeytab) {
+			if (localizeKeytab) {
 				// Localize the keytab to YARN containers via local resource.
 				LOG.info("Adding keytab {} to the AM container local resource bucket", keytab);
 				remotePathKeytab = setupSingleLocalResource(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -36,7 +36,10 @@ public class YarnConfigKeys {
 	public static final String FLINK_JAR_PATH = "_FLINK_JAR_PATH"; // the Flink jar resource location (in HDFS).
 	public static final String FLINK_YARN_FILES = "_FLINK_YARN_FILES"; // the root directory for all yarn application files
 
+	@Deprecated
 	public static final String KEYTAB_PATH = "_KEYTAB_PATH";
+	public static final String REMOTE_KEYTAB_PATH = "_REMOTE_KEYTAB_PATH";
+	public static final String LOCAL_KEYTAB_PATH = "_LOCAL_KEYTAB_PATH";
 	public static final String KEYTAB_PRINCIPAL = "_KEYTAB_PRINCIPAL";
 	public static final String ENV_HADOOP_USER_NAME = "HADOOP_USER_NAME";
 	public static final String ENV_ZOOKEEPER_NAMESPACE = "_ZOOKEEPER_NAMESPACE";

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -36,8 +36,6 @@ public class YarnConfigKeys {
 	public static final String FLINK_JAR_PATH = "_FLINK_JAR_PATH"; // the Flink jar resource location (in HDFS).
 	public static final String FLINK_YARN_FILES = "_FLINK_YARN_FILES"; // the root directory for all yarn application files
 
-	@Deprecated
-	public static final String KEYTAB_PATH = "_KEYTAB_PATH";
 	public static final String REMOTE_KEYTAB_PATH = "_REMOTE_KEYTAB_PATH";
 	public static final String LOCAL_KEYTAB_PATH = "_LOCAL_KEYTAB_PATH";
 	public static final String KEYTAB_PRINCIPAL = "_KEYTAB_PRINCIPAL";

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
@@ -138,23 +137,7 @@ public class YarnTaskExecutorRunner {
 		// tell akka to die in case of an error
 		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
 
-		String keytabPath;
-		File f = new File(localKeytabPath);
-		if (f.exists()) {
-			keytabPath = f.getAbsolutePath();
-			LOG.info("keytab path: {}", keytabPath);
-		} else {
-			// try using relative paths, this is the case when the keytab was shipped
-			// as a local resource
-			f = new File(currDir, localKeytabPath);
-			if (f.exists()) {
-				keytabPath = f.getAbsolutePath();
-				LOG.info("keytab path: {}", keytabPath);
-			} else {
-				LOG.warn("Could not find keytab file: {}", localKeytabPath);
-				keytabPath = null;
-			}
-		}
+		String keytabPath = Utils.resolveKeytabPath(currDir, localKeytabPath);
 
 		UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -19,8 +19,8 @@
 package org.apache.flink.yarn.configuration;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.description.Description;
-import org.apache.flink.yarn.Utils;
 
 import java.util.List;
 
@@ -240,20 +240,25 @@ public class YarnConfigOptions {
 				.withDescription("Specify YARN node label for the YARN application.");
 
 	public static final ConfigOption<Boolean> SHIP_LOCAL_KEYTAB =
-		key("yarn.security.kerberos.ship-local-keytab")
-			.defaultValue(Utils.DEFAULT_KEYTAB_LOCALIZE)
-			.withDescription("With this configuration option, user can specify whether to submit the kerberos keytab" +
-				" file used on the client side as a localize resource. If set to true, Flink will upload the the keytab" +
-				" file configured in SecurityOption('security.kerberos.login.keytab') to YARN's container localize" +
-				" resource bucket with the specified relative path defined in 'yarn.security.kerberos.keytab.path'.");
+			key("yarn.security.kerberos.ship-local-keytab")
+					.booleanType()
+					.defaultValue(true)
+					.withDescription(
+							"When this is true Flink will ship the keytab file configured via " +
+									SecurityOptions.KERBEROS_LOGIN_KEYTAB.key() +
+									" as a localized YARN resource.");
 
 	public static final ConfigOption<String> LOCALIZED_KEYTAB_PATH =
-		key("yarn.security.kerberos.keytab")
-			.defaultValue(Utils.DEFAULT_KEYTAB_FILE)
-			.withDescription("With this configuration option, user can specify the path where kerberos keytab file will be" +
-				" localized to. If 'yarn.security.kerberos.require.localize.keytab' set to true, Flink will set the keytab" +
-				" file as YARN localize resource, path is relative to the local resource directory; If set to false, Flink" +
-				" will try to directly locate the keytab from the path itself.");
+			key("yarn.security.kerberos.localized-keytab-path")
+					.stringType()
+					.defaultValue("krb5.keytab")
+					.withDescription(
+							"Local (on NodeManager) path where kerberos keytab file will be" +
+									" localized to. If " + SHIP_LOCAL_KEYTAB.key() + " set to " +
+									"true, Flink willl ship the keytab file as a YARN local " +
+									"resource. In this case, the path is relative to the local " +
+									"resource directory. If set to false, Flink" +
+									" will try to directly locate the keytab from the path itself.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn.configuration;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.yarn.Utils;
 
 import java.util.List;
 
@@ -237,6 +238,22 @@ public class YarnConfigOptions {
 				.stringType()
 				.noDefaultValue()
 				.withDescription("Specify YARN node label for the YARN application.");
+
+	public static final ConfigOption<Boolean> SHIP_LOCAL_KEYTAB =
+		key("yarn.security.kerberos.ship-local-keytab")
+			.defaultValue(Utils.DEFAULT_KEYTAB_LOCALIZE)
+			.withDescription("With this configuration option, user can specify whether to submit the kerberos keytab" +
+				" file used on the client side as a localize resource. If set to true, Flink will upload the the keytab" +
+				" file configured in SecurityOption('security.kerberos.login.keytab') to YARN's container localize" +
+				" resource bucket with the specified relative path defined in 'yarn.security.kerberos.keytab.path'.");
+
+	public static final ConfigOption<String> LOCALIZED_KEYTAB_PATH =
+		key("yarn.security.kerberos.keytab")
+			.defaultValue(Utils.DEFAULT_KEYTAB_FILE)
+			.withDescription("With this configuration option, user can specify the path where kerberos keytab file will be" +
+				" localized to. If 'yarn.security.kerberos.require.localize.keytab' set to true, Flink will set the keytab" +
+				" file as YARN localize resource, path is relative to the local resource directory; If set to false, Flink" +
+				" will try to directly locate the keytab from the path itself.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -87,7 +87,7 @@ public class YarnEntrypointUtils {
 			ConfigConstants.YARN_TASK_MANAGER_ENV_PREFIX,
 			ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX);
 
-		final String keytabPath = Utils.resolveKeytabPath(workingDirectory, YarnConfigKeys.LOCAL_KEYTAB_PATH);
+		final String keytabPath = Utils.resolveKeytabPath(workingDirectory, env.get(YarnConfigKeys.LOCAL_KEYTAB_PATH));
 
 		if (keytabPath != null && keytabPrincipal != null) {
 			configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -29,13 +29,13 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.yarn.Utils;
 import org.apache.flink.yarn.YarnConfigKeys;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.slf4j.Logger;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
@@ -87,20 +87,7 @@ public class YarnEntrypointUtils {
 			ConfigConstants.YARN_TASK_MANAGER_ENV_PREFIX,
 			ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX);
 
-		final String keytabPath;
-
-		if (env.get(YarnConfigKeys.LOCAL_KEYTAB_PATH) == null) { // keytab not exist
-			keytabPath = null;
-		} else {
-			File f;
-			f = new File(env.get(YarnConfigKeys.LOCAL_KEYTAB_PATH));
-			if (f.exists()) { // keytab file exist in host environment.
-				keytabPath = f.getAbsolutePath();
-			} else {
-				f = new File(workingDirectory, env.get(YarnConfigKeys.LOCAL_KEYTAB_PATH));
-				keytabPath = f.getAbsolutePath();
-			}
-		}
+		final String keytabPath = Utils.resolveKeytabPath(workingDirectory, YarnConfigKeys.LOCAL_KEYTAB_PATH);
 
 		if (keytabPath != null && keytabPrincipal != null) {
 			configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.yarn.Utils;
 import org.apache.flink.yarn.YarnConfigKeys;
 
 import org.apache.hadoop.security.UserGroupInformation;
@@ -99,12 +98,7 @@ public class YarnEntrypointUtils {
 				keytabPath = f.getAbsolutePath();
 			} else {
 				f = new File(workingDirectory, env.get(YarnConfigKeys.LOCAL_KEYTAB_PATH));
-				if (f.exists()) { // keytab file exist in working directory.
-					keytabPath = f.getAbsolutePath();
-				} else { // fall back to default keytab file
-					f = new File(workingDirectory, Utils.DEFAULT_KEYTAB_FILE);
-					keytabPath = f.getAbsolutePath();
-				}
+				keytabPath = f.getAbsolutePath();
 			}
 		}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -44,12 +45,14 @@ import static org.junit.Assert.fail;
 public class YarnTaskExecutorRunnerTest extends TestLogger {
 
 	@Test
-	public void testKerberosKeytabConfiguration() throws Exception {
+	public void testDefaultKerberosKeytabConfiguration() throws Exception {
 		final String resourceDirPath = Paths.get("src", "test", "resources").toAbsolutePath().toString();
 
 		final Map<String, String> envs = new HashMap<>(2);
 		envs.put(YarnConfigKeys.KEYTAB_PRINCIPAL, "testuser1@domain");
-		envs.put(YarnConfigKeys.KEYTAB_PATH, resourceDirPath);
+		envs.put(YarnConfigKeys.REMOTE_KEYTAB_PATH, resourceDirPath);
+		// Local keytab path will be populated from default YarnConfigOptions.LOCALIZED_KEYTAB_PATH
+		envs.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, Utils.DEFAULT_KEYTAB_FILE);
 
 		Configuration configuration = new Configuration();
 		YarnTaskExecutorRunner.setupConfigurationAndInstallSecurityContext(configuration, resourceDirPath, envs);
@@ -60,13 +63,41 @@ public class YarnTaskExecutorRunnerTest extends TestLogger {
 		if (moduleOpt.isPresent()) {
 			HadoopModule hadoopModule = (HadoopModule) moduleOpt.get();
 			assertThat(hadoopModule.getSecurityConfig().getPrincipal(), is("testuser1@domain"));
-			assertThat(hadoopModule.getSecurityConfig().getKeytab(), is(new File(resourceDirPath, Utils.KEYTAB_FILE_NAME).getAbsolutePath()));
+			assertThat(hadoopModule.getSecurityConfig().getKeytab(), is(new File(resourceDirPath, Utils.DEFAULT_KEYTAB_FILE).getAbsolutePath()));
 		} else {
 			fail("Can not find HadoopModule!");
 		}
 
-		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB), is(new File(resourceDirPath, Utils.KEYTAB_FILE_NAME).getAbsolutePath()));
+		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB), is(new File(resourceDirPath, Utils.DEFAULT_KEYTAB_FILE).getAbsolutePath()));
 		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL), is("testuser1@domain"));
 	}
 
+	@Test
+	public void testPreInstallKerberosKeytabConfiguration() throws Exception {
+		final String resourceDirPath = Paths.get("src", "test", "resources").toAbsolutePath().toString();
+
+		final Map<String, String> envs = new HashMap<>(2);
+		envs.put(YarnConfigKeys.KEYTAB_PRINCIPAL, "testuser1@domain");
+		// Try directly resolving local path when no remote keytab path is provided.
+		envs.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, "src/test/resources/krb5.keytab");
+
+		Configuration configuration = new Configuration();
+		YarnTaskExecutorRunner.setupConfigurationAndInstallSecurityContext(configuration, resourceDirPath, envs);
+
+		final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
+		Optional<SecurityModule> moduleOpt = modules.stream().filter(module -> module instanceof HadoopModule).findFirst();
+
+		if (moduleOpt.isPresent()) {
+			HadoopModule hadoopModule = (HadoopModule) moduleOpt.get();
+			assertThat(hadoopModule.getSecurityConfig().getPrincipal(), is("testuser1@domain"));
+			// Using containString verification as the absolute path varies depending on runtime environment
+			assertThat(hadoopModule.getSecurityConfig().getKeytab(), containsString("src/test/resources/krb5.keytab"));
+		} else {
+			fail("Can not find HadoopModule!");
+		}
+
+		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB), containsString("src/test/resources/krb5.keytab"));
+		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL), is("testuser1@domain"));
+
+	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.modules.HadoopModule;
 import org.apache.flink.runtime.security.modules.SecurityModule;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.junit.Test;
 
@@ -52,7 +53,7 @@ public class YarnTaskExecutorRunnerTest extends TestLogger {
 		envs.put(YarnConfigKeys.KEYTAB_PRINCIPAL, "testuser1@domain");
 		envs.put(YarnConfigKeys.REMOTE_KEYTAB_PATH, resourceDirPath);
 		// Local keytab path will be populated from default YarnConfigOptions.LOCALIZED_KEYTAB_PATH
-		envs.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, Utils.DEFAULT_KEYTAB_FILE);
+		envs.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, YarnConfigOptions.LOCALIZED_KEYTAB_PATH.defaultValue());
 
 		Configuration configuration = new Configuration();
 		YarnTaskExecutorRunner.setupConfigurationAndInstallSecurityContext(configuration, resourceDirPath, envs);
@@ -63,12 +64,12 @@ public class YarnTaskExecutorRunnerTest extends TestLogger {
 		if (moduleOpt.isPresent()) {
 			HadoopModule hadoopModule = (HadoopModule) moduleOpt.get();
 			assertThat(hadoopModule.getSecurityConfig().getPrincipal(), is("testuser1@domain"));
-			assertThat(hadoopModule.getSecurityConfig().getKeytab(), is(new File(resourceDirPath, Utils.DEFAULT_KEYTAB_FILE).getAbsolutePath()));
+			assertThat(hadoopModule.getSecurityConfig().getKeytab(), is(new File(resourceDirPath, YarnConfigOptions.LOCALIZED_KEYTAB_PATH.defaultValue()).getAbsolutePath()));
 		} else {
 			fail("Can not find HadoopModule!");
 		}
 
-		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB), is(new File(resourceDirPath, Utils.DEFAULT_KEYTAB_FILE).getAbsolutePath()));
+		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB), is(new File(resourceDirPath, YarnConfigOptions.LOCALIZED_KEYTAB_PATH.defaultValue()).getAbsolutePath()));
 		assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL), is("testuser1@domain"));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

There're 2 ways of utilizing Kerberos keytab files:
1. Flink client upload Kerberos keytab files through Yarn local resource bucket.
2. Flink YARN containers directly load pre-installed Kerberos keytab files from local file system.

Previously Flink only support method #1. This PR introduces two new configuration keys in the YARN configurations to support method #2.


## Brief change log

  - Added two new key with default values 
    - `yarn.security.kerberos.keytab` indicates where the keytab file should be on YARN container.
    - `yarn.security.kerberos.ship-local-keytab`: If set to true, Flink will upload the client keytab used in its own section to YARN local resource bucket. if set to false, Flink will assume the path configured in `yarn.security.kerberos.keytab` already exists and with proper permission.
  - Changed YarnClusterDescriptor to work with 2 options above.
  - Changed the YarnTaskExecutorRunner to load keytab configurations differently according to 2 options above.


## Verifying this change

This change is already covered by existing tests in `flink-yarn-test` component.

This change also added tests 
  - added additional test config parsing in YarnTaskExecutorRunnerTest.
  - Modified YARNSessionFIFOITCase and YARNSessionFIFOSecuredITCase to allow dynamic properties loading during test sections.
  - Added specific section for pre-installed YARN Kerberos keytab file.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? document regenerated
