### PR TITLE
[FLINK-11604][network] Extend the necessary methods in ResultPartitionWriter interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -19,8 +19,14 @@
 package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferPoolOwner;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 
 import java.io.IOException;
 
@@ -31,11 +37,25 @@ public interface ResultPartitionWriter {
 
 	BufferProvider getBufferProvider();
 
+	BufferPool getBufferPool();
+
+	BufferPoolOwner getBufferPoolOwner();
+
 	ResultPartitionID getPartitionId();
+
+	ResultPartitionType getPartitionType();
+
+	ResultSubpartition[] getAllSubPartitions();
 
 	int getNumberOfSubpartitions();
 
+	int getNumberOfQueuedBuffers();
+
 	int getNumTargetKeyGroups();
+
+	void registerBufferPool(BufferPool bufferPool);
+
+	void destroyBufferPool();
 
 	/**
 	 * Adds the bufferConsumer to the subpartition with the given index.
@@ -60,4 +80,10 @@ public interface ResultPartitionWriter {
 	 * Manually trigger consumption from enqueued {@link BufferConsumer BufferConsumers} in one specified subpartition.
 	 */
 	void flush(int subpartitionIndex);
+
+	ResultSubpartitionView createSubpartitionView(int index, BufferAvailabilityListener availabilityListener) throws IOException;
+
+	void release(Throwable cause);
+
+	void finish() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -28,11 +29,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class ResultPartitionMetrics {
 
-	private final ResultPartition partition;
+	private final ResultPartitionWriter partition;
 
 	// ------------------------------------------------------------------------
 
-	private ResultPartitionMetrics(ResultPartition partition) {
+	private ResultPartitionMetrics(ResultPartitionWriter partition) {
 		this.partition = checkNotNull(partition);
 	}
 
@@ -49,7 +50,7 @@ public class ResultPartitionMetrics {
 	long refreshAndGetTotal() {
 		long total = 0;
 
-		for (ResultSubpartition part : partition.getAllPartitions()) {
+		for (ResultSubpartition part : partition.getAllSubPartitions()) {
 			total += part.unsynchronizedGetNumberOfQueuedBuffers();
 		}
 
@@ -65,7 +66,7 @@ public class ResultPartitionMetrics {
 	int refreshAndGetMin() {
 		int min = Integer.MAX_VALUE;
 
-		ResultSubpartition[] allPartitions = partition.getAllPartitions();
+		ResultSubpartition[] allPartitions = partition.getAllSubPartitions();
 		if (allPartitions.length == 0) {
 			// meaningful value when no channels exist:
 			return 0;
@@ -88,7 +89,7 @@ public class ResultPartitionMetrics {
 	int refreshAndGetMax() {
 		int max = 0;
 
-		for (ResultSubpartition part : partition.getAllPartitions()) {
+		for (ResultSubpartition part : partition.getAllSubPartitions()) {
 			int size = part.unsynchronizedGetNumberOfQueuedBuffers();
 			max = Math.max(max, size);
 		}
@@ -105,7 +106,7 @@ public class ResultPartitionMetrics {
 	float refreshAndGetAvg() {
 		long total = 0;
 
-		ResultSubpartition[] allPartitions = partition.getAllPartitions();
+		ResultSubpartition[] allPartitions = partition.getAllSubPartitions();
 		for (ResultSubpartition part : allPartitions) {
 			int size = part.unsynchronizedGetNumberOfQueuedBuffers();
 			total += size;
@@ -158,7 +159,7 @@ public class ResultPartitionMetrics {
 	//  Static access
 	// ------------------------------------------------------------------------
 
-	public static void registerQueueLengthMetrics(MetricGroup group, ResultPartition partition) {
+	public static void registerQueueLengthMetrics(MetricGroup group, ResultPartitionWriter partition) {
 		ResultPartitionMetrics metrics = new ResultPartitionMetrics(partition);
 
 		group.gauge("totalQueueLen", metrics.getTotalQueueLenGauge());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -25,7 +25,7 @@ import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
-import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -184,7 +184,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 		public Integer getValue() {
 			int totalBuffers = 0;
 
-			for (ResultPartition producedPartition : task.getProducedPartitions()) {
+			for (ResultPartitionWriter producedPartition : task.getProducedPartitions()) {
 				totalBuffers += producedPartition.getNumberOfQueuedBuffers();
 			}
 
@@ -237,7 +237,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 			int usedBuffers = 0;
 			int bufferPoolSize = 0;
 
-			for (ResultPartition resultPartition : task.getProducedPartitions()) {
+			for (ResultPartitionWriter resultPartition : task.getProducedPartitions()) {
 				usedBuffers += resultPartition.getBufferPool().bestEffortGetNumOfUsedBuffers();
 				bufferPoolSize += resultPartition.getBufferPool().getNumBuffers();
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
@@ -188,7 +189,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 	/** Serialized version of the job specific execution configuration (see {@link ExecutionConfig}). */
 	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
 
-	private final ResultPartition[] producedPartitions;
+	private final ResultPartitionWriter[] producedPartitions;
 
 	private final SingleInputGate[] inputGates;
 
@@ -440,7 +441,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		return inputGates;
 	}
 
-	public ResultPartition[] getProducedPartitions() {
+	public ResultPartitionWriter[] getProducedPartitions() {
 		return producedPartitions;
 	}
 
@@ -714,7 +715,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 			// ----------------------------------------------------------------
 
 			// finish the produced partitions. if this fails, we consider the execution failed.
-			for (ResultPartition partition : producedPartitions) {
+			for (ResultPartitionWriter partition : producedPartitions) {
 				if (partition != null) {
 					partition.finish();
 				}
@@ -1434,7 +1435,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		private final AbstractInvokable invokable;
 		private final Thread executer;
 		private final String taskName;
-		private final ResultPartition[] producedPartitions;
+		private final ResultPartitionWriter[] producedPartitions;
 		private final SingleInputGate[] inputGates;
 
 		public TaskCanceler(
@@ -1442,7 +1443,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				AbstractInvokable invokable,
 				Thread executer,
 				String taskName,
-				ResultPartition[] producedPartitions,
+				ResultPartitionWriter[] producedPartitions,
 				SingleInputGate[] inputGates) {
 
 			this.logger = logger;
@@ -1472,7 +1473,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				//
 				// Don't do this before cancelling the invokable. Otherwise we
 				// will get misleading errors in the logs.
-				for (ResultPartition partition : producedPartitions) {
+				for (ResultPartitionWriter partition : producedPartitions) {
 					try {
 						partition.destroyBufferPool();
 					} catch (Throwable t) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -131,7 +131,7 @@ public class NetworkEnvironmentTest {
 		verify(ig4, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
 
 		for (ResultPartition rp : resultPartitions) {
-			rp.release();
+			rp.release(null);
 		}
 		for (SingleInputGate ig : inputGates) {
 			ig.releaseAllResources();
@@ -255,7 +255,7 @@ public class NetworkEnvironmentTest {
 		verify(ig4, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);
 
 		for (ResultPartition rp : resultPartitions) {
-			rp.release();
+			rp.release(null);
 		}
 		for (SingleInputGate ig : inputGates) {
 			ig.releaseAllResources();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.io.network.api.writer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -35,32 +34,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  * {@link ResultPartitionWriter} that collects output on the List.
  */
 @ThreadSafe
-public abstract class AbstractCollectingResultPartitionWriter implements ResultPartitionWriter {
-	private final BufferProvider bufferProvider;
+public abstract class AbstractCollectingResultPartitionWriter extends TestResultPartitionWriter {
 	private final ArrayDeque<BufferConsumer> bufferConsumers = new ArrayDeque<>();
 
 	public AbstractCollectingResultPartitionWriter(BufferProvider bufferProvider) {
-		this.bufferProvider = checkNotNull(bufferProvider);
-	}
-
-	@Override
-	public BufferProvider getBufferProvider() {
-		return bufferProvider;
-	}
-
-	@Override
-	public ResultPartitionID getPartitionId() {
-		return new ResultPartitionID();
-	}
-
-	@Override
-	public int getNumberOfSubpartitions() {
-		return 1;
-	}
-
-	@Override
-	public int getNumTargetKeyGroups() {
-		return 1;
+		super(checkNotNull(bufferProvider));
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/TestResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/TestResultPartitionWriter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferPoolOwner;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+
+import java.io.IOException;
+
+/**
+ * A dummy implementation of {@link ResultPartitionWriter} used for tests.
+ */
+public class TestResultPartitionWriter implements ResultPartitionWriter {
+	private final BufferProvider bufferProvider;
+
+	public TestResultPartitionWriter(BufferProvider bufferProvider) {
+		this.bufferProvider = bufferProvider;
+	}
+
+	@Override
+	public BufferProvider getBufferProvider() {
+		return bufferProvider;
+	}
+
+	@Override
+	public BufferPool getBufferPool() {
+		return null;
+	}
+
+	@Override
+	public BufferPoolOwner getBufferPoolOwner() {
+		return null;
+	}
+
+	@Override
+	public ResultPartitionID getPartitionId() {
+		return new ResultPartitionID();
+	}
+
+	@Override
+	public ResultPartitionType getPartitionType() {
+		return ResultPartitionType.PIPELINED;
+	}
+
+	@Override
+	public ResultSubpartition[] getAllSubPartitions() {
+		return new ResultSubpartition[1];
+	}
+
+	@Override
+	public int getNumberOfSubpartitions() {
+		return 1;
+	}
+
+	@Override
+	public int getNumberOfQueuedBuffers() {
+		return 1;
+	}
+
+	@Override
+	public int getNumTargetKeyGroups() {
+		return 1;
+	}
+
+	@Override
+	public void registerBufferPool(BufferPool bufferPool) {
+	}
+
+	@Override
+	public void destroyBufferPool() {
+	}
+
+	@Override
+	public void addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {}
+
+	@Override
+	public void flushAll() {
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+	}
+
+	@Override
+	public ResultSubpartitionView createSubpartitionView(
+			int index,
+			BufferAvailabilityListener availabilityListener) {
+		return null;
+	}
+
+	@Override
+	public void release(Throwable cause) {
+	}
+
+	@Override
+	public void finish() {
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -156,7 +156,7 @@ public class ResultPartitionTest {
 		ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 		try {
 			ResultPartition partition = createPartition(notifier, pipelined, true);
-			partition.release();
+			partition.release(null);
 			// partition.add() silently drops the bufferConsumer but recycles it
 			partition.addBufferConsumer(bufferConsumer, 0);
 		} finally {
@@ -251,7 +251,7 @@ public class ResultPartitionTest {
 				assertEquals(0, resultPartition.getBufferPool().getNumberOfAvailableMemorySegments());
 			}
 		} finally {
-			resultPartition.release();
+			resultPartition.release(null);
 			network.shutdown();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPartitionProducer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPartitionProducer.java
@@ -92,7 +92,7 @@ public class TestPartitionProducer implements Callable<Boolean> {
 		}
 		finally {
 			if (!success) {
-				partition.release();
+				partition.release(null);
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This is a preparation work for future creating `ResultPartitionWriter` via proposed `ShuffleService`.*

*Currently there exists only one `ResultPartition` implementation for `ResultPartitionWriter` interface, so the specific `ResultPartition` instance is easily referenced in many other classes such as `Task`, `NetworkEnvironment`, etc. Even some private methods in `ResultPartition` would be called directly in these reference classes.*

*Considering ShuffleService might create multiple different `ResultPartitionWriter` implementations future, then all the other classes should only reference with the interface and call the common methods. Therefore we extend the related methods in `ResultPartitionWriter` interface in order to cover existing logics in `ResultPartition`.*

## Brief change log

  - *Extend more methods in `ResultPartitionWriter` interface*
  - *Reference `ResultPartitionWriter` instead of `ResultPartition` in related classes*
  - *Introduce `TestResultPartitionWriter` for reusing and simplifying related tests*

## Verifying this change

This change is already covered by existing tests, such as *RecordWriterTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
