### PR TITLE
[FLINK-11639] Provide readSequenceFile for Hadoop new API

### DIFF
--- a/docs/dev/batch/index.md
+++ b/docs/dev/batch/index.md
@@ -876,7 +876,7 @@ DataSet<Person>> csvInput = env.readCsvFile("hdfs:///the/CSV/file")
 
 // read a file from the specified path of type SequenceFileInputFormat
 DataSet<Tuple2<IntWritable, Text>> tuples =
- env.createInput(HadoopInputs.readSequenceFile(IntWritable.class, Text.class, "hdfs://nnHost:nnPort/path/to/file"));
+ env.createInput(HadoopInputs.readMapReduceSequenceFile(IntWritable.class, Text.class, "hdfs://nnHost:nnPort/path/to/file"));
 
 // creates a set from some given elements
 DataSet<String> value = env.fromElements("Foo", "bar", "foobar", "fubar");
@@ -965,7 +965,7 @@ File-based:
 - `readFileOfPrimitives(path, delimiter)` / `PrimitiveInputFormat` - Parses files of new-line (or another char sequence)
   delimited primitive data types such as `String` or `Integer` using the given delimiter.
 
-- `readSequenceFile(Key, Value, path)` / `SequenceFileInputFormat` - Creates a JobConf and reads file from the specified path with
+- `readMapReduceSequenceFile(Key, Value, path)` / `SequenceFileInputFormat` - Creates a JobConf and reads file from the specified path with
    type SequenceFileInputFormat, Key class and Value class and returns them as Tuple2<Key, Value>.
 
 Collection-based:
@@ -1028,8 +1028,8 @@ val values = env.fromElements("Foo", "bar", "foobar", "fubar")
 val numbers = env.generateSequence(1, 10000000)
 
 // read a file from the specified path of type SequenceFileInputFormat
-val tuples = env.createInput(HadoopInputs.readSequenceFile(classOf[IntWritable], classOf[Text],
- "hdfs://nnHost:nnPort/path/to/file"))
+val tuples = env.readMapReduceSequenceFile(classOf[IntWritable], classOf[Text],
+ "hdfs://nnHost:nnPort/path/to/file")
 
 {% endhighlight %}
 

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/HadoopInputs.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/HadoopInputs.java
@@ -66,9 +66,20 @@ public final class HadoopInputs {
 	/**
 	 * Creates a Flink {@link InputFormat} to read a Hadoop sequence file for the given key and value classes.
 	 *
-	 * @return A Flink InputFormat that wraps a Hadoop SequenceFileInputFormat.
+	 * @return A Flink InputFormat that wraps a Hadoop {@link org.apache.hadoop.mapred.SequenceFileInputFormat}.
+	 * @deprecated Use {@link #readMapRedSequenceFile(Class, Class, String)} instead
 	 */
+	@Deprecated
 	public static <K, V> HadoopInputFormat<K, V> readSequenceFile(Class<K> key, Class<V> value, String inputPath) throws IOException {
+		return readMapRedSequenceFile(key, value, inputPath);
+	}
+
+	/**
+	 * Creates a Flink {@link InputFormat} to read a Hadoop sequence file for the given key and value classes.
+	 *
+	 * @return A Flink InputFormat that wraps a Hadoop {@link org.apache.hadoop.mapred.SequenceFileInputFormat}.
+	 */
+	public static <K, V> HadoopInputFormat<K, V> readMapRedSequenceFile(Class<K> key, Class<V> value, String inputPath) throws IOException {
 		return readHadoopFile(new org.apache.hadoop.mapred.SequenceFileInputFormat<K, V>(), key, value, inputPath);
 	}
 
@@ -102,6 +113,15 @@ public final class HadoopInputs {
 	public static <K, V> org.apache.flink.api.java.hadoop.mapreduce.HadoopInputFormat<K, V> readHadoopFile(
 			org.apache.hadoop.mapreduce.lib.input.FileInputFormat<K, V> mapreduceInputFormat, Class<K> key, Class<V> value, String inputPath) throws IOException {
 		return readHadoopFile(mapreduceInputFormat, key, value, inputPath, Job.getInstance());
+	}
+
+	/**
+	 * Creates a Flink {@link InputFormat} to read a Hadoop sequence file for the given key and value classes.
+	 *
+	 * @return A Flink InputFormat that wraps a Hadoop {@link org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat}.
+	 */
+	public static <K, V> org.apache.flink.api.java.hadoop.mapreduce.HadoopInputFormat<K, V> readMapReduceSequenceFile(Class<K> key, Class<V> value, String inputPath) throws IOException {
+		return readHadoopFile(new org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat<>(), key, value, inputPath);
 	}
 
 	/**

--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/hadoopcompatibility/scala/HadoopInputs.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/hadoopcompatibility/scala/HadoopInputs.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.hadoop.{mapred, mapreduce}
 import org.apache.hadoop.fs.{Path => HadoopPath}
 import org.apache.hadoop.mapred.{JobConf, FileInputFormat => MapredFileInputFormat, InputFormat => MapredInputFormat}
-import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => MapreduceFileInputFormat}
+import org.apache.hadoop.mapreduce.lib.input.{SequenceFileInputFormat, FileInputFormat => MapreduceFileInputFormat}
 import org.apache.hadoop.mapreduce.{Job, InputFormat => MapreduceInputFormat}
 
 /**
@@ -70,8 +70,23 @@ object HadoopInputs {
   /**
     * Creates a Flink [[org.apache.flink.api.common.io.InputFormat]] that reads a Hadoop sequence
     * file with the given key and value classes.
+    * @deprecated Use [[readMapRedSequenceFile(Class, Class String)]] instead.
     */
+  @deprecated
   def readSequenceFile[K, V](
+      key: Class[K],
+      value: Class[V],
+      inputPath: String)(implicit tpe: TypeInformation[(K, V)]): mapred.HadoopInputFormat[K, V] = {
+
+    readMapRedSequenceFile(key, value, inputPath)
+  }
+
+  /**
+    * Creates a Flink [[org.apache.flink.api.common.io.InputFormat]] that reads a Hadoop
+    * [[org.apache.hadoop.mapred.SequenceFileInputFormat]] file with the given key
+    * and value classes.
+    */
+  def readMapRedSequenceFile[K, V](
       key: Class[K],
       value: Class[V],
       inputPath: String)(implicit tpe: TypeInformation[(K, V)]): mapred.HadoopInputFormat[K, V] = {
@@ -81,7 +96,7 @@ object HadoopInputs {
       key,
       value,
       inputPath
-   )
+    )
   }
 
   /**
@@ -125,6 +140,24 @@ object HadoopInputs {
       inputPath: String)(implicit tpe: TypeInformation[(K, V)]): mapreduce.HadoopInputFormat[K, V] =
   {
     readHadoopFile(mapreduceInputFormat, key, value, inputPath, Job.getInstance)
+  }
+
+  /**
+    * Creates a Flink [[org.apache.flink.api.common.io.InputFormat]] that reads a Hadoop
+    * [[org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat]] file with the given key
+    * and value classes.
+    */
+  def readMapReduceSequenceFile[K, V](
+      key: Class[K],
+      value: Class[V],
+      inputPath: String)(implicit ti: TypeInformation[(K, V)]): mapreduce.HadoopInputFormat[K, V] =
+  {
+    readHadoopFile(
+      new SequenceFileInputFormat[K, V],
+      key,
+      value,
+      inputPath
+    )
   }
 
   /**

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopSequenceFormatITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopSequenceFormatITCase.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.hadoopcompatibility.mapred;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.test.testdata.WordCountData;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.OperatingSystem;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.SequenceFileOutputFormat;
+import org.apache.hadoop.mapred.TextOutputFormat;
+import org.junit.Assume;
+import org.junit.Before;
+
+import static org.apache.flink.hadoopcompatibility.HadoopInputs.readMapReduceSequenceFile;
+
+/**
+ * IT cases for both the {@link SequenceFileOutputFormat} and
+ * {@link org.apache.hadoop.mapred.SequenceFileInputFormat}.
+ */
+public class HadoopSequenceFormatITCase extends JavaProgramTestBase {
+
+	protected String textPath;
+	protected String resultPath;
+
+	@Before
+	public void checkOperatingSystem() {
+		// FLINK-5164 - see https://wiki.apache.org/hadoop/WindowsProblems
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		textPath = createAndRegisterTempFile("text.bin").getAbsolutePath();
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		// get input data
+		DataSet<Tuple2<LongWritable, Text>> text = env.fromElements(WordCountData.TEXT.split("\n")).map(new MapFunction<String, Tuple2<LongWritable, Text>>() {
+			@Override
+			public Tuple2<LongWritable, Text> map(String value) throws Exception {
+				return new Tuple2<>(new LongWritable(-1), new Text(value));
+			}
+		});
+		// Set up Hadoop Output Format
+		JobConf jobConf = new JobConf();
+		HadoopOutputFormat<LongWritable, Text> hadoopOutputFormat =
+			new HadoopOutputFormat<LongWritable, Text>(new SequenceFileOutputFormat<LongWritable, Text>(), jobConf);
+		SequenceFileOutputFormat.setOutputPath(jobConf, new Path(textPath));
+
+		// Output & Execute
+		text.output(hadoopOutputFormat);
+		env.execute("Generate test sequence file");
+
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath, new String[]{".", "_"});
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Tuple2<LongWritable, Text>> input;
+		input = env.createInput(readMapReduceSequenceFile(LongWritable.class, Text.class, textPath));
+
+		DataSet<String> text = input.map(new MapFunction<Tuple2<LongWritable, Text>, String>() {
+			@Override
+			public String map(Tuple2<LongWritable, Text> value) throws Exception {
+				return value.f1.toString();
+			}
+		});
+
+		DataSet<Tuple2<String, Integer>> counts =
+			// split up the lines in pairs (2-tuples) containing: (word,1)
+			text.flatMap(new WordCountMapredITCase.Tokenizer())
+				// group by the tuple field "0" and sum up tuple field "1"
+				.groupBy(0)
+				.sum(1);
+
+		DataSet<Tuple2<Text, LongWritable>> words = counts.map(new MapFunction<Tuple2<String, Integer>, Tuple2<Text, LongWritable>>() {
+
+			@Override
+			public Tuple2<Text, LongWritable> map(Tuple2<String, Integer> value) throws Exception {
+				return new Tuple2<Text, LongWritable>(new Text(value.f0), new LongWritable(value.f1));
+			}
+		});
+
+		// Set up Hadoop Output Format
+		JobConf jobConf = new JobConf();
+		HadoopOutputFormat<Text, LongWritable> hadoopOutputFormat =
+			new HadoopOutputFormat<Text, LongWritable>(new TextOutputFormat<Text, LongWritable>(), jobConf);
+		hadoopOutputFormat.getJobConf().set("mapred.textoutputformat.separator", " ");
+		TextOutputFormat.setOutputPath(hadoopOutputFormat.getJobConf(), new Path(resultPath));
+
+		// Output & Execute
+		words.output(hadoopOutputFormat);
+		env.execute("Hadoop Compat WordCount");
+	}
+}

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/HadoopSequenceFormatITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/HadoopSequenceFormatITCase.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.hadoopcompatibility.mapreduce;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.hadoop.mapreduce.HadoopOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.test.testdata.WordCountData;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.OperatingSystem;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.junit.Assume;
+import org.junit.Before;
+
+import static org.apache.flink.hadoopcompatibility.HadoopInputs.readMapReduceSequenceFile;
+
+/**
+ * IT cases for both the {@link SequenceFileOutputFormat} and
+ * {@link org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat}.
+ */
+public class HadoopSequenceFormatITCase extends JavaProgramTestBase {
+
+	protected String textPath;
+	protected String resultPath;
+
+	@Before
+	public void checkOperatingSystem() {
+		// FLINK-5164 - see https://wiki.apache.org/hadoop/WindowsProblems
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		textPath = createAndRegisterTempFile("text.bin").getAbsolutePath();
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		// get input data
+		DataSet<Tuple2<LongWritable, Text>> text = env.fromElements(WordCountData.TEXT.split("\n")).map(new MapFunction<String, Tuple2<LongWritable, Text>>() {
+			@Override
+			public Tuple2<LongWritable, Text> map(String value) throws Exception {
+				return new Tuple2<>(new LongWritable(-1), new Text(value));
+			}
+		});
+		// Set up Hadoop Output Format
+		Job job = Job.getInstance();
+		HadoopOutputFormat<LongWritable, Text> hadoopOutputFormat =
+			new HadoopOutputFormat<>(new SequenceFileOutputFormat<>(), job);
+		SequenceFileOutputFormat.setOutputPath(job, new Path(textPath));
+
+		// Output & Execute
+		text.output(hadoopOutputFormat);
+		env.execute("Generate test sequence file");
+
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath, new String[]{".", "_"});
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Tuple2<LongWritable, Text>> input;
+		input = env.createInput(readMapReduceSequenceFile(LongWritable.class, Text.class, textPath));
+
+		DataSet<String> text = input.map(new MapFunction<Tuple2<LongWritable, Text>, String>() {
+			@Override
+			public String map(Tuple2<LongWritable, Text> value) throws Exception {
+				return value.f1.toString();
+			}
+		});
+
+		DataSet<Tuple2<String, Integer>> counts =
+			// split up the lines in pairs (2-tuples) containing: (word,1)
+			text.flatMap(new WordCountMapreduceITCase.Tokenizer())
+				// group by the tuple field "0" and sum up tuple field "1"
+				.groupBy(0)
+				.sum(1);
+
+		DataSet<Tuple2<Text, LongWritable>> words = counts.map(new MapFunction<Tuple2<String, Integer>, Tuple2<Text, LongWritable>>() {
+
+			@Override
+			public Tuple2<Text, LongWritable> map(Tuple2<String, Integer> value) throws Exception {
+				return new Tuple2<Text, LongWritable>(new Text(value.f0), new LongWritable(value.f1));
+			}
+		});
+
+		// Set up Hadoop Output Format
+		Job job = Job.getInstance();
+		HadoopOutputFormat<Text, LongWritable> hadoopOutputFormat =
+			new HadoopOutputFormat<Text, LongWritable>(new TextOutputFormat<Text, LongWritable>(), job);
+		job.getConfiguration().set("mapred.textoutputformat.separator", " ");
+		TextOutputFormat.setOutputPath(job, new Path(resultPath));
+
+		// Output & Execute
+		words.output(hadoopOutputFormat);
+		env.execute("Hadoop Compat WordCount");
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request provides readSequenceFile for Hadoop new API*

## Brief change log

  - *Add `readMapReduceSequenceFile` and `readMapRedSequenceFile` and deprecated `readSequenceFile` for java and scala API*
  - *Add HadoopSequenceFormatITCase*

## Verifying this change

This change is already covered by existing tests, such as *HadoopSequenceFormatITCase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
