### PR TITLE
[FLINK-11657][tests] Fix deprecated API compatibility issue for WordCountMapreduceITCase.

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/WordCountMapreduceITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/WordCountMapreduceITCase.java
@@ -39,8 +39,6 @@ import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.junit.Assume;
 import org.junit.Before;
 
-import static org.apache.flink.hadoopcompatibility.HadoopInputs.readHadoopFile;
-
 /**
  * Test WordCount with Hadoop input and output "mapreduce" (modern) formats.
  */
@@ -68,24 +66,16 @@ public class WordCountMapreduceITCase extends JavaProgramTestBase {
 
 	@Override
 	protected void testProgram() throws Exception {
-		internalRun(true);
-		postSubmit();
-		resultPath = getTempDirPath("result2");
-		internalRun(false);
+		internalRun();
 		postSubmit();
 	}
 
-	private void internalRun(boolean isTestDeprecatedAPI) throws Exception {
+	private void internalRun() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
 		DataSet<Tuple2<LongWritable, Text>> input;
-		if (isTestDeprecatedAPI) {
-			input = env.createInput(HadoopInputs.readHadoopFile(new TextInputFormat(),
-				LongWritable.class, Text.class, textPath));
-		} else {
-			input = env.createInput(readHadoopFile(new TextInputFormat(),
-				LongWritable.class, Text.class, textPath));
-		}
+		input = env.createInput(HadoopInputs.readHadoopFile(new TextInputFormat(),
+			LongWritable.class, Text.class, textPath));
 
 		DataSet<String> text = input.map(new MapFunction<Tuple2<LongWritable, Text>, String>() {
 			@Override

--- a/flink-connectors/flink-hadoop-compatibility/src/test/scala/org/apache/flink/api/hadoopcompatibility/scala/WordCountMapreduceITCase.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/scala/org/apache/flink/api/hadoopcompatibility/scala/WordCountMapreduceITCase.scala
@@ -52,25 +52,16 @@ class WordCountMapreduceITCase extends JavaProgramTestBase {
   }
 
   protected def testProgram() {
-    internalRun(testDeprecatedAPI = true)
-    postSubmit()
-    resultPath = getTempDirPath("result2")
-    internalRun(testDeprecatedAPI = false)
+    internalRun()
     postSubmit()
   }
 
-  private def internalRun (testDeprecatedAPI: Boolean): Unit = {
+  private def internalRun (): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
 
     val input =
-      if (testDeprecatedAPI) {
-        env.createInput(
-          HadoopInputs.readHadoopFile(
-            new TextInputFormat, classOf[LongWritable], classOf[Text], textPath))
-      } else {
-        env.createInput(HadoopInputs.readHadoopFile(new TextInputFormat, classOf[LongWritable],
-          classOf[Text], textPath))
-      }
+      env.createInput(HadoopInputs.readHadoopFile(new TextInputFormat, classOf[LongWritable],
+        classOf[Text], textPath))
 
     val counts = input
       .map(_._2.toString)


### PR DESCRIPTION
## What is the purpose of the change

 This pull request fixed deprecated API compatibility issue for WordCountMapreduceITCase.

## Brief change log
WordCountMapreduceITCase tested deprecated API, but the related APIs have been removed , so this pull request removed the useless code.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no

