### PR TITLE
[hotfix] Remove redundant keyword public

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/InMemorySorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/InMemorySorter.java
@@ -102,9 +102,9 @@ public interface InMemorySorter<T> extends IndexedSortable, Disposable {
 	 * @param output The output view to write the records to.
 	 * @throws IOException Thrown, if an I/O exception occurred writing to the output view.
 	 */
-	public void writeToOutput(ChannelWriterOutputView output) throws IOException;
+	void writeToOutput(ChannelWriterOutputView output) throws IOException;
 	
-	public void writeToOutput(ChannelWriterOutputView output, LargeRecordHandler<T> largeRecordsOutput) throws IOException;
+	void writeToOutput(ChannelWriterOutputView output, LargeRecordHandler<T> largeRecordsOutput) throws IOException;
 	
 	/**
 	 * Writes a subset of the records in this buffer in their logical order to the given output.
@@ -114,5 +114,5 @@ public interface InMemorySorter<T> extends IndexedSortable, Disposable {
 	 * @param num The number of elements to write.
 	 * @throws IOException Thrown, if an I/O exception occurred writing to the output view.
 	 */
-	public void writeToOutput(ChannelWriterOutputView output, int start, int num) throws IOException;
+	void writeToOutput(ChannelWriterOutputView output, int start, int num) throws IOException;
 }


### PR DESCRIPTION


## What is the purpose of the change

Remove redundant keyword public in InMemorySorter interface.


## Brief change log

Remove redundant keyword public in InMemorySorter interface.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
