### PR TITLE
[FLINK-11618][state] Refactor operator state repartition mechanism

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -88,6 +88,8 @@ public class BucketingSinkTest extends TestLogger {
 	private static org.apache.hadoop.fs.FileSystem dfs;
 	private static String hdfsURI;
 
+	private final int maxParallelism = 10;
+
 	private OneInputStreamOperatorTestHarness<String, Object> createRescalingTestSink(
 		File outDir, int totalParallelism, int taskIdx, long inactivityInterval) throws Exception {
 
@@ -137,7 +139,7 @@ public class BucketingSinkTest extends TestLogger {
 
 	private <T> OneInputStreamOperatorTestHarness<T, Object> createTestSink(
 			BucketingSink<T> sink, int totalParallelism, int taskIdx) throws Exception {
-		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 10, totalParallelism, taskIdx);
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), maxParallelism, totalParallelism, taskIdx);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, Object> createRescalingTestSinkWithRollover(
@@ -329,18 +331,24 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness2.processElement(new StreamRecord<>("test3", 0L));
 		checkLocalFs(outDir, 3, 0, 0, 0);
 
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 2, 2, 0);
+
 		testHarness1 = createRescalingTestSink(outDir, 2, 0, 100);
 		testHarness1.setup();
-		testHarness1.initializeState(mergedSnapshot);
+		testHarness1.initializeState(initState1);
 		testHarness1.open();
 
 		// the one in-progress will be the one assigned to the next instance,
 		// the other is the test3 which is just not cleaned up
 		checkLocalFs(outDir, 2, 0, 1, 1);
 
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 2, 2, 1);
+
 		testHarness2 = createRescalingTestSink(outDir, 2, 1, 100);
 		testHarness2.setup();
-		testHarness2.initializeState(mergedSnapshot);
+		testHarness2.initializeState(initState2);
 		testHarness2.open();
 
 		checkLocalFs(outDir, 1, 0, 2, 2);
@@ -385,16 +393,22 @@ public class BucketingSinkTest extends TestLogger {
 			testHarness2.snapshot(0, 0)
 		);
 
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 3, 2, 0);
+
 		testHarness1 = createRescalingTestSink(outDir, 2, 0, 100);
 		testHarness1.setup();
-		testHarness1.initializeState(mergedSnapshot);
+		testHarness1.initializeState(initState1);
 		testHarness1.open();
 
 		checkLocalFs(outDir, 1, 0, 3, 3);
 
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 3, 2, 1);
+
 		testHarness2 = createRescalingTestSink(outDir, 2, 1, 100);
 		testHarness2.setup();
-		testHarness2.initializeState(mergedSnapshot);
+		testHarness2.initializeState(initState2);
 		testHarness2.open();
 
 		checkLocalFs(outDir, 0, 0, 4, 4);
@@ -429,23 +443,32 @@ public class BucketingSinkTest extends TestLogger {
 			testHarness1.snapshot(0, 0)
 		);
 
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 2, 3, 0);
+
 		testHarness1 = createRescalingTestSink(outDir, 3, 0, 100);
 		testHarness1.setup();
-		testHarness1.initializeState(mergedSnapshot);
+		testHarness1.initializeState(initState1);
 		testHarness1.open();
 
 		checkLocalFs(outDir, 2, 0, 3, 3);
 
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 2, 3, 1);
+
 		testHarness2 = createRescalingTestSink(outDir, 3, 1, 100);
 		testHarness2.setup();
-		testHarness2.initializeState(mergedSnapshot);
+		testHarness2.initializeState(initState2);
 		testHarness2.open();
 
 		checkLocalFs(outDir, 0, 0, 5, 5);
 
+		OperatorSubtaskState initState3 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 2, 3, 2);
+
 		OneInputStreamOperatorTestHarness<String, Object> testHarness3 = createRescalingTestSink(outDir, 3, 2, 100);
 		testHarness3.setup();
-		testHarness3.initializeState(mergedSnapshot);
+		testHarness3.initializeState(initState3);
 		testHarness3.open();
 
 		checkLocalFs(outDir, 0, 0, 5, 5);

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -23,10 +23,9 @@ import org.apache.flink.api.common.serialization.TypeInformationSerializationSch
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchemaWrapper;
@@ -383,9 +382,10 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		final int parallelism3 = 3;
 		final int maxParallelism = Math.max(parallelism1, Math.max(parallelism2, parallelism3));
 
-		List<OperatorStateHandle> operatorSubtaskState = repartitionAndExecute(
+		OperatorSubtaskState operatorSubtaskState = repartitionAndExecute(
 			topic,
-			Collections.emptyList(),
+			new OperatorSubtaskState(),
+			parallelism1,
 			parallelism1,
 			maxParallelism,
 			IntStream.range(0, parallelism1).boxed().iterator());
@@ -393,6 +393,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		operatorSubtaskState = repartitionAndExecute(
 			topic,
 			operatorSubtaskState,
+			parallelism1,
 			parallelism2,
 			maxParallelism,
 			IntStream.range(parallelism1,  parallelism1 + parallelism2).boxed().iterator());
@@ -400,6 +401,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		operatorSubtaskState = repartitionAndExecute(
 			topic,
 			operatorSubtaskState,
+			parallelism2,
 			parallelism3,
 			maxParallelism,
 			IntStream.range(parallelism1 + parallelism2,  parallelism1 + parallelism2 + parallelism3).boxed().iterator());
@@ -408,9 +410,10 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		// not allow us to read all committed messages from the topic. Thus we initialize operators from
 		// OperatorSubtaskState once more, but without any new data. This should terminate all ongoing transactions.
 
-		operatorSubtaskState = repartitionAndExecute(
+		repartitionAndExecute(
 			topic,
 			operatorSubtaskState,
+			parallelism3,
 			1,
 			maxParallelism,
 			Collections.emptyIterator());
@@ -423,28 +426,28 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 		deleteTestTopic(topic);
 	}
 
-	private List<OperatorStateHandle> repartitionAndExecute(
+	private OperatorSubtaskState repartitionAndExecute(
 			String topic,
-			List<OperatorStateHandle> inputStates,
-			int parallelism,
+			OperatorSubtaskState inputStates,
+			int oldParallelism,
+			int newParallelism,
 			int maxParallelism,
 			Iterator<Integer> inputData) throws Exception {
 
-		List<OperatorStateHandle> outputStates = new ArrayList<>();
+		List<OperatorSubtaskState> outputStates = new ArrayList<>();
 		List<OneInputStreamOperatorTestHarness<Integer, Object>> testHarnesses = new ArrayList<>();
 
-		for (int subtaskIndex = 0; subtaskIndex < parallelism; subtaskIndex++) {
+		for (int subtaskIndex = 0; subtaskIndex < newParallelism; subtaskIndex++) {
+			OperatorSubtaskState initState = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+				inputStates, maxParallelism, oldParallelism, newParallelism, subtaskIndex);
+
 			OneInputStreamOperatorTestHarness<Integer, Object> testHarness =
-				createTestHarness(topic, maxParallelism, parallelism, subtaskIndex, EXACTLY_ONCE);
+				createTestHarness(topic, maxParallelism, newParallelism, subtaskIndex, EXACTLY_ONCE);
 			testHarnesses.add(testHarness);
 
 			testHarness.setup();
 
-			testHarness.initializeState(new OperatorSubtaskState(
-				new StateObjectCollection<>(inputStates),
-				StateObjectCollection.empty(),
-				StateObjectCollection.empty(),
-				StateObjectCollection.empty()));
+			testHarness.initializeState(initState);
 			testHarness.open();
 
 			if (inputData.hasNext()) {
@@ -452,7 +455,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 				testHarness.processElement(nextValue, 0);
 				OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
 
-				outputStates.addAll(snapshot.getManagedOperatorState());
+				outputStates.add(snapshot);
 				checkState(snapshot.getRawOperatorState().isEmpty(), "Unexpected raw operator state");
 				checkState(snapshot.getManagedKeyedState().isEmpty(), "Unexpected managed keyed state");
 				checkState(snapshot.getRawKeyedState().isEmpty(), "Unexpected raw keyed state");
@@ -468,7 +471,8 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBaseWithFlink {
 			testHarness.close();
 		}
 
-		return outputStates;
+		return AbstractStreamOperatorTestHarness.repackageState(
+			outputStates.toArray(new OperatorSubtaskState[outputStates.size()]));
 	}
 
 	@Test

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -112,10 +112,16 @@ public class CEPRescalingTest {
 			// so we initialize the two tasks and we put the rest of
 			// the valid elements for the pattern on task 0.
 
+			OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+				snapshot, maxParallelism, 1, 2, 0);
+
+			OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+				snapshot, maxParallelism, 1, 2, 1);
+
 			harness1 = getTestHarness(maxParallelism, 2, 0);
 
 			harness1.setup();
-			harness1.initializeState(snapshot);
+			harness1.initializeState(initState1);
 			harness1.open();
 
 			// if element timestamps are not correctly checkpointed/restored this will lead to
@@ -137,7 +143,7 @@ public class CEPRescalingTest {
 			harness2 = getTestHarness(maxParallelism, 2, 1);
 
 			harness2.setup();
-			harness2.initializeState(snapshot);
+			harness2.initializeState(initState2);
 			harness2.open();
 
 			// now we move to the second parallel task
@@ -281,14 +287,20 @@ public class CEPRescalingTest {
 				harness3.snapshot(0, 0)
 			);
 
+			OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+				snapshot, maxParallelism, 3, 2, 0);
+
+			OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+				snapshot, maxParallelism, 3, 2, 1);
+
 			harness4 = getTestHarness(maxParallelism, 2, 0);
 			harness4.setup();
-			harness4.initializeState(snapshot);
+			harness4.initializeState(initState1);
 			harness4.open();
 
 			harness5 = getTestHarness(maxParallelism, 2, 1);
 			harness5.setup();
-			harness5.initializeState(snapshot);
+			harness5.initializeState(initState2);
 			harness5.open();
 
 			harness5.processElement(new StreamRecord<>(endEvent2, 11));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 
 import java.util.List;
@@ -25,17 +26,20 @@ import java.util.List;
 /**
  * Interface that allows to implement different strategies for repartitioning of operator state as parallelism changes.
  */
+@Internal
 public interface OperatorStateRepartitioner {
 
 	/**
-	 * @param previousParallelSubtaskStates List of state handles to the parallel subtask states of an operator, as they
+	 * @param previousParallelSubtaskStates List with one entry of state handles per parallel subtask of an operator, as they
 	 *                                      have been checkpointed.
+	 * @param oldParallelism               	The parallelism before we start redistribution.
 	 * @param newParallelism                The parallelism that we consider for the state redistribution. Determines the size of the
 	 *                                      returned list.
 	 * @return List with one entry per parallel subtask. Each subtask receives now one collection of states that build
 	 * of the new total state for this subtask.
 	 */
 	List<List<OperatorStateHandle>> repartitionState(
-			List<OperatorStateHandle> previousParallelSubtaskStates,
+			List<List<OperatorStateHandle>> previousParallelSubtaskStates,
+			int oldParallelism,
 			int newParallelism);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -317,7 +318,8 @@ public class StateAssignmentOperation {
 		}
 	}
 
-	private void reDistributePartitionableStates(
+	@VisibleForTesting
+	static void reDistributePartitionableStates(
 			List<OperatorState> oldOperatorStates,
 			int newParallelism,
 			List<OperatorID> newOperatorIDs,
@@ -328,24 +330,25 @@ public class StateAssignmentOperation {
 		checkState(newOperatorIDs.size() == oldOperatorStates.size(),
 			"This method still depends on the order of the new and old operators");
 
-		//collect the old partitionable state
-		List<List<OperatorStateHandle>> oldManagedOperatorStates = new ArrayList<>(oldOperatorStates.size());
-		List<List<OperatorStateHandle>> oldRawOperatorStates = new ArrayList<>(oldOperatorStates.size());
+		List<List<List<OperatorStateHandle>>> oldManagedOperatorStates = new ArrayList<>(oldOperatorStates.size());
+		List<List<List<OperatorStateHandle>>> oldRawOperatorStates = new ArrayList<>(oldOperatorStates.size());
 
-		collectPartionableStates(oldOperatorStates, oldManagedOperatorStates, oldRawOperatorStates);
-
-		//redistribute
+		collectPartitionableStates(oldOperatorStates, oldManagedOperatorStates, oldRawOperatorStates);
 		OperatorStateRepartitioner opStateRepartitioner = RoundRobinOperatorStateRepartitioner.INSTANCE;
 
-		for (int operatorIndex = 0; operatorIndex < oldOperatorStates.size(); operatorIndex++) {
+		for (int operatorIndex = 0; operatorIndex < newOperatorIDs.size(); operatorIndex++) {
+			OperatorState operatorState = oldOperatorStates.get(operatorIndex);
+			int oldParallelism = operatorState.getParallelism();
+
 			OperatorID operatorID = newOperatorIDs.get(operatorIndex);
-			int oldParallelism = oldOperatorStates.get(operatorIndex).getParallelism();
+
 			newManagedOperatorStates.putAll(applyRepartitioner(
 				operatorID,
 				opStateRepartitioner,
 				oldManagedOperatorStates.get(operatorIndex),
 				oldParallelism,
 				newParallelism));
+
 			newRawOperatorStates.putAll(applyRepartitioner(
 				operatorID,
 				opStateRepartitioner,
@@ -355,38 +358,32 @@ public class StateAssignmentOperation {
 		}
 	}
 
-	private void collectPartionableStates(
-			List<OperatorState> operatorStates,
-			List<List<OperatorStateHandle>> managedOperatorStates,
-			List<List<OperatorStateHandle>> rawOperatorStates) {
+	private static void collectPartitionableStates(
+		List<OperatorState> operatorStates,
+		List<List<List<OperatorStateHandle>>> managedOperatorStates,
+		List<List<List<OperatorStateHandle>>> rawOperatorStates) {
 
 		for (OperatorState operatorState : operatorStates) {
 
 			final int parallelism = operatorState.getParallelism();
+			List<List<OperatorStateHandle>> managedOpState = new ArrayList<>(parallelism);
+			List<List<OperatorStateHandle>> rawOpState = new ArrayList<>(parallelism);
 
-			List<OperatorStateHandle> managedOperatorState = null;
-			List<OperatorStateHandle> rawOperatorState = null;
-
-			for (int i = 0; i < parallelism; i++) {
-				OperatorSubtaskState operatorSubtaskState = operatorState.getState(i);
-				if (operatorSubtaskState != null) {
-
+			for (int subTaskIndex = 0; subTaskIndex < parallelism; subTaskIndex++) {
+				OperatorSubtaskState operatorSubtaskState = operatorState.getState(subTaskIndex);
+				if (operatorSubtaskState == null) {
+					managedOpState.add(Collections.emptyList());
+					rawOpState.add(Collections.emptyList());
+				} else {
 					StateObjectCollection<OperatorStateHandle> managed = operatorSubtaskState.getManagedOperatorState();
 					StateObjectCollection<OperatorStateHandle> raw = operatorSubtaskState.getRawOperatorState();
 
-					if (managedOperatorState == null) {
-						managedOperatorState = new ArrayList<>(parallelism * managed.size());
-					}
-					managedOperatorState.addAll(managed);
-
-					if (rawOperatorState == null) {
-						rawOperatorState = new ArrayList<>(parallelism * raw.size());
-					}
-					rawOperatorState.addAll(raw);
+					managedOpState.add(new ArrayList<>(managed));
+					rawOpState.add(new ArrayList<>(raw));
 				}
 			}
-			managedOperatorStates.add(managedOperatorState);
-			rawOperatorStates.add(rawOperatorState);
+			managedOperatorStates.add(managedOpState);
+			rawOperatorStates.add(rawOpState);
 		}
 	}
 
@@ -573,11 +570,11 @@ public class StateAssignmentOperation {
 	}
 
 	public static Map<OperatorInstanceID, List<OperatorStateHandle>> applyRepartitioner(
-			OperatorID operatorID,
-			OperatorStateRepartitioner opStateRepartitioner,
-			List<OperatorStateHandle> chainOpParallelStates,
-			int oldParallelism,
-			int newParallelism) {
+		OperatorID operatorID,
+		OperatorStateRepartitioner opStateRepartitioner,
+		List<List<OperatorStateHandle>> chainOpParallelStates,
+		int oldParallelism,
+		int newParallelism) {
 
 		List<List<OperatorStateHandle>> states = applyRepartitioner(
 			opStateRepartitioner,
@@ -607,45 +604,20 @@ public class StateAssignmentOperation {
 	 */
 	// TODO rewrite based on operator id
 	public static List<List<OperatorStateHandle>> applyRepartitioner(
-			OperatorStateRepartitioner opStateRepartitioner,
-			List<OperatorStateHandle> chainOpParallelStates,
-			int oldParallelism,
-			int newParallelism) {
+		OperatorStateRepartitioner opStateRepartitioner,
+		List<List<OperatorStateHandle>> chainOpParallelStates,
+		int oldParallelism,
+		int newParallelism) {
 
 		if (chainOpParallelStates == null) {
 			return Collections.emptyList();
 		}
 
-		//We only redistribute if the parallelism of the operator changed from previous executions
-		if (newParallelism != oldParallelism) {
-
-			return opStateRepartitioner.repartitionState(
-					chainOpParallelStates,
-					newParallelism);
-		} else {
-			List<List<OperatorStateHandle>> repackStream = new ArrayList<>(newParallelism);
-			for (OperatorStateHandle operatorStateHandle : chainOpParallelStates) {
-
-				if (operatorStateHandle != null) {
-					Map<String, OperatorStateHandle.StateMetaInfo> partitionOffsets =
-						operatorStateHandle.getStateNameToPartitionOffsets();
-
-					for (OperatorStateHandle.StateMetaInfo metaInfo : partitionOffsets.values()) {
-
-						// if we find any broadcast state, we cannot take the shortcut and need to go through repartitioning
-						if (OperatorStateHandle.Mode.UNION.equals(metaInfo.getDistributionMode())) {
-							return opStateRepartitioner.repartitionState(
-								chainOpParallelStates,
-								newParallelism);
-						}
-					}
-
-					repackStream.add(Collections.singletonList(operatorStateHandle));
-				}
-			}
-			return repackStream;
+		return opStateRepartitioner.repartitionState(
+			chainOpParallelStates,
+			oldParallelism,
+			newParallelism);
 		}
-	}
 
 	/**
 	 * Determine the subset of {@link KeyGroupsStateHandle KeyGroupsStateHandles} with correct

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -67,6 +67,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -2721,62 +2723,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		}
 	}
 
-	@Test
-	public void testReplicateModeStateHandle() {
-		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap = new HashMap<>(1);
-		metaInfoMap.put("t-1", new OperatorStateHandle.StateMetaInfo(new long[]{0, 23}, OperatorStateHandle.Mode.UNION));
-		metaInfoMap.put("t-2", new OperatorStateHandle.StateMetaInfo(new long[]{42, 64}, OperatorStateHandle.Mode.UNION));
-		metaInfoMap.put("t-3", new OperatorStateHandle.StateMetaInfo(new long[]{72, 83}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-		metaInfoMap.put("t-4", new OperatorStateHandle.StateMetaInfo(new long[]{87, 94, 95}, OperatorStateHandle.Mode.BROADCAST));
-		metaInfoMap.put("t-5", new OperatorStateHandle.StateMetaInfo(new long[]{97, 108, 112}, OperatorStateHandle.Mode.BROADCAST));
-		metaInfoMap.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{121, 143, 147}, OperatorStateHandle.Mode.BROADCAST));
-
-		// this is what a single task will return
-		OperatorStateHandle osh = new OperatorStreamStateHandle(metaInfoMap, new ByteStreamStateHandle("test", new byte[150]));
-
-		OperatorStateRepartitioner repartitioner = RoundRobinOperatorStateRepartitioner.INSTANCE;
-		List<List<OperatorStateHandle>> repartitionedStates =
-				repartitioner.repartitionState(Collections.singletonList(osh), 3);
-
-		Map<String, Integer> checkCounts = new HashMap<>(3);
-
-		for (Collection<OperatorStateHandle> operatorStateHandles : repartitionedStates) {
-			for (OperatorStateHandle operatorStateHandle : operatorStateHandles) {
-				for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> stateNameToMetaInfo :
-						operatorStateHandle.getStateNameToPartitionOffsets().entrySet()) {
-
-					String stateName = stateNameToMetaInfo.getKey();
-					Integer count = checkCounts.get(stateName);
-					if (null == count) {
-						checkCounts.put(stateName, 1);
-					} else {
-						checkCounts.put(stateName, 1 + count);
-					}
-
-					OperatorStateHandle.StateMetaInfo stateMetaInfo = stateNameToMetaInfo.getValue();
-					if (OperatorStateHandle.Mode.SPLIT_DISTRIBUTE.equals(stateMetaInfo.getDistributionMode())) {
-						// SPLIT_DISTRIBUTE: so split the state and re-distribute it -> each one will go to one task
-						Assert.assertEquals(1, stateNameToMetaInfo.getValue().getOffsets().length);
-					} else if (OperatorStateHandle.Mode.UNION.equals(stateMetaInfo.getDistributionMode())) {
-						// BROADCAST: so all to all
-						Assert.assertEquals(2, stateNameToMetaInfo.getValue().getOffsets().length);
-					} else {
-						// UNIFORM_BROADCAST: so all to all
-						Assert.assertEquals(3, stateNameToMetaInfo.getValue().getOffsets().length);
-					}
-				}
-			}
-		}
-
-		Assert.assertEquals(6, checkCounts.size());
-		Assert.assertEquals(3, checkCounts.get("t-1").intValue());
-		Assert.assertEquals(3, checkCounts.get("t-2").intValue());
-		Assert.assertEquals(2, checkCounts.get("t-3").intValue());
-		Assert.assertEquals(3, checkCounts.get("t-4").intValue());
-		Assert.assertEquals(3, checkCounts.get("t-5").intValue());
-		Assert.assertEquals(3, checkCounts.get("t-6").intValue());
-	}
-
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -3243,7 +3189,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 	private void doTestPartitionableStateRepartitioning(
 			Random r, int oldParallelism, int newParallelism, int numNamedStates, int maxPartitionsPerState) {
 
-		List<OperatorStateHandle> previousParallelOpInstanceStates = new ArrayList<>(oldParallelism);
+		List<List<OperatorStateHandle>> previousParallelOpInstanceStates = new ArrayList<>(oldParallelism);
 
 		for (int i = 0; i < oldParallelism; ++i) {
 			Path fakePath = new Path("/fake-" + i);
@@ -3275,58 +3221,62 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			}
 
 			previousParallelOpInstanceStates.add(
-					new OperatorStreamStateHandle(namedStatesToOffsets, new FileStateHandle(fakePath, -1)));
+					Collections.singletonList(new OperatorStreamStateHandle(namedStatesToOffsets, new FileStateHandle(fakePath, -1))));
 		}
 
 		Map<StreamStateHandle, Map<String, List<Long>>> expected = new HashMap<>();
 
 		int taskIndex = 0;
 		int expectedTotalPartitions = 0;
-		for (OperatorStateHandle psh : previousParallelOpInstanceStates) {
-			Map<String, OperatorStateHandle.StateMetaInfo> offsMap = psh.getStateNameToPartitionOffsets();
-			Map<String, List<Long>> offsMapWithList = new HashMap<>(offsMap.size());
-			for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> e : offsMap.entrySet()) {
+		for (List<OperatorStateHandle> previousParallelOpInstanceState : previousParallelOpInstanceStates) {
+			Assert.assertEquals(1, previousParallelOpInstanceState.size());
 
-				long[] offs = e.getValue().getOffsets();
-				int replication;
-				switch (e.getValue().getDistributionMode()) {
-					case UNION:
-						replication = newParallelism;
-						break;
-					case BROADCAST:
-						int extra = taskIndex < (newParallelism % oldParallelism) ? 1 : 0;
-						replication = newParallelism / oldParallelism + extra;
-						break;
-					case SPLIT_DISTRIBUTE:
-						replication = 1;
-						break;
-					default:
-						throw new RuntimeException("Unknown distribution mode " + e.getValue().getDistributionMode());
-				}
+			for (OperatorStateHandle psh : previousParallelOpInstanceState) {
+				Map<String, OperatorStateHandle.StateMetaInfo> offsMap = psh.getStateNameToPartitionOffsets();
+				Map<String, List<Long>> offsMapWithList = new HashMap<>(offsMap.size());
+				for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> e : offsMap.entrySet()) {
 
-				if (replication > 0) {
-					expectedTotalPartitions += replication * offs.length;
-					List<Long> offsList = new ArrayList<>(offs.length);
-
-					for (long off : offs) {
-						for (int p = 0; p < replication; ++p) {
-							offsList.add(off);
-						}
+					long[] offs = e.getValue().getOffsets();
+					int replication;
+					switch (e.getValue().getDistributionMode()) {
+						case UNION:
+							replication = newParallelism;
+							break;
+						case BROADCAST:
+							int extra = taskIndex < (newParallelism % oldParallelism) ? 1 : 0;
+							replication = newParallelism / oldParallelism + extra;
+							break;
+						case SPLIT_DISTRIBUTE:
+							replication = 1;
+							break;
+						default:
+							throw new RuntimeException("Unknown distribution mode " + e.getValue().getDistributionMode());
 					}
-					offsMapWithList.put(e.getKey(), offsList);
-				}
-			}
 
-			if (!offsMapWithList.isEmpty()) {
-				expected.put(psh.getDelegateStateHandle(), offsMapWithList);
+					if (replication > 0) {
+						expectedTotalPartitions += replication * offs.length;
+						List<Long> offsList = new ArrayList<>(offs.length);
+
+						for (long off : offs) {
+							for (int p = 0; p < replication; ++p) {
+								offsList.add(off);
+							}
+						}
+						offsMapWithList.put(e.getKey(), offsList);
+					}
+				}
+
+				if (!offsMapWithList.isEmpty()) {
+					expected.put(psh.getDelegateStateHandle(), offsMapWithList);
+				}
+				taskIndex++;
 			}
-			taskIndex++;
 		}
 
 		OperatorStateRepartitioner repartitioner = RoundRobinOperatorStateRepartitioner.INSTANCE;
 
 		List<List<OperatorStateHandle>> pshs =
-				repartitioner.repartitionState(previousParallelOpInstanceStates, newParallelism);
+				repartitioner.repartitionState(previousParallelOpInstanceStates, oldParallelism, newParallelism);
 
 		Map<StreamStateHandle, Map<String, List<Long>>> actual = new HashMap<>();
 
@@ -3371,8 +3321,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			}
 		}
 
-		int maxLoadDiff = maxCount - minCount;
-		Assert.assertTrue("Difference in partition load is > 1 : " + maxLoadDiff, maxLoadDiff <= 1);
+		// if newParallelism equals to oldParallelism, we would only redistribute UNION state if possible.
+		if (oldParallelism != newParallelism) {
+			int maxLoadDiff = maxCount - minCount;
+			Assert.assertTrue("Difference in partition load is > 1 : " + maxLoadDiff, maxLoadDiff <= 1);
+		}
 		Assert.assertEquals(expectedTotalPartitions, actualTotalPartitions);
 		Assert.assertEquals(expected, actual);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests to verify state assignment operation.
+ */
+public class StateAssignmentOperationTest extends TestLogger {
+
+	@Test
+	public void testReDistributePartitionableStates() {
+		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap1 = new HashMap<>(6);
+		metaInfoMap1.put("t-1", new OperatorStateHandle.StateMetaInfo(new long[]{0}, OperatorStateHandle.Mode.UNION));
+		metaInfoMap1.put("t-2", new OperatorStateHandle.StateMetaInfo(new long[]{22, 44}, OperatorStateHandle.Mode.UNION));
+		metaInfoMap1.put("t-3", new OperatorStateHandle.StateMetaInfo(new long[]{52, 63}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
+		metaInfoMap1.put("t-4", new OperatorStateHandle.StateMetaInfo(new long[]{67, 74, 75}, OperatorStateHandle.Mode.BROADCAST));
+		metaInfoMap1.put("t-5", new OperatorStateHandle.StateMetaInfo(new long[]{77, 88, 92}, OperatorStateHandle.Mode.BROADCAST));
+		metaInfoMap1.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{101, 123, 127}, OperatorStateHandle.Mode.BROADCAST));
+
+		OperatorStateHandle osh1 = new OperatorStreamStateHandle(metaInfoMap1, new ByteStreamStateHandle("test", new byte[130]));
+		OperatorID operatorID = new OperatorID();
+		OperatorState operatorState = new OperatorState(operatorID, 2, 4);
+		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null));
+
+		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap2 = new HashMap<>(3);
+		metaInfoMap2.put("t-1", new OperatorStateHandle.StateMetaInfo(new long[]{0}, OperatorStateHandle.Mode.UNION));
+		metaInfoMap2.put("t-4", new OperatorStateHandle.StateMetaInfo(new long[]{20, 27, 28}, OperatorStateHandle.Mode.BROADCAST));
+		metaInfoMap2.put("t-5", new OperatorStateHandle.StateMetaInfo(new long[]{30, 44, 48}, OperatorStateHandle.Mode.BROADCAST));
+		metaInfoMap2.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{57, 79, 83}, OperatorStateHandle.Mode.BROADCAST));
+
+		OperatorStateHandle osh2 = new OperatorStreamStateHandle(metaInfoMap2, new ByteStreamStateHandle("test2", new byte[86]));
+		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null));
+
+		// rescale up case, parallelism 2 --> 3
+		verifyPartitionableStateRescale(operatorState, operatorID, 2, 3);
+
+		// rescale down case, parallelism 2 --> 1
+		verifyPartitionableStateRescale(operatorState, operatorID, 2, 1);
+
+		// not rescale
+		verifyPartitionableStateRescale(operatorState, operatorID, 2, 2);
+
+	}
+
+	private void verifyPartitionableStateRescale(
+		OperatorState operatorState,
+		OperatorID operatorID,
+		int oldParallelism,
+		int newParallelism) {
+
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates =
+			new HashMap<>(newParallelism);
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates =
+			new HashMap<>(newParallelism);
+
+		StateAssignmentOperation.reDistributePartitionableStates(
+			Collections.singletonList(operatorState),
+			newParallelism,
+			Collections.singletonList(operatorID),
+			newManagedOperatorStates,
+			newRawOperatorStates
+		);
+
+		Map<String, Integer> checkCounts = new HashMap<>(6);
+
+		for (List<OperatorStateHandle> operatorStateHandles : newManagedOperatorStates.values()) {
+
+			final EnumMap<OperatorStateHandle.Mode, Map<String, Integer>> stateModeOffsets = new EnumMap<>(OperatorStateHandle.Mode.class);
+			for (OperatorStateHandle.Mode mode : OperatorStateHandle.Mode.values()) {
+				stateModeOffsets.put(
+					mode,
+					new HashMap<>(6));
+			}
+
+			for (OperatorStateHandle operatorStateHandle : operatorStateHandles) {
+				for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> stateNameToMetaInfo :
+					operatorStateHandle.getStateNameToPartitionOffsets().entrySet()) {
+
+					String stateName = stateNameToMetaInfo.getKey();
+					checkCounts.merge(stateName, 1, (count, inc) -> count + inc);
+
+					OperatorStateHandle.StateMetaInfo stateMetaInfo = stateNameToMetaInfo.getValue();
+
+					stateModeOffsets.get(stateMetaInfo.getDistributionMode()).merge(
+						stateName, stateMetaInfo.getOffsets().length, (count, inc) -> count + inc);
+				}
+			}
+
+			for (Map.Entry<OperatorStateHandle.Mode, Map<String, Integer>> modeMapEntry : stateModeOffsets.entrySet()) {
+				OperatorStateHandle.Mode mode = modeMapEntry.getKey();
+				Map<String, Integer> stateOffsets = modeMapEntry.getValue();
+				if (OperatorStateHandle.Mode.SPLIT_DISTRIBUTE.equals(mode)) {
+					if (oldParallelism < newParallelism) {
+						// SPLIT_DISTRIBUTE: when rescale up, split the state and re-distribute it -> each one will go to one task
+						stateOffsets.values().forEach(length -> Assert.assertEquals(1, (int) length));
+					} else {
+						// SPLIT_DISTRIBUTE: when rescale down to 1 or not rescale, not re-distribute them.
+						stateOffsets.values().forEach(length -> Assert.assertEquals(2, (int) length));
+					}
+				} else if (OperatorStateHandle.Mode.UNION.equals(mode)) {
+					// UNION: all to all
+					stateOffsets.values().forEach(length -> Assert.assertEquals(2, (int) length));
+				} else {
+					// BROADCAST: so all to all
+					stateOffsets.values().forEach(length -> Assert.assertEquals(3, (int) length));
+				}
+			}
+		}
+
+		Assert.assertEquals(6, checkCounts.size());
+		// t-1 is UNION state and original two sub-tasks both contains one.
+		Assert.assertEquals(2 * newParallelism, checkCounts.get("t-1").intValue());
+		Assert.assertEquals(newParallelism, checkCounts.get("t-2").intValue());
+
+		// t-3 is SPLIT_DISTRIBUTE state, when rescale up, they will be split to re-distribute.
+		if (oldParallelism < newParallelism) {
+			Assert.assertEquals(2, checkCounts.get("t-3").intValue());
+		} else {
+			Assert.assertEquals(1, checkCounts.get("t-3").intValue());
+		}
+		Assert.assertEquals(newParallelism, checkCounts.get("t-4").intValue());
+		Assert.assertEquals(newParallelism, checkCounts.get("t-5").intValue());
+		Assert.assertEquals(newParallelism, checkCounts.get("t-6").intValue());
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksIncrementalCheckpointRescalingTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksIncrementalCheckpointRescalingTest.java
@@ -113,6 +113,14 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 
 		// -----------------------------------------> test rescaling from 1 to 2 <---------------------------------------
 
+		// init state for new subtask-0
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelism, 1, 2, 0);
+
+		// init state for new subtask-1
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelism, 1, 2, 1);
+
 		KeyedOneInputStreamOperatorTestHarness<String, String, Integer>[] harness2 =
 			new KeyedOneInputStreamOperatorTestHarness[3];
 
@@ -129,7 +137,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness2[0] = getHarnessTest(keySelector, maxParallelism, 2, 0);
 			harness2[0].setStateBackend(getStateBackend());
 			harness2[0].setup();
-			harness2[0].initializeState(snapshot);
+			harness2[0].initializeState(initState1);
 			harness2[0].open();
 
 			// task's key-group [5, 9]
@@ -138,7 +146,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness2[1] = getHarnessTest(keySelector, maxParallelism, 2, 1);
 			harness2[1].setStateBackend(getStateBackend());
 			harness2[1].setup();
-			harness2[1].initializeState(snapshot);
+			harness2[1].initializeState(initState2);
 			harness2[1].open();
 
 			validHarnessResult(harness2[0], 2, records[0], records[1], records[2], records[3], records[4]);
@@ -159,6 +167,18 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 
 		// -----------------------------------------> test rescaling from 2 to 3 <---------------------------------------
 
+		// init state for new subtask-0
+		initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot2, maxParallelism, 2, 3, 0);
+
+		// init state for new subtask-1
+		initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot2, maxParallelism, 2, 3, 1);
+
+		// init state for new subtask-2
+		OperatorSubtaskState initState3 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot2, maxParallelism, 2, 3, 2);
+
 		KeyedOneInputStreamOperatorTestHarness<String, String, Integer>[] harness3 =
 			new KeyedOneInputStreamOperatorTestHarness[3];
 
@@ -174,7 +194,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness3[0] = getHarnessTest(keySelector, maxParallelism, 3, 0);
 			harness3[0].setStateBackend(getStateBackend());
 			harness3[0].setup();
-			harness3[0].initializeState(snapshot2);
+			harness3[0].initializeState(initState1);
 			harness3[0].open();
 
 			// task's key-group [4, 6]
@@ -183,7 +203,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness3[1] = getHarnessTest(keySelector, maxParallelism, 3, 1);
 			harness3[1].setStateBackend(getStateBackend());
 			harness3[1].setup();
-			harness3[1].initializeState(snapshot2);
+			harness3[1].initializeState(initState2);
 			harness3[1].open();
 
 			// task's key-group [7, 9]
@@ -192,7 +212,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness3[2] = getHarnessTest(keySelector, maxParallelism, 3, 2);
 			harness3[2].setStateBackend(getStateBackend());
 			harness3[2].setup();
-			harness3[2].initializeState(snapshot2);
+			harness3[2].initializeState(initState3);
 			harness3[2].open();
 
 			validHarnessResult(harness3[0], 3, records[0], records[1], records[2], records[3]);
@@ -258,6 +278,14 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 
 		// -----------------------------------------> test rescaling from 3 to 2 <---------------------------------------
 
+		// init state for new subtask-0
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot3, maxParallelism, 3, 2, 0);
+
+		// init state for new subtask-1
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot3, maxParallelism, 3, 2, 1);
+
 		KeyedOneInputStreamOperatorTestHarness<String, String, Integer>[] harness2 =
 			new KeyedOneInputStreamOperatorTestHarness[3];
 
@@ -275,7 +303,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness2[0] = getHarnessTest(keySelector, maxParallelism, 2, 0);
 			harness2[0].setStateBackend(getStateBackend());
 			harness2[0].setup();
-			harness2[0].initializeState(snapshot3);
+			harness2[0].initializeState(initState1);
 			harness2[0].open();
 
 			// task's key-group [5, 9], this will open a empty db, and insert records from two state handles.
@@ -284,7 +312,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			harness2[1] = getHarnessTest(keySelector, maxParallelism, 2, 1);
 			harness2[1].setStateBackend(getStateBackend());
 			harness2[1].setup();
-			harness2[1].initializeState(snapshot3);
+			harness2[1].initializeState(initState2);
 			harness2[1].open();
 
 			validHarnessResult(harness2[0], 2, records[0], records[1], records[2], records[3], records[4]);
@@ -305,6 +333,10 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 
 		// -----------------------------------------> test rescaling from 2 to 1 <---------------------------------------
 
+		// init state for new subtask-0
+		initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot2, maxParallelism, 2, 1, 0);
+
 		try (
 			KeyedOneInputStreamOperatorTestHarness<String, String, Integer> harness =
 				getHarnessTest(keySelector, maxParallelism, 1, 0)) {
@@ -312,7 +344,7 @@ public class RocksIncrementalCheckpointRescalingTest extends TestLogger {
 			// this will choose the state handle generated by harness2[0] to init the target db without any clipping.
 			harness.setStateBackend(getStateBackend());
 			harness.setup();
-			harness.initializeState(snapshot2);
+			harness.initializeState(initState1);
 			harness.open();
 
 			validHarnessResult(harness, 3, records);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/StatefulSequenceSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/StatefulSequenceSourceTest.java
@@ -45,6 +45,7 @@ public class StatefulSequenceSourceTest {
 	public void testCheckpointRestore() throws Exception {
 		final int initElement = 0;
 		final int maxElement = 100;
+		final int maxParallelsim = 2;
 
 		final Set<Long> expectedOutput = new HashSet<>();
 		for (long i = initElement; i <= maxElement; i++) {
@@ -61,14 +62,14 @@ public class StatefulSequenceSourceTest {
 		StreamSource<Long, StatefulSequenceSource> src1 = new StreamSource<>(source1);
 
 		final AbstractStreamOperatorTestHarness<Long> testHarness1 =
-			new AbstractStreamOperatorTestHarness<>(src1, 2, 2, 0);
+			new AbstractStreamOperatorTestHarness<>(src1, maxParallelsim, 2, 0);
 		testHarness1.open();
 
 		final StatefulSequenceSource source2 = new StatefulSequenceSource(initElement, maxElement);
 		StreamSource<Long, StatefulSequenceSource> src2 = new StreamSource<>(source2);
 
 		final AbstractStreamOperatorTestHarness<Long> testHarness2 =
-			new AbstractStreamOperatorTestHarness<>(src2, 2, 2, 1);
+			new AbstractStreamOperatorTestHarness<>(src2, maxParallelsim, 2, 1);
 		testHarness2.open();
 
 		final Throwable[] error = new Throwable[3];
@@ -120,10 +121,13 @@ public class StatefulSequenceSourceTest {
 		final StatefulSequenceSource source3 = new StatefulSequenceSource(initElement, maxElement);
 		StreamSource<Long, StatefulSequenceSource> src3 = new StreamSource<>(source3);
 
+		final OperatorSubtaskState initState = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelsim, 2, 1, 0);
+
 		final AbstractStreamOperatorTestHarness<Long> testHarness3 =
-			new AbstractStreamOperatorTestHarness<>(src3, 2, 1, 0);
+			new AbstractStreamOperatorTestHarness<>(src3, maxParallelsim, 1, 0);
 		testHarness3.setup();
-		testHarness3.initializeState(snapshot);
+		testHarness3.initializeState(initState);
 		testHarness3.open();
 
 		final OneShotLatch latchToTrigger3 = new OneShotLatch();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -456,12 +456,15 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 			);
 		}
 
+		final OperatorSubtaskState initState = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, TestUtils.MAX_PARALLELISM, 2, 1, 0);
+
 		try (
 				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness = TestUtils.createRescalingTestSink(
 						outDir, 1, 0, 100L, 10L)
 		) {
 			testHarness.setup();
-			testHarness.initializeState(mergedSnapshot);
+			testHarness.initializeState(initState);
 			testHarness.open();
 
 			// still everything in-progress but the in-progress for prev task 1 should be put in pending now

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -51,6 +51,8 @@ import java.util.Map;
  */
 public class TestUtils {
 
+	static final int MAX_PARALLELISM = 10;
+
 	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createRescalingTestSink(
 			File outDir,
 			int totalParallelism,
@@ -102,7 +104,7 @@ public class TestUtils {
 				.withBucketFactory(bucketFactory)
 				.build();
 
-		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 10, totalParallelism, taskIdx);
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}
 
 	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithBulkEncoder(
@@ -121,7 +123,7 @@ public class TestUtils {
 				.withBucketFactory(bucketFactory)
 				.build();
 
-		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 10, totalParallelism, taskIdx);
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}
 
 	static void checkLocalFs(File outDir, int expectedInProgress, int expectedCompleted) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -308,6 +308,8 @@ public class AbstractStreamOperatorTest {
 		OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
 
 		// now, restore in two operators, first operator 1
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelism, 1, 2, 0);
 
 		TestOperator testOperator1 = new TestOperator();
 
@@ -321,7 +323,7 @@ public class AbstractStreamOperatorTest {
 						0 /* subtask index */);
 
 		testHarness1.setup();
-		testHarness1.initializeState(snapshot);
+		testHarness1.initializeState(initState1);
 		testHarness1.open();
 
 		testHarness1.processWatermark(10L);
@@ -349,6 +351,9 @@ public class AbstractStreamOperatorTest {
 		assertTrue(extractResult(testHarness1).isEmpty());
 
 		// now, for the second operator
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelism, 1, 2, 1);
+
 		TestOperator testOperator2 = new TestOperator();
 
 		KeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String> testHarness2 =
@@ -361,7 +366,7 @@ public class AbstractStreamOperatorTest {
 						1 /* subtask index */);
 
 		testHarness2.setup();
-		testHarness2.initializeState(snapshot);
+		testHarness2.initializeState(initState2);
 		testHarness2.open();
 
 		testHarness2.processWatermark(10L);
@@ -453,6 +458,9 @@ public class AbstractStreamOperatorTest {
 				testHarness2.snapshot(0, 0)
 			);
 
+		OperatorSubtaskState initSubTaskState =
+			AbstractStreamOperatorTestHarness.repartitionOperatorState(repackagedState, maxParallelism, 2, 1, 0);
+
 		// now, for the third operator that scales down from parallelism of 2 to 1
 		TestOperator testOperator3 = new TestOperator();
 
@@ -466,7 +474,7 @@ public class AbstractStreamOperatorTest {
 				0 /* subtask index */);
 
 		testHarness3.setup();
-		testHarness3.initializeState(repackagedState);
+		testHarness3.initializeState(initSubTaskState);
 		testHarness3.open();
 
 		testHarness3.processWatermark(30L);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
@@ -513,7 +513,12 @@ public class CoBroadcastWithKeyedOperatorTest {
 		expected.add("test2=3");
 		expected.add("test3=3");
 
+		OperatorSubtaskState operatorSubtaskState1 = repartitionInitState(mergedSnapshot, 10, 2, 3, 0);
+		OperatorSubtaskState operatorSubtaskState2 = repartitionInitState(mergedSnapshot, 10, 2, 3, 1);
+		OperatorSubtaskState operatorSubtaskState3 = repartitionInitState(mergedSnapshot, 10, 2, 3, 2);
+
 		try (
+
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
 						new IdentityKeySelector<>(),
@@ -521,7 +526,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 						10,
 						3,
 						0,
-						mergedSnapshot);
+						operatorSubtaskState1);
 
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
@@ -530,7 +535,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 						10,
 						3,
 						1,
-						mergedSnapshot);
+						operatorSubtaskState2);
 
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness3 = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
@@ -539,7 +544,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 						10,
 						3,
 						2,
-						mergedSnapshot)
+						operatorSubtaskState3)
 		) {
 			testHarness1.processElement1(new StreamRecord<>("trigger"));
 			testHarness2.processElement1(new StreamRecord<>("trigger"));
@@ -621,6 +626,9 @@ public class CoBroadcastWithKeyedOperatorTest {
 		expected.add("test2=3");
 		expected.add("test3=3");
 
+		OperatorSubtaskState operatorSubtaskState1 = repartitionInitState(mergedSnapshot, 10, 3, 2, 0);
+		OperatorSubtaskState operatorSubtaskState2 = repartitionInitState(mergedSnapshot, 10, 3, 2, 1);
+
 		try (
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
@@ -629,7 +637,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 						10,
 						2,
 						0,
-						mergedSnapshot);
+						operatorSubtaskState1);
 
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
@@ -638,7 +646,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 						10,
 						2,
 						1,
-						mergedSnapshot)
+						operatorSubtaskState2)
 		) {
 
 			testHarness1.processElement1(new StreamRecord<>("trigger"));
@@ -765,6 +773,16 @@ public class CoBroadcastWithKeyedOperatorTest {
 				numTasks,
 				taskIdx,
 				null);
+	}
+
+	private static OperatorSubtaskState repartitionInitState(
+		final OperatorSubtaskState initState,
+		final int numKeyGroups,
+		final int oldParallelism,
+		final int newParallelism,
+		final int subtaskIndex
+	) {
+		return AbstractStreamOperatorTestHarness.repartitionOperatorState(initState, numKeyGroups, oldParallelism, newParallelism, subtaskIndex);
 	}
 
 	private static <KEY, IN1, IN2, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperatorTest.java
@@ -275,13 +275,17 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 		expected.add("test2=3");
 		expected.add("test3=3");
 
+		final OperatorSubtaskState initState1 = repartitionInitState(mergedSnapshot, 10, 2, 3, 0);
+		final OperatorSubtaskState initState2 = repartitionInitState(mergedSnapshot, 10, 2, 3, 1);
+		final OperatorSubtaskState initState3 = repartitionInitState(mergedSnapshot, 10, 2, 3, 2);
+
 		try (
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
 						new TestFunctionWithOutput(keysToRegister),
 						10,
 						3,
 						0,
-						mergedSnapshot,
+						initState1,
 						STATE_DESCRIPTOR);
 
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
@@ -289,7 +293,7 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 						10,
 						3,
 						1,
-						mergedSnapshot,
+						initState2,
 						STATE_DESCRIPTOR);
 
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness3 = getInitializedTestHarness(
@@ -297,7 +301,7 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 						10,
 						3,
 						2,
-						mergedSnapshot,
+						initState3,
 						STATE_DESCRIPTOR)
 		) {
 			testHarness1.processElement1(new StreamRecord<>("trigger"));
@@ -377,13 +381,16 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 		expected.add("test2=3");
 		expected.add("test3=3");
 
+		final OperatorSubtaskState initState1 = repartitionInitState(mergedSnapshot, 10, 3, 2, 0);
+		final OperatorSubtaskState initState2 = repartitionInitState(mergedSnapshot, 10, 3, 2, 1);
+
 		try (
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
 						new TestFunctionWithOutput(keysToRegister),
 						10,
 						2,
 						0,
-						mergedSnapshot,
+						initState1,
 						STATE_DESCRIPTOR);
 
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
@@ -391,7 +398,7 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 						10,
 						2,
 						1,
-						mergedSnapshot,
+						initState2,
 						STATE_DESCRIPTOR)
 		) {
 			testHarness1.processElement1(new StreamRecord<>("trigger"));
@@ -542,15 +549,15 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 				descriptors);
 	}
 
-//	private static <IN1, IN2, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
-//			final BroadcastProcessFunction<IN1, IN2, OUT> function,
-//			final int maxParallelism,
-//			final int numTasks,
-//			final int taskIdx,
-//			final OperatorSubtaskState initState) throws Exception {
-//
-//		return getInitializedTestHarness(function, maxParallelism, numTasks, taskIdx, initState, STATE_DESCRIPTOR);
-//	}
+	private static OperatorSubtaskState repartitionInitState(
+			final OperatorSubtaskState initState,
+			final int numKeyGroups,
+			final int oldParallelism,
+			final int newParallelism,
+			final int subtaskIndex
+	) {
+		return AbstractStreamOperatorTestHarness.repartitionOperatorState(initState, numKeyGroups, oldParallelism, newParallelism, subtaskIndex);
+	}
 
 	private static <IN1, IN2, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
 			final BroadcastProcessFunction<IN1, IN2, OUT> function,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
@@ -46,6 +46,8 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 
 	protected abstract void verifyResultsWhenReScaling(S sink, int startElementCounter, int endElementCounter) throws Exception;
 
+	private final int maxParallelism = 10;
+
 	@Test
 	public void testIdealCircumstances() throws Exception {
 		S sink = createSink();
@@ -173,12 +175,12 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 	public void testScalingDown() throws Exception {
 		S sink1 = createSink();
 		OneInputStreamOperatorTestHarness<IN, IN> testHarness1 =
-			new OneInputStreamOperatorTestHarness<>(sink1, 10, 2, 0);
+			new OneInputStreamOperatorTestHarness<>(sink1, maxParallelism, 2, 0);
 		testHarness1.open();
 
 		S sink2 = createSink();
 		OneInputStreamOperatorTestHarness<IN, IN> testHarness2 =
-			new OneInputStreamOperatorTestHarness<>(sink2, 10, 2, 1);
+			new OneInputStreamOperatorTestHarness<>(sink2, maxParallelism, 2, 1);
 		testHarness2.open();
 
 		int elementCounter = 1;
@@ -208,12 +210,15 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 		// and create a third instance that operates alone but
 		// has the merged state of the previous 2 instances
 
+		OperatorSubtaskState initState = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			mergedSnapshot, maxParallelism, 2, 1, 0);
+
 		S sink3 = createSink();
 		OneInputStreamOperatorTestHarness<IN, IN> mergedTestHarness =
-			new OneInputStreamOperatorTestHarness<>(sink3, 10, 1, 0);
+			new OneInputStreamOperatorTestHarness<>(sink3, maxParallelism, 1, 0);
 
 		mergedTestHarness.setup();
-		mergedTestHarness.initializeState(mergedSnapshot);
+		mergedTestHarness.initializeState(initState);
 		mergedTestHarness.open();
 
 		for (int x = 0; x < 12; x++) {
@@ -234,7 +239,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 
 		S sink1 = createSink();
 		OneInputStreamOperatorTestHarness<IN, IN> testHarness1 =
-			new OneInputStreamOperatorTestHarness<>(sink1, 10, 1, 0);
+			new OneInputStreamOperatorTestHarness<>(sink1, maxParallelism, 1, 0);
 
 		int elementCounter = 1;
 		int snapshotCount = 0;
@@ -265,14 +270,20 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 		// we will create two operator instances, testHarness2 and testHarness3,
 		// that will share the state of testHarness1
 
+		OperatorSubtaskState initState1 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelism, 1, 2, 0);
+
+		OperatorSubtaskState initState2 = AbstractStreamOperatorTestHarness.repartitionOperatorState(
+			snapshot, maxParallelism, 1, 2, 1);
+
 		++snapshotCount;
 
 		S sink2 = createSink();
 		OneInputStreamOperatorTestHarness<IN, IN> testHarness2 =
-			new OneInputStreamOperatorTestHarness<>(sink2, 10, 2, 0);
+			new OneInputStreamOperatorTestHarness<>(sink2, maxParallelism, 2, 0);
 
 		testHarness2.setup();
-		testHarness2.initializeState(snapshot);
+		testHarness2.initializeState(initState1);
 		testHarness2.open();
 
 		testHarness2.notifyOfCompletedCheckpoint(snapshotCount);
@@ -281,10 +292,10 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 
 		S sink3 = createSink();
 		OneInputStreamOperatorTestHarness<IN, IN> testHarness3 =
-			new OneInputStreamOperatorTestHarness<>(sink3, 10, 2, 1);
+			new OneInputStreamOperatorTestHarness<>(sink3, maxParallelism, 2, 1);
 
 		testHarness3.setup();
-		testHarness3.initializeState(snapshot);
+		testHarness3.initializeState(initState2);
 		testHarness3.open();
 
 		// add some more elements to verify that everything functions normally from now on...

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -113,7 +114,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 	private final Object checkpointLock;
 
-	private final OperatorStateRepartitioner operatorStateRepartitioner =
+	private static final OperatorStateRepartitioner operatorStateRepartitioner =
 			RoundRobinOperatorStateRepartitioner.INSTANCE;
 
 	/**
@@ -290,9 +291,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	 * Calls {@link org.apache.flink.streaming.api.operators.StreamOperator#setup(StreamTask, StreamConfig, Output)}
 	 * if it was not called before.
 	 *
-	 * <p>This will reshape the state handles to include only those key-group states
-	 * in the local key-group range and the operator states that would be assigned to the local
-	 * subtask.
 	 */
 	public void initializeState(OperatorSubtaskState operatorStateHandles) throws Exception {
 		initializeState(operatorStateHandles, null);
@@ -304,6 +302,72 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 	public void initializeEmptyState() throws Exception {
 		initializeState((OperatorSubtaskState) null);
+	}
+
+	/**
+	 * Returns the reshaped the state handles to include only those key-group states in the local key-group range
+	 * and the operator states that would be assigned to the local subtask.
+	 */
+	public static OperatorSubtaskState repartitionOperatorState(
+		final OperatorSubtaskState operatorStateHandles,
+		final int numKeyGroups,
+		final int oldParallelism,
+		final int newParallelism,
+		final int subtaskIndex) {
+
+		Preconditions.checkNotNull(operatorStateHandles, "the previous operatorStateHandles should not be null.");
+
+		// create a new OperatorStateHandles that only contains the state for our key-groups
+
+		List<KeyGroupRange> keyGroupPartitions = StateAssignmentOperation.createKeyGroupPartitions(
+			numKeyGroups,
+			newParallelism);
+
+		KeyGroupRange localKeyGroupRange = keyGroupPartitions.get(subtaskIndex);
+
+		List<KeyedStateHandle> localManagedKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
+			operatorStateHandles.getManagedKeyedState(),
+			localKeyGroupRange);
+
+		List<KeyedStateHandle> localRawKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
+			operatorStateHandles.getRawKeyedState(),
+			localKeyGroupRange);
+
+		StateObjectCollection<OperatorStateHandle> managedOperatorStates = operatorStateHandles.getManagedOperatorState();
+		Collection<OperatorStateHandle> localManagedOperatorState;
+
+		if (!managedOperatorStates.isEmpty()) {
+			List<List<OperatorStateHandle>> managedOperatorState =
+				managedOperatorStates.stream().map(Collections::singletonList).collect(Collectors.toList());
+
+			localManagedOperatorState = operatorStateRepartitioner.repartitionState(
+				managedOperatorState,
+				oldParallelism,
+				newParallelism).get(subtaskIndex);
+		} else {
+			localManagedOperatorState = Collections.emptyList();
+		}
+
+		StateObjectCollection<OperatorStateHandle> rawOperatorStates = operatorStateHandles.getRawOperatorState();
+		Collection<OperatorStateHandle> localRawOperatorState;
+
+		if (!rawOperatorStates.isEmpty()) {
+			List<List<OperatorStateHandle>> rawOperatorState =
+				rawOperatorStates.stream().map(Collections::singletonList).collect(Collectors.toList());
+
+			localRawOperatorState = operatorStateRepartitioner.repartitionState(
+				rawOperatorState,
+				oldParallelism,
+				newParallelism).get(subtaskIndex);
+		} else {
+			localRawOperatorState = Collections.emptyList();
+		}
+
+		return new OperatorSubtaskState(
+			new StateObjectCollection<>(nullToEmptyCollection(localManagedOperatorState)),
+			new StateObjectCollection<>(nullToEmptyCollection(localRawOperatorState)),
+			new StateObjectCollection<>(nullToEmptyCollection(localManagedKeyGroupState)),
+			new StateObjectCollection<>(nullToEmptyCollection(localRawKeyGroupState)));
 	}
 
 	/**
@@ -326,50 +390,9 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		}
 
 		if (jmOperatorStateHandles != null) {
-			int numKeyGroups = getEnvironment().getTaskInfo().getMaxNumberOfParallelSubtasks();
-			int numSubtasks = getEnvironment().getTaskInfo().getNumberOfParallelSubtasks();
-			int subtaskIndex = getEnvironment().getTaskInfo().getIndexOfThisSubtask();
-
-			// create a new OperatorStateHandles that only contains the state for our key-groups
-
-			List<KeyGroupRange> keyGroupPartitions = StateAssignmentOperation.createKeyGroupPartitions(
-				numKeyGroups,
-				numSubtasks);
-
-			KeyGroupRange localKeyGroupRange = keyGroupPartitions.get(subtaskIndex);
-
-			List<KeyedStateHandle> localManagedKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
-				jmOperatorStateHandles.getManagedKeyedState(),
-				localKeyGroupRange);
-
-			List<KeyedStateHandle> localRawKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
-				jmOperatorStateHandles.getRawKeyedState(),
-				localKeyGroupRange);
-
-			List<OperatorStateHandle> managedOperatorState = new ArrayList<>();
-
-			managedOperatorState.addAll(jmOperatorStateHandles.getManagedOperatorState());
-
-			Collection<OperatorStateHandle> localManagedOperatorState = operatorStateRepartitioner.repartitionState(
-				managedOperatorState,
-				numSubtasks).get(subtaskIndex);
-
-			List<OperatorStateHandle> rawOperatorState = new ArrayList<>();
-
-			rawOperatorState.addAll(jmOperatorStateHandles.getRawOperatorState());
-
-			Collection<OperatorStateHandle> localRawOperatorState = operatorStateRepartitioner.repartitionState(
-				rawOperatorState,
-				numSubtasks).get(subtaskIndex);
-
-			OperatorSubtaskState processedJmOpSubtaskState = new OperatorSubtaskState(
-				new StateObjectCollection<>(nullToEmptyCollection(localManagedOperatorState)),
-				new StateObjectCollection<>(nullToEmptyCollection(localRawOperatorState)),
-				new StateObjectCollection<>(nullToEmptyCollection(localManagedKeyGroupState)),
-				new StateObjectCollection<>(nullToEmptyCollection(localRawKeyGroupState)));
 
 			TaskStateSnapshot jmTaskStateSnapshot = new TaskStateSnapshot();
-			jmTaskStateSnapshot.putSubtaskStateByOperatorID(operator.getOperatorID(), processedJmOpSubtaskState);
+			jmTaskStateSnapshot.putSubtaskStateByOperatorID(operator.getOperatorID(), jmOperatorStateHandles);
 
 			taskStateManager.setReportedCheckpointId(0);
 			taskStateManager.setJobManagerTaskStateSnapshotsByCheckpointId(
@@ -397,8 +420,10 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	 * and repacks them into a single {@link OperatorSubtaskState} so that the parallelism of the test
 	 * can change arbitrarily (i.e. be able to scale both up and down).
 	 *
-	 * <p>After repacking the partial states, use {@link #initializeState(OperatorSubtaskState)} to initialize
-	 * a new instance with the resulting state. Bear in mind that for parallelism greater than one, you
+	 * <p>After repacking the partial states, remember to use
+	 * {@link #repartitionOperatorState(OperatorSubtaskState, int, int, int, int)} to reshape the state handles
+	 * to include only those key-group states in the local key-group range and the operator states that would
+	 * be assigned to the local subtask. Bear in mind that for parallelism greater than one, you
 	 * have to use the constructor {@link #AbstractStreamOperatorTestHarness(StreamOperator, int, int, int)}.
 	 *
 	 * <p><b>NOTE: </b> each of the {@code handles} in the argument list is assumed to be from a single task of a single


### PR DESCRIPTION
## What is the purpose of the change
There existed two problems during state assignment when parallelism not changed:

1.  If we only have even-split redistributed state, current implementation actually cannot ensure state assignment to keep as the same as previously. This is because current `StateAssignmentOperation#collectPartitionableStates` would repartition managedOperatorStates without subtask-index information. Take an example, if we have a operator-state with parallelism as 2, and subtask-0's managed-operatorstate is empty while subtask-1 not. Although new parallelism still keeps as 2, after `StateAssignmentOperation#collectPartitionableStates` and state assigned, subtask-0 would be assigned the managed-operatorstate while subtask-1 got none.
1.  We should only redistribute union state and not touch the even-split state. Redistribute even-split state would cause unexpected behavior after `RestartPipelinedRegionStrategy` supported to restore state.

This PR will fix the above two problems.

## Brief change log

  - Refactor `StateAssignmentOperation#collectPartitionableStates` to let returned `managedOperatorStates` has subtask-index information.
  - Refactor API of `OperatorStateRepartitioner` and its implementation `RoundRobinOperatorStateRepartitioner`. The logical of comparing old and new parallelism is now located in `OperatorStateRepartitioner#repartitionState`.
  - Refactor `AbstractStreamOperatorTestHarness` to extract the logic of  repartitioning operator state into a new method `AbstractStreamOperatorTestHarness#repartitionOperatorState` instead of previously contained in `AbstractStreamOperatorTestHarness#initializeState`.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `StateAssignmentOperationTest` to verify the logic of `StateAssignmentOperation#reDistributePartitionableStates`.
  - Existed all tests using `AbstractStreamOperatorTestHarness` could verify the refactor of `StateAssignmentOperation` generate the expected results as before.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes, this could affect state assignment when restoring checkpoint
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable, this is a internal implementation, current doc should be enough.
