### PR TITLE
[hotfix][docs] Add that LIMIT requires ORDER BY.

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -722,9 +722,11 @@ ORDER BY orderTime
         <span class="label label-primary">Batch</span>
       </td>
       <td>
+<b>Note:</b> The LIMIT clause requires an ORDER BY clause. 
 {% highlight sql %}
 SELECT *
 FROM Orders
+ORDER BY orderTime
 LIMIT 3
 {% endhighlight %}
       </td>


### PR DESCRIPTION
## What is the purpose of the change

Fixes the documentation of SQL `LIMIT` which requires the `ORDER BY` clause.

## Brief change log

* add a note explaining that `LIMIT` requires `ORDER BY`
* fix example

## Verifying this change

* build docs and check manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**
