### PR TITLE
[FLINK-11630] Triggers the termination of all running Tasks when shutting down TaskExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -344,10 +344,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			}
 		}
 
-		jobManagerHeartbeatManager.stop();
-
-		resourceManagerHeartbeatManager.stop();
-
 		if (throwable != null) {
 			try {
 				stopTaskExecutorServices();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -266,6 +266,9 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 	/** Initialized from the Flink configuration. May also be set at the ExecutionConfig */
 	private long taskCancellationTimeout;
 
+	/** Future which is completed once the Task#run method is completed */
+	private CompletableFuture<Void> taskCompletionFuture = new CompletableFuture<>();
+
 	/**
 	 * This class loader should be set as the context class loader of the threads in
 	 * {@link #asyncCallDispatcher} because user code may dynamically load classes in all callbacks.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -267,7 +267,7 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 	private long taskCancellationTimeout;
 
 	/** Future which is completed once the Task#run method is completed */
-	private CompletableFuture<Void> taskCompletionFuture = new CompletableFuture<>();
+	private final CompletableFuture<Void> taskCompletionFuture = new CompletableFuture<>();
 
 	/**
 	 * This class loader should be set as the context class loader of the threads in

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -266,9 +266,6 @@ public class Task implements Runnable, TaskActions, PartitionProducerStateProvid
 	/** Initialized from the Flink configuration. May also be set at the ExecutionConfig */
 	private long taskCancellationTimeout;
 
-	/** Future which is completed once the Task#run method is completed */
-	private final CompletableFuture<Void> taskCompletionFuture = new CompletableFuture<>();
-
 	/**
 	 * This class loader should be set as the context class loader of the threads in
 	 * {@link #asyncCallDispatcher} because user code may dynamically load classes in all callbacks.


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `TaskExecutor` does not properly wait for the termination of `Task`s when terminating. This patch triggers the termination of all running `Task`s when shutting down `TaskExecutor`.

## Brief change log

  - Make `Task#stopExecution` returns a `CompletableFuture`
  - Make `Task#cancelExecution` returns a `CompletableFuture`
  - Call `Task#cancelExecution` when invoking `TaskExecutor#onStop`

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
