### PR TITLE
[FLINK-11632] Add new config option for TaskManager automatic address binding

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -60,7 +60,13 @@
         <tr>
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The hostname of the network interface that the TaskManager binds to. By default, the TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers. This option can be used to define a hostname if that strategy fails for some reason. Because different TaskManagers need different values for this option, it usually is specified in an additional non-shared TaskManager-specific config file.</td>
+            <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.host.bind-policy</h5></td>
+            <td style="word-wrap: break-word;">"hostname"</td>
+            <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
+<ul><li>"hostname" - uses host's hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li><li>"auto-detect-hostname" - searches for network interfaces that can connect to the JobManager</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -64,7 +64,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.host.bind-policy</h5></td>
-            <td style="word-wrap: break-word;">"hostname"</td>
+            <td style="word-wrap: break-word;">"auto-detect-hostname"</td>
             <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
 <ul><li>"hostname" - uses host's hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li><li>"auto-detect-hostname" - searches for network interfaces that can connect to the JobManager</li></ul></td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -20,8 +20,10 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * The set of configuration options relating to TaskManager and Task settings.
@@ -83,11 +85,26 @@ public class TaskManagerOptions {
 	public static final ConfigOption<String> HOST =
 		key("taskmanager.host")
 			.noDefaultValue()
-			.withDescription("The hostname of the network interface that the TaskManager binds to. By default, the" +
-				" TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers." +
-				" This option can be used to define a hostname if that strategy fails for some reason. Because" +
-				" different TaskManagers need different values for this option, it usually is specified in an" +
+			.withDescription("The address of the network interface that the TaskManager binds to." +
+				" This option can be used to define explicitly a binding address. Because" +
+				" different TaskManagers need different values for this option, usually it is specified in an" +
 				" additional non-shared TaskManager-specific config file.");
+
+	/**
+	 * The config parameter for automatically defining the TaskManager's binding address,
+	 * if {@link #HOST} configuration option is not set.
+	 */
+	public static final ConfigOption<String> HOST_BIND_POLICY =
+		key("taskmanager.host.bind-policy")
+		.defaultValue("hostname")
+		.withDescription(Description.builder()
+			.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +
+				" The value should be one of the following:\n")
+			.list(
+				text("\"hostname\" - uses host's hostname as binding address"),
+				text("\"ip\" - uses host's ip address as binding address"),
+				text("\"auto-detect-hostname\" - searches for network interfaces that can connect to the JobManager"))
+			.build());
 
 	/**
 	 * The default network port range the task manager expects incoming IPC connections. The {@code "0"} means that

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -96,7 +96,7 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<String> HOST_BIND_POLICY =
 		key("taskmanager.host.bind-policy")
-		.defaultValue("hostname")
+		.defaultValue("auto-detect-hostname")
 		.withDescription(Description.builder()
 			.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +
 				" The value should be one of the following:\n")


### PR DESCRIPTION
## What is the purpose of the change

Introduce a new configuration option for TaskManager to explicitly control address bind policy. See [[FLINK-11632]](https://issues.apache.org/jira/browse/FLINK-11632).

## Brief change log

  - `flink-config.yaml` is extended with a new optional config key `taskmanager.host.bind-policy`
  - the TM's automatic address binding mechanism is changed to not use heuristics by default. Instead a simpler hostname picking mechanism is used.
  - the old automatic address binding mechanism is kept available via explicit configuration `taskmanager.host.bind-policy: auto-detect-hostname`.
  - the TM's automatic binding mechanism is extended to be configured to use host's ip address, instead of hostname (for setups, where TMs are not reachable by DNS name, for example Kubernetes).


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **don't know**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs**
