### PR TITLE
[FLINK-11688][checkstyle] Enforce whitespace around TYPE_EXTENSION_AND

### DIFF
--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -514,7 +514,7 @@ This file is based on the checkstyle file of Apache Beam.
         LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
         LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
         MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
-        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
       <property name="severity" value="error"/>
     </module>
 


### PR DESCRIPTION
Enforce whitespaces around & when used in type definitions, e.g. <T extends T1&T2> would be rejected.

Haven't found a single violation yet, might as well set it in stone. This gets us a step closer to the default checkstyle config, i.e. one special Flink-rule less.