### PR TITLE
[FLINK-10718] Use IO executor in RpcService for message serialization

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -159,6 +159,14 @@ public interface RpcService {
 	ScheduledExecutor getScheduledExecutor();
 
 	/**
+	 * Gets the executor, provided by this RPC service. This executor can be used for the
+	 * serialization of the rpc messages.
+	 *
+	 * @return The execution context provided by the RPC service
+	 */
+	Executor getIOExecutor();
+
+	/**
 	 * Execute the runnable in the execution context of this RPC Service, as returned by
 	 * {@link #getExecutor()}, after a scheduled delay.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -165,7 +165,8 @@ public class AkkaRpcService implements RpcService {
 					actorRef,
 					configuration.getTimeout(),
 					configuration.getMaximumFramesize(),
-					null);
+					null,
+					this);
 			});
 	}
 
@@ -185,7 +186,8 @@ public class AkkaRpcService implements RpcService {
 					configuration.getTimeout(),
 					configuration.getMaximumFramesize(),
 					null,
-					() -> fencingToken);
+					() -> fencingToken,
+					this);
 			});
 	}
 
@@ -247,7 +249,8 @@ public class AkkaRpcService implements RpcService {
 				configuration.getTimeout(),
 				configuration.getMaximumFramesize(),
 				terminationFuture,
-				((FencedRpcEndpoint<?>) rpcEndpoint)::getFencingToken);
+				((FencedRpcEndpoint<?>) rpcEndpoint)::getFencingToken,
+				this);
 
 			implementedRpcGateways.add(FencedMainThreadExecutable.class);
 		} else {
@@ -257,7 +260,8 @@ public class AkkaRpcService implements RpcService {
 				actorRef,
 				configuration.getTimeout(),
 				configuration.getMaximumFramesize(),
-				terminationFuture);
+				terminationFuture,
+				this);
 		}
 
 		// Rather than using the System ClassLoader directly, we derive the ClassLoader
@@ -285,7 +289,8 @@ public class AkkaRpcService implements RpcService {
 				configuration.getTimeout(),
 				configuration.getMaximumFramesize(),
 				null,
-				() -> fencingToken);
+				() -> fencingToken,
+				this);
 
 			// Rather than using the System ClassLoader directly, we derive the ClassLoader
 			// from this class . That works better in cases where Flink runs embedded and all Flink
@@ -389,6 +394,11 @@ public class AkkaRpcService implements RpcService {
 	@Override
 	public ScheduledExecutor getScheduledExecutor() {
 		return internalScheduledExecutor;
+	}
+
+	@Override
+	public Executor getIOExecutor() {
+		return actorSystem.dispatcher();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
+import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.messages.CallAsync;
 import org.apache.flink.runtime.rpc.messages.FencedMessage;
 import org.apache.flink.runtime.rpc.messages.LocalFencedMessage;
@@ -61,8 +62,9 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
 			Time timeout,
 			long maximumFramesize,
 			@Nullable CompletableFuture<Void> terminationFuture,
-			Supplier<F> fencingTokenSupplier) {
-		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
+			Supplier<F> fencingTokenSupplier,
+			RpcService rpcService) {
+		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture, rpcService);
 
 		this.fencingTokenSupplier = Preconditions.checkNotNull(fencingTokenSupplier);
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduced an IO Executor in RpcServer for message serialization*

## Brief change log

  - *Introduced an IO executor in `RpcServer` and implemented in `AkkaRpcService`*
  - *Serialize RPC message in `AkkaRpcActor`*
  - *Deserialize RPC message in `AkkaInvocationHandler`*

## Verifying this change

This change is already covered by existing tests, such as *AkkaRpcActorOversizedResponseMessageTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
