### PR TITLE
[FLINK-11707][network] Make InputGate extend AutoCloseable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -315,7 +315,7 @@ public class NetworkEnvironment {
 				for (SingleInputGate gate : inputGates) {
 					try {
 						if (gate != null) {
-							gate.releaseAllResources();
+							gate.close();
 						}
 					}
 					catch (IOException e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -65,7 +65,7 @@ import java.util.Optional;
  * will have an input gate attached to it. This will provide its input, which will consist of one
  * subpartition from each partition of the intermediate result.
  */
-public interface InputGate {
+public interface InputGate extends AutoCloseable {
 
 	int getNumberOfInputChannels();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -421,7 +421,8 @@ public class SingleInputGate implements InputGate {
 		}
 	}
 
-	public void releaseAllResources() throws IOException {
+	@Override
+	public void close() throws IOException {
 		boolean released = false;
 		synchronized (requestLock) {
 			if (!isReleased) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
-import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Maps;
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
@@ -267,19 +266,6 @@ public class UnionInputGate implements InputGate, InputGateListener {
 
 	@Override
 	public void close() throws IOException {
-		Throwable throwable = null;
-
-		for (InputGate gate : inputGates) {
-			try {
-				gate.close();
-			} catch (Throwable t) {
-				throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
-			}
-		}
-
-		if (throwable != null) {
-			ExceptionUtils.rethrowIOException(throwable);
-		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionMetrics;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGateMetrics;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -1435,7 +1436,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		private final Thread executer;
 		private final String taskName;
 		private final ResultPartition[] producedPartitions;
-		private final SingleInputGate[] inputGates;
+		private final InputGate[] inputGates;
 
 		public TaskCanceler(
 				Logger logger,
@@ -1443,7 +1444,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 				Thread executer,
 				String taskName,
 				ResultPartition[] producedPartitions,
-				SingleInputGate[] inputGates) {
+				InputGate[] inputGates) {
 
 			this.logger = logger;
 			this.invokable = invokable;
@@ -1481,9 +1482,9 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 					}
 				}
 
-				for (SingleInputGate inputGate : inputGates) {
+				for (InputGate inputGate : inputGates) {
 					try {
-						inputGate.releaseAllResources();
+						inputGate.close();
 					} catch (Throwable t) {
 						ExceptionUtils.rethrowIfFatalError(t);
 						LOG.error("Failed to release input gate for task {}.", taskName, t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -134,7 +134,7 @@ public class NetworkEnvironmentTest {
 			rp.release();
 		}
 		for (SingleInputGate ig : inputGates) {
-			ig.releaseAllResources();
+			ig.close();
 		}
 		network.shutdown();
 	}
@@ -258,7 +258,7 @@ public class NetworkEnvironmentTest {
 			rp.release();
 		}
 		for (SingleInputGate ig : inputGates) {
-			ig.releaseAllResources();
+			ig.close();
 		}
 		network.shutdown();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -157,7 +157,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 			assertEquals(2, inputChannel.getSenderBacklog());
 		} finally {
 			// Release all the buffer resources
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			networkBufferPool.destroyAllBufferPools();
 			networkBufferPool.destroy();
@@ -328,7 +328,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 			assertNull(channel.readOutbound());
 		} finally {
 			// Release all the buffer resources
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			networkBufferPool.destroyAllBufferPools();
 			networkBufferPool.destroy();
@@ -370,7 +370,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 			assertEquals(2, inputChannel.getUnannouncedCredit());
 
 			// Release the input channel
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			// it should send a close request after releasing the input channel,
 			// but will not notify credits for a released input channel.
@@ -382,7 +382,7 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 			assertNull(channel.readOutbound());
 		} finally {
 			// Release all the buffer resources
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			networkBufferPool.destroyAllBufferPools();
 			networkBufferPool.destroy();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -150,7 +150,7 @@ public class PartitionRequestClientHandlerTest {
 			assertEquals(1, inputChannel.getNumberOfQueuedBuffers());
 		} finally {
 			// Release all the buffer resources
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			networkBufferPool.destroyAllBufferPools();
 			networkBufferPool.destroy();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientTest.java
@@ -92,7 +92,7 @@ public class PartitionRequestClientTest {
 			assertNull(channel.readOutbound());
 		} finally {
 			// Release all the buffer resources
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			networkBufferPool.destroyAllBufferPools();
 			networkBufferPool.destroy();
@@ -127,7 +127,7 @@ public class PartitionRequestClientTest {
 			assertNull(channel.readOutbound());
 		} finally {
 			// Release all the buffer resources
-			inputGate.releaseAllResources();
+			inputGate.close();
 
 			networkBufferPool.destroyAllBufferPools();
 			networkBufferPool.destroy();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -339,7 +339,7 @@ public class LocalInputChannelTest {
 			@Override
 			public void run() {
 				try {
-					gate.releaseAllResources();
+					gate.close();
 				} catch (IOException ignored) {
 				}
 			}
@@ -557,7 +557,7 @@ public class LocalInputChannelTest {
 				}
 			}
 			finally {
-				inputGate.releaseAllResources();
+				inputGate.close();
 			}
 
 			return null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -298,7 +298,7 @@ public class SingleInputGateTest {
 		assertTrue("Did not trigger blocking buffer request.", success);
 
 		// Release the input gate
-		inputGate.releaseAllResources();
+		inputGate.close();
 
 		// Wait for Thread to finish and verify expected Exceptions. If the
 		// input gate status is not properly checked during requests, this
@@ -388,7 +388,7 @@ public class SingleInputGateTest {
 				assertFalse(ch.increaseBackoff());
 			}
 		} finally {
-			gate.releaseAllResources();
+			gate.close();
 			netEnv.shutdown();
 		}
 	}
@@ -426,7 +426,7 @@ public class SingleInputGateTest {
 				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			}
 		} finally {
-			inputGate.releaseAllResources();
+			inputGate.close();
 			network.shutdown();
 		}
 	}
@@ -479,7 +479,7 @@ public class SingleInputGateTest {
 				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			}
 		} finally {
-			inputGate.releaseAllResources();
+			inputGate.close();
 			network.shutdown();
 		}
 	}
@@ -530,7 +530,7 @@ public class SingleInputGateTest {
 			assertThat(inputGate.getInputChannels().get(localResultPartitionId.getPartitionId()),
 				is(instanceOf((LocalInputChannel.class))));
 		} finally {
-			inputGate.releaseAllResources();
+			inputGate.close();
 			network.shutdown();
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -205,5 +205,9 @@ public class BarrierBufferMassiveRandomTest {
 		public int getPageSize() {
 			return PAGE_SIZE;
 		}
+
+		@Override
+		public void close() {
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -114,4 +114,7 @@ public class MockInputGate implements InputGate {
 	public void registerListener(InputGateListener listener) {
 	}
 
+	@Override
+	public void close() {
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This is a sub-task for refactoring the interface of `InputGate` which would be created by `ShuffleService` future. So it is reasonable to reference with general `InputGate` anywhere instead of specific `SingleInputGate`.*

*To make `InputGate` extend `AutoCloseable` interface, the `TaskCanceler` could call `InputGate#close` instead of `SingleInputGate#releaseAllResources`.*

*Next we can further remove the reference with `SingleInputGate` in Task class by refactoring the `updatePartitionInfo` into `NetworkEnvironment`.*

## Brief change log

  - *Make `InputGate` extend `AutoCloseable` interface*
  - *Change to reference with `InputGate` in `TaskCanceler`*
  - *Rename `releaseAllResources` into `close` in `ResultPartition`*

## Verifying this change

This change is already covered by existing tests, such as *SingleInputGateTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
