### PR TITLE
[FLINK-9803] Drop canEqual() from TypeSerializer

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -1228,11 +1228,6 @@ public class FlinkKafkaProducer011<IN>
 			target.writeShort(source.readShort());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof TransactionStateSerializer;
-		}
-
 		// ------------------------------------------------------------------------
 
 		@Override
@@ -1325,11 +1320,6 @@ public class FlinkKafkaProducer011<IN>
 			for (int i = 0; i < numIds; i++) {
 				target.writeUTF(source.readUTF());
 			}
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof ContextStateSerializer;
 		}
 
 		// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -1234,11 +1234,6 @@ public class FlinkKafkaProducer<IN>
 			target.writeShort(source.readShort());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof FlinkKafkaProducer.TransactionStateSerializer;
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override
@@ -1332,11 +1327,6 @@ public class FlinkKafkaProducer<IN>
 			for (int i = 0; i < numIds; i++) {
 				target.writeUTF(source.readUTF());
 			}
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof FlinkKafkaProducer.ContextStateSerializer;
 		}
 
 		// -----------------------------------------------------------------------------------

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializer.java
@@ -146,15 +146,10 @@ public final class WritableSerializer<T extends Writable> extends TypeSerializer
 		if (obj instanceof WritableSerializer) {
 			WritableSerializer<?> other = (WritableSerializer<?>) obj;
 
-			return other.canEqual(this) && typeClass == other.typeClass;
+			return typeClass == other.typeClass;
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof WritableSerializer;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeSerializer.java
@@ -190,18 +190,9 @@ public abstract class CompositeSerializer<T> extends TypeSerializer<T> {
 	@SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
 	@Override
 	public boolean equals(Object obj) {
-		if (canEqual(obj)) {
-			CompositeSerializer<?> other = (CompositeSerializer<?>) obj;
-			return precomputed.immutable == other.precomputed.immutable
-				&& Arrays.equals(fieldSerializers, other.fieldSerializers);
-		}
-		return false;
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		// as this is an abstract class, we allow equality only between instances of the same class
-		return obj != null && getClass().equals(obj.getClass());
+		CompositeSerializer<?> other = (CompositeSerializer<?>) obj;
+		return precomputed.immutable == other.precomputed.immutable
+			&& Arrays.equals(fieldSerializers, other.fieldSerializers);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeDeserializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeDeserializer.java
@@ -74,14 +74,6 @@ public interface TypeDeserializer<T> {
 	 */
 	int getLength();
 
-	/**
-	 * Returns true if the given object can be equaled with this object. If not, it returns false.
-	 *
-	 * @param obj Object which wants to take part in the equality relation
-	 * @return true if obj can be equaled with this, otherwise false
-	 */
-	boolean canEqual(Object obj);
-
 	boolean equals(Object obj);
 
 	int hashCode();

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeDeserializerAdapter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeDeserializerAdapter.java
@@ -88,10 +88,6 @@ public final class TypeDeserializerAdapter<T> extends TypeSerializer<T> implemen
 		return (deserializer != null) ? deserializer.equals(obj) : serializer.equals(obj);
 	}
 
-	public boolean canEqual(Object obj) {
-		return (deserializer != null) ? deserializer.canEqual(obj) : serializer.canEqual(obj);
-	}
-
 	public int hashCode() {
 		return (deserializer != null) ? deserializer.hashCode() : serializer.hashCode();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -177,14 +177,6 @@ public abstract class TypeSerializer<T> implements Serializable {
 
 	public abstract boolean equals(Object obj);
 
-	/**
-	 * Returns true if the given object can be equaled with this object. If not, it returns false.
-	 *
-	 * @param obj Object which wants to take part in the equality relation
-	 * @return true if obj can be equaled with this, otherwise false
-	 */
-	public abstract boolean canEqual(Object obj);
-
 	public abstract int hashCode();
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/UnloadableDummyTypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/UnloadableDummyTypeSerializer.java
@@ -119,11 +119,6 @@ public class UnloadableDummyTypeSerializer<T> extends TypeSerializer<T> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return false;
-	}
-
-	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BigDecSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BigDecSerializer.java
@@ -110,11 +110,6 @@ public final class BigDecSerializer extends TypeSerializerSingleton<BigDecimal> 
 		}
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof BigDecSerializer;
-	}
-
 	// --------------------------------------------------------------------------------------------
 	//                           Static Helpers for BigInteger Serialization
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BigIntSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BigIntSerializer.java
@@ -82,11 +82,6 @@ public final class BigIntSerializer extends TypeSerializerSingleton<BigInteger> 
 		copyBigInteger(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof BigIntSerializer;
-	}
-
 	// --------------------------------------------------------------------------------------------
 	//                           Static Helpers for BigInteger Serialization
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanSerializer.java
@@ -85,11 +85,6 @@ public final class BooleanSerializer extends TypeSerializerSingleton<Boolean> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof BooleanSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Boolean> snapshotConfiguration() {
 		return new BooleanSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/BooleanValueSerializer.java
@@ -84,11 +84,6 @@ public final class BooleanValueSerializer extends TypeSerializerSingleton<Boolea
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof BooleanValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<BooleanValue> snapshotConfiguration() {
 		return new BooleanValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteSerializer.java
@@ -85,11 +85,6 @@ public final class ByteSerializer extends TypeSerializerSingleton<Byte> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ByteSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Byte> snapshotConfiguration() {
 		return new ByteSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ByteValueSerializer.java
@@ -82,11 +82,6 @@ public final class ByteValueSerializer extends TypeSerializerSingleton<ByteValue
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ByteValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<ByteValue> snapshotConfiguration() {
 		return new ByteValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharSerializer.java
@@ -85,11 +85,6 @@ public final class CharSerializer extends TypeSerializerSingleton<Character> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof CharSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Character> snapshotConfiguration() {
 		return new CharSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharValueSerializer.java
@@ -82,11 +82,6 @@ public class CharValueSerializer extends TypeSerializerSingleton<CharValue> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof CharValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<CharValue> snapshotConfiguration() {
 		return new CharValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DateSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DateSerializer.java
@@ -100,11 +100,6 @@ public final class DateSerializer extends TypeSerializerSingleton<Date> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof DateSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Date> snapshotConfiguration() {
 		return new DateSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleSerializer.java
@@ -85,11 +85,6 @@ public final class DoubleSerializer extends TypeSerializerSingleton<Double> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof DoubleSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Double> snapshotConfiguration() {
 		return new DoubleSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/DoubleValueSerializer.java
@@ -82,11 +82,6 @@ public final class DoubleValueSerializer extends TypeSerializerSingleton<DoubleV
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof DoubleValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<DoubleValue> snapshotConfiguration() {
 		return new DoubleValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/EnumSerializer.java
@@ -134,15 +134,10 @@ public final class EnumSerializer<T extends Enum<T>> extends TypeSerializer<T> {
 		if(obj instanceof EnumSerializer) {
 			EnumSerializer<?> other = (EnumSerializer<?>) obj;
 
-			return other.canEqual(this) && other.enumClass == this.enumClass;
+			return other.enumClass == this.enumClass;
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof EnumSerializer;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatSerializer.java
@@ -85,11 +85,6 @@ public final class FloatSerializer extends TypeSerializerSingleton<Float> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof FloatSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Float> snapshotConfiguration() {
 		return new FloatSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/FloatValueSerializer.java
@@ -82,11 +82,6 @@ public class FloatValueSerializer extends TypeSerializerSingleton<FloatValue> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof FloatValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<FloatValue> snapshotConfiguration() {
 		return new FloatValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializer.java
@@ -183,17 +183,11 @@ public final class GenericArraySerializer<C> extends TypeSerializer<C[]> {
 		if (obj instanceof GenericArraySerializer) {
 			GenericArraySerializer<?> other = (GenericArraySerializer<?>)obj;
 
-			return other.canEqual(this) &&
-				componentClass == other.componentClass &&
+			return componentClass == other.componentClass &&
 				componentSerializer.equals(other.componentSerializer);
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof GenericArraySerializer;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/InstantSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/InstantSerializer.java
@@ -32,6 +32,9 @@ import java.time.Instant;
  */
 @Internal
 public final class InstantSerializer extends TypeSerializerSingleton<Instant> {
+
+	private static final long serialVersionUID = -4131715684999061277L;
+
 	static final int SECONDS_BYTES = Long.BYTES;
 	static final int NANOS_BYTES = Integer.BYTES;
 
@@ -98,11 +101,6 @@ public final class InstantSerializer extends TypeSerializerSingleton<Instant> {
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
 		target.writeLong(source.readLong());
 		target.writeInt(source.readInt());
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof InstantSerializer;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntSerializer.java
@@ -85,11 +85,6 @@ public final class IntSerializer extends TypeSerializerSingleton<Integer> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof IntSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Integer> snapshotConfiguration() {
 		return new IntSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/IntValueSerializer.java
@@ -82,11 +82,6 @@ public final class IntValueSerializer extends TypeSerializerSingleton<IntValue> 
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof IntValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<IntValue> snapshotConfiguration() {
 		return new IntValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
@@ -160,11 +160,6 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return true;
-	}
-
-	@Override
 	public int hashCode() {
 		return elementSerializer.hashCode();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongSerializer.java
@@ -85,11 +85,6 @@ public final class LongSerializer extends TypeSerializerSingleton<Long> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof LongSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Long> snapshotConfiguration() {
 		return new LongSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LongValueSerializer.java
@@ -82,11 +82,6 @@ public final class LongValueSerializer extends TypeSerializerSingleton<LongValue
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<LongValue> snapshotConfiguration() {
 		return new LongValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
@@ -187,11 +187,6 @@ public final class MapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return (obj != null && obj.getClass() == getClass());
-	}
-
-	@Override
 	public int hashCode() {
 		return keySerializer.hashCode() * 31 + valueSerializer.hashCode();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/NullValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/NullValueSerializer.java
@@ -78,11 +78,6 @@ public final class NullValueSerializer extends TypeSerializerSingleton<NullValue
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof NullValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<NullValue> snapshotConfiguration() {
 		return new NullValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortSerializer.java
@@ -85,11 +85,6 @@ public final class ShortSerializer extends TypeSerializerSingleton<Short> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ShortSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Short> snapshotConfiguration() {
 		return new ShortSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ShortValueSerializer.java
@@ -82,11 +82,6 @@ public final class ShortValueSerializer extends TypeSerializerSingleton<ShortVal
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ShortValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<ShortValue> snapshotConfiguration() {
 		return new ShortValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/SqlDateSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/SqlDateSerializer.java
@@ -101,11 +101,6 @@ public final class SqlDateSerializer extends TypeSerializerSingleton<Date> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof SqlDateSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Date> snapshotConfiguration() {
 		return new SqlDateSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/SqlTimeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/SqlTimeSerializer.java
@@ -99,11 +99,6 @@ public final class SqlTimeSerializer extends TypeSerializerSingleton<Time> {
 		target.writeLong(source.readLong());
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof SqlTimeSerializer;
-	}
-
 	// --------------------------------------------------------------------------------------------
 	// Serializer configuration snapshotting
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/SqlTimestampSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/SqlTimestampSerializer.java
@@ -109,11 +109,6 @@ public final class SqlTimestampSerializer extends TypeSerializerSingleton<Timest
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof SqlTimestampSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Timestamp> snapshotConfiguration() {
 		return new SqlTimestampSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringSerializer.java
@@ -86,11 +86,6 @@ public final class StringSerializer extends TypeSerializerSingleton<String> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof StringSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<String> snapshotConfiguration() {
 		return new StringSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/StringValueSerializer.java
@@ -107,11 +107,6 @@ public final class StringValueSerializer extends TypeSerializerSingleton<StringV
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof StringValueSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<StringValue> snapshotConfiguration() {
 		return new StringValueSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
@@ -43,13 +43,7 @@ public abstract class TypeSerializerSingleton<T> extends TypeSerializer<T>{
 	
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof TypeSerializerSingleton) {
-			TypeSerializerSingleton<?> other = (TypeSerializerSingleton<?>) obj;
-
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
+		return obj.getClass().equals(this.getClass());
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/VoidSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/VoidSerializer.java
@@ -86,11 +86,6 @@ public final class VoidSerializer extends TypeSerializerSingleton<Void> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof VoidSerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<Void> snapshotConfiguration() {
 		return new VoidSerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BooleanPrimitiveArraySerializer.java
@@ -106,11 +106,6 @@ public final class BooleanPrimitiveArraySerializer extends TypeSerializerSinglet
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof BooleanPrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<boolean[]> snapshotConfiguration() {
 		return new BooleanPrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/BytePrimitiveArraySerializer.java
@@ -99,11 +99,6 @@ public final class BytePrimitiveArraySerializer extends TypeSerializerSingleton<
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof BytePrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<byte[]> snapshotConfiguration() {
 		return new BytePrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/CharPrimitiveArraySerializer.java
@@ -105,11 +105,6 @@ public final class CharPrimitiveArraySerializer extends TypeSerializerSingleton<
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof CharPrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<char[]> snapshotConfiguration() {
 		return new CharPrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/DoublePrimitiveArraySerializer.java
@@ -105,11 +105,6 @@ public final class DoublePrimitiveArraySerializer extends TypeSerializerSingleto
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof DoublePrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<double[]> snapshotConfiguration() {
 		return new DoublePrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/FloatPrimitiveArraySerializer.java
@@ -105,11 +105,6 @@ public final class FloatPrimitiveArraySerializer extends TypeSerializerSingleton
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof FloatPrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<float[]> snapshotConfiguration() {
 		return new FloatPrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/IntPrimitiveArraySerializer.java
@@ -105,11 +105,6 @@ public class IntPrimitiveArraySerializer extends TypeSerializerSingleton<int[]>{
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof IntPrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<int[]> snapshotConfiguration() {
 		return new IntPrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/LongPrimitiveArraySerializer.java
@@ -105,11 +105,6 @@ public final class LongPrimitiveArraySerializer extends TypeSerializerSingleton<
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof LongPrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<long[]> snapshotConfiguration() {
 		return new LongPrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/ShortPrimitiveArraySerializer.java
@@ -105,11 +105,6 @@ public final class ShortPrimitiveArraySerializer extends TypeSerializerSingleton
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ShortPrimitiveArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<short[]> snapshotConfiguration() {
 		return new ShortPrimitiveArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/array/StringArraySerializer.java
@@ -109,11 +109,6 @@ public final class StringArraySerializer extends TypeSerializerSingleton<String[
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof StringArraySerializer;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<String[]> snapshotConfiguration() {
 		return new StringArraySerializerSnapshot();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoField.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoField.java
@@ -77,7 +77,7 @@ public class PojoField implements Serializable {
 		if (obj instanceof PojoField) {
 			PojoField other = (PojoField) obj;
 
-			return other.canEqual(this) && type.equals(other.type) &&
+			return type.equals(other.type) &&
 				Objects.equals(field, other.field);
 		} else {
 			return false;
@@ -87,9 +87,5 @@ public class PojoField implements Serializable {
 	@Override
 	public int hashCode() {
 		return Objects.hash(field, type);
-	}
-
-	public boolean canEqual(Object obj) {
-		return obj instanceof PojoField;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/CopyableValueSerializer.java
@@ -123,17 +123,10 @@ public final class CopyableValueSerializer<T extends CopyableValue<T>> extends T
 			@SuppressWarnings("unchecked")
 			CopyableValueSerializer<T> copyableValueSerializer = (CopyableValueSerializer<T>) obj;
 
-			return copyableValueSerializer.canEqual(this) &&
-				valueClass == copyableValueSerializer.valueClass;
-		}
-		else {
+			return valueClass == copyableValueSerializer.valueClass;
+		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof CopyableValueSerializer;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
@@ -182,17 +182,11 @@ public class EitherSerializer<L, R> extends TypeSerializer<Either<L, R>> {
 		if (obj instanceof EitherSerializer) {
 			EitherSerializer<L, R> other = (EitherSerializer<L, R>) obj;
 
-			return other.canEqual(this) &&
-				leftSerializer.equals(other.leftSerializer) &&
+			return leftSerializer.equals(other.leftSerializer) &&
 				rightSerializer.equals(other.rightSerializer);
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof EitherSerializer;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -236,12 +236,6 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return (obj != null && obj.getClass() == getClass() &&
-			originalSerializer.canEqual(((NullableSerializer) obj).originalSerializer));
-	}
-
-	@Override
 	public int hashCode() {
 		return originalSerializer.hashCode();
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -565,8 +565,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		if (obj instanceof PojoSerializer) {
 			PojoSerializer<?> other = (PojoSerializer<?>) obj;
 
-			return other.canEqual(this) &&
-				clazz == other.clazz &&
+			return clazz == other.clazz &&
 				Arrays.equals(fieldSerializers, other.fieldSerializers) &&
 				Arrays.equals(registeredSerializers, other.registeredSerializers) &&
 				numFields == other.numFields &&
@@ -574,11 +573,6 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof PojoSerializer;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -229,7 +229,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (canEqual(obj)) {
+		if (obj instanceof RowSerializer) {
 			RowSerializer other = (RowSerializer) obj;
 			if (this.fieldSerializers.length == other.fieldSerializers.length) {
 				for (int i = 0; i < this.fieldSerializers.length; i++) {
@@ -242,11 +242,6 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		}
 
 		return false;
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof RowSerializer;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/Tuple0Serializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/Tuple0Serializer.java
@@ -111,17 +111,6 @@ public class Tuple0Serializer extends TupleSerializer<Tuple0> implements SelfRes
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof Tuple0Serializer) {
-			Tuple0Serializer other = (Tuple0Serializer) obj;
-
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
 		return obj instanceof Tuple0Serializer;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -103,18 +103,12 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 		if (obj instanceof TupleSerializerBase) {
 			TupleSerializerBase<?> other = (TupleSerializerBase<?>) obj;
 
-			return other.canEqual(this) &&
-				tupleClass == other.tupleClass &&
+			return tupleClass == other.tupleClass &&
 				Arrays.equals(fieldSerializers, other.fieldSerializers) &&
 				arity == other.arity;
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof TupleSerializerBase;
 	}
 
 	@VisibleForTesting

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -160,15 +160,10 @@ public final class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 		if (obj instanceof ValueSerializer) {
 			ValueSerializer<?> other = (ValueSerializer<?>) obj;
 
-			return other.canEqual(this) && type == other.type;
+			return type == other.type;
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ValueSerializer;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -374,19 +374,13 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 		if (obj instanceof KryoSerializer) {
 			KryoSerializer<?> other = (KryoSerializer<?>) obj;
 
-			return other.canEqual(this) &&
-				type == other.type &&
+			return type == other.type &&
 				Objects.equals(kryoRegistrations, other.kryoRegistrations) &&
 				Objects.equals(defaultSerializerClasses, other.defaultSerializerClasses) &&
 				Objects.equals(defaultSerializers, other.defaultSerializers);
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof KryoSerializer;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
@@ -287,7 +287,7 @@ public class CompositeTypeSerializerSnapshotTest {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (canEqual(obj)) {
+			if (obj instanceof TestCompositeTypeSerializer) {
 				return Arrays.equals(nestedSerializers, ((TestCompositeTypeSerializer) obj).getNestedSerializers());
 			}
 			return false;
@@ -296,11 +296,6 @@ public class CompositeTypeSerializerSnapshotTest {
 		@Override
 		public int hashCode() {
 			return Arrays.hashCode(nestedSerializers);
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof TestCompositeTypeSerializer;
 		}
 	}
 
@@ -438,20 +433,12 @@ public class CompositeTypeSerializerSnapshotTest {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (canEqual(obj)) {
-				return targetCompatibility == ((NestedSerializer) obj).targetCompatibility;
-			}
-			return false;
+			return targetCompatibility == ((NestedSerializer) obj).targetCompatibility;
 		}
 
 		@Override
 		public int hashCode() {
 			return targetCompatibility.hashCode();
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof NestedSerializer;
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
@@ -54,7 +54,6 @@ public abstract class TypeInformationTestBase<T extends TypeInformation<?>> exte
 
 			// compare among test data
 			for (T otherTypeInfo : testData) {
-				assertTrue("canEqual() returns inconsistent results.", typeInfo.canEqual(otherTypeInfo));
 				// test equality
 				if (typeInfo == otherTypeInfo) {
 					assertTrue("hashCode() returns inconsistent results.", typeInfo.hashCode() == otherTypeInfo.hashCode());

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -420,11 +420,6 @@ public class TypeSerializerSerializationUtilTest implements Serializable {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return IntSerializer.INSTANCE.canEqual(obj);
-		}
-
-		@Override
 		public boolean equals(Object obj) {
 			return IntSerializer.INSTANCE.equals(obj);
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotTest.java
@@ -168,11 +168,6 @@ public class TypeSerializerSnapshotTest {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
 		public int hashCode() {
 			return 0;
 		}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/StatefulComplexPayloadSerializer.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/StatefulComplexPayloadSerializer.java
@@ -131,11 +131,6 @@ public class StatefulComplexPayloadSerializer extends TypeSerializer<ComplexPayl
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return getClass().equals(obj.getClass());
-	}
-
-	@Override
 	public int hashCode() {
 		return 42;
 	}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializer.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializer.java
@@ -309,11 +309,6 @@ public class AvroSerializer<T> extends TypeSerializer<T> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj.getClass() == this.getClass();
-	}
-
-	@Override
 	public String toString() {
 		return getClass().getName() + " (" + getType().getName() + ')';
 	}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CollectionInputFormatTest.java
@@ -378,15 +378,10 @@ public class CollectionInputFormatTest {
 			if (obj instanceof TestSerializer) {
 				TestSerializer other = (TestSerializer) obj;
 
-				return other.canEqual(this) && failOnRead == other.failOnRead && failOnWrite == other.failOnWrite;
+				return failOnRead == other.failOnRead && failOnWrite == other.failOnWrite;
 			} else {
 				return false;
 			}
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof TestSerializer;
 		}
 
 		@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/DeweyNumber.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/DeweyNumber.java
@@ -262,11 +262,6 @@ public class DeweyNumber implements Serializable {
 			return obj == this || obj.getClass().equals(getClass());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -995,11 +995,6 @@ public class NFA<T> {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
 		public int hashCode() {
 			return 37 * sharedBufferSerializer.hashCode() + eventSerializer.hashCode();
 		}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializer.java
@@ -141,11 +141,6 @@ public class NFAStateSerializer extends TypeSerializerSingleton<NFAState> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return true;
-	}
-
-	@Override
 	public TypeSerializerSnapshot<NFAState> snapshotConfiguration() {
 		return new NFAStateSerializerSnapshot(this);
 	}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
@@ -346,11 +346,6 @@ public class SharedBuffer<V> {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
 		public int hashCode() {
 			return 37 * keySerializer.hashCode() + valueSerializer.hashCode();
 		}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/EventId.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/EventId.java
@@ -143,11 +143,6 @@ public class EventId implements Comparable<EventId> {
 			target.writeLong(source.readLong());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj.getClass().equals(EventIdSerializer.class);
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/Lockable.java
@@ -182,11 +182,6 @@ public final class Lockable<T> {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return obj.getClass().equals(LockableTypeSerializer.class);
-		}
-
-		@Override
 		public TypeSerializerSnapshot<Lockable<E>> snapshotConfiguration() {
 			return new LockableTypeSerializerSnapshot<>(this);
 		}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/NodeId.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/NodeId.java
@@ -160,11 +160,6 @@ public class NodeId {
 			StringValue.copyString(source, target);
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj.getClass().equals(NodeIdSerializer.class);
-		}
-
 		// ------------------------------------------------------------------------
 
 		@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferEdge.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferEdge.java
@@ -139,11 +139,6 @@ public class SharedBufferEdge {
 			deweyNumberSerializer.copy(source, target);
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj.getClass().equals(SharedBufferEdgeSerializer.class);
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferNode.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferNode.java
@@ -124,11 +124,6 @@ public class SharedBufferNode {
 			edgesSerializer.copy(source, target);
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj.getClass().equals(SharedBufferNodeSerializer.class);
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCode.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCode.java
@@ -216,11 +216,6 @@ extends LongValue {
 			target.writeLong(source.readLong());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof LongValueWithProperHashCodeSerializer;
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArraySerializer.java
@@ -81,11 +81,6 @@ public final class ByteValueArraySerializer extends TypeSerializerSingleton<Byte
 		ByteValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ByteValueArraySerializer;
-	}
-
 	// ------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArraySerializer.java
@@ -81,11 +81,6 @@ public final class CharValueArraySerializer extends TypeSerializerSingleton<Char
 		CharValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof CharValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArraySerializer.java
@@ -81,11 +81,6 @@ public final class DoubleValueArraySerializer extends TypeSerializerSingleton<Do
 		DoubleValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof DoubleValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArraySerializer.java
@@ -81,11 +81,6 @@ public final class FloatValueArraySerializer extends TypeSerializerSingleton<Flo
 		FloatValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof FloatValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/IntValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/IntValueArraySerializer.java
@@ -80,11 +80,6 @@ public final class IntValueArraySerializer extends TypeSerializerSingleton<IntVa
 		IntValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof IntValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/LongValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/LongValueArraySerializer.java
@@ -80,11 +80,6 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 		LongValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/NullValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/NullValueArraySerializer.java
@@ -80,11 +80,6 @@ public final class NullValueArraySerializer extends TypeSerializerSingleton<Null
 		target.write(source, getLength());
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof NullValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArraySerializer.java
@@ -81,11 +81,6 @@ public final class ShortValueArraySerializer extends TypeSerializerSingleton<Sho
 		ShortValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof ShortValueArraySerializer;
-	}
-
 	// ------------------------------------------------------------------------
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/StringValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/StringValueArraySerializer.java
@@ -80,11 +80,6 @@ public final class StringValueArraySerializer extends TypeSerializerSingleton<St
 		StringValueArray.copyInternal(source, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof StringValueArraySerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/VoidNamespaceSerializer.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/VoidNamespaceSerializer.java
@@ -91,11 +91,6 @@ public final class VoidNamespaceSerializer extends TypeSerializerSingleton<VoidN
 		target.write(source.readByte());
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof VoidNamespaceSerializer;
-	}
-
 	// ------------------------------------------------------------------------
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializer.java
@@ -132,11 +132,6 @@ final public class ArrayListSerializer<T> extends TypeSerializer<ArrayList<T>> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return true;
-	}
-
-	@Override
 	public int hashCode() {
 		return elementSerializer.hashCode();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/JavaSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/JavaSerializer.java
@@ -95,11 +95,6 @@ final class JavaSerializer<T extends Serializable> extends TypeSerializerSinglet
 		serialize(tmp, target);
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof JavaSerializer;
-	}
-
 	// ------------------------------------------------------------------------
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceSerializer.java
@@ -87,11 +87,6 @@ public final class VoidNamespaceSerializer extends TypeSerializerSingleton<VoidN
 		target.write(source.readByte());
 	}
 
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof VoidNamespaceSerializer;
-	}
-
 	// -----------------------------------------------------------------------------------
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntListSerializer.java
@@ -111,17 +111,6 @@ public class IntListSerializer extends TypeSerializer<IntList> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IntListSerializer) {
-			IntListSerializer other = (IntListSerializer) obj;
-
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
 		return obj instanceof IntListSerializer;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/IntPairSerializer.java
@@ -92,17 +92,6 @@ public class IntPairSerializer extends TypeSerializer<IntPair> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IntPairSerializer) {
-			IntPairSerializer other = (IntPairSerializer) obj;
-
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
 		return obj instanceof IntPairSerializer;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/types/StringPairSerializer.java
@@ -88,17 +88,6 @@ public class StringPairSerializer extends TypeSerializer<StringPair> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof StringPairSerializer) {
-			StringPairSerializer other = (StringPairSerializer) obj;
-
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
 		return obj instanceof StringPairSerializer;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateRegistryTest.java
@@ -396,11 +396,6 @@ public class KvStateRegistryTest extends TestLogger {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
 		public int hashCode() {
 			return 0;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
@@ -487,11 +487,6 @@ public abstract class InternalPriorityQueueTestBase extends TestLogger {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return false;
-		}
-
-		@Override
 		public int hashCode() {
 			return 4711;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -330,15 +330,6 @@ public class OperatorStateBackendTest {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (obj instanceof VerifyingIntSerializer) {
-				return ((VerifyingIntSerializer)obj).canEqual(this);
-			} else {
-				return false;
-			}
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
 			return obj instanceof VerifyingIntSerializer;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -911,11 +911,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof CustomVoidNamespaceSerializer;
-		}
-
-		@Override
 		public boolean equals(Object obj) {
 			return obj instanceof CustomVoidNamespaceSerializer;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -271,13 +271,6 @@ class StateSnapshotTransformerTest {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return (obj != null && obj.getClass() == getClass() &&
-				StringSerializer.INSTANCE.canEqual(obj));
-		}
-
-		@Override
 		public int hashCode() {
 			singleThreadAccessChecker.checkSingleThreadAccess();
 			return StringSerializer.INSTANCE.hashCode();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/TestDuplicateSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/TestDuplicateSerializer.java
@@ -104,11 +104,6 @@ public class TestDuplicateSerializer extends TypeSerializer<Integer> {
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof TestDuplicateSerializer;
-	}
-
-	@Override
 	public int hashCode() {
 		return getClass().hashCode();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/RecordSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/RecordSerializer.java
@@ -126,16 +126,6 @@ public final class RecordSerializer extends TypeSerializer<Record> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof RecordSerializer) {
-			RecordSerializer other = (RecordSerializer) obj;
-			return other.canEqual(this);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
 		return obj instanceof RecordSerializer;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
@@ -243,11 +243,6 @@ public class TestType implements HeapPriorityQueueElement, PriorityComparable<Te
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return getClass().equals(obj.getClass());
-		}
-
-		@Override
 		public int hashCode() {
 			return getClass().hashCode();
 		}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherSerializer.scala
@@ -101,15 +101,10 @@ class EitherSerializer[A, B](
   override def equals(obj: Any): Boolean = {
     obj match {
       case eitherSerializer: EitherSerializer[_, _] =>
-        eitherSerializer.canEqual(this) &&
         leftSerializer.equals(eitherSerializer.leftSerializer) &&
         rightSerializer.equals(eitherSerializer.rightSerializer)
       case _ => false
     }
-  }
-
-  override def canEqual(obj: Any): Boolean = {
-    obj.isInstanceOf[EitherSerializer[_, _]]
   }
 
   override def hashCode(): Int = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializer.scala
@@ -62,17 +62,13 @@ class EnumValueSerializer[E <: Enumeration](val enum: E) extends TypeSerializer[
   override def equals(obj: Any): Boolean = {
     obj match {
       case enumValueSerializer: EnumValueSerializer[_] =>
-        enumValueSerializer.canEqual(this) && enum == enumValueSerializer.enum
+        enum == enumValueSerializer.enum
       case _ => false
     }
   }
 
   override def hashCode(): Int = {
     enum.hashCode()
-  }
-
-  override def canEqual(obj: scala.Any): Boolean = {
-    obj.isInstanceOf[EnumValueSerializer[_]]
   }
 
   // --------------------------------------------------------------------------------------------

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/NothingSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/NothingSerializer.scala
@@ -65,13 +65,9 @@ class NothingSerializer extends TypeSerializer[Any] {
 
   override def equals(obj: Any): Boolean = {
     obj match {
-      case nothingSerializer: NothingSerializer => nothingSerializer.canEqual(this)
+      case nothingSerializer: NothingSerializer => true
       case _ => false
     }
-  }
-
-  override def canEqual(obj: scala.Any): Boolean = {
-    obj.isInstanceOf[NothingSerializer]
   }
 
   override def hashCode(): Int = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
@@ -84,13 +84,9 @@ class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
   override def equals(obj: Any): Boolean = {
     obj match {
       case optionSerializer: OptionSerializer[_] =>
-        optionSerializer.canEqual(this) && elemSerializer.equals(optionSerializer.elemSerializer)
+        elemSerializer.equals(optionSerializer.elemSerializer)
       case _ => false
     }
-  }
-
-  override def canEqual(obj: scala.Any): Boolean = {
-    obj.isInstanceOf[OptionSerializer[_]]
   }
 
   override def hashCode(): Int = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
@@ -160,17 +160,13 @@ class TraversableSerializer[T <: TraversableOnce[E], E](
   override def equals(obj: Any): Boolean = {
     obj match {
       case other: TraversableSerializer[_, _] =>
-        other.canEqual(this) && elementSerializer.equals(other.elementSerializer)
+        elementSerializer.equals(other.elementSerializer)
       case _ => false
     }
   }
 
   override def hashCode(): Int = {
     elementSerializer.hashCode()
-  }
-
-  override def canEqual(obj: Any): Boolean = {
-    obj.isInstanceOf[TraversableSerializer[_, _]]
   }
 
   override def snapshotConfiguration(): TraversableSerializerSnapshot[T, E] = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TrySerializer.scala
@@ -87,13 +87,9 @@ class TrySerializer[A](
   override def equals(obj: Any): Boolean = {
     obj match {
       case other: TrySerializer[_] =>
-        other.canEqual(this) && elemSerializer.equals(other.elemSerializer)
+        elemSerializer.equals(other.elemSerializer)
       case _ => false
     }
-  }
-
-  override def canEqual(obj: Any): Boolean = {
-    obj.isInstanceOf[TrySerializer[_]]
   }
 
   override def hashCode(): Int = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitSerializer.scala
@@ -59,10 +59,6 @@ class UnitSerializer extends TypeSerializerSingleton[Unit] {
 
   override def hashCode(): Int = classOf[UnitSerializer].hashCode
 
-  override def canEqual(obj: scala.Any): Boolean = {
-    obj.isInstanceOf[UnitSerializer]
-  }
-
   // -----------------------------------------------------------------------------------
 
   @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -607,15 +607,10 @@ public class CoGroupedStreams<T1, T2> {
 			if (obj instanceof UnionSerializer) {
 				UnionSerializer<T1, T2> other = (UnionSerializer<T1, T2>) obj;
 
-				return other.canEqual(this) && oneSerializer.equals(other.oneSerializer) && twoSerializer.equals(other.twoSerializer);
+				return oneSerializer.equals(other.oneSerializer) && twoSerializer.equals(other.twoSerializer);
 			} else {
 				return false;
 			}
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof UnionSerializer;
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -757,11 +757,6 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof StateSerializer;
-		}
-
-		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
 				return true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -391,11 +391,6 @@ public class InternalTimersSnapshotReaderWriters {
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
 		public int hashCode() {
 			return getClass().hashCode();
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializer.java
@@ -200,11 +200,6 @@ public class TimerSerializer<K, N> extends TypeSerializer<TimerHeapInternalTimer
 	}
 
 	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof TimerSerializer;
-	}
-
-	@Override
 	public TimerSerializerSnapshot<K, N> snapshotConfiguration() {
 		return new TimerSerializerSnapshot<>(this);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -461,11 +461,6 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 		}
 
 		@Override
-		public boolean canEqual(Object obj) {
-			return obj.getClass().equals(BufferEntrySerializer.class);
-		}
-
-		@Override
 		public TypeSerializerSnapshot<BufferEntry<T>> snapshotConfiguration() {
 			return new BufferEntrySerializerSnapshot<>(this);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/GlobalWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/GlobalWindow.java
@@ -118,11 +118,6 @@ public class GlobalWindow extends Window {
 			target.writeByte(0);
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof Serializer;
-		}
-
 		// ------------------------------------------------------------------------
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
@@ -186,11 +186,6 @@ public class TimeWindow extends Window {
 			target.writeLong(source.readLong());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof Serializer;
-		}
-
 		// ------------------------------------------------------------------------
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
@@ -254,15 +254,10 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 		if (obj instanceof StreamElementSerializer) {
 			StreamElementSerializer<?> other = (StreamElementSerializer<?>) obj;
 
-			return other.canEqual(this) && typeSerializer.equals(other.typeSerializer);
+			return typeSerializer.equals(other.typeSerializer);
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean canEqual(Object obj) {
-		return obj instanceof StreamElementSerializer;
 	}
 
 	@Override

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/dataview/ListViewSerializer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/dataview/ListViewSerializer.scala
@@ -69,11 +69,9 @@ class ListViewSerializer[T](val listSerializer: TypeSerializer[java.util.List[T]
   override def copy(source: DataInputView, target: DataOutputView): Unit =
     listSerializer.copy(source, target)
 
-  override def canEqual(obj: scala.Any): Boolean = obj != null && obj.getClass == getClass
-
   override def hashCode(): Int = listSerializer.hashCode()
 
-  override def equals(obj: Any): Boolean = canEqual(this) &&
+  override def equals(obj: Any): Boolean =
     listSerializer.equals(obj.asInstanceOf[ListViewSerializer[_]].listSerializer)
 
   override def snapshotConfiguration(): ListViewSerializerSnapshot[T] =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/dataview/MapViewSerializer.scala
@@ -70,11 +70,9 @@ class MapViewSerializer[K, V](val mapSerializer: TypeSerializer[java.util.Map[K,
   override def copy(source: DataInputView, target: DataOutputView): Unit =
     mapSerializer.copy(source, target)
 
-  override def canEqual(obj: Any): Boolean = obj != null && obj.getClass == getClass
-
   override def hashCode(): Int = mapSerializer.hashCode()
 
-  override def equals(obj: Any): Boolean = canEqual(this) &&
+  override def equals(obj: Any): Boolean =
     mapSerializer.equals(obj.asInstanceOf[MapViewSerializer[_, _]].mapSerializer)
 
   override def snapshotConfiguration(): MapViewSerializerSnapshot[K, V] =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/types/CRowSerializer.scala
@@ -63,16 +63,9 @@ class CRowSerializer(val rowSerializer: TypeSerializer[Row]) extends TypeSeriali
     target.writeBoolean(source.readBoolean())
   }
 
-  override def canEqual(obj: Any): Boolean = obj.isInstanceOf[CRowSerializer]
-
   override def equals(obj: Any): Boolean = {
-
-    if (canEqual(obj)) {
-      val other = obj.asInstanceOf[CRowSerializer]
-      rowSerializer.equals(other.rowSerializer)
-    } else {
-      false
-    }
+    val other = obj.asInstanceOf[CRowSerializer]
+    rowSerializer.equals(other.rowSerializer)
   }
 
   override def hashCode: Int = rowSerializer.hashCode() * 13

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointingCustomKvStateProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointingCustomKvStateProgram.java
@@ -228,11 +228,6 @@ public class CheckpointingCustomKvStateProgram {
 			target.writeInt(source.readInt());
 		}
 
-		@Override
-		public boolean canEqual(Object obj) {
-			return obj instanceof CustomIntSerializer;
-		}
-
 		// -----------------------------------------------------------------------------------
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
@@ -252,11 +252,6 @@ public class TypeSerializerSnapshotMigrationITCase extends SavepointMigrationTes
 		public boolean equals(Object obj) {
 			return obj instanceof TestSerializer;
 		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This change removes `TypeSerializer.canEqual()` because it is not useful on that class hierachy. Serializers can only `equals()` on an exact match, not with different serializers up and down the hierarchy.

## Verifying this change

This is covered by existing tests. We simply remove the method in the interface and all subclasses.