### PR TITLE
[FLINK-11589][Security] Service provider for security module and context discovery

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -53,7 +53,7 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -1121,8 +1121,8 @@ public class CliFrontend {
 				configuration,
 				customCommandLines);
 
-			SecurityUtils.install(new SecurityConfiguration(cli.configuration));
-			int retCode = SecurityUtils.getInstalledContext()
+			SecurityEnvironment.install(new SecurityConfiguration(cli.configuration));
+			int retCode = SecurityEnvironment.getInstalledContext()
 					.runSecured(() -> cli.parseParameters(args));
 			System.exit(retCode);
 		}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkSecuredITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkSecuredITCase.java
@@ -24,9 +24,10 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.factories.DefaultSecurityContextFactory;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.connectors.fs.utils.TestHadoopModuleFactory;
 import org.apache.flink.test.util.SecureTestEnvironment;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.test.util.TestingSecurityContext;
@@ -117,7 +118,11 @@ public class RollingSinkSecuredITCase extends RollingSinkITCase {
 		SecurityConfiguration ctx =
 			new SecurityConfiguration(
 				flinkConfig,
-				Collections.singletonList(securityConfig -> new HadoopModule(securityConfig, conf)));
+				DefaultSecurityContextFactory.class.getName(),
+				Collections.singletonList(TestHadoopModuleFactory.class.getCanonicalName()));
+
+		ctx.setProperty(TestHadoopModuleFactory.HADOOP_PROPERTY_CONFIG_KEY, conf);
+
 		try {
 			TestingSecurityContext.install(ctx, SecureTestEnvironment.getClientSecurityConfigurationMap());
 		} catch (Exception e) {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/utils/TestHadoopModuleFactory.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/utils/TestHadoopModuleFactory.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.fs.utils;
+
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.factories.SecurityModuleFactory;
+import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Test hadoop security module factory that loads customized hadoop configuration properties.
+ */
+public class TestHadoopModuleFactory implements SecurityModuleFactory {
+
+	public static final String HADOOP_PROPERTY_CONFIG_KEY = "testing.hadoop.configuration";
+
+	@Override
+	public SecurityModule createModule(SecurityConfiguration securityConfig) {
+		return new HadoopModule(securityConfig, (Configuration) securityConfig.getProperty(HADOOP_PROPERTY_CONFIG_KEY));
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
+++ b/flink-connectors/flink-connector-filesystem/src/test/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.streaming.connectors.fs.utils.TestHadoopModuleFactory

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -25,7 +25,7 @@ import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
@@ -102,10 +102,10 @@ public class MesosTaskExecutorRunner {
 
 		// Run the TM in the security context
 		SecurityConfiguration sc = new SecurityConfiguration(configuration);
-		SecurityUtils.install(sc);
+		SecurityEnvironment.install(sc);
 
 		try {
-			SecurityUtils.getInstalledContext().runSecured(() -> {
+			SecurityEnvironment.getInstalledContext().runSecured(() -> {
 				TaskManagerRunner.runTaskManager(configuration, resourceId);
 
 				return 0;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.rest.handler.legacy.JsonFactory;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.runtime.webmonitor.utils.WebFrontendBootstrap;
 import org.apache.flink.util.ExceptionUtils;
@@ -116,10 +116,10 @@ public class HistoryServer {
 		}
 
 		// run the history server
-		SecurityUtils.install(new SecurityConfiguration(flinkConfig));
+		SecurityEnvironment.install(new SecurityConfiguration(flinkConfig));
 
 		try {
-			SecurityUtils.getInstalledContext().runSecured(new Callable<Integer>() {
+			SecurityEnvironment.getInstalledContext().runSecured(new Callable<Integer>() {
 				@Override
 				public Integer call() throws Exception {
 					HistoryServer hs = new HistoryServer(flinkConfig);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -51,8 +51,8 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityContext;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaQueryServiceRetriever;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -197,9 +197,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {
 		LOG.info("Install security context.");
 
-		SecurityUtils.install(new SecurityConfiguration(configuration));
+		SecurityEnvironment.install(new SecurityConfiguration(configuration));
 
-		return SecurityUtils.getInstalledContext();
+		return SecurityEnvironment.getInstalledContext();
 	}
 
 	private void runCluster(Configuration configuration) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/contexts/NoOpSecurityContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/contexts/NoOpSecurityContext.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.contexts;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A security context that simply runs a Callable without performing a login action.
+ */
+public class NoOpSecurityContext implements SecurityContext {
+
+	@Override
+	public <T> T runSecured(Callable<T> securedCallable) throws Exception {
+		return securedCallable.call();
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/contexts/SecurityContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/contexts/SecurityContext.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.contexts;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A security context with may be required to run a Callable.
+ */
+public interface SecurityContext {
+
+	<T> T runSecured(Callable<T> securedCallable) throws Exception;
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/DefaultSecurityContextFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/DefaultSecurityContextFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.factories;
+
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.contexts.HadoopSecurityContext;
+import org.apache.flink.runtime.security.contexts.NoOpSecurityContext;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Default security context factory that instantiates {@link SecurityContext}
+ * based on installed modules, it would instantiate {@link HadoopSecurityContext} if
+ * a {@link HadoopModuleFactory} is included.
+ */
+public class DefaultSecurityContextFactory implements SecurityContextFactory {
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultSecurityContextFactory.class);
+
+	@Override
+	public SecurityContext createContext(SecurityConfiguration securityConfig) {
+		// First check if we have installed hadoop security module and if Hadoop is in the ClassPath.
+		// If required by the context but doesn't exist in ClassPath, we return default NoOpContext
+		if (securityConfig.getSecurityModuleFactories().contains(HadoopModuleFactory.class.getCanonicalName())) {
+			try {
+				Class.forName(
+					"org.apache.hadoop.security.UserGroupInformation",
+					false,
+					DefaultSecurityContextFactory.class.getClassLoader());
+				UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
+				return new HadoopSecurityContext(loginUser);
+			} catch (ClassNotFoundException e) {
+				LOG.info("Cannot install HadoopSecurityContext because Hadoop cannot be found in the Classpath.");
+			} catch (LinkageError | IOException e) {
+				LOG.error("Cannot install HadoopSecurityContext.", e);
+			}
+			return new NoOpSecurityContext();
+		}
+		else {
+			return new NoOpSecurityContext();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/HadoopModuleFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/HadoopModuleFactory.java
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.modules;
+package org.apache.flink.runtime.security.factories;
 
 import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
 import org.apache.flink.runtime.util.HadoopUtils;
 
 import org.apache.hadoop.conf.Configuration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/JaasModuleFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/JaasModuleFactory.java
@@ -16,18 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security;
+package org.apache.flink.runtime.security.factories;
 
-import java.util.concurrent.Callable;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.modules.JaasModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
 
 /**
- * A security context that simply runs a Callable without performing a login action.
+ * A {@link SecurityModuleFactory} for {@link JaasModule}.
  */
-class NoOpSecurityContext implements SecurityContext {
+public class JaasModuleFactory implements SecurityModuleFactory {
 
 	@Override
-	public <T> T runSecured(Callable<T> securedCallable) throws Exception {
-		return securedCallable.call();
+	public SecurityModule createModule(SecurityConfiguration securityConfig) {
+		return new JaasModule(securityConfig);
 	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/NoMatchSecurityFactoryException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/NoMatchSecurityFactoryException.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.factories;
+
+import java.util.List;
+
+/**
+ * Exception for not finding suitable {@link SecurityFactory}.
+ */
+public class NoMatchSecurityFactoryException extends RuntimeException {
+
+	/**
+	 * Exception for not finding suitable {@link SecurityFactory}.
+	 *
+	 * @param message message that indicates the current matching step
+	 * @param factoryClassCanonicalName required factory class
+	 * @param matchingFactories all found factories
+	 * @param cause the cause
+	 */
+	public NoMatchSecurityFactoryException(
+		String message,
+		String factoryClassCanonicalName,
+		List<SecurityFactory> matchingFactories,
+		Throwable cause) {
+		super("Could not find a suitable security factory for '"
+			+ factoryClassCanonicalName + "' in the classpath. all matching factories: "
+			+ matchingFactories + ". Reason: " + message, cause);
+	}
+
+	/**
+	 * Exception for not finding suitable {@link SecurityFactory}.
+	 *
+	 * @param message message that indicates the current matching step
+	 * @param factoryClassCanonicalName required factory class
+	 * @param matchingFactories all found factories
+	 */
+	public NoMatchSecurityFactoryException(
+		String message,
+		String factoryClassCanonicalName,
+		List<SecurityFactory> matchingFactories) {
+		this(message, factoryClassCanonicalName, matchingFactories, null);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityContextFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityContextFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.factories;
+
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
+
+/**
+ *
+ */
+@FunctionalInterface
+public interface SecurityContextFactory extends SecurityFactory {
+
+	/**
+	 *
+	 * @param securityConfig
+	 * @return
+	 */
+	SecurityContext createContext(SecurityConfiguration securityConfig);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.factories;
+
+/**
+ * Base class for all security related security factory instantiable.
+ */
+public interface SecurityFactory {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityFactoryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityFactoryService.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.factories;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * The Service provider discovery for searching suitable {@link SecurityFactory}
+ * based on provided requirements.
+ */
+public class SecurityFactoryService {
+
+	private static ServiceLoader<SecurityFactory> defaultLoader =
+		ServiceLoader.load(SecurityFactory.class);
+
+	/**
+	 * Find a suitable {@link SecurityModuleFactory} based on canonical name.
+	 */
+	public static SecurityModuleFactory findModuleFactory(String securityModuleFactoryClass) throws NoMatchSecurityFactoryException {
+		return (SecurityModuleFactory) findFactoryInternal(
+			securityModuleFactoryClass,
+			SecurityModuleFactory.class.getClassLoader());
+	}
+
+	/**
+	 * Find a suitable {@link SecurityContextFactory} based on canonical name.
+	 */
+	public static SecurityContextFactory findContextFactory(String securityContextFactoryClass) throws NoMatchSecurityFactoryException {
+		return (SecurityContextFactory) findFactoryInternal(
+			securityContextFactoryClass,
+			SecurityContextFactory.class.getClassLoader());
+	}
+
+	private static SecurityFactory findFactoryInternal(
+		String factoryClassCanonicalName,
+		ClassLoader classLoader) throws NoMatchSecurityFactoryException {
+
+		Preconditions.checkNotNull(factoryClassCanonicalName);
+
+		ServiceLoader<SecurityFactory> serviceLoader = null;
+
+		if (classLoader != null) {
+			serviceLoader = ServiceLoader.load(SecurityFactory.class, classLoader);
+		} else {
+			serviceLoader = defaultLoader;
+		}
+
+		List<SecurityFactory> matchingFactories = new ArrayList<>();
+		Iterator<SecurityFactory> classFactoryIterator = serviceLoader.iterator();
+		classFactoryIterator.forEachRemaining(classFactory -> {
+			if (factoryClassCanonicalName.matches(classFactory.getClass().getCanonicalName())) {
+				matchingFactories.add(classFactory);
+			}
+		});
+
+		if (matchingFactories.isEmpty() || matchingFactories.size() > 1) {
+			throw new NoMatchSecurityFactoryException(
+				"zero or more than one security factory found",
+				factoryClassCanonicalName,
+				matchingFactories
+			);
+		}
+		return matchingFactories.get(0);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityModuleFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/SecurityModuleFactory.java
@@ -16,29 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security;
+package org.apache.flink.runtime.security.factories;
 
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.modules.SecurityModule;
 
-import org.apache.hadoop.security.UserGroupInformation;
-
-import java.security.PrivilegedExceptionAction;
-import java.util.concurrent.Callable;
-
-/*
- * Hadoop security context which runs a Callable with the previously
- * initialized UGI and appropriate security credentials.
+/**
+ * A factory for a {@link SecurityModule}. A factory can determine whether a {@link SecurityModule}
+ * works in the given environment (for example, it can check whether Hadoop dependencies are
+ * available) and can then create (or not) a module based on that.
  */
-class HadoopSecurityContext implements SecurityContext {
+@FunctionalInterface
+public interface SecurityModuleFactory extends SecurityFactory {
 
-	private final UserGroupInformation ugi;
-
-	HadoopSecurityContext(UserGroupInformation ugi) {
-		this.ugi = Preconditions.checkNotNull(ugi, "UGI passed cannot be null");
-	}
-
-	public <T> T runSecured(final Callable<T> securedCallable) throws Exception {
-		return ugi.doAs((PrivilegedExceptionAction<T>) securedCallable::call);
-	}
-
+	/**
+	 * Creates and returns a {@link SecurityModule}. This can return {@code null} if the type
+	 * of {@link SecurityModule} that this factory can create does not work in the current
+	 * environment.
+	 */
+	SecurityModule createModule(SecurityConfiguration securityConfig);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/ZookeeperModuleFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/factories/ZookeeperModuleFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.factories;
+
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.modules.SecurityModule;
+import org.apache.flink.runtime.security.modules.ZooKeeperModule;
+
+/**
+ * A {@link SecurityModuleFactory} for {@link ZooKeeperModule}.
+ */
+public class ZookeeperModuleFactory implements SecurityModuleFactory {
+
+	@Override
+	public SecurityModule createModule(SecurityConfiguration securityConfig) {
+		return new ZooKeeperModule(securityConfig);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -46,7 +46,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
@@ -294,10 +294,10 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 				"filesystem scheme from configuration.", e);
 		}
 
-		SecurityUtils.install(new SecurityConfiguration(configuration));
+		SecurityEnvironment.install(new SecurityConfiguration(configuration));
 
 		try {
-			SecurityUtils.getInstalledContext().runSecured(new Callable<Void>() {
+			SecurityEnvironment.getInstalledContext().runSecured(new Callable<Void>() {
 				@Override
 				public Void call() throws Exception {
 					runTaskManager(configuration, ResourceID.generate());

--- a/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
+++ b/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.runtime.security.factories.DefaultSecurityContextFactory
+org.apache.flink.runtime.security.factories.HadoopModuleFactory
+org.apache.flink.runtime.security.factories.JaasModuleFactory
+org.apache.flink.runtime.security.factories.ZookeeperModuleFactory

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -78,7 +78,7 @@ import org.apache.flink.runtime.metrics.{MetricRegistryConfiguration, MetricRegi
 import org.apache.flink.runtime.process.ProcessReaper
 import org.apache.flink.runtime.query.KvStateMessage.{LookupKvStateLocation, NotifyKvStateRegistered, NotifyKvStateUnregistered}
 import org.apache.flink.runtime.query.{KvStateMessage, UnknownKvStateLocation}
-import org.apache.flink.runtime.security.{SecurityConfiguration, SecurityUtils}
+import org.apache.flink.runtime.security.{SecurityConfiguration, SecurityEnvironment}
 import org.apache.flink.runtime.taskexecutor.TaskExecutor
 import org.apache.flink.runtime.taskmanager.TaskManager
 import org.apache.flink.runtime.util._
@@ -1969,10 +1969,10 @@ object JobManager {
     }
 
     // run the job manager
-    SecurityUtils.install(new SecurityConfiguration(configuration))
+    SecurityEnvironment.install(new SecurityConfiguration(configuration))
 
     try {
-      SecurityUtils.getInstalledContext.runSecured(new Callable[Unit] {
+      SecurityEnvironment.getInstalledContext.runSecured(new Callable[Unit] {
         override def call(): Unit = {
           runJobManager(
             configuration,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -66,7 +66,7 @@ import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup
 import org.apache.flink.runtime.metrics.util.MetricUtils
 import org.apache.flink.runtime.metrics.{MetricRegistryConfiguration, MetricRegistryImpl, MetricRegistry => FlinkMetricRegistry}
 import org.apache.flink.runtime.process.ProcessReaper
-import org.apache.flink.runtime.security.{SecurityConfiguration, SecurityUtils}
+import org.apache.flink.runtime.security.{SecurityConfiguration, SecurityEnvironment}
 import org.apache.flink.runtime.state.{TaskExecutorLocalStateStoresManager, TaskStateManagerImpl}
 import org.apache.flink.runtime.taskexecutor.{TaskExecutor, TaskManagerConfiguration, TaskManagerServices, TaskManagerServicesConfiguration}
 import org.apache.flink.runtime.util._
@@ -1608,10 +1608,10 @@ object TaskManager {
     val resourceId = ResourceID.generate()
 
     // run the TaskManager (if requested in an authentication enabled context)
-    SecurityUtils.install(new SecurityConfiguration(configuration))
+    SecurityEnvironment.install(new SecurityConfiguration(configuration))
 
     try {
-      SecurityUtils.getInstalledContext.runSecured(new Callable[Unit] {
+      SecurityEnvironment.getInstalledContext.runSecured(new Callable[Unit] {
         override def call(): Unit = {
           selectNetworkInterfaceAndRunTaskManager(configuration, resourceId, classOf[TaskManager])
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/factories/TestSecurityContextFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/factories/TestSecurityContextFactory.java
@@ -16,17 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.modules;
+package org.apache.flink.runtime.security.factories;
 
 import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
+
+import java.util.concurrent.Callable;
 
 /**
- * A {@link SecurityModuleFactory} for {@link JaasModule}.
+ * Test security context factory class for service provider discovery.
  */
-public class JaasModuleFactory implements SecurityModuleFactory {
+public class TestSecurityContextFactory implements SecurityContextFactory {
 
 	@Override
-	public SecurityModule createModule(SecurityConfiguration securityConfig) {
-		return new JaasModule(securityConfig);
+	public SecurityContext createContext(SecurityConfiguration securityConfig) {
+		return new TestSecurityContext();
+	}
+
+	/**
+	 * Test security context class.
+	 */
+	public static class TestSecurityContext implements SecurityContext {
+
+		@Override
+		public <T> T runSecured(Callable<T> securedCallable) throws Exception {
+			return null;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/factories/TestSecurityModuleFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/factories/TestSecurityModuleFactory.java
@@ -16,15 +16,35 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security;
+package org.apache.flink.runtime.security.factories;
 
-import java.util.concurrent.Callable;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.modules.SecurityModule;
 
 /**
- * A security context with may be required to run a Callable.
+ * Test security module factory class for service provider discovery.
  */
-public interface SecurityContext {
+public class TestSecurityModuleFactory implements SecurityModuleFactory {
 
-	<T> T runSecured(Callable<T> securedCallable) throws Exception;
+	@Override
+	public SecurityModule createModule(SecurityConfiguration securityConfig) {
+		return new TestSecurityModule();
+	}
 
+	/**
+	 * Test security module class.
+	 */
+	public static class TestSecurityModule implements SecurityModule {
+		public boolean installed;
+
+		@Override
+		public void install() throws SecurityInstallException {
+			installed = true;
+		}
+
+		@Override
+		public void uninstall() throws SecurityInstallException {
+			installed = false;
+		}
+	}
 }

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.runtime.security.factories.TestSecurityContextFactory
+org.apache.flink.runtime.security.factories.TestSecurityModuleFactory

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestingSecurityContext.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestingSecurityContext.java
@@ -22,9 +22,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.security.DynamicConfiguration;
 import org.apache.flink.runtime.security.KerberosUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
-import org.apache.flink.runtime.security.modules.JaasModuleFactory;
-import org.apache.flink.runtime.security.modules.SecurityModuleFactory;
+import org.apache.flink.runtime.security.SecurityEnvironment;
+import org.apache.flink.runtime.security.factories.JaasModuleFactory;
+import org.apache.flink.runtime.security.factories.SecurityFactoryService;
+import org.apache.flink.runtime.security.factories.SecurityModuleFactory;
 
 import javax.security.auth.login.AppConfigurationEntry;
 
@@ -41,10 +42,11 @@ public class TestingSecurityContext {
 						Map<String, ClientSecurityConfiguration> clientSecurityConfigurationMap)
 			throws Exception {
 
-		SecurityUtils.install(config);
+		SecurityEnvironment.install(config);
 
 		// install dynamic JAAS entries
-		for (SecurityModuleFactory factory : config.getSecurityModuleFactories()) {
+		for (String factoryClassName : config.getSecurityModuleFactories()) {
+			SecurityModuleFactory factory = SecurityFactoryService.findModuleFactory(factoryClassName);
 			if (factory instanceof JaasModuleFactory) {
 				DynamicConfiguration jaasConf = (DynamicConfiguration) javax.security.auth.login.Configuration.getConfiguration();
 				for (Map.Entry<String, ClientSecurityConfiguration> e : clientSecurityConfigurationMap.entrySet()) {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/TestHadoopModuleFactory.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/util/TestHadoopModuleFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.modules;
+package org.apache.flink.yarn.util;
 
 import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.factories.SecurityModuleFactory;
+import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
+
+import org.apache.hadoop.conf.Configuration;
 
 /**
- * A {@link SecurityModuleFactory} for {@link ZooKeeperModule}.
+ * Test hadoop security module factory that loads customized hadoop configuration properties.
  */
-public class ZookeeperModuleFactory implements SecurityModuleFactory {
+public class TestHadoopModuleFactory implements SecurityModuleFactory {
+
+	public static final String HADOOP_PROPERTY_CONFIG_KEY = "testing.hadoop.configuration";
 
 	@Override
 	public SecurityModule createModule(SecurityConfiguration securityConfig) {
-		return new ZooKeeperModule(securityConfig);
+		return new HadoopModule(securityConfig, (Configuration) securityConfig.getProperty(HADOOP_PROPERTY_CONFIG_KEY));
 	}
 }

--- a/flink-yarn-tests/src/test/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
+++ b/flink-yarn-tests/src/test/resources/META-INF/services/org.apache.flink.runtime.security.factories.SecurityFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.yarn.util.TestHadoopModuleFactory

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -28,7 +28,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
@@ -100,7 +100,7 @@ public class YarnTaskExecutorRunner {
 			Preconditions.checkArgument(containerId != null,
 				"ContainerId variable %s not set", YarnResourceManager.ENV_FLINK_CONTAINER_ID);
 
-			SecurityUtils.getInstalledContext().runSecured((Callable<Void>) () -> {
+			SecurityEnvironment.getInstalledContext().runSecured((Callable<Void>) () -> {
 				TaskManagerRunner.runTaskManager(configuration, new ResourceID(containerId));
 				return null;
 			});
@@ -163,6 +163,6 @@ public class YarnTaskExecutorRunner {
 
 	private static void installSecurityContext(Configuration configuration) throws Exception {
 		SecurityConfiguration sc = new SecurityConfiguration(configuration);
-		SecurityUtils.install(sc);
+		SecurityEnvironment.install(sc);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
@@ -833,9 +833,9 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 				"",
 				""); // no prefix for the YARN session
 
-			SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
+			SecurityEnvironment.install(new SecurityConfiguration(flinkConfiguration));
 
-			retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args));
+			retCode = SecurityEnvironment.getInstalledContext().runSecured(() -> cli.run(args));
 		} catch (CliArgsException e) {
 			retCode = handleCliArgsException(e);
 		} catch (Throwable t) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -29,8 +29,8 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.SecurityContext;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.Utils;
 import org.apache.flink.yarn.YarnConfigKeys;
@@ -56,9 +56,9 @@ public class YarnEntrypointUtils {
 
 		SecurityConfiguration sc = new SecurityConfiguration(configuration);
 
-		SecurityUtils.install(sc);
+		SecurityEnvironment.install(sc);
 
-		return SecurityUtils.getInstalledContext();
+		return SecurityEnvironment.getInstalledContext();
 	}
 
 	public static Configuration loadConfiguration(String workingDirectory, Map<String, String> env, Logger log) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever;
 import org.apache.flink.runtime.entrypoint.component.JobDispatcherResourceManagerComponentFactory;
-import org.apache.flink.runtime.security.SecurityContext;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.SessionDispatcherResourceManagerComponentFactory;
-import org.apache.flink.runtime.security.SecurityContext;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.SecurityEnvironment;
 import org.apache.flink.runtime.security.modules.HadoopModule;
 import org.apache.flink.runtime.security.modules.SecurityModule;
 import org.apache.flink.util.TestLogger;
@@ -54,7 +54,7 @@ public class YarnTaskExecutorRunnerTest extends TestLogger {
 		Configuration configuration = new Configuration();
 		YarnTaskExecutorRunner.setupConfigurationAndInstallSecurityContext(configuration, resourceDirPath, envs);
 
-		final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
+		final List<SecurityModule> modules = SecurityEnvironment.getInstalledModules();
 		Optional<SecurityModule> moduleOpt = modules.stream().filter(module -> module instanceof HadoopModule).findFirst();
 
 		if (moduleOpt.isPresent()) {


### PR DESCRIPTION
## What is the purpose of the change

This PR refactors `SecurityUtils.class` in `flink-runtime` and replace with an extendable module based on the [service provider pattern](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html). With this extension, users can {create extendable security modules](https://docs.oracle.com/javase/tutorial/ext/basics/spi.html) with 3rd-party implementations. 


## Brief change log

  - Added SecurityFactoryService class for discovering installed SecurityFactory(s) in the classpath.
    - Extended into SecurityModuleFactory and SecurityContextFactory.
  - Replace SecurityUtils with SecurityEnvironment class that holds all installed security-related objects. 
  - Replace current security installation process with a 2-step installation - first install security module(s) per user-defined properties, then install security context based on security modules and properties
  - Refactored current Hadoop/JaaS/Zookeeper modules into extendable class. 


## Verifying this change

This change is already covered by existing tests in `flink-runtime` and ITCases in YARN and Kafka modules, also added to the tests:
  - Modified YARN and Kafka test modules to install modules/context through service provider discovery
  - Included test module factories and a default security context factory in test path.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes (affects security installation)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not yet, awaits review.
