### PR TITLE
[FLINK-11533] [container] Add option parse JAR manifest for jobClassName

### DIFF
--- a/flink-container/kubernetes/README.md
+++ b/flink-container/kubernetes/README.md
@@ -9,14 +9,13 @@ Please follow the instructions you can find [here](../docker/README.md) to build
 
 This directory contains a predefined K8s service and two template files for the job cluster entry point and the task managers.
 
-The K8s service is used to let the cluster pods find each other. 
+The K8s service is used to let the cluster pods find each other.
 If you start the Flink cluster in HA mode, then this is not necessary, because the HA implementation is used to detect leaders.
 
 In order to use the template files, please replace the `${VARIABLES}` in the file with concrete values.
 The files contain the following variables:
 
 - `${FLINK_IMAGE_NAME}`: Name of the image to use for the container
-- `${FLINK_JOB}`: Name of the Flink job to start (the user code jar must be included in the container image)
 - `${FLINK_JOB_PARALLELISM}`: Degree of parallelism with which to start the Flink job and the number of required task managers
 
 One way to substitute the variables is to use `envsubst`.
@@ -42,6 +41,7 @@ At last, you should start the task manager deployment:
 
 You can provide the following additional command line arguments to the cluster entrypoint:
 
+- `--job-classname <job class name>`: Class name of the job to run. By default, the Flink class path is scanned for a JAR with a `Main-Class` or `program-class` manifest entry and chosen as the job class. Use this command line argument to manually set the job class. This argument is required in case that no or more than one JAR with such a manifest entry is available on the class path.
 - `--job-id <job id>`: Manually set a Flink job ID for the job (default: `00000000000000000000000000000000`)
 
 ## Resuming from a savepoint

--- a/flink-container/kubernetes/job-cluster-job.yaml.template
+++ b/flink-container/kubernetes/job-cluster-job.yaml.template
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: flink-job-cluster
         image: ${FLINK_IMAGE_NAME}
-        args: ["job-cluster", "--job-classname", "${FLINK_JOB}", "-Djobmanager.rpc.address=flink-job-cluster",
+        args: ["job-cluster", "-Djobmanager.rpc.address=flink-job-cluster",
                "-Dparallelism.default=${FLINK_JOB_PARALLELISM}", "-Dblob.server.port=6124", "-Dqueryable-state.server.ports=6125"]
         ports:
         - containerPort: 6123

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -66,4 +66,37 @@ under the License.
 		</dependency>
 
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- Assemble a test jar for EntryClassParserTest. More information on this:
+			 http://stackoverflow.com/questions/1401857/using-maven-to-build-separate-jar-files-for-unit-testing-a-custom-class-loader
+			 -->
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
+				<executions>
+					<execution>
+						<id>create-test-dependency</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.apache.flink.container.entrypoint.TestJob</mainClass>
+								</manifest>
+							</archive>
+							<finalName>maven</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.container.entrypoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.container.entrypoint.JarManifestParser.JarFileWithEntryClass;
 import org.apache.flink.runtime.entrypoint.component.JobGraphRetriever;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -35,6 +37,13 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -44,9 +53,6 @@ import static java.util.Objects.requireNonNull;
 class ClassPathJobGraphRetriever implements JobGraphRetriever {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClassPathJobGraphRetriever.class);
-	private static final String JAVA_CLASS_PATH = "java.class.path";
-	private static final String PATH_SEPARATOR = "path.separator";
-	private static final String DEFAULT_PATH_SEPARATOR = ":";
 
 	@Nonnull
 	private final JobID jobId;
@@ -60,15 +66,29 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	@Nullable
 	private final String jobClassName;
 
+	@Nonnull
+	private final Supplier<Iterable<File>> jarsOnClassPath;
+
 	ClassPathJobGraphRetriever(
 			@Nonnull JobID jobId,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
 			@Nonnull String[] programArguments,
 			@Nullable String jobClassName) {
+		this(jobId, savepointRestoreSettings, programArguments, jobClassName, JarsOnClassPath.INSTANCE);
+	}
+
+	@VisibleForTesting
+	ClassPathJobGraphRetriever(
+			@Nonnull JobID jobId,
+			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
+			@Nonnull String[] programArguments,
+			@Nullable String jobClassName,
+			@Nonnull Supplier<Iterable<File>> jarsOnClassPath) {
 		this.jobId = requireNonNull(jobId, "jobId");
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
 		this.programArguments = requireNonNull(programArguments, "programArguments");
 		this.jobClassName = jobClassName;
+		this.jarsOnClassPath = requireNonNull(jarsOnClassPath, "jarsOnClassPath");
 	}
 
 	@Override
@@ -91,11 +111,57 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	}
 
 	private PackagedProgram createPackagedProgram() throws FlinkException {
+		final String entryClass = getJobClassNameOrScanClassPath();
 		try {
-			final Class<?> mainClass = getClass().getClassLoader().loadClass(jobClassName);
+			final Class<?> mainClass = getClass().getClassLoader().loadClass(entryClass);
 			return new PackagedProgram(mainClass, programArguments);
 		} catch (ClassNotFoundException | ProgramInvocationException e) {
 			throw new FlinkException("Could not load the provided entrypoint class.", e);
+		}
+	}
+
+	private String getJobClassNameOrScanClassPath() throws FlinkException {
+		if (jobClassName != null) {
+			return jobClassName;
+		}
+
+		try {
+			return scanClassPathForJobJar();
+		} catch (IOException | NoSuchElementException | IllegalArgumentException e) {
+			throw new FlinkException("Failed to find job JAR on class path. Please provide the job class name explicitly.", e);
+		}
+	}
+
+	private String scanClassPathForJobJar() throws IOException {
+		LOG.info("Scanning class path for job JAR");
+		JarFileWithEntryClass jobJar = JarManifestParser.findOnlyEntryClass(jarsOnClassPath.get());
+
+		LOG.info("Using {} as job jar", jobJar);
+		return jobJar.getEntryClass();
+	}
+
+	@VisibleForTesting
+	enum JarsOnClassPath implements Supplier<Iterable<File>> {
+		INSTANCE;
+
+		static final String JAVA_CLASS_PATH = "java.class.path";
+		static final String PATH_SEPARATOR = "path.separator";
+		static final String DEFAULT_PATH_SEPARATOR = ":";
+
+		@Override
+		public Iterable<File> get() {
+			String classPath = System.getProperty(JAVA_CLASS_PATH, "");
+			String pathSeparator = System.getProperty(PATH_SEPARATOR, DEFAULT_PATH_SEPARATOR);
+
+			return Arrays.stream(classPath.split(pathSeparator))
+				.filter(JarsOnClassPath::notNullAndNotEmpty)
+				.map(File::new)
+				.filter(File::isFile)
+				.collect(Collectors.toList());
+		}
+
+		private static boolean notNullAndNotEmpty(String string) {
+			return string != null && !string.equals("");
 		}
 	}
 

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetriever.java
@@ -29,7 +29,11 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.FlinkException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -39,8 +43,10 @@ import static java.util.Objects.requireNonNull;
  */
 class ClassPathJobGraphRetriever implements JobGraphRetriever {
 
-	@Nonnull
-	private final String jobClassName;
+	private static final Logger LOG = LoggerFactory.getLogger(ClassPathJobGraphRetriever.class);
+	private static final String JAVA_CLASS_PATH = "java.class.path";
+	private static final String PATH_SEPARATOR = "path.separator";
+	private static final String DEFAULT_PATH_SEPARATOR = ":";
 
 	@Nonnull
 	private final JobID jobId;
@@ -51,15 +57,18 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 	@Nonnull
 	private final String[] programArguments;
 
+	@Nullable
+	private final String jobClassName;
+
 	ClassPathJobGraphRetriever(
-			@Nonnull String jobClassName,
 			@Nonnull JobID jobId,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
-			@Nonnull String[] programArguments) {
-		this.jobClassName = requireNonNull(jobClassName, "jobClassName");
+			@Nonnull String[] programArguments,
+			@Nullable String jobClassName) {
 		this.jobId = requireNonNull(jobId, "jobId");
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
 		this.programArguments = requireNonNull(programArguments, "programArguments");
+		this.jobClassName = jobClassName;
 	}
 
 	@Override
@@ -89,4 +98,5 @@ class ClassPathJobGraphRetriever implements JobGraphRetriever {
 			throw new FlinkException("Could not load the provided entrypoint class.", e);
 		}
 	}
+
 }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/JarManifestParser.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/JarManifestParser.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.client.program.PackagedProgram;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utility that parses JAR manifest attributes.
+ */
+class JarManifestParser {
+
+	static class JarFileWithEntryClass {
+		private final File jarFile;
+		private final String entryClass;
+
+		private JarFileWithEntryClass(File jarFile, String entryClass) {
+			this.jarFile = requireNonNull(jarFile, "jarFile");
+			this.entryClass = requireNonNull(entryClass, "entryClass");
+		}
+
+		File getJarFile() {
+			return jarFile;
+		}
+
+		String getEntryClass() {
+			return entryClass;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("%s (entry class: %s)", jarFile.getAbsolutePath(), entryClass);
+		}
+	}
+
+	/**
+	 * Returns a JAR file with its entry class as specified in the manifest.
+	 *
+	 * @param jarFiles JAR files to parse
+	 *
+	 * @throws NoSuchElementException if no JAR file contains an entry class attribute
+	 * @throws IllegalArgumentException if multiple JAR files contain an entry class manifest attribute
+	 */
+	static JarFileWithEntryClass findOnlyEntryClass(Iterable<File> jarFiles) throws IOException {
+		List<JarFileWithEntryClass> jarsWithEntryClasses = new ArrayList<>();
+		for (File jarFile : jarFiles) {
+			findEntryClass(jarFile)
+				.ifPresent(entryClass -> jarsWithEntryClasses.add(new JarFileWithEntryClass(jarFile, entryClass)));
+		}
+		int size = jarsWithEntryClasses.size();
+		if (size == 0) {
+			throw new NoSuchElementException("No JAR with manifest attribute for entry class");
+		}
+		if (size == 1) {
+			return jarsWithEntryClasses.get(0);
+		}
+		// else: size > 1
+		throw new IllegalArgumentException("Multiple JARs with manifest attribute for entry class: "
+			+ jarsWithEntryClasses);
+	}
+
+	/**
+	 * Returns the entry class as specified in the manifest of the provided JAR file.
+	 *
+	 * <p>The following manifest attributes are checked in order to find the entry class:
+	 * <ol>
+	 * <li>{@link PackagedProgram#MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS}</li>
+	 * <li>{@link PackagedProgram#MANIFEST_ATTRIBUTE_MAIN_CLASS}</li>
+	 * </ol>
+	 *
+	 * @param jarFileZO JAR file to parse
+	 * @return Optional holding entry class
+	 * @throws IOException If there is an error accessing the JAR
+	 */
+	@VisibleForTesting
+	static Optional<String> findEntryClass(File jarFile) throws IOException {
+		return findFirstManifestAttribute(
+			jarFile,
+			PackagedProgram.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS,
+			PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS);
+	}
+
+	/**
+	 * Returns the value of the first manifest attribute found in the provided JAR file.
+	 *
+	 * @param jarFile    JAR file to parse
+	 * @param attributes Attributes to check
+	 * @return Optional holding value of first found attribute
+	 * @throws IOException If there is an error accessing the JAR
+	 */
+	private static Optional<String> findFirstManifestAttribute(File jarFile, String... attributes) throws IOException {
+		if (attributes.length == 0) {
+			return Optional.empty();
+		}
+		try (JarFile f = new JarFile(jarFile)) {
+			return findFirstManifestAttribute(f, attributes);
+		}
+	}
+
+	private static Optional<String> findFirstManifestAttribute(JarFile jarFile, String... attributes) throws IOException {
+		Manifest manifest = jarFile.getManifest();
+		if (manifest == null) {
+			return Optional.empty();
+		}
+
+		Attributes mainAttributes = manifest.getMainAttributes();
+		for (String attribute : attributes) {
+			String value = mainAttributes.getValue(attribute);
+			if (value != null) {
+				return Optional.of(value);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+}

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/JarManifestParser.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/JarManifestParser.java
@@ -96,7 +96,7 @@ class JarManifestParser {
 	 * <li>{@link PackagedProgram#MANIFEST_ATTRIBUTE_MAIN_CLASS}</li>
 	 * </ol>
 	 *
-	 * @param jarFileZO JAR file to parse
+	 * @param jarFile JAR file to parse
 	 * @return Optional holding entry class
 	 * @throws IOException If there is an error accessing the JAR
 	 */

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfiguration.java
@@ -35,13 +35,13 @@ import static java.util.Objects.requireNonNull;
 final class StandaloneJobClusterConfiguration extends EntrypointClusterConfiguration {
 
 	@Nonnull
-	private final String jobClassName;
-
-	@Nonnull
 	private final SavepointRestoreSettings savepointRestoreSettings;
 
 	@Nonnull
 	private final JobID jobId;
+
+	@Nullable
+	private final String jobClassName;
 
 	StandaloneJobClusterConfiguration(
 			@Nonnull String configDir,
@@ -49,18 +49,13 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 			@Nonnull String[] args,
 			@Nullable String hostname,
 			int restPort,
-			@Nonnull String jobClassName,
 			@Nonnull SavepointRestoreSettings savepointRestoreSettings,
-			@Nonnull JobID jobId) {
+			@Nonnull JobID jobId,
+			@Nullable String jobClassName) {
 		super(configDir, dynamicProperties, args, hostname, restPort);
-		this.jobClassName = requireNonNull(jobClassName, "jobClassName");
 		this.savepointRestoreSettings = requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
 		this.jobId = requireNonNull(jobId, "jobId");
-	}
-
-	@Nonnull
-	String getJobClassName() {
-		return jobClassName;
+		this.jobClassName = jobClassName;
 	}
 
 	@Nonnull
@@ -71,5 +66,10 @@ final class StandaloneJobClusterConfiguration extends EntrypointClusterConfigura
 	@Nonnull
 	JobID getJobId() {
 		return jobId;
+	}
+
+	@Nullable
+	String getJobClassName() {
+		return jobClassName;
 	}
 }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactory.java
@@ -47,7 +47,7 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 
 	private static final Option JOB_CLASS_NAME_OPTION = Option.builder("j")
 		.longOpt("job-classname")
-		.required(true)
+		.required(false)
 		.hasArg(true)
 		.argName("job class name")
 		.desc("Class name of the job to run.")
@@ -81,9 +81,9 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 		final Properties dynamicProperties = commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
 		final int restPort = getRestPort(commandLine);
 		final String hostname = commandLine.getOptionValue(HOST_OPTION.getOpt());
-		final String jobClassName = commandLine.getOptionValue(JOB_CLASS_NAME_OPTION.getOpt());
 		final SavepointRestoreSettings savepointRestoreSettings = CliFrontendParser.createSavepointRestoreSettings(commandLine);
 		final JobID jobId = getJobId(commandLine);
+		final String jobClassName = commandLine.getOptionValue(JOB_CLASS_NAME_OPTION.getOpt());
 
 		return new StandaloneJobClusterConfiguration(
 			configDir,
@@ -91,9 +91,9 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 			commandLine.getArgs(),
 			hostname,
 			restPort,
-			jobClassName,
 			savepointRestoreSettings,
-			jobId);
+			jobId,
+			jobClassName);
 	}
 
 	private int getRestPort(CommandLine commandLine) throws FlinkParseException {
@@ -101,7 +101,7 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 		try {
 			return Integer.parseInt(restPortString);
 		} catch (NumberFormatException e) {
-			throw flinkParseException(REST_PORT_OPTION, e);
+			throw createFlinkParseException(REST_PORT_OPTION, e);
 		}
 	}
 
@@ -113,11 +113,11 @@ public class StandaloneJobClusterConfigurationParserFactory implements ParserRes
 		try {
 			return JobID.fromHexString(jobId);
 		} catch (IllegalArgumentException e) {
-			throw flinkParseException(JOB_ID_OPTION, e);
+			throw createFlinkParseException(JOB_ID_OPTION, e);
 		}
 	}
 
-	private static FlinkParseException flinkParseException(Option option, Exception cause) {
+	private static FlinkParseException createFlinkParseException(Option option, Exception cause) {
 		return new FlinkParseException(String.format("Failed to parse '--%s' option", option.getLongOpt()), cause);
 	}
 }

--- a/flink-container/src/test/assembly/test-assembly.xml
+++ b/flink-container/src/test/assembly/test-assembly.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/container/entrypoint/TestJob</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
@@ -48,10 +48,10 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 		final JobID jobId = new JobID();
 
 		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
-			TestJob.class.getCanonicalName(),
 			jobId,
 			SavepointRestoreSettings.none(),
-			PROGRAM_ARGUMENTS);
+			PROGRAM_ARGUMENTS,
+			TestJob.class.getCanonicalName());
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 
@@ -67,10 +67,10 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 		final JobID jobId = new JobID();
 
 		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
-			TestJob.class.getCanonicalName(),
 			jobId,
 			savepointRestoreSettings,
-			PROGRAM_ARGUMENTS);
+			PROGRAM_ARGUMENTS,
+			TestJob.class.getCanonicalName());
 
 		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(configuration);
 

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/ClassPathJobGraphRetrieverTest.java
@@ -21,14 +21,26 @@ package org.apache.flink.container.entrypoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.container.entrypoint.ClassPathJobGraphRetriever.JarsOnClassPath;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -37,6 +49,9 @@ import static org.junit.Assert.assertThat;
  * Tests for the {@link ClassPathJobGraphRetriever}.
  */
 public class ClassPathJobGraphRetrieverTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	private static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
 
@@ -61,6 +76,40 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 	}
 
 	@Test
+	public void testJobGraphRetrievalFromJar() throws FlinkException, FileNotFoundException {
+		final File testJar = TestJob.getTestJobJar();
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
+			new JobID(),
+			SavepointRestoreSettings.none(),
+			PROGRAM_ARGUMENTS,
+			// No class name specified, but the test JAR "is" on the class path
+			null,
+			() -> Collections.singleton(testJar));
+
+		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+
+		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName() + "-suffix")));
+	}
+
+	@Test
+	public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClassPath() throws FlinkException, FileNotFoundException {
+		final File testJar = new File("non-existing");
+
+		final ClassPathJobGraphRetriever classPathJobGraphRetriever = new ClassPathJobGraphRetriever(
+			new JobID(),
+			SavepointRestoreSettings.none(),
+			PROGRAM_ARGUMENTS,
+			// Both a class name is specified and a JAR "is" on the class path
+			// The class name should have precedence.
+			TestJob.class.getCanonicalName(),
+			() -> Collections.singleton(testJar));
+
+		final JobGraph jobGraph = classPathJobGraphRetriever.retrieveJobGraph(new Configuration());
+
+		assertThat(jobGraph.getName(), is(equalTo(TestJob.class.getCanonicalName() + "-suffix")));
+	}
+
+	@Test
 	public void testSavepointRestoreSettings() throws FlinkException {
 		final Configuration configuration = new Configuration();
 		final SavepointRestoreSettings savepointRestoreSettings = SavepointRestoreSettings.forPath("foobar", true);
@@ -77,4 +126,54 @@ public class ClassPathJobGraphRetrieverTest extends TestLogger {
 		assertThat(jobGraph.getSavepointRestoreSettings(), is(equalTo(savepointRestoreSettings)));
 		assertEquals(jobGraph.getJobID(), jobId);
 	}
+
+	@Test
+	public void testJarFromClassPathSupplierSanityCheck() {
+		Iterable<File> jarFiles = JarsOnClassPath.INSTANCE.get();
+
+		// Junit executes this test, so it should be returned as part of JARs on the class path
+		assertThat(jarFiles, hasItem(hasProperty("name", containsString("junit"))));
+	}
+
+	@Test
+	public void testJarFromClassPathSupplier() throws IOException {
+		final File file1 = temporaryFolder.newFile();
+		final File file2 = temporaryFolder.newFile();
+		final File directory = temporaryFolder.newFolder();
+
+		// Mock java.class.path property. The empty strings are important as the shell scripts
+		// that prepare the Flink class path often have such entries.
+		final String classPath = javaClassPath(
+			"",
+			"",
+			"",
+			file1.getAbsolutePath(),
+			"",
+			directory.getAbsolutePath(),
+			"",
+			file2.getAbsolutePath(),
+			"",
+			"");
+
+		Iterable<File> jarFiles = setClassPathAndGetJarsOnClassPath(classPath);
+
+		assertThat(jarFiles, contains(file1, file2));
+	}
+
+	private static String javaClassPath(String... entries) {
+		String pathSeparator = System.getProperty(JarsOnClassPath.PATH_SEPARATOR);
+		return String.join(pathSeparator, entries);
+	}
+
+	private static Iterable<File> setClassPathAndGetJarsOnClassPath(String classPath) {
+		final String originalClassPath = System.getProperty(JarsOnClassPath.JAVA_CLASS_PATH);
+		try {
+			System.setProperty(JarsOnClassPath.JAVA_CLASS_PATH, classPath);
+			return JarsOnClassPath.INSTANCE.get();
+		} finally {
+			// Reset property
+			System.setProperty(JarsOnClassPath.JAVA_CLASS_PATH, originalClassPath);
+		}
+	}
+
 }

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/JarManifestParserTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/JarManifestParserTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.container.entrypoint.JarManifestParser.JarFileWithEntryClass;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for JAR file manifest parsing.
+ */
+public class JarManifestParserTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testFindEntryClassNoEntry() throws IOException {
+		File jarFile = createJarFileWithManifest(ImmutableMap.of());
+
+		Optional<String> entry = JarManifestParser.findEntryClass(jarFile);
+
+		assertFalse(entry.isPresent());
+	}
+
+	@Test
+	public void testFindEntryClassAssemblerClass() throws IOException {
+		File jarFile = createJarFileWithManifest(ImmutableMap.of(
+			PackagedProgram.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS, "AssemblerClass"));
+
+		Optional<String> entry = JarManifestParser.findEntryClass(jarFile);
+
+		assertTrue(entry.isPresent());
+		assertThat(entry.get(), is(equalTo("AssemblerClass")));
+	}
+
+	@Test
+	public void testFindEntryClassMainClass() throws IOException {
+		File jarFile = createJarFileWithManifest(ImmutableMap.of(
+			PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS, "MainClass"));
+
+		Optional<String> entry = JarManifestParser.findEntryClass(jarFile);
+
+		assertTrue(entry.isPresent());
+		assertThat(entry.get(), is(equalTo("MainClass")));
+	}
+
+	@Test
+	public void testFindEntryClassAssemblerClassAndMainClass() throws IOException {
+		// We want the assembler class entry to have precedence over main class
+		File jarFile = createJarFileWithManifest(ImmutableMap.of(
+			PackagedProgram.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS, "AssemblerClass",
+			PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS, "MainClass"));
+
+		Optional<String> entry = JarManifestParser.findEntryClass(jarFile);
+
+		assertTrue(entry.isPresent());
+		assertThat(entry.get(), is(equalTo("AssemblerClass")));
+	}
+
+	@Test
+	public void testFindEntryClassWithTestJobJar() throws IOException {
+		File jarFile = TestJob.getTestJobJar();
+
+		Optional<String> entryClass = JarManifestParser.findEntryClass(jarFile);
+
+		assertTrue(entryClass.isPresent());
+		assertThat(entryClass.get(), is(equalTo(TestJob.class.getCanonicalName())));
+	}
+
+	@Test(expected = NoSuchElementException.class)
+	public void testFindOnlyEntryClassEmptyArgument() throws IOException {
+		JarManifestParser.findOnlyEntryClass(Collections.emptyList());
+	}
+
+	@Test(expected = NoSuchElementException.class)
+	public void testFindOnlyEntryClassSingleJarWithNoManifest() throws IOException {
+		File jarWithNoManifest = createJarFileWithManifest(ImmutableMap.of());
+		JarManifestParser.findOnlyEntryClass(ImmutableList.of(jarWithNoManifest));
+	}
+
+	@Test
+	public void testFindOnlyEntryClassSingleJar() throws IOException {
+		File jarFile = TestJob.getTestJobJar();
+
+		JarFileWithEntryClass jarFileWithEntryClass = JarManifestParser.findOnlyEntryClass(ImmutableList.of(jarFile));
+
+		assertThat(jarFileWithEntryClass.getEntryClass(), is(equalTo(TestJob.class.getCanonicalName())));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFindOnlyEntryClassMultipleJarsWithMultipleManifestEntries() throws IOException {
+		File jarFile = TestJob.getTestJobJar();
+
+		JarManifestParser.findOnlyEntryClass(ImmutableList.of(jarFile, jarFile, jarFile));
+	}
+
+	@Test
+	public void testFindOnlyEntryClassMultipleJarsWithSingleManifestEntry() throws IOException {
+		File jarWithNoManifest = createJarFileWithManifest(ImmutableMap.of());
+		File jarFile = TestJob.getTestJobJar();
+
+		JarFileWithEntryClass jarFileWithEntryClass = JarManifestParser
+			.findOnlyEntryClass(ImmutableList.of(jarWithNoManifest, jarFile));
+
+		assertThat(jarFileWithEntryClass.getEntryClass(), is(equalTo(TestJob.class.getCanonicalName())));
+	}
+
+	private File createJarFileWithManifest(Map<String, String> manifest) throws IOException {
+		final File jarFile = temporaryFolder.newFile();
+		try (ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(jarFile)));
+				PrintWriter pw = new PrintWriter(zos)) {
+			zos.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
+			manifest.forEach((key, value) -> pw.println(String.format("%s: %s", key, value)));
+		}
+		return jarFile;
+	}
+
+}

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -22,10 +22,12 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.apache.flink.container.entrypoint.StandaloneJobClusterConfigurationParserFactory.DEFAULT_JOB_ID;
@@ -35,6 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -115,15 +118,17 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	}
 
 	@Test
-	public void testInvalidJobIdThrows() throws FlinkParseException {
+	public void testInvalidJobIdThrows() {
 		final String invalidJobId = "0xINVALID";
 		final String[] args = {"--configDir", "/foo/bar", "--job-classname", "foobar", "--job-id", invalidJobId};
 
 		try {
 			commandLineParser.parse(args);
 			fail("Did not throw expected FlinkParseException");
-		} catch (IllegalArgumentException e) {
-			assertThat(e.getMessage(), containsString(invalidJobId));
+		} catch (FlinkParseException e) {
+			Optional<IllegalArgumentException> cause = ExceptionUtils.findThrowable(e, IllegalArgumentException.class);
+			assertTrue(cause.isPresent());
+			assertThat(cause.get().getMessage(), containsString(invalidJobId));
 		}
 	}
 

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneJobClusterConfigurationParserFactoryTest.java
@@ -36,6 +36,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -77,14 +79,18 @@ public class StandaloneJobClusterConfigurationParserFactoryTest extends TestLogg
 	@Test
 	public void testOnlyRequiredArguments() throws FlinkParseException {
 		final String configDir = "/foo/bar";
-		final String jobClassName = "foobar";
-		final String[] args = {"--configDir", configDir, "--job-classname", jobClassName};
+		final String[] args = {"--configDir", configDir};
 
 		final StandaloneJobClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
 
 		assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
-		assertThat(clusterConfiguration.getJobClassName(), is(equalTo(jobClassName)));
+		assertThat(clusterConfiguration.getDynamicProperties(), is(equalTo(new Properties())));
+		assertThat(clusterConfiguration.getArgs(), is(new String[0]));
 		assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
+		assertThat(clusterConfiguration.getHostname(), is(nullValue()));
+		assertThat(clusterConfiguration.getSavepointRestoreSettings(), is(equalTo(SavepointRestoreSettings.none())));
+		assertThat(clusterConfiguration.getJobId(), is(not(nullValue())));
+		assertThat(clusterConfiguration.getJobClassName(),  is(nullValue()));
 	}
 
 	@Test(expected = FlinkParseException.class)

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/TestJob.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/TestJob.java
@@ -24,6 +24,9 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+
 /**
  * Test job which is used for {@link ClassPathJobGraphRetrieverTest}.
  */
@@ -38,5 +41,21 @@ public class TestJob {
 
 		ParameterTool parameterTool = ParameterTool.fromArgs(args);
 		env.execute(TestJob.class.getCanonicalName() + "-" + parameterTool.getRequired("arg"));
+	}
+
+	/**
+	 * Returns the test jar including {@link TestJob} (see pom.xml and assembly/test-assembly.xml).
+	 *
+	 * @return Test jar file
+	 * @throws FileNotFoundException If test-jar can not be found
+	 */
+	static File getTestJobJar() throws FileNotFoundException {
+		// Check the module's pom.xml for how we create the JAR
+		File f = new File("target/maven-test-jar.jar");
+		if (!f.exists()) {
+			throw new FileNotFoundException("Test jar not present. Invoke tests using Maven "
+				+ "or build the jar using 'mvn process-test-classes' in flink-container");
+		}
+		return f;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ParserResultFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ParserResultFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.entrypoint.parser;
 
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
@@ -43,6 +45,7 @@ public interface ParserResultFactory<T> {
 	 *
 	 * @param commandLine to extract the options from
 	 * @return Result of the parsing
+	 * @throws FlinkParseException Thrown on failures while parsing command line arguments
 	 */
-	T createResult(@Nonnull CommandLine commandLine);
+	T createResult(@Nonnull CommandLine commandLine) throws FlinkParseException;
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR allows users to point the `StandaloneJobClusterEntryPoint` to a JAR file instead of requiring a job class name of the job to execute.

Users can provide the argument as follows: `--job-classname from-jar:/foo/bar.jar` and let the entry point parse the JAR manifest for the entry class. The prefix is not a valid class name and should not conflict with existing usage of this option.

The original plan in the ticket was to add an additional command line argument like `--job-jar` but that seemed confusing as the JAR would only be used to parse the job class name. Also, an additional argument would have made the entry point argument validation slightly more complex (e.g. both `--job-classname` and `--job-jar` would be optional, but exactly one of the two required).

I think the current approach is a step into the right direction. Eventually, I think there is a case to be made for having a `--job-jar` argument that actually distributes the user JAR between the cluster components (with proper distribution of blobs, setup of the user class loader, etc.) instead of requiring it to be on the class path.

## Brief change log

- Add `JarManifestParser` utility
- Check `PackagedProgram.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS`, `PackagedProgram.MANIFEST_ATTRIBUTE_MAIN_CLASS` manifest attributes if `job-classname` starts with `from-jar:`

## Verifying this change

- This change added unit tests
- Additionally, a test JAR assembly step has been added to test the new functionality with a proper job jar

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (adds special case behavior of command line argument `--job-classname`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

- Updated command line argument help page
- Added note to Kubernetes template README
