### PR TITLE
[hotfix][sql-client] bump jline version

### DIFF
--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -114,13 +114,13 @@ under the License.
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-terminal</artifactId>
-			<version>3.9.0</version>
+			<version>3.10.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-reader</artifactId>
-			<version>3.9.0</version>
+			<version>3.10.0</version>
 		</dependency>
 
 		<!-- configuration -->


### PR DESCRIPTION
This PR tried to bump jline-terminal and jline-reader version to 3.10.0 which was released recently..