### PR TITLE
[hotfix] Forbid instantiate util class Executors

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -26,7 +26,8 @@ import scala.concurrent.ExecutionContext;
 /**
  * Collection of {@link Executor}, {@link ExecutorService} and {@link ExecutionContext} implementations.
  */
-public class Executors {
+public enum Executors {
+	;
 
 	/**
 	 * Return a direct executor. The direct executor directly executes the runnable in the calling


### PR DESCRIPTION
## What is the purpose of the change

Forbid instantiate util class `Executors`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol  
