### PR TITLE
[FLINK-11357] Make ExecutionGraph#suspend terminate ExecutionGraph atomically

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -116,9 +116,7 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 		when(clusterClient.listJobs()).thenReturn(CompletableFuture.completedFuture(Arrays.asList(
 			new JobStatusMessage(new JobID(), "job1", JobStatus.RUNNING, 1L),
 			new JobStatusMessage(new JobID(), "job2", JobStatus.CREATED, 1L),
-			new JobStatusMessage(new JobID(), "job3", JobStatus.SUSPENDING, 3L),
-			new JobStatusMessage(new JobID(), "job4", JobStatus.SUSPENDING, 2L),
-			new JobStatusMessage(new JobID(), "job5", JobStatus.FINISHED, 3L)
+			new JobStatusMessage(new JobID(), "job3", JobStatus.FINISHED, 3L)
 		)));
 		return clusterClient;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1307,10 +1307,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			ComponentMainThreadExecutor jobMasterMainThreadExecutor =
 				getVertex().getExecutionGraph().getJobMasterMainThreadExecutor();
 
-			FutureUtils.whenCompleteAsyncIfNotDone(
-				slot.releaseSlot(cause),
-				jobMasterMainThreadExecutor,
-				(Object ignored, Throwable throwable) -> {
+			slot.releaseSlot(cause)
+				.whenComplete((Object ignored, Throwable throwable) -> {
+					jobMasterMainThreadExecutor.assertRunningInMainThread();
 					if (throwable != null) {
 						releaseFuture.completeExceptionally(throwable);
 					} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -701,8 +701,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			// these two are the common cases where we need to send a cancel call
 			else if (current == RUNNING || current == DEPLOYING) {
 				// try to transition to canceling, if successful, send the cancel call
-				if (transitionState(current, CANCELING)) {
-					sendCancelRpcCall();
+				if (startCancelling(NUM_CANCEL_CALL_TRIES)) {
 					return;
 				}
 				// else: fall through the loop
@@ -717,22 +716,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			}
 			else if (current == CREATED || current == SCHEDULED) {
 				// from here, we can directly switch to cancelled, because no task has been deployed
-				if (transitionState(current, CANCELED)) {
-
-					// we skip the canceling state. set the timestamp, for a consistent appearance
-					markTimestamp(CANCELING, getStateTimestamp(CANCELED));
-
-					// cancel the future in order to fail depending scheduling operations
-					taskManagerLocationFuture.cancel(false);
-
-					try {
-						vertex.getExecutionGraph().deregisterExecution(this);
-
-						releaseAssignedResource(new FlinkException("Execution " + this + " was cancelled."));
-					}
-					finally {
-						vertex.executionCanceled(this);
-					}
+				if (cancelAtomically()) {
 					return;
 				}
 				// else: fall through the loop
@@ -741,6 +725,33 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				throw new IllegalStateException(current.name());
 			}
 		}
+	}
+
+	public CompletableFuture<?> suspend() {
+		switch(state) {
+			case RUNNING:
+			case DEPLOYING:
+			case CREATED:
+			case SCHEDULED:
+				if (!cancelAtomically()) {
+					throw new IllegalStateException(
+						String.format("Could not directly go to %s from %s.", CANCELED.name(), state.name()));
+				}
+				break;
+			case CANCELING:
+				completeCancelling();
+				break;
+			case FINISHED:
+			case FAILED:
+				sendFailIntermediateResultPartitionsRpcCall();
+				break;
+			case CANCELED:
+				break;
+			default:
+				throw new IllegalStateException(state.name());
+		}
+
+		return releaseFuture;
 	}
 
 	private void scheduleConsumer(ExecutionVertex consumerVertex) {
@@ -1020,7 +1031,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			else if (current == CANCELING) {
 				// we sent a cancel call, and the task manager finished before it arrived. We
 				// will never get a CANCELED call back from the job manager
-				cancelingComplete(userAccumulators, metrics);
+				completeCancelling(userAccumulators, metrics);
 				return;
 			}
 			else if (current == CANCELED || current == FAILED) {
@@ -1037,11 +1048,30 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		}
 	}
 
-	void cancelingComplete() {
-		cancelingComplete(null, null);
+	private boolean cancelAtomically() {
+		if (startCancelling(0)) {
+			completeCancelling();
+			return true;
+		} else {
+			return false;
+		}
 	}
 
-	void cancelingComplete(Map<String, Accumulator<?, ?>> userAccumulators, IOMetrics metrics) {
+	private boolean startCancelling(int numberCancelRetries) {
+		if (transitionState(state, CANCELING)) {
+			taskManagerLocationFuture.cancel(false);
+			sendCancelRpcCall(numberCancelRetries);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	void completeCancelling() {
+		completeCancelling(null, null);
+	}
+
+	void completeCancelling(Map<String, Accumulator<?, ?>> userAccumulators, IOMetrics metrics) {
 
 		// the taskmanagers can themselves cancel tasks without an external trigger, if they find that the
 		// network stack is canceled (for example by a failing / canceling receiver or sender
@@ -1059,14 +1089,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				updateAccumulatorsAndMetrics(userAccumulators, metrics);
 
 				if (transitionState(current, CANCELED)) {
-					try {
-						releaseAssignedResource(new FlinkException("Execution " + this + " was cancelled."));
-
-						vertex.getExecutionGraph().deregisterExecution(this);
-					}
-					finally {
-						vertex.executionCanceled(this);
-					}
+					finishCancellation();
 					return;
 				}
 
@@ -1082,6 +1105,15 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				}
 				return;
 			}
+		}
+	}
+
+	private void finishCancellation() {
+		try {
+			releaseAssignedResource(new FlinkException("Execution " + this + " was cancelled."));
+			vertex.getExecutionGraph().deregisterExecution(this);
+		} finally {
+			vertex.executionCanceled(this);
 		}
 	}
 
@@ -1141,7 +1173,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			}
 
 			if (current == CANCELING) {
-				cancelingComplete(userAccumulators, metrics);
+				completeCancelling(userAccumulators, metrics);
 				return false;
 			}
 
@@ -1166,7 +1198,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 					try {
 						if (assignedResource != null) {
-							sendCancelRpcCall();
+							sendCancelRpcCall(NUM_CANCEL_CALL_TRIES);
 						}
 					} catch (Throwable tt) {
 						// no reason this should ever happen, but log it to be safe
@@ -1205,7 +1237,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					// performs string concatenations
 					LOG.debug("Concurrent canceling/failing of {} while deployment was in progress.", getVertexWithAttempt());
 				}
-				sendCancelRpcCall();
+				sendCancelRpcCall(NUM_CANCEL_CALL_TRIES);
 			}
 			else {
 				String message = String.format("Concurrent unexpected state transition of task %s to %s while deployment was in progress.",
@@ -1216,7 +1248,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				}
 
 				// undo the deployment
-				sendCancelRpcCall();
+				sendCancelRpcCall(NUM_CANCEL_CALL_TRIES);
 
 				// record the failure
 				markFailed(new Exception(message));
@@ -1231,7 +1263,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 *
 	 * <p>The sending is tried up to NUM_CANCEL_CALL_TRIES times.
 	 */
-	private void sendCancelRpcCall() {
+	private void sendCancelRpcCall(int numberRetries) {
 		final LogicalSlot slot = assignedResource;
 
 		if (slot != null) {
@@ -1241,7 +1273,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 			CompletableFuture<Acknowledge> cancelResultFuture = FutureUtils.retry(
 				() -> taskManagerGateway.cancelTask(attemptId, rpcTimeout),
-				NUM_CANCEL_CALL_TRIES,
+				numberRetries,
 				jobMasterMainThreadExecutor);
 
 			cancelResultFuture.whenComplete(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1028,7 +1028,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 								executionMessageBuilder.append("completed exceptionally: " + completionException + "/" + executionFuture);
 							}
 
-							if (i < allAllocationFutures.size() - 1 ) {
+							if (i < allAllocationFutures.size() - 1) {
 								executionMessageBuilder.append(", ");
 							}
 						}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -68,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * An {@code ExecutionJobVertex} is part of the {@link ExecutionGraph}, and the peer
@@ -553,13 +555,18 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	 * @return A future that is complete once all tasks have canceled.
 	 */
 	public CompletableFuture<Void> cancelWithFuture() {
-		// we collect all futures from the task cancellations
-		CompletableFuture<ExecutionState>[] futures = Arrays.stream(getTaskVertices())
-			.map(ExecutionVertex::cancel)
-			.<CompletableFuture<ExecutionState>>toArray(CompletableFuture[]::new);
+		return FutureUtils.waitForAll(mapExecutionVertices(ExecutionVertex::cancel));
+	}
 
-		// return a conjunct future, which is complete once all individual tasks are canceled
-		return CompletableFuture.allOf(futures);
+	public CompletableFuture<Void> suspend() {
+		return FutureUtils.waitForAll(mapExecutionVertices(ExecutionVertex::suspend));
+	}
+
+	@Nonnull
+	private Collection<CompletableFuture<?>> mapExecutionVertices(final Function<ExecutionVertex, CompletableFuture<?>> mapFunction) {
+		return Arrays.stream(getTaskVertices())
+			.map(mapFunction)
+			.collect(Collectors.toList());
 	}
 
 	public void fail(Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -664,6 +664,10 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		return exec.getReleaseFuture();
 	}
 
+	public CompletableFuture<?> suspend() {
+		return currentExecution.suspend();
+	}
+
 	public void stop() {
 		this.currentExecution.stop();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
@@ -29,25 +29,25 @@ public enum JobStatus {
 	/** Some tasks are scheduled or running, some may be pending, some may be finished. */
 	RUNNING(TerminalState.NON_TERMINAL),
 
-	/** The job has failed and is currently waiting for the cleanup to complete */
+	/** The job has failed and is currently waiting for the cleanup to complete. */
 	FAILING(TerminalState.NON_TERMINAL),
-	
-	/** The job has failed with a non-recoverable task failure */
+
+	/** The job has failed with a non-recoverable task failure. */
 	FAILED(TerminalState.GLOBALLY),
 
-	/** Job is being cancelled */
+	/** Job is being cancelled. */
 	CANCELLING(TerminalState.NON_TERMINAL),
-	
-	/** Job has been cancelled */
+
+	/** Job has been cancelled. */
 	CANCELED(TerminalState.GLOBALLY),
 
 	/** All of the job's tasks have successfully finished. */
 	FINISHED(TerminalState.GLOBALLY),
-	
-	/** The job is currently undergoing a reset and total restart */
+
+	/** The job is currently undergoing a reset and total restart. */
 	RESTARTING(TerminalState.NON_TERMINAL),
 
-	/** The job has been suspended and is currently waiting for the cleanup to complete */
+	/** The job has been suspended and is currently waiting for the cleanup to complete. */
 	SUSPENDING(TerminalState.NON_TERMINAL),
 
 	/**
@@ -58,7 +58,7 @@ public enum JobStatus {
 
 	/** The job is currently reconciling and waits for task execution report to recover state. */
 	RECONCILING(TerminalState.NON_TERMINAL);
-	
+
 	// --------------------------------------------------------------------------------------------
 
 	private enum TerminalState {
@@ -66,9 +66,9 @@ public enum JobStatus {
 		LOCALLY,
 		GLOBALLY
 	}
-	
+
 	private final TerminalState terminalState;
-	
+
 	JobStatus(TerminalState terminalState) {
 		this.terminalState = terminalState;
 	}
@@ -77,10 +77,10 @@ public enum JobStatus {
 	 * Checks whether this state is <i>globally terminal</i>. A globally terminal job
 	 * is complete and cannot fail any more and will not be restarted or recovered by another
 	 * standby master node.
-	 * 
+	 *
 	 * <p>When a globally terminal state has been reached, all recovery data for the job is
 	 * dropped from the high-availability services.
-	 * 
+	 *
 	 * @return True, if this job status is globally terminal, false otherwise.
 	 */
 	public boolean isGloballyTerminalState() {
@@ -90,11 +90,11 @@ public enum JobStatus {
 	/**
 	 * Checks whether this state is <i>locally terminal</i>. Locally terminal refers to the
 	 * state of a job's execution graph within an executing JobManager. If the execution graph
-	 * is locally terminal, the JobManager will not continue executing or recovering the job. 
+	 * is locally terminal, the JobManager will not continue executing or recovering the job.
 	 *
 	 * <p>The only state that is locally terminal, but not globally terminal is {@link #SUSPENDED},
 	 * which is typically entered when the executing JobManager looses its leader status.
-	 * 
+	 *
 	 * @return True, if this job status is terminal, false otherwise.
 	 */
 	public boolean isTerminalState() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
@@ -47,9 +47,6 @@ public enum JobStatus {
 	/** The job is currently undergoing a reset and total restart. */
 	RESTARTING(TerminalState.NON_TERMINAL),
 
-	/** The job has been suspended and is currently waiting for the cleanup to complete. */
-	SUSPENDING(TerminalState.NON_TERMINAL),
-
 	/**
 	 * The job has been suspended which means that it has been stopped but not been removed from a
 	 * potential HA job store.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -20,16 +20,12 @@ package org.apache.flink.runtime.jobmanager.slots;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.messages.StackTrace;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
@@ -46,30 +42,6 @@ public interface TaskManagerGateway {
 	 * @return Address of the task manager with which this gateway is associated.
 	 */
 	String getAddress();
-
-	/**
-	 * Disconnect the task manager from the job manager.
-	 *
-	 * @param instanceId identifying the task manager
-	 * @param cause of the disconnection
-	 */
-	void disconnectFromJobManager(InstanceID instanceId, Exception cause);
-
-	/**
-	 * Stop the cluster.
-	 *
-	 * @param applicationStatus to stop the cluster with
-	 * @param message to deliver
-	 */
-	void stopCluster(final ApplicationStatus applicationStatus, final String message);
-
-	/**
-	 * Request the stack trace from the task manager.
-	 *
-	 * @param timeout for the stack trace request
-	 * @return Future for a stack trace
-	 */
-	CompletableFuture<StackTrace> requestStackTrace(final Time timeout);
 
 	/**
 	 * Request a stack trace sample from the given task.
@@ -172,22 +144,6 @@ public interface TaskManagerGateway {
 		long checkpointId,
 		long timestamp,
 		CheckpointOptions checkpointOptions);
-
-	/**
-	 * Request the task manager log from the task manager.
-	 *
-	 * @param timeout for the request
-	 * @return Future blob key under which the task manager log has been stored
-	 */
-	CompletableFuture<TransientBlobKey> requestTaskManagerLog(final Time timeout);
-
-	/**
-	 * Request the task manager stdout from the task manager.
-	 *
-	 * @param timeout for the request
-	 * @return Future blob key under which the task manager stdout file has been stored
-	 */
-	CompletableFuture<TransientBlobKey> requestTaskManagerStdout(final Time timeout);
 
 	/**
 	 * Frees the slot with the given allocation ID.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1098,6 +1098,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		try {
 			resourceManagerLeaderRetriever.stop();
+			resourceManagerAddress = null;
 		} catch (Throwable t) {
 			log.warn("Failed to stop resource manager leader retriever when suspending.", t);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.core.io.InputSplit;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -20,19 +20,14 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.messages.StackTrace;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
-import org.apache.flink.runtime.taskexecutor.FileType;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.util.Preconditions;
 
@@ -55,24 +50,6 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 	@Override
 	public String getAddress() {
 		return taskExecutorGateway.getAddress();
-	}
-
-	@Override
-	public void disconnectFromJobManager(InstanceID instanceId, Exception cause) {
-//		taskExecutorGateway.disconnectFromJobManager(instanceId, cause);
-		throw new UnsupportedOperationException("Operation is not yet supported.");
-	}
-
-	@Override
-	public void stopCluster(ApplicationStatus applicationStatus, String message) {
-//		taskExecutorGateway.stopCluster(applicationStatus, message);
-		throw new UnsupportedOperationException("Operation is not yet supported.");
-	}
-
-	@Override
-	public CompletableFuture<StackTrace> requestStackTrace(Time timeout) {
-//		return taskExecutorGateway.requestStackTrace(timeout);
-		throw new UnsupportedOperationException("Operation is not yet supported.");
 	}
 
 	@Override
@@ -130,16 +107,6 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 			checkpointId,
 			timestamp,
 			checkpointOptions);
-	}
-
-	@Override
-	public CompletableFuture<TransientBlobKey> requestTaskManagerLog(Time timeout) {
-		return taskExecutorGateway.requestFileUpload(FileType.LOG, timeout);
-	}
-
-	@Override
-	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
-		return taskExecutorGateway.requestFileUpload(FileType.STDOUT, timeout);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1172,19 +1172,16 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
+			runAsync(() -> {
+				log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
 
-					if (jmResourceIdRegistrations.containsKey(resourceID)) {
-						JobManagerRegistration jobManagerRegistration = jmResourceIdRegistrations.get(resourceID);
+				if (jmResourceIdRegistrations.containsKey(resourceID)) {
+					JobManagerRegistration jobManagerRegistration = jmResourceIdRegistrations.get(resourceID);
 
-						if (jobManagerRegistration != null) {
-							closeJobManagerConnection(
-								jobManagerRegistration.getJobID(),
-								new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
-						}
+					if (jobManagerRegistration != null) {
+						closeJobManagerConnection(
+							jobManagerRegistration.getJobID(),
+							new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
 					}
 				}
 			});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
@@ -97,8 +97,7 @@ public class ExecutionGraphCache implements Closeable {
 						// TODO: Remove once we no longer request the actual ExecutionGraph from the JobManager but only the ArchivedExecutionGraph
 						try {
 							final AccessExecutionGraph executionGraph = executionGraphFuture.get();
-							if (executionGraph.getState() != JobStatus.SUSPENDING &&
-								executionGraph.getState() != JobStatus.SUSPENDED) {
+							if (executionGraph.getState() != JobStatus.SUSPENDED) {
 								return executionGraphFuture;
 							}
 							// send a new request to get the ExecutionGraph from the new leader
@@ -138,8 +137,7 @@ public class ExecutionGraphCache implements Closeable {
 							newEntry.getExecutionGraphFuture().complete(executionGraph);
 
 							// TODO: Remove once we no longer request the actual ExecutionGraph from the JobManager but only the ArchivedExecutionGraph
-							if (executionGraph.getState() == JobStatus.SUSPENDING ||
-								executionGraph.getState() == JobStatus.SUSPENDED) {
+							if (executionGraph.getState() == JobStatus.SUSPENDED) {
 								// remove the entry in case of suspension --> triggers new request when accessed next time
 								cachedExecutionGraphs.remove(jobId, newEntry);
 							}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -36,12 +36,12 @@ import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.OptionalFailure;
@@ -67,6 +67,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests for the {@link ArchivedExecutionGraph}.
+ */
 public class ArchivedExecutionGraphTest extends TestLogger {
 
 	private static ExecutionGraph runtimeGraph;
@@ -117,7 +120,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		List<ExecutionJobVertex> jobVertices = new ArrayList<>();
 		jobVertices.add(runtimeGraph.getJobVertex(v1ID));
 		jobVertices.add(runtimeGraph.getJobVertex(v2ID));
-		
+
 		CheckpointStatsTracker statsTracker = new CheckpointStatsTracker(
 				0,
 				jobVertices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -179,7 +179,6 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.CANCELED), archivedGraph.getStatusTimestamp(JobStatus.CANCELED));
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.FINISHED), archivedGraph.getStatusTimestamp(JobStatus.FINISHED));
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.RESTARTING), archivedGraph.getStatusTimestamp(JobStatus.RESTARTING));
-		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.SUSPENDING), archivedGraph.getStatusTimestamp(JobStatus.SUSPENDING));
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.SUSPENDED), archivedGraph.getStatusTimestamp(JobStatus.SUSPENDED));
 		assertEquals(runtimeGraph.isStoppable(), archivedGraph.isStoppable());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
@@ -146,7 +146,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		blocker.complete(null);
 
 		// now report that cancelling is complete for the other vertex
-		vertex2.getCurrentExecutionAttempt().cancelingComplete();
+		vertex2.getCurrentExecutionAttempt().completeCancelling();
 
 		assertEquals(JobStatus.CANCELED, graph.getTerminationFuture().get());
 		assertTrue(vertex1.getCurrentExecutionAttempt().getState().isTerminal());
@@ -215,7 +215,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		blocker.complete(null);
 
 		// now report that cancelling is complete for the other vertex
-		vertex2.getCurrentExecutionAttempt().cancelingComplete();
+		vertex2.getCurrentExecutionAttempt().completeCancelling();
 
 		assertEquals(JobStatus.FAILED, graph.getState());
 		assertTrue(vertex1.getCurrentExecutionAttempt().getState().isTerminal());
@@ -283,7 +283,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		assertEquals(ExecutionState.CANCELING, vertex1.getCurrentExecutionAttempt().getState());
 
 		// now report that cancelling is complete for the other vertex
-		vertex1.getCurrentExecutionAttempt().cancelingComplete();
+		vertex1.getCurrentExecutionAttempt().completeCancelling();
 
 		waitUntilJobStatus(graph, JobStatus.RUNNING, 1000);
 		assertEquals(JobStatus.RUNNING, graph.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -96,7 +96,7 @@ public class ExecutionGraphCoLocationRestartTest extends SchedulerTestBase {
 		assertEquals(JobStatus.FAILING, eg.getState());
 
 		for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
-			vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().completeCancelling();
 		}
 
 		// wait until we have restarted

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -353,7 +353,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 	}
 
 	/**
-	 * Verifies that {@link Execution#cancelingComplete(Map, IOMetrics)} and {@link Execution#markFailed(Throwable, Map, IOMetrics)}
+	 * Verifies that {@link Execution#completeCancelling(Map, IOMetrics)} and {@link Execution#markFailed(Throwable, Map, IOMetrics)}
 	 * store the given accumulators and metrics correctly.
 	 */
 	@Test
@@ -371,7 +371,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		Execution execution1 = executions.values().iterator().next();
 		execution1.cancel();
-		execution1.cancelingComplete(accumulators, ioMetrics);
+		execution1.completeCancelling(accumulators, ioMetrics);
 		
 		assertEquals(ioMetrics, execution1.getIOMetrics());
 		assertEquals(accumulators, execution1.getUserAccumulators());
@@ -397,7 +397,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 			for (Execution e : executions.values()) {
 				e.cancel();
-				e.cancelingComplete();
+				e.completeCancelling();
 			}
 
 			assertEquals(0, executions.size());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -195,6 +195,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			new InfiniteDelayRestartStrategy(),
 			scheduler);
 
+		executionGraph.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
+
 		JobVertex jobVertex = new JobVertex("NoOpInvokable");
 		jobVertex.setInvokableClass(NoOpInvokable.class);
 		jobVertex.setParallelism(NUM_TASKS);
@@ -211,8 +213,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		// Kill the instance and wait for the job to restart
 		instance.markDead();
-
-		Assert.assertEquals(JobStatus.RESTARTING, executionGraph.getState());
 
 		assertEquals(JobStatus.RESTARTING, executionGraph.getState());
 
@@ -797,7 +797,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	}
 
 	private static ExecutionGraph newExecutionGraph(RestartStrategy restartStrategy, SlotProvider slotProvider) throws IOException {
-		return new ExecutionGraph(
+		final ExecutionGraph executionGraph = new ExecutionGraph(
 			TestingUtils.defaultExecutor(),
 			TestingUtils.defaultExecutor(),
 			new JobID(),
@@ -807,6 +807,10 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			AkkaUtils.getDefaultTimeout(),
 			restartStrategy,
 			slotProvider);
+
+		executionGraph.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+		return executionGraph;
 	}
 
 	private void restartAfterFailure(ExecutionGraph eg, FiniteDuration timeout, boolean haltAfterRestart) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -127,7 +127,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	}
 
 	private void completeCanceling(ExecutionGraph eg) {
-		executeOperationForAllExecutions(eg, Execution::cancelingComplete);
+		executeOperationForAllExecutions(eg, Execution::completeCancelling);
 	}
 
 	private void executeOperationForAllExecutions(ExecutionGraph eg, Consumer<Execution> operation) {
@@ -346,7 +346,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		finishedExecution.markFinished();
 
 		failedExecution.fail(new Exception("Test Exception"));
-		failedExecution.cancelingComplete();
+		failedExecution.completeCancelling();
 
 		assertEquals(JobStatus.RUNNING, eg.getState());
 
@@ -412,7 +412,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		Execution execution = eg.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt();
 
-		execution.cancelingComplete();
+		execution.completeCancelling();
 		assertEquals(JobStatus.CANCELED, eg.getState());
 	}
 
@@ -456,7 +456,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		Execution execution = eg.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt();
 
-		execution.cancelingComplete();
+		execution.completeCancelling();
 		assertEquals(JobStatus.RESTARTING, eg.getState());
 	}
 
@@ -820,7 +820,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		assertEquals(JobStatus.FAILING, eg.getState());
 
 		for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
-			vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().completeCancelling();
 		}
 
 		assertEquals(JobStatus.RUNNING, eg.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
@@ -49,7 +48,6 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
-import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -58,7 +56,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Test;
-import org.mockito.verification.Timeout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -80,12 +77,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the scheduling of the execution graph. This tests that
@@ -105,7 +96,6 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 	//  Tests
 	// ------------------------------------------------------------------------
 
-	
 	/**
 	 * Tests that with scheduling futures and pipelined deployment, the target vertex will
 	 * not deploy its task before the source vertex does.
@@ -143,8 +133,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 		//  set up two TaskManager gateways and slots
 
-		final TaskManagerGateway gatewaySource = createTaskManager();
-		final TaskManagerGateway gatewayTarget = createTaskManager();
+		final InteractionsCountingTaskManagerGateway gatewaySource = createTaskManager();
+		final InteractionsCountingTaskManagerGateway gatewayTarget = createTaskManager();
 
 		final SimpleSlot sourceSlot = createSlot(gatewaySource, jobId);
 		final SimpleSlot targetSlot = createSlot(gatewayTarget, jobId);
@@ -160,15 +150,15 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		// that should not cause a deployment or deployment related failure
 		targetFuture.complete(targetSlot);
 
-		verify(gatewayTarget, new Timeout(50, times(0))).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		assertThat(gatewayTarget.getSubmitTaskCount(), is(0));
 		assertEquals(JobStatus.RUNNING, eg.getState());
 
 		// now supply the source slot
 		sourceFuture.complete(sourceSlot);
 
 		// by now, all deployments should have happened
-		verify(gatewaySource, timeout(1000)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
-		verify(gatewayTarget, timeout(1000)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		assertThat(gatewaySource.getSubmitTaskCount(), is(1));
+		assertThat(gatewayTarget.getSubmitTaskCount(), is(1));
 
 		assertEquals(JobStatus.RUNNING, eg.getState());
 	}
@@ -207,8 +197,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		//
 		//  Create the slots, futures, and the slot provider
 
-		final TaskManagerGateway[] sourceTaskManagers = new TaskManagerGateway[parallelism];
-		final TaskManagerGateway[] targetTaskManagers = new TaskManagerGateway[parallelism];
+		final InteractionsCountingTaskManagerGateway[] sourceTaskManagers = new InteractionsCountingTaskManagerGateway[parallelism];
+		final InteractionsCountingTaskManagerGateway[] targetTaskManagers = new InteractionsCountingTaskManagerGateway[parallelism];
 
 		final SimpleSlot[] sourceSlots = new SimpleSlot[parallelism];
 		final SimpleSlot[] targetSlots = new SimpleSlot[parallelism];
@@ -264,11 +254,11 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		//
 		//  verify that all deployments have happened
 
-		for (TaskManagerGateway gateway : sourceTaskManagers) {
-			verify(gateway, timeout(500L)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		for (InteractionsCountingTaskManagerGateway gateway : sourceTaskManagers) {
+			assertThat(gateway.getSubmitTaskCount(), is(1));
 		}
-		for (TaskManagerGateway gateway : targetTaskManagers) {
-			verify(gateway, timeout(500L)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		for (InteractionsCountingTaskManagerGateway gateway : targetTaskManagers) {
+			assertThat(gateway.getSubmitTaskCount(), is(1));
 		}
 	}
 
@@ -299,7 +289,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		//
 		//  Create the slots, futures, and the slot provider
 
-		final TaskManagerGateway taskManager = mock(TaskManagerGateway.class);
+		final InteractionsCountingTaskManagerGateway taskManager = createTaskManager();
 		final BlockingQueue<AllocationID> returnedSlots = new ArrayBlockingQueue<>(parallelism);
 		final TestingSlotOwner slotOwner = new TestingSlotOwner();
 		slotOwner.setReturnAllocatedSlotConsumer(
@@ -355,7 +345,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		}
 
 		// no deployment calls must have happened
-		verify(taskManager, times(0)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		assertThat(taskManager.getSubmitTaskCount(), is(0));
 
 		// all completed futures must have been returns
 		for (int i = 0; i < parallelism; i += 2) {
@@ -387,7 +377,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		slotOwner.setReturnAllocatedSlotConsumer(
 			(LogicalSlot logicalSlot) -> returnedSlots.offer(logicalSlot.getAllocationId()));
 
-		final TaskManagerGateway taskManager = mock(TaskManagerGateway.class);
+		final InteractionsCountingTaskManagerGateway taskManager = createTaskManager();
 		final SimpleSlot[] slots = new SimpleSlot[parallelism];
 		@SuppressWarnings({"unchecked", "rawtypes"})
 		final CompletableFuture<LogicalSlot>[] slotFutures = new CompletableFuture[parallelism];
@@ -428,12 +418,12 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		}
 
 		//  verify that no deployments have happened
-		verify(taskManager, times(0)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		assertThat(taskManager.getSubmitTaskCount(), is(0));
 	}
 
 	/**
 	 * Tests that an ongoing scheduling operation does not fail the {@link ExecutionGraph}
-	 * if it gets concurrently cancelled
+	 * if it gets concurrently cancelled.
 	 */
 	@Test
 	public void testSchedulingOperationCancellationWhenCancel() throws Exception {
@@ -604,7 +594,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 	}
 
 	private SimpleSlot createSlot(TaskManagerGateway taskManager, JobID jobId) {
-		return createSlot(taskManager, jobId, mock(SlotOwner.class));
+		return createSlot(taskManager, jobId, new TestingSlotOwner());
 	}
 
 	private SimpleSlot createSlot(TaskManagerGateway taskManager, JobID jobId, SlotOwner slotOwner) {
@@ -639,20 +629,17 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			slotOwner);
 	}
 
-	private static TaskManagerGateway createTaskManager() {
-		TaskManagerGateway tm = mock(TaskManagerGateway.class);
-		when(tm.submitTask(any(TaskDeploymentDescriptor.class), any(Time.class)))
-				.thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
-		return tm;
+	private static InteractionsCountingTaskManagerGateway createTaskManager() {
+		return new InteractionsCountingTaskManagerGateway();
 	}
 
-	private static void verifyNothingDeployed(ExecutionGraph eg, TaskManagerGateway[] taskManagers) {
+	private static void verifyNothingDeployed(ExecutionGraph eg, InteractionsCountingTaskManagerGateway[] taskManagers) {
 		// job should still be running
 		assertEquals(JobStatus.RUNNING, eg.getState());
 
 		// none of the TaskManager should have gotten a deployment call, yet
-		for (TaskManagerGateway gateway : taskManagers) {
-			verify(gateway, new Timeout(50, times(0))).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+		for (InteractionsCountingTaskManagerGateway gateway : taskManagers) {
+			assertThat(gateway.getSubmitTaskCount(), is(0));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -567,7 +567,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 
 				// if the execution was cancelled in state SCHEDULING, then it might already have been removed
 				if (execution != null) {
-					execution.cancelingComplete();
+					execution.completeCancelling();
 				}
 			}
 		);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -19,25 +19,18 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
-import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -306,35 +299,4 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 		return simpleTestGraph;
 	}
 
-	private static class InteractionsCountingTaskManagerGateway extends SimpleAckingTaskManagerGateway {
-
-		private final AtomicInteger cancelTaskCount = new AtomicInteger(0);
-
-		private final AtomicInteger submitTaskCount = new AtomicInteger(0);
-
-		@Override
-		public CompletableFuture<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, Time timeout) {
-			cancelTaskCount.incrementAndGet();
-			return CompletableFuture.completedFuture(Acknowledge.get());
-		}
-
-		@Override
-		public CompletableFuture<Acknowledge> submitTask(TaskDeploymentDescriptor tdd, Time timeout) {
-			submitTaskCount.incrementAndGet();
-			return CompletableFuture.completedFuture(Acknowledge.get());
-		}
-
-		private void resetCounts() {
-			cancelTaskCount.set(0);
-			submitTaskCount.set(0);
-		}
-
-		private int getCancelTaskCount() {
-			return cancelTaskCount.get();
-		}
-
-		private int getInteractionsCount() {
-			return cancelTaskCount.get() + submitTaskCount.get();
-		}
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -25,17 +25,16 @@ import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -133,7 +132,7 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 	}
 
 	/**
-	 * Suspending from FAILING goes to SUSPENDING and sends no additional RPC calls
+	 * Suspending from FAILING goes to SUSPENDING and sends no additional RPC calls.
 	 */
 	@Test
 	public void testSuspendedOutOfFailing() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -270,7 +270,7 @@ public class ExecutionGraphTestUtils {
 		assertEquals(JobStatus.FAILING, executionGraph.getState());
 
 		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
-			vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().completeCancelling();
 		}
 	}
 
@@ -290,7 +290,7 @@ public class ExecutionGraphTestUtils {
 	 */
 	public static void completeCancellingForAllVertices(ExecutionGraph eg) {
 		for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
-			vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().completeCancelling();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -237,7 +237,7 @@ public class ExecutionTest extends TestLogger {
 		execution.cancel();
 		assertEquals(ExecutionState.CANCELING, execution.getState());
 
-		execution.cancelingComplete();
+		execution.completeCancelling();
 
 		assertEquals(slot, slotOwner.getReturnedSlotFuture().get());
 	}
@@ -385,7 +385,7 @@ public class ExecutionTest extends TestLogger {
 		CompletableFuture<LogicalSlot> returnedSlotFuture = slotOwner.getReturnedSlotFuture();
 		CompletableFuture<?> terminationFuture = executionVertex.cancel();
 
-		currentExecutionAttempt.cancelingComplete();
+		currentExecutionAttempt.completeCancelling();
 
 		CompletableFuture<Boolean> restartFuture = terminationFuture.thenApply(
 			ignored -> {
@@ -474,7 +474,7 @@ public class ExecutionTest extends TestLogger {
 		taskManagerGateway.setCancelConsumer(
 			executionAttemptID -> {
 				if (execution.getAttemptId().equals(executionAttemptID)) {
-					execution.cancelingComplete();
+					execution.completeCancelling();
 				}
 			}
 		);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
@@ -51,6 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -59,6 +61,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -501,6 +504,48 @@ public class ExecutionTest extends TestLogger {
 		}
 
 		assertThat(returnedSlotFuture.get(), is(equalTo(slotRequestIdFuture.get())));
+	}
+
+	/**
+	 * Tests that a slot release will atomically release the assigned {@link Execution}.
+	 */
+	@Test
+	public void testSlotReleaseAtomicallyReleasesExecution() throws Exception {
+		final JobVertex jobVertex = createNoOpJobVertex();
+
+		final SingleSlotTestingSlotOwner slotOwner = new SingleSlotTestingSlotOwner();
+		final SingleLogicalSlot slot = ExecutionGraphSchedulingTest.createSingleLogicalSlot(
+			slotOwner,
+			new SimpleAckingTaskManagerGateway(),
+			new SlotRequestId());
+		final CompletableFuture<LogicalSlot> slotFuture = CompletableFuture.completedFuture(slot);
+
+		final CountDownLatch slotRequestLatch = new CountDownLatch(1);
+		final TestingSlotProvider slotProvider = new TestingSlotProvider(slotRequestId -> {
+			slotRequestLatch.countDown();
+			return slotFuture;
+		});
+		final ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
+			new JobID(),
+			slotProvider,
+			new NoRestartStrategy(),
+			jobVertex);
+
+		final Execution execution = executionGraph.getJobVertex(jobVertex.getID()).getTaskVertices()[0].getCurrentExecutionAttempt();
+
+		executionGraph.start(testMainThreadUtil.getMainThreadExecutor());
+		testMainThreadUtil.execute(executionGraph::scheduleForExecution);
+
+		// wait until the slot has been requested
+		slotRequestLatch.await();
+
+		testMainThreadUtil.execute(() -> {
+			assertThat(execution.getAssignedResource(), is(sameInstance(slot)));
+
+			slot.release(new FlinkException("Test exception"));
+
+			assertThat(execution.getReleaseFuture().isDone(), is(true));
+		});
 	}
 
 	@Nonnull

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -137,7 +137,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 			assertEquals(ExecutionState.RUNNING, vertex.getExecutionState());
 
 			vertex.cancel();
-			vertex.getCurrentExecutionAttempt().cancelingComplete(); // response by task manager once actually canceled
+			vertex.getCurrentExecutionAttempt().completeCancelling(); // response by task manager once actually canceled
 
 			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
@@ -185,7 +185,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 			assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
 			// callback by TaskManager after canceling completes
-			vertex.getCurrentExecutionAttempt().cancelingComplete();
+			vertex.getCurrentExecutionAttempt().completeCancelling();
 
 			assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
@@ -223,7 +223,7 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 
 		for (ExecutionVertex ev : eg.getAllExecutionVertices()) {
 			if (ev.getCurrentExecutionAttempt().getState() == ExecutionState.CANCELING) {
-				ev.getCurrentExecutionAttempt().cancelingComplete();
+				ev.getCurrentExecutionAttempt().completeCancelling();
 			}
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -78,7 +78,7 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev).getState());
 
 		for (ExecutionVertex evs : eg.getAllExecutionVertices()) {
-			evs.getCurrentExecutionAttempt().cancelingComplete();
+			evs.getCurrentExecutionAttempt().completeCancelling();
 		}
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev).getState());
 	}
@@ -164,7 +164,7 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
 
-		ev11.getCurrentExecutionAttempt().cancelingComplete();
+		ev11.getCurrentExecutionAttempt().completeCancelling();
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
@@ -185,7 +185,7 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev31).getState());
 
-		ev32.getCurrentExecutionAttempt().cancelingComplete();
+		ev32.getCurrentExecutionAttempt().completeCancelling();
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
@@ -205,7 +205,7 @@ public class FailoverRegionTest extends TestLogger {
 		ev.fail(new Exception("Test Exception"));
 
 		for (ExecutionVertex evs : eg.getAllExecutionVertices()) {
-			evs.getCurrentExecutionAttempt().cancelingComplete();
+			evs.getCurrentExecutionAttempt().completeCancelling();
 		}
 		assertEquals(JobStatus.FAILED, eg.getState());
 	}
@@ -281,10 +281,10 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev31).getState());
 
-		ev32.getCurrentExecutionAttempt().cancelingComplete();
+		ev32.getCurrentExecutionAttempt().completeCancelling();
 		waitUntilFailoverRegionState(strategy.getFailoverRegion(ev31), JobStatus.RUNNING, 1000);
 
-		ev12.getCurrentExecutionAttempt().cancelingComplete();
+		ev12.getCurrentExecutionAttempt().completeCancelling();
 		waitUntilFailoverRegionState(strategy.getFailoverRegion(ev11), JobStatus.RUNNING, 1000);
 	}
 
@@ -392,7 +392,7 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev1).getState());
 
 		for (ExecutionVertex evs : eg.getAllExecutionVertices()) {
-			evs.getCurrentExecutionAttempt().cancelingComplete();
+			evs.getCurrentExecutionAttempt().completeCancelling();
 		}
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev1).getState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -85,7 +85,7 @@ public class GlobalModVersionTest extends TestLogger {
 		// all cancellations are done now
 		for (ExecutionVertex v : graph.getVerticesTopologically().iterator().next().getTaskVertices()) {
 			final Execution exec = v.getCurrentExecutionAttempt();
-			exec.cancelingComplete();
+			exec.completeCancelling();
 		}
 
 		assertEquals(JobStatus.CANCELED, graph.getTerminationFuture().get());
@@ -139,7 +139,7 @@ public class GlobalModVersionTest extends TestLogger {
 		// all cancellations are done now
 		for (ExecutionVertex v : graph.getVerticesTopologically().iterator().next().getTaskVertices()) {
 			final Execution exec = v.getCurrentExecutionAttempt();
-			exec.cancelingComplete();
+			exec.completeCancelling();
 		}
 
 		assertEquals(JobStatus.RESTARTING, graph.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/InteractionsCountingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/InteractionsCountingTaskManagerGateway.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class InteractionsCountingTaskManagerGateway extends SimpleAckingTaskManagerGateway {
+
+	private final AtomicInteger cancelTaskCount = new AtomicInteger(0);
+
+	private final AtomicInteger submitTaskCount = new AtomicInteger(0);
+
+	@Override
+	public CompletableFuture<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, Time timeout) {
+		cancelTaskCount.incrementAndGet();
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> submitTask(TaskDeploymentDescriptor tdd, Time timeout) {
+		submitTaskCount.incrementAndGet();
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	void resetCounts() {
+		cancelTaskCount.set(0);
+		submitTaskCount.set(0);
+	}
+
+	int getCancelTaskCount() {
+		return cancelTaskCount.get();
+	}
+
+	int getSubmitTaskCount() {
+		return submitTaskCount.get();
+	}
+
+	int getInteractionsCount() {
+		return cancelTaskCount.get() + submitTaskCount.get();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -20,26 +20,19 @@ package org.apache.flink.runtime.executiongraph.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.messages.StackTrace;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
-
-import javax.annotation.Nonnull;
 
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -56,9 +49,6 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 	private Optional<Consumer<ExecutionAttemptID>> optCancelConsumer;
 
 	private volatile BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction;
-
-	@Nonnull
-	private volatile BiConsumer<InstanceID, Exception> disconnectFromJobManagerConsumer = (ignoredA, ignoredB) -> {};
 
 	public SimpleAckingTaskManagerGateway() {
 		optSubmitConsumer = Optional.empty();
@@ -77,26 +67,9 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 		this.freeSlotFunction = freeSlotFunction;
 	}
 
-	public void setDisconnectFromJobManagerConsumer(@Nonnull BiConsumer<InstanceID, Exception> disconnectFromJobManagerConsumer) {
-		this.disconnectFromJobManagerConsumer = disconnectFromJobManagerConsumer;
-	}
-
 	@Override
 	public String getAddress() {
 		return address;
-	}
-
-	@Override
-	public void disconnectFromJobManager(InstanceID instanceId, Exception cause) {
-		disconnectFromJobManagerConsumer.accept(instanceId, cause);
-	}
-
-	@Override
-	public void stopCluster(ApplicationStatus applicationStatus, String message) {}
-
-	@Override
-	public CompletableFuture<StackTrace> requestStackTrace(Time timeout) {
-		return FutureUtils.completedExceptionally(new UnsupportedOperationException());
 	}
 
 	@Override
@@ -149,16 +122,6 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 			long checkpointId,
 			long timestamp,
 			CheckpointOptions checkpointOptions) {}
-
-	@Override
-	public CompletableFuture<TransientBlobKey> requestTaskManagerLog(Time timeout) {
-		return FutureUtils.completedExceptionally(new UnsupportedOperationException());
-	}
-
-	@Override
-	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
-		return FutureUtils.completedExceptionally(new UnsupportedOperationException());
-	}
 
 	@Override
 	public CompletableFuture<Acknowledge> freeSlot(AllocationID allocationId, Throwable cause, Time timeout) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -104,6 +104,7 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcCheckpointResponder;
@@ -159,9 +160,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -282,7 +284,7 @@ public class JobMasterTest extends TestLogger {
 				jobManagerSharedServices,
 				heartbeatServices,
 				UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
-				new NoOpOnCompletionActions(),
+				new TestingOnCompletionActions(),
 				testingFatalErrorHandler,
 				JobMasterTest.class.getClassLoader()) {
 				@Override
@@ -1224,10 +1226,6 @@ public class JobMasterTest extends TestLogger {
 			// wait for the start to complete
 			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
-			final TestingResourceManagerGateway testingResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
-			final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
-			testingResourceManagerGateway.setRequestSlotConsumer(slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
-
 			final CompletableFuture<TaskDeploymentDescriptor> tddFuture = new CompletableFuture<>();
 			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
 				.setSubmitTaskConsumer((taskDeploymentDescriptor, jobMasterId) -> {
@@ -1235,23 +1233,12 @@ public class JobMasterTest extends TestLogger {
 					return CompletableFuture.completedFuture(Acknowledge.get());
 				})
 				.createTestingTaskExecutorGateway();
-			rpcService.registerGateway(testingTaskExecutorGateway.getAddress(), testingTaskExecutorGateway);
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-			notifyResourceManagerLeaderListeners(testingResourceManagerGateway);
-
-			final AllocationID allocationId = allocationIdFuture.get();
-
-			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-			jobMasterGateway.registerTaskManager(testingTaskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
-
-			final SlotOffer slotOffer = new SlotOffer(allocationId, 0, ResourceProfile.UNKNOWN);
-
-			final Collection<SlotOffer> slotOffers = jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout).get();
+			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, testingTaskExecutorGateway);
 
 			assertThat(slotOffers, hasSize(1));
-			assertThat(slotOffers, contains(slotOffer));
 
 			// obtain tdd for the result partition ids
 			final TaskDeploymentDescriptor tdd = tddFuture.get();
@@ -1326,7 +1313,7 @@ public class JobMasterTest extends TestLogger {
 			new TestingJobManagerSharedServicesBuilder().build(),
 			heartbeatServices,
 			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
-			new NoOpOnCompletionActions(),
+			new TestingOnCompletionActions(),
 			testingFatalErrorHandler,
 			JobMasterTest.class.getClassLoader()) {
 
@@ -1377,14 +1364,6 @@ public class JobMasterTest extends TestLogger {
 			jobManagerSharedServices,
 			heartbeatServices);
 
-		final TestingResourceManagerGateway testingResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
-		notifyResourceManagerLeaderListeners(testingResourceManagerGateway);
-
-		final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
-
-		testingResourceManagerGateway.setRequestSlotConsumer(
-			slotRequest -> allocationIdFuture.complete(slotRequest.getAllocationId()));
-
 		final CompletableFuture<JobID> disconnectTaskExecutorFuture = new CompletableFuture<>();
 		final CompletableFuture<AllocationID> freedSlotFuture = new CompletableFuture<>();
 		final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
@@ -1395,25 +1374,17 @@ public class JobMasterTest extends TestLogger {
 				})
 			.setDisconnectJobManagerConsumer((jobID, throwable) -> disconnectTaskExecutorFuture.complete(jobID))
 			.createTestingTaskExecutorGateway();
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-		rpcService.registerGateway(testingTaskExecutorGateway.getAddress(), testingTaskExecutorGateway);
 
 		try {
 			jobMaster.start(jobMasterId).get();
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-			final AllocationID allocationId = allocationIdFuture.get();
-
-			jobMasterGateway.registerTaskManager(testingTaskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
-
-			final SlotOffer slotOffer = new SlotOffer(allocationId, 0, ResourceProfile.UNKNOWN);
-			final CompletableFuture<Collection<SlotOffer>> acceptedSlotOffers = jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout);
-
-			final Collection<SlotOffer> slotOffers = acceptedSlotOffers.get();
+			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, testingTaskExecutorGateway);
 
 			// check that we accepted the offered slot
 			assertThat(slotOffers, hasSize(1));
+			final AllocationID allocationId = slotOffers.iterator().next().getAllocationId();
 
 			// now fail the allocation and check that we close the connection to the TaskExecutor
 			jobMasterGateway.notifyAllocationFailure(allocationId, new FlinkException("Fail alloction test exception"));
@@ -1551,9 +1522,6 @@ public class JobMasterTest extends TestLogger {
 			heartbeatServices,
 			onCompletionActions);
 
-		final TestingResourceManagerGateway testingResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
-		notifyResourceManagerLeaderListeners(testingResourceManagerGateway);
-
 		try {
 			jobMaster.start(jobMasterId).get();
 
@@ -1568,11 +1536,9 @@ public class JobMasterTest extends TestLogger {
 				})
 				.setHeartbeatJobManagerConsumer(heartbeatConsumerFunction.apply(jobMasterGateway, taskManagerLocation.getResourceID()))
 				.createTestingTaskExecutorGateway();
-			rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-			jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
-
-			offerSingleSlot(jobMasterGateway, taskManagerLocation);
+			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, taskExecutorGateway, taskManagerLocation);
+			assertThat(slotOffers, hasSize(1));
 
 			final ExecutionAttemptID executionAttemptId = taskDeploymentFuture.get();
 
@@ -1586,13 +1552,6 @@ public class JobMasterTest extends TestLogger {
 		} finally {
 			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
 		}
-	}
-
-	private void offerSingleSlot(JobMasterGateway jobMasterGateway, LocalTaskManagerLocation taskManagerLocation) throws InterruptedException, ExecutionException {
-		final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN);
-		final Collection<SlotOffer> slotOffers = jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout).get();
-
-		assertThat(slotOffers, hasSize(1));
 	}
 
 	private static final class TestingOnCompletionActions implements OnCompletionActions {
@@ -1618,6 +1577,62 @@ public class JobMasterTest extends TestLogger {
 
 		public CompletableFuture<ArchivedExecutionGraph> getJobReachedGloballyTerminalStateFuture() {
 			return jobReachedGloballyTerminalStateFuture;
+		}
+	}
+
+	private Collection<SlotOffer> registerSlotsAtJobMaster(
+		int numberSlots,
+		JobMasterGateway jobMasterGateway,
+		TaskExecutorGateway taskExecutorGateway) throws ExecutionException, InterruptedException {
+		return registerSlotsAtJobMaster(
+			numberSlots,
+			jobMasterGateway,
+			taskExecutorGateway,
+			new LocalTaskManagerLocation());
+	}
+
+	private Collection<SlotOffer> registerSlotsAtJobMaster(
+			int numberSlots,
+			JobMasterGateway jobMasterGateway,
+			TaskExecutorGateway taskExecutorGateway,
+			TaskManagerLocation taskManagerLocation) throws ExecutionException, InterruptedException {
+		final AllocationIdsResourceManagerGateway allocationIdsResourceManagerGateway = new AllocationIdsResourceManagerGateway();
+		rpcService.registerGateway(allocationIdsResourceManagerGateway.getAddress(), allocationIdsResourceManagerGateway);
+		notifyResourceManagerLeaderListeners(allocationIdsResourceManagerGateway);
+
+		rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
+
+		jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
+
+		Collection<SlotOffer> slotOffers = IntStream
+			.range(0, numberSlots)
+			.mapToObj(
+				index -> {
+					final AllocationID allocationId = allocationIdsResourceManagerGateway.takeAllocationId();
+					return new SlotOffer(allocationId, index, ResourceProfile.UNKNOWN);
+				})
+			.collect(Collectors.toList());
+
+		return jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), slotOffers, testingTimeout).get();
+	}
+
+	private static final class AllocationIdsResourceManagerGateway extends TestingResourceManagerGateway {
+		private final BlockingQueue<AllocationID> allocationIds;
+
+		private AllocationIdsResourceManagerGateway() {
+			this.allocationIds = new ArrayBlockingQueue<>(10);
+			setRequestSlotConsumer(
+				slotRequest -> allocationIds.offer(slotRequest.getAllocationId())
+			);
+		}
+
+		AllocationID takeAllocationId() {
+			try {
+				return allocationIds.take();
+			} catch (InterruptedException e) {
+				ExceptionUtils.rethrow(e);
+				return null;
+			}
 		}
 	}
 
@@ -1727,7 +1742,7 @@ public class JobMasterTest extends TestLogger {
 			highAvailabilityServices,
 			jobManagerSharedServices,
 			heartbeatServices,
-			new NoOpOnCompletionActions());
+			new TestingOnCompletionActions());
 	}
 
 	@Nonnull
@@ -1776,27 +1791,6 @@ public class JobMasterTest extends TestLogger {
 		return jobGraph;
 	}
 
-	/**
-	 * No op implementation of {@link OnCompletionActions}.
-	 */
-	private static final class NoOpOnCompletionActions implements OnCompletionActions {
-
-		@Override
-		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
-
-		}
-
-		@Override
-		public void jobFinishedByOther() {
-
-		}
-
-		@Override
-		public void jobMasterFailed(Throwable cause) {
-
-		}
-	}
-
 	private static final class DummyCheckpointStorageLocation implements CompletedCheckpointStorageLocation {
 
 		private static final long serialVersionUID = 164095949572620688L;
@@ -1816,5 +1810,4 @@ public class JobMasterTest extends TestLogger {
 
 		}
 	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
@@ -247,7 +247,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 
 	/**
 	 * Tests that a cache entry is invalidated if the retrieved {@link AccessExecutionGraph} is in
-	 * state {@link JobStatus#SUSPENDING} or {@link JobStatus#SUSPENDED}.
+	 * state {@link JobStatus#SUSPENDED}.
 	 *
 	 * <p>This test can be removed once we no longer request the actual {@link ExecutionGraph} from the
 	 * JobManager.
@@ -258,11 +258,9 @@ public class ExecutionGraphCacheTest extends TestLogger {
 		final Time timeToLive = Time.hours(1L);
 		final JobID expectedJobId = new JobID();
 
-		final ArchivedExecutionGraph suspendingExecutionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.SUSPENDING).build();
 		final ArchivedExecutionGraph suspendedExecutionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.SUSPENDED).build();
 		final ConcurrentLinkedQueue<CompletableFuture<? extends AccessExecutionGraph>> requestJobAnswers = new ConcurrentLinkedQueue<>();
 
-		requestJobAnswers.offer(CompletableFuture.completedFuture(suspendingExecutionGraph));
 		requestJobAnswers.offer(CompletableFuture.completedFuture(suspendedExecutionGraph));
 		requestJobAnswers.offer(CompletableFuture.completedFuture(expectedExecutionGraph));
 
@@ -279,10 +277,6 @@ public class ExecutionGraphCacheTest extends TestLogger {
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
 			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(suspendingExecutionGraph, executionGraphFuture.get());
-
-			executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
-
 			assertEquals(suspendedExecutionGraph, executionGraphFuture.get());
 
 			executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
@@ -293,7 +287,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 
 	/**
 	 * Tests that a cache entry is invalidated if the retrieved {@link AccessExecutionGraph} changes its
-	 * state to {@link JobStatus#SUSPENDING} or {@link JobStatus#SUSPENDED}.
+	 * state to {@link JobStatus#SUSPENDED}.
 	 *
 	 * <p>This test can be removed once we no longer request the actual {@link ExecutionGraph} from the
 	 * JobManager.
@@ -304,24 +298,15 @@ public class ExecutionGraphCacheTest extends TestLogger {
 		final Time timeToLive = Time.hours(1L);
 		final JobID expectedJobId = new JobID();
 
-		final SuspendableAccessExecutionGraph toBeSuspendingExecutionGraph = new SuspendableAccessExecutionGraph(expectedJobId);
 		final SuspendableAccessExecutionGraph toBeSuspendedExecutionGraph = new SuspendableAccessExecutionGraph(expectedJobId);
 
 		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
 			expectedJobId,
-			CompletableFuture.completedFuture(toBeSuspendingExecutionGraph),
 			CompletableFuture.completedFuture(toBeSuspendedExecutionGraph),
 			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
 			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
-
-			assertEquals(toBeSuspendingExecutionGraph, executionGraphFuture.get());
-
-			toBeSuspendingExecutionGraph.setJobStatus(JobStatus.SUSPENDING);
-
-			// retrieve the same job from the cache again --> this should return it and invalidate the cache entry
-			executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			assertEquals(toBeSuspendedExecutionGraph, executionGraphFuture.get());
 
@@ -336,7 +321,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 
 			assertEquals(expectedExecutionGraph, executionGraphFuture.get());
 
-			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(3));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(1));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
@@ -321,7 +321,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 
 			assertEquals(expectedExecutionGraph, executionGraphFuture.get());
 
-			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(1));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(2));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -66,7 +66,19 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final Consumer<Exception> disconnectResourceManagerConsumer;
 
-	TestingTaskExecutorGateway(String address, String hostname, Consumer<ResourceID> heartbeatJobManagerConsumer, BiConsumer<JobID, Throwable> disconnectJobManagerConsumer, BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer, Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction, BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction, Consumer<ResourceID> heartbeatResourceManagerConsumer, Consumer<Exception> disconnectResourceManagerConsumer) {
+	private final Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction;
+
+	TestingTaskExecutorGateway(
+			String address,
+			String hostname,
+			Consumer<ResourceID> heartbeatJobManagerConsumer,
+			BiConsumer<JobID, Throwable> disconnectJobManagerConsumer,
+			BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer,
+			Function<Tuple5<SlotID, JobID, AllocationID, String, ResourceManagerId>, CompletableFuture<Acknowledge>> requestSlotFunction,
+			BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction,
+			Consumer<ResourceID> heartbeatResourceManagerConsumer,
+			Consumer<Exception> disconnectResourceManagerConsumer,
+			Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction) {
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
 		this.heartbeatJobManagerConsumer = Preconditions.checkNotNull(heartbeatJobManagerConsumer);
@@ -76,6 +88,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 		this.freeSlotFunction = Preconditions.checkNotNull(freeSlotFunction);
 		this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
 		this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
+		this.cancelTaskFunction = cancelTaskFunction;
 	}
 
 	@Override
@@ -126,7 +139,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public CompletableFuture<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, Time timeout) {
-		return CompletableFuture.completedFuture(Acknowledge.get());
+		return cancelTaskFunction.apply(executionAttemptID);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -46,6 +47,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private static final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> NOOP_FREE_SLOT_FUNCTION = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
 	private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
 	private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER = ignored -> {};
+	private static final Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> NOOP_CANCEL_TASK_FUNCTION = ignored -> CompletableFuture.completedFuture(Acknowledge.get());
 
 	private String address = "foobar:1234";
 	private String hostname = "foobar";
@@ -56,6 +58,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction = NOOP_FREE_SLOT_FUNCTION;
 	private Consumer<ResourceID> heartbeatResourceManagerConsumer = NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
 	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
+	private Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction = NOOP_CANCEL_TASK_FUNCTION;
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
 		this.address = address;
@@ -102,7 +105,22 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
+	public TestingTaskExecutorGatewayBuilder setCancelTaskFunction(Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction) {
+		this.cancelTaskFunction = cancelTaskFunction;
+		return this;
+	}
+
 	public TestingTaskExecutorGateway createTestingTaskExecutorGateway() {
-		return new TestingTaskExecutorGateway(address, hostname, heartbeatJobManagerConsumer, disconnectJobManagerConsumer, submitTaskConsumer, requestSlotFunction, freeSlotFunction, heartbeatResourceManagerConsumer, disconnectResourceManagerConsumer);
+		return new TestingTaskExecutorGateway(
+			address,
+			hostname,
+			heartbeatJobManagerConsumer,
+			disconnectJobManagerConsumer,
+			submitTaskConsumer,
+			requestSlotFunction,
+			freeSlotFunction,
+			heartbeatResourceManagerConsumer,
+			disconnectResourceManagerConsumer,
+			cancelTaskFunction);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This commit makes the suspend call transition the ExecutionGraph atomically into the
SUSPENDED state without requiring a round-trip to cancel all task properly. Instead it
simply notifies the TaskExecutors about the suspension and then transitions the Executions
into a terminal state. Moreover, this commit removes JobStatus#SUSPENDING.

This PR is based on #7755.

## Brief change log

- Introduce `Execution#suspend` which transition all non terminal states except for `RECONCILING` directly into `CANCELED`
- Add `ExecutionVertex#suspend` and `ExecutionJobVertex#suspend` to forward suspend calls to `Execution`
- Update `ExecutionGraph#suspend` to make sure that suspend happens atomically

## Verifying this change

- Updated the `ExecutionGraphSuspendTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
