### PR TITLE
[WIP][FLINK-10569][tests] Clean up uses of Scheduler and Instance in valid tests(Batch 2)

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -42,7 +41,6 @@ import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -54,7 +52,6 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
-import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.operators.BatchTask;
@@ -195,14 +192,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 				tdd.complete(taskDeploymentDescriptor);
 			});
 
-			LogicalSlot slot = new TestingLogicalSlot(
-				new LocalTaskManagerLocation(),
-				taskManagerGateway,
-				0,
-				new AllocationID(),
-				new SlotRequestId(),
-				new SlotSharingGroupId(),
-				null);
+			LogicalSlot slot = new TestingLogicalSlot(taskManagerGateway);
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -76,7 +75,6 @@ import java.util.function.Consumer;
 
 import scala.concurrent.duration.FiniteDuration;
 
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.SimpleActorGateway;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.completeCancellingForAllVertices;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createSimpleTestGraph;
@@ -111,8 +109,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testNoManualRestart() throws Exception {
 		NoRestartStrategy restartStrategy = new NoRestartStrategy();
-		Tuple2<ExecutionGraph, Instance> executionGraphInstanceTuple = createExecutionGraph(restartStrategy);
-		ExecutionGraph eg = executionGraphInstanceTuple.f0;
+		ExecutionGraph eg = createExecutionGraph(restartStrategy).f0;
 
 		eg.getAllExecutionVertices().iterator().next().fail(new Exception("Test Exception"));
 
@@ -138,10 +135,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	@Test
 	public void testRestartAutomatically() throws Exception {
-		Tuple2<ExecutionGraph, Instance> executionGraphInstanceTuple =
-			createExecutionGraph(TestRestartStrategy.directExecuting());
-
-		ExecutionGraph eg = executionGraphInstanceTuple.f0;
+		ExecutionGraph eg = createExecutionGraph(TestRestartStrategy.directExecuting()).f0;
 
 		restartAfterFailure(eg, new FiniteDuration(2, TimeUnit.MINUTES), true);
 	}
@@ -150,12 +144,12 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	public void testCancelWhileRestarting() throws Exception {
 		// We want to manually control the restart and delay
 		RestartStrategy restartStrategy = new InfiniteDelayRestartStrategy();
-		Tuple2<ExecutionGraph, Instance> executionGraphInstanceTuple = createExecutionGraph(restartStrategy);
-		ExecutionGraph executionGraph = executionGraphInstanceTuple.f0;
-		Instance instance = executionGraphInstanceTuple.f1;
+		Tuple2<ExecutionGraph, SimpleSlotProvider> executionGraphSimpleSlotProviderTuple = createExecutionGraph(restartStrategy);
+		ExecutionGraph executionGraph = executionGraphSimpleSlotProviderTuple.f0;
+		SimpleSlotProvider slotProvider = executionGraphSimpleSlotProviderTuple.f1;
 
 		// Kill the instance and wait for the job to restart
-		instance.markDead();
+		slotProvider.releaseSlots();
 		Assert.assertEquals(JobStatus.RESTARTING, executionGraph.getState());
 
 		assertEquals(JobStatus.RESTARTING, executionGraph.getState());
@@ -173,27 +167,21 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	@Test
 	public void testFailWhileRestarting() throws Exception {
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new ActorTaskManagerGateway(
-				new SimpleActorGateway(TestingUtils.directExecutionContext())),
-			NUM_TASKS);
-
-		scheduler.newInstanceAvailable(instance);
+		JobID jobID = new JobID();
+		SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobID, NUM_TASKS);
 
 		// Blocking program
 		ExecutionGraph executionGraph = new ExecutionGraph(
 			TestingUtils.defaultExecutor(),
 			TestingUtils.defaultExecutor(),
-			new JobID(),
+			jobID,
 			"TestJob",
 			new Configuration(),
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			// We want to manually control the restart and delay
 			new InfiniteDelayRestartStrategy(),
-			scheduler);
+			slotProvider);
 
 		JobVertex jobVertex = new JobVertex("NoOpInvokable");
 		jobVertex.setInvokableClass(NoOpInvokable.class);
@@ -210,7 +198,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		assertEquals(JobStatus.RUNNING, executionGraph.getState());
 
 		// Kill the instance and wait for the job to restart
-		instance.markDead();
+		slotProvider.releaseSlots();
 
 		Assert.assertEquals(JobStatus.RESTARTING, executionGraph.getState());
 
@@ -316,20 +304,15 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	 */
 	@Test
 	public void testFailingExecutionAfterRestart() throws Exception {
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new ActorTaskManagerGateway(
-				new SimpleActorGateway(TestingUtils.directExecutionContext())),
-			2);
-
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-		scheduler.newInstanceAvailable(instance);
+		JobID jobID = new JobID();
+		SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobID, 2);
 
 		TestRestartStrategy restartStrategy = TestRestartStrategy.directExecuting();
 
 		JobVertex sender = ExecutionGraphTestUtils.createJobVertex("Task1", 1, NoOpInvokable.class);
 		JobVertex receiver = ExecutionGraphTestUtils.createJobVertex("Task2", 1, NoOpInvokable.class);
 		JobGraph jobGraph = new JobGraph("Pointwise job", sender, receiver);
-		ExecutionGraph eg = newExecutionGraph(restartStrategy, scheduler);
+		ExecutionGraph eg = newExecutionGraph(jobID, restartStrategy, slotProvider);
 		eg.start(mainThreadExecutor);
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -376,13 +359,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	 */
 	@Test
 	public void testFailExecutionAfterCancel() throws Exception {
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new ActorTaskManagerGateway(
-				new SimpleActorGateway(TestingUtils.directExecutionContext())),
-			2);
-
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-		scheduler.newInstanceAvailable(instance);
+		JobID jobID = new JobID();
+		SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobID, 2);
 
 		JobVertex vertex = ExecutionGraphTestUtils.createJobVertex("Test Vertex", 1, NoOpInvokable.class);
 
@@ -392,7 +370,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Test Job", vertex);
 		jobGraph.setExecutionConfig(executionConfig);
 
-		ExecutionGraph eg = newExecutionGraph(new InfiniteDelayRestartStrategy(), scheduler);
+		ExecutionGraph eg = newExecutionGraph(jobID, new InfiniteDelayRestartStrategy(), slotProvider);
 
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -422,13 +400,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	 */
 	@Test
 	public void testFailExecutionGraphAfterCancel() throws Exception {
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new ActorTaskManagerGateway(
-				new SimpleActorGateway(TestingUtils.directExecutionContext())),
-			2);
-
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-		scheduler.newInstanceAvailable(instance);
+		JobID jobID = new JobID();
+		SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobID, 2);
 
 		JobVertex vertex = ExecutionGraphTestUtils.createJobVertex("Test Vertex", 1, NoOpInvokable.class);
 
@@ -438,7 +411,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		JobGraph jobGraph = new JobGraph("Test Job", vertex);
 		jobGraph.setExecutionConfig(executionConfig);
 
-		ExecutionGraph eg = newExecutionGraph(new InfiniteDelayRestartStrategy(), scheduler);
+		ExecutionGraph eg = newExecutionGraph(jobID, new InfiniteDelayRestartStrategy(), slotProvider);
 
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -465,14 +438,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	 */
 	@Test
 	public void testSuspendWhileRestarting() throws Exception {
-
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new ActorTaskManagerGateway(
-				new SimpleActorGateway(TestingUtils.directExecutionContext())),
-			NUM_TASKS);
-
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-		scheduler.newInstanceAvailable(instance);
+		JobID jobID = new JobID();
+		SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobID, NUM_TASKS);
 
 		JobVertex sender = new JobVertex("Task");
 		sender.setInvokableClass(NoOpInvokable.class);
@@ -485,13 +452,13 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		ExecutionGraph eg = new ExecutionGraph(
 			TestingUtils.defaultExecutor(),
 			TestingUtils.defaultExecutor(),
-			new JobID(),
+			jobID,
 			"Test job",
 			new Configuration(),
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			controllableRestartStrategy,
-			scheduler);
+			slotProvider);
 
 		eg.start(mainThreadExecutor);
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
@@ -502,7 +469,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		assertEquals(JobStatus.RUNNING, eg.getState());
 
-		instance.markDead();
+		slotProvider.releaseSlots();
 
 		Assert.assertEquals(1, controllableRestartStrategy.getNumberOfQueuedActions());
 
@@ -610,9 +577,9 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		// this test is inconclusive if not used with a proper multi-threaded executor
 		assertTrue("test assumptions violated", ((ThreadPoolExecutor) executor).getCorePoolSize() > 1);
 
-		SimpleAckingTaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
+		final JobID jobID = new JobID();
 		final int parallelism = 20;
-		final Scheduler scheduler = createSchedulerWithInstances(parallelism, taskManagerGateway);
+		final SlotProvider slotProvider = createSchedulerWithInstances(jobID, parallelism);
 
 		final SlotSharingGroup sharingGroup = new SlotSharingGroup();
 
@@ -630,8 +597,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		TestRestartStrategy restartStrategy = TestRestartStrategy.directExecuting();
 
 		final ExecutionGraph eg = ExecutionGraphTestUtils.createExecutionGraph(
-			new JobID(),
-			scheduler,
+			jobID,
+			slotProvider,
 			restartStrategy,
 			executor,
 			source,
@@ -669,8 +636,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final int numRestarts = 10;
 		final int parallelism = 20;
 
-		TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
-		final Scheduler scheduler = createSchedulerWithInstances(parallelism - 1, taskManagerGateway);
+		final JobID jobID = new JobID();
+		final SlotProvider slotProvider = createSchedulerWithInstances(jobID, parallelism - 1);
 
 		final SlotSharingGroup sharingGroup = new SlotSharingGroup();
 
@@ -688,9 +655,13 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		TestRestartStrategy restartStrategy =
 			new TestRestartStrategy(numRestarts, false);
 
-
 		final ExecutionGraph eg = ExecutionGraphTestUtils.createExecutionGraph(
-			new JobID(), scheduler, restartStrategy, executor, source, sink);
+			jobID,
+			slotProvider,
+			restartStrategy,
+			executor,
+			source,
+			sink);
 
 		eg.start(mainThreadExecutor);
 		eg.setScheduleMode(ScheduleMode.EAGER);
@@ -717,7 +688,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	public void testFailureWhileRestarting() throws Exception {
 
 		final TestRestartStrategy restartStrategy = TestRestartStrategy.manuallyTriggered();
-		final ExecutionGraph executionGraph = createSimpleExecutionGraph(restartStrategy, new TestingSlotProvider(ignored -> new CompletableFuture<>()));
+		final ExecutionGraph executionGraph = createSimpleExecutionGraph(new JobID(), restartStrategy, new TestingSlotProvider(ignored -> new CompletableFuture<>()));
 
 		executionGraph.start(mainThreadExecutor);
 		executionGraph.setQueuedSchedulingAllowed(true);
@@ -740,49 +711,39 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	//  Utilities
 	// ------------------------------------------------------------------------
 
-	private Scheduler createSchedulerWithInstances(int num, TaskManagerGateway taskManagerGateway) {
+	private SlotProvider createSchedulerWithInstances(JobID jobID, int slots) {
 		final Scheduler scheduler = new Scheduler(executor);
-		final Instance[] instances = new Instance[num];
 
-		for (int i = 0; i < instances.length; i++) {
-			instances[i] = createInstance(taskManagerGateway, 55443 + i);
-			scheduler.newInstanceAvailable(instances[i]);
+		for (int i = 0; i < slots; i++) {
+			final int port = 55443 + i;
+			final HardwareDescription resources = new HardwareDescription(4, 1_000_000_000, 500_000_000, 400_000_000);
+			final TaskManagerLocation location = new TaskManagerLocation(ResourceID.generate(), InetAddress.getLoopbackAddress(), port);
+			final TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
+			scheduler.newInstanceAvailable(new Instance(taskManagerGateway, location, new InstanceID(), resources, 1));
 		}
 
 		return scheduler;
 	}
 
-	private static Instance createInstance(TaskManagerGateway taskManagerGateway, int port) {
-		final HardwareDescription resources = new HardwareDescription(4, 1_000_000_000, 500_000_000, 400_000_000);
-		final TaskManagerLocation location = new TaskManagerLocation(
-			ResourceID.generate(), InetAddress.getLoopbackAddress(), port);
-		return new Instance(taskManagerGateway, location, new InstanceID(), resources, 1);
-	}
-
 	// ------------------------------------------------------------------------
 
-	private Tuple2<ExecutionGraph, Instance> createExecutionGraph(RestartStrategy restartStrategy) throws Exception {
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new ActorTaskManagerGateway(
-				new SimpleActorGateway(TestingUtils.directExecutionContext())),
-			NUM_TASKS);
+	private Tuple2<ExecutionGraph, SimpleSlotProvider> createExecutionGraph(RestartStrategy restartStrategy) throws Exception {
+		JobID jobID = new JobID();
+		SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobID, NUM_TASKS);
 
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-		scheduler.newInstanceAvailable(instance);
-
-		ExecutionGraph eg = createSimpleExecutionGraph(restartStrategy, scheduler);
+		ExecutionGraph eg = createSimpleExecutionGraph(jobID, restartStrategy, slotProvider);
 
 		assertEquals(JobStatus.CREATED, eg.getState());
 
 		eg.scheduleForExecution();
 		assertEquals(JobStatus.RUNNING, eg.getState());
-		return new Tuple2<>(eg, instance);
+		return new Tuple2<>(eg, slotProvider);
 	}
 
-	private ExecutionGraph createSimpleExecutionGraph(RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException, JobException {
+	private ExecutionGraph createSimpleExecutionGraph(JobID jobID, RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException, JobException {
 		JobGraph jobGraph = createJobGraph(NUM_TASKS);
 
-		ExecutionGraph eg = newExecutionGraph(restartStrategy, slotProvider);
+		ExecutionGraph eg = newExecutionGraph(jobID, restartStrategy, slotProvider);
 		eg.start(mainThreadExecutor);
 		eg.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
 
@@ -796,11 +757,11 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		return new JobGraph("Pointwise job", sender);
 	}
 
-	private static ExecutionGraph newExecutionGraph(RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException {
+	private static ExecutionGraph newExecutionGraph(JobID jobID, RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException {
 		return new ExecutionGraph(
 			TestingUtils.defaultExecutor(),
 			TestingUtils.defaultExecutor(),
-			new JobID(),
+			jobID,
 			"Test job",
 			new Configuration(),
 			new SerializedValue<>(new ExecutionConfig()),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -25,12 +25,10 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -60,7 +58,6 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.SerializedValue;
 
-import akka.actor.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -517,35 +514,6 @@ public class ExecutionGraphTestUtils {
 				return new Object();
 			} else {
 				return null;
-			}
-		}
-	}
-
-	@SuppressWarnings("serial")
-	public static class SimpleActorGatewayWithTDD extends SimpleActorGateway {
-
-		public TaskDeploymentDescriptor lastTDD;
-		private final PermanentBlobService blobCache;
-
-		public SimpleActorGatewayWithTDD(ExecutionContext executionContext, PermanentBlobService blobCache) {
-			super(executionContext);
-			this.blobCache = blobCache;
-		}
-
-		@Override
-		public Object handleMessage(Object message) {
-			if(message instanceof SubmitTask) {
-				SubmitTask submitTask = (SubmitTask) message;
-				lastTDD = submitTask.tasks();
-				try {
-					lastTDD.loadBigData(blobCache);
-					return Acknowledge.get();
-				} catch (Exception e) {
-					e.printStackTrace();
-					return new Status.Failure(e);
-				}
-			} else {
-				return super.handleMessage(message);
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -337,7 +338,7 @@ public class ExecutionGraphTestUtils {
 		}
 	}
 	
-	public static void setVertexResource(ExecutionVertex vertex, SimpleSlot slot) {
+	public static void setVertexResource(ExecutionVertex vertex, LogicalSlot slot) {
 		Execution exec = vertex.getCurrentExecutionAttempt();
 
 		if(!exec.tryAssignResource(slot)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -20,18 +20,14 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.util.TestLogger;
 
@@ -237,14 +233,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 					return result;
 				}};
 
-			LogicalSlot slot = new TestingLogicalSlot(
-				new LocalTaskManagerLocation(),
-				taskManagerGateway,
-				0,
-				new AllocationID(),
-				new SlotRequestId(),
-				new SlotSharingGroupId(),
-				null);
+			LogicalSlot slot = new TestingLogicalSlot(taskManagerGateway);
 
 			setVertexResource(vertex, slot);
 			setVertexState(vertex, ExecutionState.RUNNING);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -35,10 +34,8 @@ import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
-import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.util.TestLogger;
@@ -273,15 +270,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
 				}
 			};
 
-			TestingLogicalSlot testingLogicalSlot =
-				new TestingLogicalSlot(
-					new LocalTaskManagerLocation(),
-					blockSubmitGateway,
-					0,
-					new AllocationID(),
-					new SlotRequestId(),
-					new SlotSharingGroupId(),
-					null);
+			TestingLogicalSlot testingLogicalSlot = new TestingLogicalSlot(blockSubmitGateway);
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			vertex.deployToSlot(testingLogicalSlot);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraintTest.java
@@ -18,160 +18,105 @@
 
 package org.apache.flink.runtime.jobmanager.scheduler;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.instance.Instance;
-import org.apache.flink.runtime.instance.SharedSlot;
-import org.apache.flink.runtime.instance.SlotSharingGroupAssignment;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.AbstractID;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link CoLocationConstraint}.
  */
 public class CoLocationConstraintTest {
-	
+
 	@Test
 	public void testCreateConstraints() {
-		try {
-			JobVertexID id1 = new JobVertexID();
-			JobVertexID id2 = new JobVertexID();
+		JobVertexID id1 = new JobVertexID();
+		JobVertexID id2 = new JobVertexID();
 
-			JobVertex vertex1 = new JobVertex("vertex1", id1);
-			vertex1.setParallelism(2);
-			
-			JobVertex vertex2 = new JobVertex("vertex2", id2);
-			vertex2.setParallelism(3);
-			
-			CoLocationGroup group = new CoLocationGroup(vertex1, vertex2);
-			
-			AbstractID groupId = group.getId();
-			assertNotNull(groupId);
-			
-			CoLocationConstraint constraint1 = group.getLocationConstraint(0);
-			CoLocationConstraint constraint2 = group.getLocationConstraint(1);
-			CoLocationConstraint constraint3 = group.getLocationConstraint(2);
-			
-			assertFalse(constraint1 == constraint2);
-			assertFalse(constraint1 == constraint3);
-			assertFalse(constraint2 == constraint3);
-			
-			assertEquals(groupId, constraint1.getGroupId());
-			assertEquals(groupId, constraint2.getGroupId());
-			assertEquals(groupId, constraint3.getGroupId());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		JobVertex vertex1 = new JobVertex("vertex1", id1);
+		vertex1.setParallelism(2);
+
+		JobVertex vertex2 = new JobVertex("vertex2", id2);
+		vertex2.setParallelism(3);
+
+		CoLocationGroup group = new CoLocationGroup(vertex1, vertex2);
+
+		AbstractID groupId = group.getId();
+		assertThat(groupId, not(nullValue()));
+
+		CoLocationConstraint constraint1 = group.getLocationConstraint(0);
+		CoLocationConstraint constraint2 = group.getLocationConstraint(1);
+		CoLocationConstraint constraint3 = group.getLocationConstraint(2);
+
+		assertThat(constraint1, not(constraint2));
+		assertThat(constraint1, not(constraint3));
+		assertThat(constraint2, not(constraint3));
+
+		assertThat(constraint1.getGroupId(), is(groupId));
+		assertThat(constraint2.getGroupId(), is(groupId));
+		assertThat(constraint3.getGroupId(), is(groupId));
 	}
 
 	@Test
-	public void testAssignSlotAndLockLocation() {
+	public void testLockLocation() {
+		JobVertex vertex = new JobVertex("vertex");
+		vertex.setParallelism(1);
+
+		CoLocationGroup constraintGroup = new CoLocationGroup(vertex);
+		CoLocationConstraint constraint = constraintGroup.getLocationConstraint(0);
+
+		assertThat(constraint.getSlotRequestId(), is(nullValue()));
+		assertThat(constraint.isAssigned(), is(false));
+
+		SlotRequestId slotRequestId1 = new SlotRequestId();
+		constraint.setSlotRequestId(slotRequestId1);
+		assertThat(constraint.getSlotRequestId(), is(slotRequestId1));
+		assertThat(constraint.isAssigned(), is(false));
+
+		SlotRequestId slotRequestId2 = new SlotRequestId();
+		constraint.setSlotRequestId(slotRequestId2);
+		assertThat(constraint.getSlotRequestId(), is(slotRequestId2));
+		assertThat(constraint.isAssigned(), is(false));
+
+		// try to get the location
 		try {
-			JobID jid = new JobID();
-					
-			JobVertex vertex = new JobVertex("vertex");
-			vertex.setParallelism(1);
-
-			SlotSharingGroup sharingGroup = new SlotSharingGroup(vertex.getID());
-			SlotSharingGroupAssignment assignment = sharingGroup.getTaskAssignment();
-			
-			CoLocationGroup constraintGroup = new CoLocationGroup(vertex);
-			CoLocationConstraint constraint = constraintGroup.getLocationConstraint(0);
-
-			// constraint is completely unassigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			Instance instance1 = SchedulerTestUtils.getRandomInstance(2);
-			Instance instance2 = SchedulerTestUtils.getRandomInstance(2);
-			
-			SharedSlot slot1_1 = instance1.allocateSharedSlot(assignment);
-			SharedSlot slot1_2 = instance1.allocateSharedSlot(assignment);
-			SharedSlot slot2_1 = instance2.allocateSharedSlot(assignment);
-			SharedSlot slot2_2 = instance2.allocateSharedSlot(assignment);
-			
-			// constraint is still completely unassigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			// set the slot, but do not lock the location yet
-			constraint.setSharedSlot(slot1_1);
-
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			// try to get the location
-			try {
-				constraint.getLocation();
-				fail("should throw an IllegalStateException");
-			}
-			catch (IllegalStateException e) {
-				// as expected
-			}
-			catch (Exception e) {
-				fail("wrong exception, should be IllegalStateException");
-			}
-
-			// check that we can reassign the slot as long as the location is not locked
-			constraint.setSharedSlot(slot2_1);
-			
-			// the previous slot should have been released now
-			assertTrue(slot1_1.isReleased());
-
-			// still the location is not assigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			// we can do an identity re-assign
-			constraint.setSharedSlot(slot2_1);
-			assertFalse(slot2_1.isReleased());
-
-			// still the location is not assigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			constraint.lockLocation();
-
-			// now, the location is assigned and we have a location
-			assertTrue(constraint.isAssigned());
-			assertTrue(constraint.isAssignedAndAlive());
-			assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
-			
-			// release the slot
-			slot2_1.releaseSlot();
-
-			// we should still have a location
-			assertTrue(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
-
-			// we can not assign a different location
-			try {
-				constraint.setSharedSlot(slot1_2);
-				fail("should throw an IllegalArgumentException");
-			}
-			catch (IllegalArgumentException e) {
-				// as expected
-			}
-			catch (Exception e) {
-				fail("wrong exception, should be IllegalArgumentException");
-			}
-			
-			// assign a new slot with the same location
-			constraint.setSharedSlot(slot2_2);
-
-			assertTrue(constraint.isAssigned());
-			assertTrue(constraint.isAssignedAndAlive());
-			assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
+			constraint.getLocation();
+			fail("should throw an IllegalStateException");
+		} catch (IllegalStateException e) {
+			// as expected
+		} catch (Exception e) {
+			fail("wrong exception, should be IllegalStateException");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+
+		TaskManagerLocation location = new LocalTaskManagerLocation();
+		constraint.lockLocation(location);
+
+		assertThat(constraint.isAssigned(), is(true));
+		assertThat(constraint.getLocation(), is(location));
+
+		// we can not lock a different location
+		try {
+			TaskManagerLocation anotherLocation = new LocalTaskManagerLocation();
+			constraint.lockLocation(anotherLocation);
+			fail("should throw an IllegalStateException");
+		} catch (IllegalStateException e) {
+			// as expected
+		} catch (Exception e) {
+			fail("wrong exception, should be IllegalStateException");
 		}
+
+		constraint.setSlotRequestId(null);
+		assertThat(constraint.getSlotRequestId(), is(nullValue()));
+		assertThat(constraint.isAssigned(), is(true));
+		assertThat(constraint.getLocation(), is(location));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -67,6 +67,17 @@ public class TestingLogicalSlot implements LogicalSlot {
 			null);
 	}
 
+	public TestingLogicalSlot(TaskManagerGateway taskManagerGateway) {
+		this(
+			new LocalTaskManagerLocation(),
+			taskManagerGateway,
+			0,
+			new AllocationID(),
+			new SlotRequestId(),
+			new SlotSharingGroupId(),
+			null);
+	}
+
 	public TestingLogicalSlot(
 			TaskManagerLocation taskManagerLocation,
 			TaskManagerGateway taskManagerGateway,


### PR DESCRIPTION
## What is the purpose of the change

1. Remove `Instance` usage in ExecutionGraphDeploymentTest

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable) 
