### PR TITLE
[FLINK-10569] Refactor CoLocationConstraintTest and remove Instance u…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraintTest.java
@@ -33,145 +33,129 @@ import static org.junit.Assert.*;
  * Tests for the {@link CoLocationConstraint}.
  */
 public class CoLocationConstraintTest {
-	
+
 	@Test
 	public void testCreateConstraints() {
-		try {
-			JobVertexID id1 = new JobVertexID();
-			JobVertexID id2 = new JobVertexID();
+		JobVertexID id1 = new JobVertexID();
+		JobVertexID id2 = new JobVertexID();
 
-			JobVertex vertex1 = new JobVertex("vertex1", id1);
-			vertex1.setParallelism(2);
-			
-			JobVertex vertex2 = new JobVertex("vertex2", id2);
-			vertex2.setParallelism(3);
-			
-			CoLocationGroup group = new CoLocationGroup(vertex1, vertex2);
-			
-			AbstractID groupId = group.getId();
-			assertNotNull(groupId);
-			
-			CoLocationConstraint constraint1 = group.getLocationConstraint(0);
-			CoLocationConstraint constraint2 = group.getLocationConstraint(1);
-			CoLocationConstraint constraint3 = group.getLocationConstraint(2);
-			
-			assertFalse(constraint1 == constraint2);
-			assertFalse(constraint1 == constraint3);
-			assertFalse(constraint2 == constraint3);
-			
-			assertEquals(groupId, constraint1.getGroupId());
-			assertEquals(groupId, constraint2.getGroupId());
-			assertEquals(groupId, constraint3.getGroupId());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		JobVertex vertex1 = new JobVertex("vertex1", id1);
+		vertex1.setParallelism(2);
+
+		JobVertex vertex2 = new JobVertex("vertex2", id2);
+		vertex2.setParallelism(3);
+
+		CoLocationGroup group = new CoLocationGroup(vertex1, vertex2);
+
+		AbstractID groupId = group.getId();
+		assertNotNull(groupId);
+
+		CoLocationConstraint constraint1 = group.getLocationConstraint(0);
+		CoLocationConstraint constraint2 = group.getLocationConstraint(1);
+		CoLocationConstraint constraint3 = group.getLocationConstraint(2);
+
+		assertFalse(constraint1 == constraint2);
+		assertFalse(constraint1 == constraint3);
+		assertFalse(constraint2 == constraint3);
+
+		assertEquals(groupId, constraint1.getGroupId());
+		assertEquals(groupId, constraint2.getGroupId());
+		assertEquals(groupId, constraint3.getGroupId());
 	}
 
 	@Test
-	public void testAssignSlotAndLockLocation() {
+	public void testAssignSlotAndLockLocation() throws Exception {
+		JobID jid = new JobID();
+
+		JobVertex vertex = new JobVertex("vertex");
+		vertex.setParallelism(1);
+
+		SlotSharingGroup sharingGroup = new SlotSharingGroup(vertex.getID());
+		SlotSharingGroupAssignment assignment = sharingGroup.getTaskAssignment();
+
+		CoLocationGroup constraintGroup = new CoLocationGroup(vertex);
+		CoLocationConstraint constraint = constraintGroup.getLocationConstraint(0);
+
+		// constraint is completely unassigned
+		assertFalse(constraint.isAssigned());
+		assertFalse(constraint.isAssignedAndAlive());
+
+		Instance instance1 = SchedulerTestUtils.getRandomInstance(2);
+		Instance instance2 = SchedulerTestUtils.getRandomInstance(2);
+
+		SharedSlot slot1_1 = instance1.allocateSharedSlot(assignment);
+		SharedSlot slot1_2 = instance1.allocateSharedSlot(assignment);
+		SharedSlot slot2_1 = instance2.allocateSharedSlot(assignment);
+		SharedSlot slot2_2 = instance2.allocateSharedSlot(assignment);
+
+		// constraint is still completely unassigned
+		assertFalse(constraint.isAssigned());
+		assertFalse(constraint.isAssignedAndAlive());
+
+		// set the slot, but do not lock the location yet
+		constraint.setSharedSlot(slot1_1);
+
+		assertFalse(constraint.isAssigned());
+		assertFalse(constraint.isAssignedAndAlive());
+
+		// try to get the location
 		try {
-			JobID jid = new JobID();
-					
-			JobVertex vertex = new JobVertex("vertex");
-			vertex.setParallelism(1);
-
-			SlotSharingGroup sharingGroup = new SlotSharingGroup(vertex.getID());
-			SlotSharingGroupAssignment assignment = sharingGroup.getTaskAssignment();
-			
-			CoLocationGroup constraintGroup = new CoLocationGroup(vertex);
-			CoLocationConstraint constraint = constraintGroup.getLocationConstraint(0);
-
-			// constraint is completely unassigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			Instance instance1 = SchedulerTestUtils.getRandomInstance(2);
-			Instance instance2 = SchedulerTestUtils.getRandomInstance(2);
-			
-			SharedSlot slot1_1 = instance1.allocateSharedSlot(assignment);
-			SharedSlot slot1_2 = instance1.allocateSharedSlot(assignment);
-			SharedSlot slot2_1 = instance2.allocateSharedSlot(assignment);
-			SharedSlot slot2_2 = instance2.allocateSharedSlot(assignment);
-			
-			// constraint is still completely unassigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			// set the slot, but do not lock the location yet
-			constraint.setSharedSlot(slot1_1);
-
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			// try to get the location
-			try {
-				constraint.getLocation();
-				fail("should throw an IllegalStateException");
-			}
-			catch (IllegalStateException e) {
-				// as expected
-			}
-			catch (Exception e) {
-				fail("wrong exception, should be IllegalStateException");
-			}
-
-			// check that we can reassign the slot as long as the location is not locked
-			constraint.setSharedSlot(slot2_1);
-			
-			// the previous slot should have been released now
-			assertTrue(slot1_1.isReleased());
-
-			// still the location is not assigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			// we can do an identity re-assign
-			constraint.setSharedSlot(slot2_1);
-			assertFalse(slot2_1.isReleased());
-
-			// still the location is not assigned
-			assertFalse(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			
-			constraint.lockLocation();
-
-			// now, the location is assigned and we have a location
-			assertTrue(constraint.isAssigned());
-			assertTrue(constraint.isAssignedAndAlive());
-			assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
-			
-			// release the slot
-			slot2_1.releaseSlot();
-
-			// we should still have a location
-			assertTrue(constraint.isAssigned());
-			assertFalse(constraint.isAssignedAndAlive());
-			assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
-
-			// we can not assign a different location
-			try {
-				constraint.setSharedSlot(slot1_2);
-				fail("should throw an IllegalArgumentException");
-			}
-			catch (IllegalArgumentException e) {
-				// as expected
-			}
-			catch (Exception e) {
-				fail("wrong exception, should be IllegalArgumentException");
-			}
-			
-			// assign a new slot with the same location
-			constraint.setSharedSlot(slot2_2);
-
-			assertTrue(constraint.isAssigned());
-			assertTrue(constraint.isAssignedAndAlive());
-			assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
+			constraint.getLocation();
+			fail("should throw an IllegalStateException");
+		} catch (IllegalStateException e) {
+			// as expected
+		} catch (Exception e) {
+			fail("wrong exception, should be IllegalStateException");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+
+		// check that we can reassign the slot as long as the location is not locked
+		constraint.setSharedSlot(slot2_1);
+
+		// the previous slot should have been released now
+		assertTrue(slot1_1.isReleased());
+
+		// still the location is not assigned
+		assertFalse(constraint.isAssigned());
+		assertFalse(constraint.isAssignedAndAlive());
+
+		// we can do an identity re-assign
+		constraint.setSharedSlot(slot2_1);
+		assertFalse(slot2_1.isReleased());
+
+		// still the location is not assigned
+		assertFalse(constraint.isAssigned());
+		assertFalse(constraint.isAssignedAndAlive());
+
+		constraint.lockLocation();
+
+		// now, the location is assigned and we have a location
+		assertTrue(constraint.isAssigned());
+		assertTrue(constraint.isAssignedAndAlive());
+		assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
+
+		// release the slot
+		slot2_1.releaseSlot();
+
+		// we should still have a location
+		assertTrue(constraint.isAssigned());
+		assertFalse(constraint.isAssignedAndAlive());
+		assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
+
+		// we can not assign a different location
+		try {
+			constraint.setSharedSlot(slot1_2);
+			fail("should throw an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			// as expected
+		} catch (Exception e) {
+			fail("wrong exception, should be IllegalArgumentException");
 		}
+
+		// assign a new slot with the same location
+		constraint.setSharedSlot(slot2_2);
+
+		assertTrue(constraint.isAssigned());
+		assertTrue(constraint.isAssignedAndAlive());
+		assertEquals(instance2.getTaskManagerLocation(), constraint.getLocation());
 	}
 }


### PR DESCRIPTION
…sage

## What is the purpose of the change

Get rid of unnecessary try/catch block. `CoLocationConstraint` now works with `setSlotRequestId` and `lockLocation(TaskManagerLocation)`. Test the new logic.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann 

