### PR TITLE
[FLINK-11643] remove useless code of externalizedCheckpointsDir

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -280,9 +280,6 @@ public class ExecutionGraphBuilder {
 					snapshotSettings.getCheckpointCoordinatorConfiguration(),
 					metrics);
 
-			// The default directory for externalized checkpoints
-			String externalizedCheckpointsDir = jobManagerConfig.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
-
 			// load the state backend from the application settings
 			final StateBackend applicationConfiguredBackend;
 			final SerializedValue<StateBackend> serializedAppConfigured = snapshotSettings.getDefaultStateBackend();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -111,9 +111,9 @@ public class StateBackendLoader {
 
 				if (logger != null) {
 					Path memExternalized = memBackend.getCheckpointPath();
-					String extern = memExternalized == null ? "" :
+					String external = memExternalized == null ? "" :
 							" (externalized to " + memExternalized + ')';
-					logger.info("State backend is set to heap memory (checkpoint to JobManager) {}", extern);
+					logger.info("State backend is set to heap memory (checkpoint to JobManager) {}", external);
 				}
 				return memBackend;
 


### PR DESCRIPTION

## What is the purpose of the change

Remove unless code of `externalizedCheckpointsDir`, besides make tiny changes to `StateBackendLoader.java` to be more readable


## Brief change log

  - Remove unused code of `externalizedCheckpointsDir` and make some tiny changes in class `StateBackendLoader`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

# Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
