### PR TITLE
[FLINK-11691] Introduce ClassLoader in the methods of StateBackendFactory and ConfigurableStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 
 /**
  * An interface for state backends that pick up additional parameters from a configuration.
  */
+@Internal
 public interface ConfigurableStateBackend {
 
 	/**
@@ -37,9 +39,10 @@ public interface ConfigurableStateBackend {
 	 * Otherwise it typically returns a modified copy.
 	 *
 	 * @param config The configuration to pick the values from.
+	 * @param classLoader The class loader that should be used to load the state backend.
 	 * @return A reconfigured state backend.
 	 *
 	 * @throws IllegalConfigurationException Thrown if the configuration contained invalid entries.
 	 */
-	StateBackend configure(Configuration config) throws IllegalConfigurationException;
+	StateBackend configure(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
@@ -40,6 +40,7 @@ public interface StateBackendFactory<T extends StateBackend> {
 	 * Creates the state backend, optionally using the given configuration.
 	 * 
 	 * @param config The Flink configuration (loaded by the TaskManager).
+	 * @param classLoader The class loader that should be used to load the state backend.
 	 * @return The created state backend. 
 	 * 
 	 * @throws IllegalConfigurationException
@@ -47,5 +48,5 @@ public interface StateBackendFactory<T extends StateBackend> {
 	 * @throws IOException
 	 *             If the state backend initialization failed due to an I/O exception
 	 */
-	T createFromConfig(Configuration config) throws IllegalConfigurationException, IOException;
+	T createFromConfig(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException, IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -68,7 +68,7 @@ public class StateBackendLoader {
 	 * <p>The state backends can be specified either via their shortcut name, or via the class name
 	 * of a {@link StateBackendFactory}. If a StateBackendFactory class name is specified, the factory
 	 * is instantiated (via its zero-argument constructor) and its
-	 * {@link StateBackendFactory#createFromConfig(Configuration)} method is called.
+	 * {@link StateBackendFactory#createFromConfig(Configuration, ClassLoader)} method is called.
 	 *
 	 * <p>Recognized shortcut names are '{@value StateBackendLoader#MEMORY_STATE_BACKEND_NAME}',
 	 * '{@value StateBackendLoader#FS_STATE_BACKEND_NAME}', and
@@ -107,7 +107,7 @@ public class StateBackendLoader {
 
 		switch (backendName.toLowerCase()) {
 			case MEMORY_STATE_BACKEND_NAME:
-				MemoryStateBackend memBackend = new MemoryStateBackendFactory().createFromConfig(config);
+				MemoryStateBackend memBackend = new MemoryStateBackendFactory().createFromConfig(config, classLoader);
 
 				if (logger != null) {
 					Path memExternalized = memBackend.getCheckpointPath();
@@ -118,7 +118,7 @@ public class StateBackendLoader {
 				return memBackend;
 
 			case FS_STATE_BACKEND_NAME:
-				FsStateBackend fsBackend = new FsStateBackendFactory().createFromConfig(config);
+				FsStateBackend fsBackend = new FsStateBackendFactory().createFromConfig(config, classLoader);
 				if (logger != null) {
 					logger.info("State backend is set to heap memory (checkpoints to filesystem \"{}\")",
 							fsBackend.getCheckpointPath());
@@ -154,7 +154,7 @@ public class StateBackendLoader {
 							backendName + ')', e);
 				}
 
-				return factory.createFromConfig(config);
+				return factory.createFromConfig(config, classLoader);
 		}
 	}
 
@@ -165,7 +165,7 @@ public class StateBackendLoader {
 	 * default state backend (the {@link MemoryStateBackend}). 
 	 *
 	 * <p>If an application-defined state backend is found, and the state backend is a
-	 * {@link ConfigurableStateBackend}, this methods calls {@link ConfigurableStateBackend#configure(Configuration)}
+	 * {@link ConfigurableStateBackend}, this methods calls {@link ConfigurableStateBackend#configure(Configuration, ClassLoader)}
 	 * on the state backend.
 	 *
 	 * <p>Refer to {@link #loadStateBackendFromConfig(Configuration, ClassLoader, Logger)} for details on
@@ -210,7 +210,7 @@ public class StateBackendLoader {
 					logger.info("Configuring application-defined state backend with job/cluster config");
 				}
 
-				backend = ((ConfigurableStateBackend) fromApplication).configure(config);
+				backend = ((ConfigurableStateBackend) fromApplication).configure(config, classLoader);
 			}
 			else {
 				// keep as is!
@@ -225,7 +225,7 @@ public class StateBackendLoader {
 			}
 			else {
 				// (3) use the default
-				backend = new MemoryStateBackendFactory().createFromConfig(config);
+				backend = new MemoryStateBackendFactory().createFromConfig(config, classLoader);
 				if (logger != null) {
 					logger.info("No state backend has been configured, using default (Memory / JobManager) {}", backend);
 				}
@@ -249,7 +249,7 @@ public class StateBackendLoader {
 						}
 						Configuration tempConfig = new Configuration(config);
 						tempConfig.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDirPath.toString());
-						return memBackend.configure(tempConfig);
+						return memBackend.configure(tempConfig, classLoader);
 					} catch (Exception ignored) {}
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -87,7 +87,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * parameters from the Flink configuration. For example, if the backend if configured in the application
  * without a default savepoint directory, it will pick up a default savepoint directory specified in the
  * Flink configuration of the running job/cluster. That behavior is implemented via the
- * {@link #configure(Configuration)} method.
+ * {@link #configure(Configuration, ClassLoader)} method.
  */
 @PublicEvolving
 public class FsStateBackend extends AbstractFileStateBackend implements ConfigurableStateBackend {
@@ -334,7 +334,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	 * @param original The state backend to re-configure
 	 * @param configuration The configuration
 	 */
-	private FsStateBackend(FsStateBackend original, Configuration configuration) {
+	private FsStateBackend(FsStateBackend original, Configuration configuration, ClassLoader classLoader) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
 
 		// if asynchronous snapshots were configured, use that setting,
@@ -430,8 +430,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override
-	public FsStateBackend configure(Configuration config) {
-		return new FsStateBackend(this, config);
+	public FsStateBackend configure(Configuration config, ClassLoader classLoader) {
+		return new FsStateBackend(this, config, classLoader);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.state.StateBackendFactory;
 public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend> {
 
 	@Override
-	public FsStateBackend createFromConfig(Configuration config) throws IllegalConfigurationException {
+	public FsStateBackend createFromConfig(Configuration config, ClassLoader classLoader) throws IllegalConfigurationException {
 		// we need to explicitly read the checkpoint directory here, because that
 		// is a required constructor parameter
 		final String checkpointDir = config.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
@@ -42,7 +42,7 @@ public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend
 		}
 
 		try {
-			return new FsStateBackend(checkpointDir).configure(config);
+			return new FsStateBackend(checkpointDir).configure(config, classLoader);
 		}
 		catch (IllegalArgumentException e) {
 			throw new IllegalConfigurationException("Invalid configuration for the state backend", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -93,7 +93,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * parameters from the Flink configuration. For example, if the backend if configured in the application
  * without a default savepoint directory, it will pick up a default savepoint directory specified in the
  * Flink configuration of the running job/cluster. That behavior is implemented via the
- * {@link #configure(Configuration)} method.
+ * {@link #configure(Configuration, ClassLoader)} method.
  */
 @PublicEvolving
 public class MemoryStateBackend extends AbstractFileStateBackend implements ConfigurableStateBackend {
@@ -226,7 +226,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 * @param original The state backend to re-configure
 	 * @param configuration The configuration
 	 */
-	private MemoryStateBackend(MemoryStateBackend original, Configuration configuration) {
+	private MemoryStateBackend(MemoryStateBackend original, Configuration configuration, ClassLoader classLoader) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
 
 		this.maxStateSize = original.maxStateSize;
@@ -273,8 +273,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override
-	public MemoryStateBackend configure(Configuration config) {
-		return new MemoryStateBackend(this, config);
+	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader) {
+		return new MemoryStateBackend(this, config, classLoader);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -225,6 +225,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 *
 	 * @param original The state backend to re-configure
 	 * @param configuration The configuration
+	 * @param classLoader The class loader
 	 */
 	private MemoryStateBackend(MemoryStateBackend original, Configuration configuration, ClassLoader classLoader) {
 		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
@@ -269,7 +270,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	 * Creates a copy of this state backend that uses the values defined in the configuration
 	 * for fields where that were not specified in this state backend.
 	 *
-	 * @param config the configuration
+	 * @param config The configuration
+	 * @param classLoader The class loader
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackendFactory.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.state.StateBackendFactory;
 public class MemoryStateBackendFactory implements StateBackendFactory<MemoryStateBackend> {
 
 	@Override
-	public MemoryStateBackend createFromConfig(Configuration config) {
-		return new MemoryStateBackend().configure(config);
+	public MemoryStateBackend createFromConfig(Configuration config, ClassLoader classLoader) {
+		return new MemoryStateBackend().configure(config, classLoader);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -433,7 +433,7 @@ public class StateBackendLoadingTest {
 	static final class FailingFactory implements StateBackendFactory<StateBackend> {
 
 		@Override
-		public StateBackend createFromConfig(Configuration config) throws IOException {
+		public StateBackend createFromConfig(Configuration config, ClassLoader classLoader) throws IOException {
 			throw new IOException("fail!");
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -56,7 +56,7 @@ public class BackendForTestStream extends MemoryStateBackend {
 
 	// make no reconfiguration!
 	@Override
-	public MemoryStateBackend configure(Configuration config) {
+	public MemoryStateBackend configure(Configuration config, ClassLoader classLoader) {
 		return this;
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -282,6 +282,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 *
 	 * @param original The state backend to re-configure.
 	 * @param config The configuration.
+	 * @param classLoader The class loader.
 	 */
 	private RocksDBStateBackend(RocksDBStateBackend original, Configuration config, ClassLoader classLoader) {
 		// reconfigure the state backend backing the streams
@@ -343,7 +344,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * Creates a copy of this state backend that uses the values defined in the configuration
 	 * for fields where that were not yet specified in this state backend.
 	 *
-	 * @param config the configuration
+	 * @param config The configuration.
+	 * @param classLoader The class loader.
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -283,11 +283,11 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @param original The state backend to re-configure.
 	 * @param config The configuration.
 	 */
-	private RocksDBStateBackend(RocksDBStateBackend original, Configuration config) {
+	private RocksDBStateBackend(RocksDBStateBackend original, Configuration config, ClassLoader classLoader) {
 		// reconfigure the state backend backing the streams
 		final StateBackend originalStreamBackend = original.checkpointStreamBackend;
 		this.checkpointStreamBackend = originalStreamBackend instanceof ConfigurableStateBackend ?
-				((ConfigurableStateBackend) originalStreamBackend).configure(config) :
+				((ConfigurableStateBackend) originalStreamBackend).configure(config, classLoader) :
 				originalStreamBackend;
 
 		// configure incremental checkpoints
@@ -347,8 +347,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	 * @return The re-configured variant of the state backend
 	 */
 	@Override
-	public RocksDBStateBackend configure(Configuration config) {
-		return new RocksDBStateBackend(this, config);
+	public RocksDBStateBackend configure(Configuration config, ClassLoader classLoader) {
+		return new RocksDBStateBackend(this, config, classLoader);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBStateBackend> {
 
 	@Override
-	public RocksDBStateBackend createFromConfig(Configuration config)
+	public RocksDBStateBackend createFromConfig(Configuration config, ClassLoader classLoader)
 			throws IllegalConfigurationException, IOException {
 
 		// we need to explicitly read the checkpoint directory here, because that
@@ -44,6 +44,6 @@ public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBSt
 				"checkpoint directory '" + CheckpointingOptions.CHECKPOINTS_DIRECTORY.key() + '\'');
 		}
 
-		return new RocksDBStateBackend(checkpointDirURI).configure(config);
+		return new RocksDBStateBackend(checkpointDirURI).configure(config, classLoader);
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -158,7 +158,7 @@ public class RocksDBStateBackendConfigTest {
 			RocksDBOptions.TIMER_SERVICE_FACTORY,
 			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
 
-		rocksDbBackend = rocksDbBackend.configure(conf);
+		rocksDbBackend = rocksDbBackend.configure(conf, Thread.currentThread().getContextClassLoader());
 		keyedBackend = createKeyedStateBackend(rocksDbBackend, env);
 		keyedBackend.restore(Collections.emptyList());
 		Assert.assertEquals(
@@ -478,7 +478,7 @@ public class RocksDBStateBackendConfigTest {
 				tempFolder.newFolder().getAbsolutePath(), tempFolder.newFolder().getAbsolutePath() };
 		original.setDbStoragePaths(localDirs);
 
-		RocksDBStateBackend copy = original.configure(new Configuration());
+		RocksDBStateBackend copy = original.configure(new Configuration(), Thread.currentThread().getContextClassLoader());
 
 		assertEquals(original.isIncrementalCheckpointsEnabled(), copy.isIncrementalCheckpointsEnabled());
 		assertArrayEquals(original.getDbStoragePaths(), copy.getDbStoragePaths());

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendMigrationTest.java
@@ -56,7 +56,7 @@ public class RocksDBStateBackendMigrationTest extends StateBackendMigrationTestB
 		configuration.setString(
 			RocksDBOptions.TIMER_SERVICE_FACTORY,
 			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
-		backend = backend.configure(configuration);
+		backend = backend.configure(configuration, Thread.currentThread().getContextClassLoader());
 		backend.setDbStoragePath(dbPath);
 		return backend;
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -131,7 +131,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		configuration.setString(
 			RocksDBOptions.TIMER_SERVICE_FACTORY,
 			RocksDBStateBackend.PriorityQueueStateType.ROCKSDB.toString());
-		backend = backend.configure(configuration);
+		backend = backend.configure(configuration, Thread.currentThread().getContextClassLoader());
 		backend.setDbStoragePath(dbPath);
 		return backend;
 	}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/RocksDBTtlStateTestBase.java
@@ -71,7 +71,7 @@ public abstract class RocksDBTtlStateTestBase extends TtlStateTestBase {
 		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath), enableIncrementalCheckpointing);
 		Configuration config = new Configuration();
 		config.setBoolean(TTL_COMPACT_FILTER_ENABLED, true);
-		backend = backend.configure(config);
+		backend = backend.configure(config, Thread.currentThread().getContextClassLoader());
 		backend.setDbStoragePath(dbPath);
 		return backend;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1011,7 +1011,7 @@ public class StreamTaskTest extends TestLogger {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public AbstractStateBackend createFromConfig(Configuration config) {
+		public AbstractStateBackend createFromConfig(Configuration config, ClassLoader classLoader) {
 			return new TestSpyWrapperStateBackend(createInnerBackend(config));
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -322,7 +322,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		}
 
 		@Override
-		public SyncFailureInducingStateBackend configure(Configuration config) {
+		public SyncFailureInducingStateBackend configure(Configuration config, ClassLoader classLoader) {
 			// retain this instance, no re-configuration!
 			return this;
 		}
@@ -354,7 +354,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		}
 
 		@Override
-		public AsyncFailureInducingStateBackend configure(Configuration config) {
+		public AsyncFailureInducingStateBackend configure(Configuration config, ClassLoader classLoader) {
 			// retain this instance, no re-configuration!
 			return this;
 		}


### PR DESCRIPTION
## What is the purpose of the change

Introduce parameter of `ClassLoader` to APIs of `StateBackend#configure(Configuration)` and `StateBackendFactory#createFromConfig(Configuration)`.
 This is really helpful for anything needed to instantiate through reflection when calling `StateBackend#configure(Configuration)`, so that those instantiated objects could be configured via the configuration. After this PR merged, `OptionsFactory` in `RocksDBStateBackend` ([FLINK-10912](https://issues.apache.org/jira/browse/FLINK-10912)) and the compression decorator in StateBackend ([FLINK-11313](https://issues.apache.org/jira/browse/FLINK-11313)) could gain the benefit to be configurable.


## Brief change log

  - Add parameter of `ClassLoader` to current API `StateBackend#configure(Configuration)`
  - Add parameter of `ClassLoader` to current API `StateBackendFactory#createFromConfig(Configuration)`


## Verifying this change

This change mainly add a parameter to two APIs by just simply handing over to next-layer methods, and should already be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
