### PR TITLE
[FLINK-11676][network] Make ResultPartitionWriter extend AutoCloseable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -306,7 +306,7 @@ public class NetworkEnvironment {
 
 			for (ResultPartition partition : task.getProducedPartitions()) {
 				taskEventDispatcher.unregisterPartition(partition.getPartitionId());
-				partition.destroyBufferPool();
+				partition.close();
 			}
 
 			final SingleInputGate[] inputGates = task.getAllInputGates();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * A buffer-oriented runtime result writer API for producing results.
  */
-public interface ResultPartitionWriter {
+public interface ResultPartitionWriter extends AutoCloseable {
 
 	BufferProvider getBufferProvider();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -324,7 +324,8 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		}
 	}
 
-	public void destroyBufferPool() {
+	@Override
+	public void close() {
 		if (bufferPool != null) {
 			bufferPool.lazyDestroy();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1474,7 +1474,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				// will get misleading errors in the logs.
 				for (ResultPartition partition : producedPartitions) {
 					try {
-						partition.destroyBufferPool();
+						partition.close();
 					} catch (Throwable t) {
 						ExceptionUtils.rethrowIfFatalError(t);
 						LOG.error("Failed to release result partition buffer pool for task {}.", taskName, t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -101,5 +101,9 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 		flushAll();
 	}
 
+	@Override
+	public void close() {
+	}
+
 	protected abstract void deserializeBuffer(Buffer buffer) throws IOException;
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -516,6 +516,10 @@ public class RecordWriterTest {
 		@Override
 		public void flush(int subpartitionIndex) {
 		}
+
+		@Override
+		public void close() {
+		}
 	}
 
 	private static BufferOrEvent parseBuffer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
@@ -572,6 +576,10 @@ public class RecordWriterTest {
 
 		@Override
 		public void flush(int subpartitionIndex) {
+		}
+
+		@Override
+		public void close() {
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This is a sub-task for refactoring the interface of `ResultPartitionWriter`.*

*We can make `ResultPartitionWriter` extend `AutoCloseable` in order to replace calling `destroyBufferPool` in specific `ResultPartition`. This is a small step for making `Task` reference with general `ResultPartitionWriter` instead of `ResultPartition`.*

## Brief change log

  - *Make `ResultPartitionWriter` extend `AutoCloseable`*
  - *Replace `destroyBufferPool` by close in `ResultPartition`*
  - *Implement empty close methods in other `ResultPartitionWriter` implementations in tests*

## Verifying this change

*This change is already covered by existing tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)