### PR TITLE
[FLINK-10569] Remove Instance usage in ExecutionVertexSchedulingTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -20,14 +20,10 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.instance.DummyActorGateway;
-import org.apache.flink.runtime.instance.Instance;
-import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
-import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -36,9 +32,8 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getExecutionVertex;
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getInstance;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class ExecutionVertexSchedulingTest extends TestLogger {
@@ -51,11 +46,10 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 					AkkaUtils.getDefaultTimeout());
 
 			// a slot than cannot be deployed to
-			final Instance instance = getInstance(new ActorTaskManagerGateway(DummyActorGateway.INSTANCE));
-			final SimpleSlot slot = instance.allocateSimpleSlot();
-			
-			slot.releaseSlot();
-			assertTrue(slot.isReleased());
+			final LogicalSlot slot = new TestingLogicalSlot();
+			slot.releaseSlot(new Exception("Test Exception"));
+
+			assertFalse(slot.isAlive());
 
 			CompletableFuture<LogicalSlot> future = new CompletableFuture<>();
 			future.complete(slot);
@@ -81,11 +75,10 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 					AkkaUtils.getDefaultTimeout());
 
 			// a slot than cannot be deployed to
-			final Instance instance = getInstance(new ActorTaskManagerGateway(DummyActorGateway.INSTANCE));
-			final SimpleSlot slot = instance.allocateSimpleSlot();
+			final LogicalSlot slot = new TestingLogicalSlot();
+			slot.releaseSlot(new Exception("Test Exception"));
 
-			slot.releaseSlot();
-			assertTrue(slot.isReleased());
+			assertFalse(slot.isAlive());
 
 			final CompletableFuture<LogicalSlot> future = new CompletableFuture<>();
 
@@ -118,12 +111,9 @@ public class ExecutionVertexSchedulingTest extends TestLogger {
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 					AkkaUtils.getDefaultTimeout());
 
-			final Instance instance = getInstance(new ActorTaskManagerGateway(
-				new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.defaultExecutionContext())));
-			final SimpleSlot slot = instance.allocateSimpleSlot();
+			final LogicalSlot slot = new TestingLogicalSlot();
 
-			CompletableFuture<LogicalSlot> future = new CompletableFuture<>();
-			future.complete(slot);
+			CompletableFuture<LogicalSlot> future = CompletableFuture.completedFuture(slot);
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 


### PR DESCRIPTION
## What is the purpose of the change

Remove Instance usage in ExecutionVertexSchedulingTest

Replace `SimpleSlot` with `TestingLogicalSlot`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann @zentol 
