### PR TITLE
[FLINK-10569] Remove Instance usage in ExecutionGraphDeploymentTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -25,12 +25,10 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -60,7 +58,6 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.SerializedValue;
 
-import akka.actor.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -517,35 +514,6 @@ public class ExecutionGraphTestUtils {
 				return new Object();
 			} else {
 				return null;
-			}
-		}
-	}
-
-	@SuppressWarnings("serial")
-	public static class SimpleActorGatewayWithTDD extends SimpleActorGateway {
-
-		public TaskDeploymentDescriptor lastTDD;
-		private final PermanentBlobService blobCache;
-
-		public SimpleActorGatewayWithTDD(ExecutionContext executionContext, PermanentBlobService blobCache) {
-			super(executionContext);
-			this.blobCache = blobCache;
-		}
-
-		@Override
-		public Object handleMessage(Object message) {
-			if(message instanceof SubmitTask) {
-				SubmitTask submitTask = (SubmitTask) message;
-				lastTDD = submitTask.tasks();
-				try {
-					lastTDD.loadBigData(blobCache);
-					return Acknowledge.get();
-				} catch (Exception e) {
-					e.printStackTrace();
-					return new Status.Failure(e);
-				}
-			} else {
-				return super.handleMessage(message);
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -57,9 +57,13 @@ public class TestingLogicalSlot implements LogicalSlot {
 	private final SlotSharingGroupId slotSharingGroupId;
 
 	public TestingLogicalSlot() {
+		this(new SimpleAckingTaskManagerGateway());
+	}
+
+	public TestingLogicalSlot(TaskManagerGateway taskManagerGateway) {
 		this(
 			new LocalTaskManagerLocation(),
-			new SimpleAckingTaskManagerGateway(),
+			taskManagerGateway,
 			0,
 			new AllocationID(),
 			new SlotRequestId(),


### PR DESCRIPTION
## What is the purpose of the change

Remove `Instance` usage in `ExecutionGraphDeploymentTest`.

Also with 2 hotfixes, refactor `SimpleAckingTaskManagerGateway` method consumer and introduce a convenient constructor of TestingLogicalSlot `<init>#(TaskManagerGateway)`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @zentol 
