### PR TITLE
[hotfix] Keep consistent implementation style in VoidHistoryServerArchivist and UnregisteredJobManagerJobMetricGroupFactory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/VoidHistoryServerArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/VoidHistoryServerArchivist.java
@@ -27,10 +27,10 @@ import java.util.concurrent.CompletableFuture;
  * No-op implementation of the {@link HistoryServerArchivist}.
  */
 public enum VoidHistoryServerArchivist implements HistoryServerArchivist {
-	INSTANCE {
-		@Override
-		public CompletableFuture<Acknowledge> archiveExecutionGraph(AccessExecutionGraph executionGraph) {
-			return CompletableFuture.completedFuture(Acknowledge.get());
-		}
+	INSTANCE;
+
+	@Override
+	public CompletableFuture<Acknowledge> archiveExecutionGraph(AccessExecutionGraph executionGraph) {
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/UnregisteredJobManagerJobMetricGroupFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/UnregisteredJobManagerJobMetricGroupFactory.java
@@ -28,10 +28,10 @@ import javax.annotation.Nonnull;
  * {@link JobManagerJobMetricGroupFactory} which returns an unregistered {@link JobManagerJobMetricGroup}.
  */
 public enum UnregisteredJobManagerJobMetricGroupFactory implements JobManagerJobMetricGroupFactory {
-	INSTANCE {
-		@Override
-		public JobManagerJobMetricGroup create(@Nonnull JobGraph jobGraph) {
-			return UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
-		}
+	INSTANCE;
+
+	@Override
+	public JobManagerJobMetricGroup create(@Nonnull JobGraph jobGraph) {
+		return UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

It is a bit more than style issue. The previous implementation create an extra subclass of `VoidHistoryServerArchivist` and `UnregisteredJobManagerJobMetricGroupFactory`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol  
