### PR TITLE
[FLINK-11681] [Metrics] Add a flink-metrics-common module to combine the metric definition an…

### DIFF
--- a/flink-metrics/flink-metrics-common/pom.xml
+++ b/flink-metrics/flink-metrics-common/pom.xml
@@ -24,43 +24,36 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-parent</artifactId>
+		<artifactId>flink-metrics</artifactId>
 		<version>1.8-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-metrics</artifactId>
-	<name>flink-metrics</name>
-	<packaging>pom</packaging>
-
-	<modules>
-		<module>flink-metrics-core</module>
-		<module>flink-metrics-dropwizard</module>
-		<module>flink-metrics-graphite</module>
-		<module>flink-metrics-influxdb</module>
-		<module>flink-metrics-jmx</module>
-		<module>flink-metrics-prometheus</module>
-		<module>flink-metrics-statsd</module>
-		<module>flink-metrics-datadog</module>
-		<module>flink-metrics-slf4j</module>
-		<module>flink-metrics-common</module>
-	</modules>
-
-	<!-- override these root dependencies as 'provided', so they don't end up
-		in the jars-with-dependencies. They are already contained
-		in the flink-dist build -->
+	<artifactId>flink-metrics-common</artifactId>
+	<name>flink-metrics-common</name>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-dropwizard</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
 </project>

--- a/flink-metrics/flink-metrics-common/src/main/java/org/apache/flink/metrics/AbstractMetrics.java
+++ b/flink-metrics/flink-metrics-common/src/main/java/org/apache/flink/metrics/AbstractMetrics.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * An abstract metrics class that helps creating metrics for components.
+ */
+public abstract class AbstractMetrics {
+	private static final Metric GAUGE_PLACEHOLDER = (Gauge<Integer>) () -> -1;
+	private final MetricGroup metricGroup;
+	private final ConcurrentMap<String, Metric> metrics = new ConcurrentHashMap<>();
+
+	// --------------- constructor ------------------------
+
+	/**
+	 * Construct the metrics based on the given {@link MetricDef}.
+	 *
+	 * @param metricGroup the metric group to register the metrics.
+	 * @param metricDef the metric definition.
+	 */
+	public AbstractMetrics(MetricGroup metricGroup, MetricDef metricDef) {
+		this.metricGroup = metricGroup;
+		metricDef.definitions().values().forEach(
+			definition -> createMetric(metricGroup, metricDef, definition.name, definition.spec));
+	}
+
+	// --------------------- public methods --------------------
+
+	/**
+	 * Get the gauge with given name.
+	 *
+	 * @param metricName the metric name of the gauge.
+	 * @return the gauge if exists.
+	 * @throws IllegalArgumentException if the metric does not exist.
+	 */
+	public Gauge<?> getGauge(String metricName) {
+		Gauge<?> gauge = get(metricName);
+		if (gauge == GAUGE_PLACEHOLDER) {
+			throw new IllegalStateException(metricName + " does not exist.");
+		}
+		return gauge;
+	}
+
+	/**
+	 * Get the counter with given name.
+	 *
+	 * @param metricName the metric name of the counter.
+	 * @return the counter if exists.
+	 * @throws IllegalArgumentException if the metric does not exist.
+	 */
+	public Counter getCounter(String metricName) {
+		return get(metricName);
+	}
+
+	/**
+	 * Get the meter with given name.
+	 *
+	 * @param metricName the metric name of the meter.
+	 * @return the meter if exists.
+	 * @throws IllegalArgumentException if the metric does not exist.
+	 */
+	public Meter getMeter(String metricName) {
+		return get(metricName);
+	}
+
+	/**
+	 * Get the histogram with given name.
+	 *
+	 * @param metricName the metric name of the histogram.
+	 * @return the histogram if exists.
+	 * @throws IllegalArgumentException if the metric does not exist.
+	 */
+	public org.apache.flink.metrics.Histogram getHistogram(String metricName) {
+		return get(metricName);
+	}
+
+	/**
+	 * Set the actual gauge.
+	 *
+	 * @param metricName the name of the gauge.
+	 * @param gauge the actual gauge instance.
+	 */
+	public void setGauge(String metricName, Gauge<?> gauge) {
+		metricGroup.gauge(metricName, gauge);
+		addMetric(metricName, metricGroup.gauge(metricName, gauge));
+	}
+
+	/**
+	 * Get a metric. It is a convenient method with adaptive types.
+	 *
+	 * @param metricName the name of the metric.
+	 * @return the metric with the given name.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T get(String metricName) {
+		return (T) notNull(metrics.get(metricName), metricName + "does not exist.");
+	}
+
+	/**
+	 * Get the name of all metrics.
+	 *
+	 * @return a set of all metric names.
+	 */
+	public Set<String> allMetricNames() {
+		return Collections.unmodifiableSet(metrics.keySet());
+	}
+
+	/**
+	 * Get the metric group in which this abstract metrics is defined.
+	 *
+	 * @return the metric group associated with this abstract metrics.
+	 */
+	public MetricGroup metricGroup() {
+		return metricGroup;
+	}
+
+	// ------------------ private helper methods ---------------------
+
+	private Metric createMetric(MetricGroup metricGroup,
+								MetricDef metricDef,
+								String metricName,
+								MetricSpec spec) {
+		// If a metric has been created, just use it.
+		Metric metric = metrics.get(metricName);
+		if (metric != null) {
+			return metric;
+		}
+
+		// Create dependency metrics recursively.
+		for (String dependencyMetric : spec.dependencies) {
+			if (!metrics.containsKey(dependencyMetric)) {
+				MetricDef.MetricInfo metricInfo = metricDef.definitions().get(dependencyMetric);
+				if (metricInfo == null) {
+					throw new IllegalStateException("Could not find metric definition for " + dependencyMetric
+														+ " which is referred by " + metricName + " as a"
+														+ " dependency metric.");
+				}
+				createMetric(metricGroup, metricDef, dependencyMetric, metricInfo.spec);
+			}
+		}
+
+		// Create metric.
+		switch (spec.type) {
+			case COUNTER:
+				if (spec instanceof MetricSpec.InstanceSpec) {
+					return addMetric(
+						metricName,
+						metricGroup.counter(metricName,	(Counter) ((MetricSpec.InstanceSpec) spec).metric));
+				} else {
+					return addMetric(metricName, metricGroup.counter(metricName));
+				}
+
+			case METER:
+				if (spec instanceof MetricSpec.InstanceSpec) {
+					return addMetric(
+						metricName,
+						metricGroup.meter(metricName, (Meter) ((MetricSpec.InstanceSpec) spec).metric));
+				} else {
+					MetricSpec.MeterSpec meterSpec = (MetricSpec.MeterSpec) spec;
+					String counterName = meterSpec.counterMetricName;
+					Counter counter;
+					if (counterName == null || counterName.isEmpty()) {
+						// No separate counter metric is required.
+						counter = new SimpleCounter();
+					} else {
+						// Separate counter metric has been created.
+						counter = (Counter) metrics.get(counterName);
+					}
+					return addMetric(
+						metricName,
+						metricGroup.meter(metricName, new MeterView(counter, meterSpec.timeSpanInSeconds)));
+				}
+
+			case HISTOGRAM:
+				if (spec instanceof MetricSpec.InstanceSpec) {
+					return addMetric(
+						metricName,
+						metricGroup.histogram(metricName, (org.apache.flink.metrics.Histogram) ((MetricSpec.InstanceSpec) spec).metric));
+				} else {
+					return addMetric(metricName, metricGroup.histogram(
+						metricName,
+						new DropwizardHistogramWrapper(new Histogram(new ExponentiallyDecayingReservoir()))));
+				}
+
+			case GAUGE:
+				if (spec instanceof MetricSpec.InstanceSpec) {
+					return addMetric(
+						metricName,
+						(Gauge) metricGroup.gauge(metricName, (Gauge) ((MetricSpec.InstanceSpec) spec).metric));
+				} else {
+					return metrics.put(metricName, GAUGE_PLACEHOLDER);
+				}
+
+			default:
+				throw new IllegalArgumentException("Unknown metric type " + spec.type);
+
+		}
+	}
+
+	private Metric addMetric(String name, Metric metric) {
+		return metrics.compute(name, (n, m) -> {
+			if (m != null && m != GAUGE_PLACEHOLDER) {
+				throw new IllegalStateException("Metric of name " + n + " already exists. The metric is " + m);
+			}
+			return metric;
+		});
+	}
+
+	private static <T> T notNull(T obj, String errorMsg) {
+		if (obj == null) {
+			throw new IllegalArgumentException(errorMsg);
+		} else {
+			return obj;
+		}
+	}
+}

--- a/flink-metrics/flink-metrics-common/src/main/java/org/apache/flink/metrics/MetricDef.java
+++ b/flink-metrics/flink-metrics-common/src/main/java/org/apache/flink/metrics/MetricDef.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * A metric definition class used by {@link AbstractMetrics}.
+ */
+public class MetricDef {
+	private final Map<String, MetricInfo> definitions = new HashMap<>();
+	private final Map<String, Set<String>> dependencies = new HashMap<>();
+
+	// ---------------- public methods ----------------
+
+	/**
+	 * Define a metric using {@link MetricSpec}.
+	 *
+	 * @param name the name of the metric.
+	 * @param doc the description of the metric.
+	 * @param spec the {@link MetricSpec} of the metric.
+	 * @return this MetricDef for chained invocation.
+	 */
+	public MetricDef define(String name, String doc, MetricSpec spec) {
+		try {
+			spec.validateMetricDef(this);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to define metric " + name);
+		}
+
+		spec.dependencies.forEach(dependency -> {
+			dependencies.computeIfAbsent(dependency, dName -> new HashSet<>()).add(name);
+			ensureNoCyclicDependency(name);
+		});
+
+		definitions.compute(name, (n, m) -> {
+			if (m != null) {
+				throw new IllegalStateException("Metric " + name + " is already defined for metric " + m);
+			}
+			return new MetricInfo(name, doc, spec);
+		});
+
+		return this;
+	}
+
+	/**
+	 * Make a copy of this metric def.
+	 *
+	 * @return a copy of this metric def.
+	 */
+	public MetricDef copy() {
+		MetricDef metricDef = new MetricDef();
+		metricDef.definitions.putAll(this.definitions);
+		metricDef.dependencies.putAll(this.dependencies);
+		return metricDef;
+	}
+
+	/**
+	 * Get a new metric def combining this metric def and the given metric def.
+	 *
+	 * @return a new metric def combining this metric def and the given metric def.
+	 */
+	public MetricDef combine(MetricDef other) {
+		MetricDef combined = copy();
+		other.definitions().values().forEach(info -> combined.define(info.name, info.doc, info.spec));
+		return combined;
+	}
+
+	/**
+	 * Get a new metric def excluding the metric.
+	 *
+	 * @param excludedMetrics the metrics to exclude.
+	 * @return A new metric def that has excluded the given set of metrics.
+	 */
+	public MetricDef exclude(Set<String> excludedMetrics) {
+		MetricDef afterExclusion = new MetricDef();
+		for (MetricInfo info : definitions.values()) {
+			if (!excludedMetrics.contains(info.name)) {
+				afterExclusion.define(info.name, info.doc, info.spec);
+			}
+		}
+		return afterExclusion;
+	}
+
+	// --------------- package private methods --------------------------
+
+	/**
+	 * @return the definitions of all the defined metrics.
+	 */
+	Map<String, MetricInfo> definitions() {
+		return Collections.unmodifiableMap(definitions);
+	}
+
+	Map<String, Set<String>> dependencies() {
+		return Collections.unmodifiableMap(dependencies);
+	}
+
+	// ----------------------------- package private class --------------------
+
+	/**
+	 * A container class hosting the definition of a metric.
+	 */
+	static class MetricInfo {
+		final String name;
+		final String doc;
+		final MetricSpec spec;
+
+		private MetricInfo(String name, String doc, MetricSpec spec) {
+			this.name = name;
+			this.doc = doc;
+			this.spec = spec;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("{name=%s,doc=\"%s\", spec=%s}", name, doc, spec);
+		}
+	}
+
+	// ----------- private helpers --------------
+
+	private void ensureNoCyclicDependency(String metricName) {
+		Deque<String> dependencyChain = new ArrayDeque<>();
+		dependencyChain.add(metricName);
+		ensureNoCyclicDependency(dependencyChain, metricName);
+	}
+
+	private void ensureNoCyclicDependency(Deque<String> dependencyChain, String toFind) {
+		String dependant = dependencyChain.peekLast();
+		Set<String> dependencies = dependencies().getOrDefault(dependant, Collections.emptySet());
+		// Cyclic dependency found.
+		if (dependencies.contains(toFind)) {
+			StringJoiner sj = new StringJoiner(" <- ", "[", "]");
+			dependencyChain.forEach(sj::add);
+			sj.add(toFind);
+			throw new IllegalStateException("Cyclic metric dependency detected: " + sj.toString());
+		}
+		// Check next tier.
+		dependencies.forEach(dependency -> {
+			dependencyChain.addLast(dependency);
+			ensureNoCyclicDependency(dependencyChain, toFind);
+			dependencyChain.removeLast();
+		});
+	}
+}

--- a/flink-metrics/flink-metrics-common/src/main/java/org/apache/flink/metrics/MetricSpec.java
+++ b/flink-metrics/flink-metrics-common/src/main/java/org/apache/flink/metrics/MetricSpec.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.apache.flink.metrics.MetricSpec.Type.COUNTER;
+import static org.apache.flink.metrics.MetricSpec.Type.GAUGE;
+import static org.apache.flink.metrics.MetricSpec.Type.HISTOGRAM;
+import static org.apache.flink.metrics.MetricSpec.Type.METER;
+
+/**
+ * A class that describes the specification of the metrics. The MetricSpec specifies the metric type and other
+ * associated requirement for that type of the metric.
+ */
+public class MetricSpec {
+	/** The metric type. */
+	final Type type;
+	/**
+	 * The dependency metrics of this metric.
+	 */
+	final Set<String> dependencies;
+
+	// ----------------------- Constructors ---------------------
+
+	private MetricSpec(Type type) {
+		this(type, Collections.emptySet());
+	}
+
+	/** We do not expect this MetricSpec to be constructed outside of this class. */
+	private MetricSpec(Type type, Set<String> dependencies) {
+		this.type = type;
+		this.dependencies = dependencies;
+	}
+
+	/**
+	 * Validate whether this metric spec could be defined in the given {@link MetricDef}.
+	 * An exception should be thrown if the validation fails.
+	 *
+	 * @param metricDef the metric def to validate.
+	 */
+	public void validateMetricDef(MetricDef metricDef) throws Exception {
+
+	}
+
+	// -------------------  public methods to create metric specs -------------------------
+	/**
+	 * Get a default counter specification which uses {@link SimpleCounter}.
+	 *
+	 * @return a counter specification.
+	 */
+	public static CounterSpec counter() {
+		return CounterSpec.INSTANCE;
+	}
+
+	/**
+	 * Get a default meter specification which uses {@link MeterView}.
+	 *
+	 * @return a default meter specification.
+	 */
+	public static MeterSpec meter() {
+		return MeterSpec.INSTANCE;
+	}
+
+	/**
+	 * Create a meter specification which uses {@link MeterView}. Also register the underlying counter as
+	 * a separate metric with the given name.
+	 *
+	 * @param counterMetricName the name of the separate metric for the underlying counter.
+	 * @return a meter specification whose underlying counter is also registered as a separate metric with the
+	 *         given name.
+	 */
+	public static MeterSpec meter(String counterMetricName) {
+		return new MeterSpec(counterMetricName, MeterSpec.DEFAULT_TIME_SPAN_IN_SECONDS);
+	}
+
+	/**
+	 * Create a meter specification which uses {@link MeterView} with the given time span setting.
+	 *
+	 * @param timeSpanInSeconds the time span for the underlying {@link MeterView}
+	 * @return a meter specification with given time span setting.
+	 */
+	public static MeterSpec meter(int timeSpanInSeconds) {
+		return new MeterSpec(null, timeSpanInSeconds);
+	}
+
+	/**
+	 * Create a meter specification which uses {@link MeterView} with the given time span setting.
+	 * Also register the underlying counter as a separate metric with the given name.
+	 *
+	 * @param counterMetricName the name of the separate metric for the underlying counter.
+	 * @param timeSpanInSeconds the time span for the underlying {@link MeterView}
+	 * @return
+	 */
+	public static MeterSpec meter(String counterMetricName, int timeSpanInSeconds) {
+		return new MeterSpec(counterMetricName, timeSpanInSeconds);
+	}
+
+	/**
+	 * Create a histogram spec which uses {@link com.codahale.metrics.Histogram} under the hood.
+	 *
+	 * @return a histogram spec.
+	 */
+	public static HistogramSpec histogram() {
+		return HistogramSpec.INSTANCE;
+	}
+
+	/**
+	 * Create a gauge spec.
+	 *
+	 * @return A gauge specification.
+	 */
+	public static GaugeSpec gauge() {
+		return new GaugeSpec();
+	}
+
+	/**
+	 * Create a metric spec for the given metric instance.
+	 *
+	 * @param metric the metric to create metric spec.
+	 * @return the metric spec for the given metric instance.
+	 */
+	public static InstanceSpec of(Metric metric) {
+		return new InstanceSpec(metric);
+	}
+
+	// ------------------  Metric specification classes for each metric type ---------------------
+
+	/**
+	 * Metric spec for counters.
+	 */
+	static class CounterSpec extends MetricSpec {
+		/** A default instance to avoid unnecessary object creation. */
+		private static final CounterSpec INSTANCE = new CounterSpec();
+
+		private CounterSpec() {
+			super(COUNTER);
+		}
+	}
+
+	/**
+	 * Metric spec for meters.
+	 */
+	static class MeterSpec extends MetricSpec {
+		/** Default time span in seconds for the meters. */
+		private static final int DEFAULT_TIME_SPAN_IN_SECONDS = 60;
+		/** A default instance to avoid unnecessary object creation. */
+		private static final MeterSpec INSTANCE = new MeterSpec(null, DEFAULT_TIME_SPAN_IN_SECONDS);
+
+		/** The name for the separate metric of the underlying counter. */
+		final String counterMetricName;
+		/** The time span in seconds for the meter. */
+		final int timeSpanInSeconds;
+
+		/**
+		 * There are two specification can be set for meters.
+		 *
+		 * @param counterMetricName when set, the counter used by the meter metric will also be registered as a
+		 *                          separate metric with this given name. Otherwise, the counter will not have a
+		 *                          separate metric.
+		 * @param timeSpanInSeconds The time span used by the meter metric. See {@link MeterView} for details.
+		 */
+		private MeterSpec(String counterMetricName, int timeSpanInSeconds) {
+			// Set the counter metric as a dependency.
+			super(METER, getDependencies(counterMetricName));
+			this.timeSpanInSeconds = timeSpanInSeconds;
+			this.counterMetricName = counterMetricName;
+		}
+
+		@Override
+		public void validateMetricDef(MetricDef metricDef) {
+			Set<String> counterMetricDependants = metricDef.dependencies().get(counterMetricName);
+			if (counterMetricDependants != null && !counterMetricDependants.isEmpty()) {
+				throw new IllegalStateException(counterMetricName + " is already a dependant of metrics "
+													+ counterMetricDependants);
+			}
+		}
+
+		private static Set<String> getDependencies(String counterMetricName) {
+			if (counterMetricName == null || counterMetricName.isEmpty()) {
+				return Collections.emptySet();
+			} else {
+				return Collections.singleton(counterMetricName);
+			}
+		}
+	}
+
+	/**
+	 * Metric spec for histograms.
+	 */
+	static class HistogramSpec extends MetricSpec {
+		/** A default instance to avoid unnecessary object creation. */
+		private static final HistogramSpec INSTANCE = new HistogramSpec();
+
+		HistogramSpec() {
+			super(HISTOGRAM);
+		}
+	}
+
+	/**
+	 * Metric spec for gauge.
+	 */
+	static class GaugeSpec extends MetricSpec {
+		private GaugeSpec() {
+			super(GAUGE);
+		}
+	}
+
+	/**
+	 * Metric spec for given instance. Users may use this
+	 */
+	static class InstanceSpec extends MetricSpec {
+		final Metric metric;
+		InstanceSpec(Metric metric) {
+			super(Type.of(metric));
+			this.metric = metric;
+		}
+	}
+
+	/**
+	 * An enum for quick metric type look up.
+	 */
+	enum Type {
+		COUNTER(Counter.class),
+		METER(Meter.class),
+		HISTOGRAM(Histogram.class),
+		GAUGE(Gauge.class);
+
+		final Class<? extends Metric> metricClass;
+
+		Type(Class<? extends Metric> metricClass) {
+			this.metricClass = metricClass;
+		}
+
+		public static Type of(Metric metric) {
+			for (Type type : Type.values()) {
+				if (type.metricClass.isAssignableFrom(metric.getClass())) {
+					return type;
+				}
+			}
+			throw new IllegalArgumentException("Unsupported metric type " + metric.getClass());
+		}
+	}
+}

--- a/flink-metrics/flink-metrics-common/src/test/java/org/apache/flink/metrics/AbstractMetricTest.java
+++ b/flink-metrics/flink-metrics-common/src/test/java/org/apache/flink/metrics/AbstractMetricTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for abstract metrics.
+ */
+public class AbstractMetricTest {
+
+	@Test
+	public void testGauge() {
+		MetricDef metricDef = new MetricDef()
+			.define("gauge", "A standalone gauge", MetricSpec.gauge());
+
+		TestMetrics testMetrics = new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+		testMetrics.setGauge("gauge", new Gauge<Integer>() {
+			int i = 0;
+			@Override
+			public Integer getValue() {
+				return i++;
+			}
+		});
+		// The gauge value should increment by 1 each time getValue() is invoked.
+		assertEquals(0, testMetrics.getGauge("gauge").getValue());
+		assertEquals(1, testMetrics.getGauge("gauge").getValue());
+	}
+
+	@Test
+	public void testStandaloneCounter() {
+		MetricDef metricDef = new MetricDef()
+			.define("counter", "A standalone counter", MetricSpec.counter());
+		TestMetrics testMetrics = new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+
+		// Increment the standalone counter.
+		testMetrics.getCounter("counter").inc();
+		assertEquals(1, testMetrics.getCounter("counter").getCount());
+	}
+
+	@Test
+	public void testSubMetricCounter() {
+		MetricDef metricDef = new MetricDef()
+			.define("counter", "A standalone counter", MetricSpec.counter())
+			.define(
+				"meter",
+				"A meter uses previously defined counter.",
+				MetricSpec.meter("counter"));
+		TestMetrics testMetrics = new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+
+		// Increment the sub-metric counter.
+		testMetrics.getCounter("counter").inc();
+		assertEquals(1, testMetrics.getCounter("counter").getCount());
+
+		// Marking an event should increment the counter to 2.
+		testMetrics.getMeter("meter").markEvent();
+		assertEquals(2, testMetrics.getMeter("meter").getCount());
+	}
+
+	@Test
+	public void testHistogram() {
+		MetricDef metricDef = new MetricDef()
+			.define("histogram", "A histogram", MetricSpec.histogram());
+		TestMetrics testMetrics = new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+
+		testMetrics.getHistogram("histogram").update(1);
+		assertEquals(1, testMetrics.getHistogram("histogram").getCount());
+	}
+
+	@Test
+	public void testInstanceSpec() {
+		final Gauge gauge = () -> 100;
+		final Meter meter = new MeterView(60);
+		final Counter counter = new SimpleCounter();
+		final Histogram histogram = new DropwizardHistogramWrapper(new com.codahale.metrics.Histogram(new ExponentiallyDecayingReservoir()));
+
+		MetricDef metricDef = new MetricDef()
+			.define("gauge", "doc", MetricSpec.of(gauge))
+			.define("meter", "doc", MetricSpec.of(meter))
+			.define("counter", "doc", MetricSpec.of(counter))
+			.define("histogram", "doc", MetricSpec.of(histogram));
+
+		TestMetrics testMetrics = new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+		meter.markEvent(100);
+		counter.inc(100);
+		histogram.update(100);
+
+		assertEquals(100, testMetrics.getGauge("gauge").getValue());
+		assertEquals(100, testMetrics.getMeter("meter").getCount());
+		assertEquals(100, testMetrics.getCounter("counter").getCount());
+		assertEquals(1, testMetrics.getHistogram("histogram").getCount());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testMissingSubMetricDefinition() {
+		MetricDef metricDef = new MetricDef()
+			.define("meter", "doc", MetricSpec.meter("non-existing-counter"));
+		new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testUnsetGauge() {
+		MetricDef metricDef = new MetricDef()
+			.define("gauge", "A standalone gauge", MetricSpec.gauge());
+
+		TestMetrics testMetrics = new TestMetrics(new UnregisteredMetricsGroup(), metricDef);
+		testMetrics.getGauge("gauge").getValue();
+	}
+
+	// ------------ Metric class for testing -------------------
+
+	private static class TestMetrics extends AbstractMetrics {
+
+		TestMetrics(MetricGroup metricGroup, MetricDef metricDef) {
+			super(metricGroup, metricDef);
+		}
+
+	}
+}

--- a/flink-metrics/flink-metrics-common/src/test/java/org/apache/flink/metrics/MetricDefTest.java
+++ b/flink-metrics/flink-metrics-common/src/test/java/org/apache/flink/metrics/MetricDefTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link MetricDef}.
+ */
+public class MetricDefTest {
+
+	@Test(expected = IllegalStateException.class)
+	public void testDuplicateDef() {
+		new MetricDef()
+			.define("name", "doc", MetricSpec.counter())
+			.define("name", "doc", MetricSpec.counter());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testDuplicateSubMetricDef() {
+		new MetricDef()
+			.define("name1", "doc", MetricSpec.meter("submetric"))
+			.define("name2", "doc", MetricSpec.meter("submetric"));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCyclicDependency() {
+		new MetricDef()
+			.define("name1", "doc1", MetricSpec.meter("name2"))
+			.define("name2", "doc2", MetricSpec.meter("name3"))
+			.define("name3", "doc3", MetricSpec.meter("name1"));
+	}
+}

--- a/flink-metrics/flink-metrics-common/src/test/java/org/apache/flink/metrics/MetricSpecTest.java
+++ b/flink-metrics/flink-metrics-common/src/test/java/org/apache/flink/metrics/MetricSpecTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for metric spec.
+ */
+public class MetricSpecTest {
+
+	@Test
+	public void testDefaultStaticInstance() {
+		assertEquals(MetricSpec.counter(), MetricSpec.counter());
+		assertEquals(MetricSpec.meter(), MetricSpec.meter());
+		assertEquals(MetricSpec.histogram(), MetricSpec.histogram());
+	}
+
+	@Test
+	public void testMeterSpec() {
+		assertTrue(MetricSpec.meter() instanceof MetricSpec.MeterSpec);
+
+		assertEquals(100, MetricSpec.meter(100).timeSpanInSeconds);
+
+		MetricSpec.MeterSpec spec = MetricSpec.meter("counterName", 100);
+		assertEquals(Collections.singleton("counterName"), spec.dependencies);
+	}
+}


### PR DESCRIPTION
…d management.

## What is the purpose of the change

This PR introduce a flink-metrics-common module to host the AbstractMetric class. It centralizes the metric definition for a component and combines the definition with the metric management.

This is the first PR for FLIP-33, although it has not introduced any standard metrics yet. The PRs in the next step will do.

## Brief change log

This PR introduce a `flink-metrics-common` module to host the `AbstractMetric` class.

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests for `MetricDef`, `MetricSpec` and `AbstractMetrics`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
