### PR TITLE
[FLINK-11706] Add the SumFunction to support KeyedStream.sum with field which is a vector

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/aggregation/SumFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/aggregation/SumFunction.java
@@ -45,6 +45,8 @@ public abstract class SumFunction implements Serializable {
 			return new FloatSum();
 		} else if (clazz == Byte.class) {
 			return new ByteSum();
+		} else if (clazz.isArray()) {
+			return new ArraySum(clazz.getComponentType());
 		} else {
 			throw new RuntimeException("DataStream cannot be summed because the class "
 					+ clazz.getSimpleName() + " does not support the + operator.");
@@ -105,4 +107,28 @@ public abstract class SumFunction implements Serializable {
 			return (byte) ((Byte) value1 + (Byte) value2);
 		}
 	}
+
+	static class ArraySum extends SumFunction {
+		private static final long serialVersionUID = 1L;
+
+		private SumFunction adder;
+
+		public ArraySum(Class<?> innerType) {
+			super();
+			adder = getForClass(innerType);
+		}
+
+		@Override
+		public Object add(Object value1, Object value2) {
+			Object[] arr1 = (Object[]) value1;
+			Object[] arr2 = (Object[]) value2;
+			Object[] result = new Object[arr1.length];
+
+			for (int index = 0; index < arr1.length; index++) {
+				result[index] = adder.add(arr1[index], arr2[index]);
+			}
+			return result;
+		}
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change
* The goal is to implement a KeyedStream API to sum with field which is array
  https://issues.apache.org/jira/browse/FLINK-11706

## Brief change log
* add the class:
  * add ArraySum in SumFucntion to support KeyedStream.sum with the field which is array 
* add unit test in follow ut
  * add unit test in AggregationFunctionTest and DataStreamTest


## Verifying this change
This change added tests and can be verified as follows:

* _Added integration tests for end-to-end deployment with small data collection_

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): _no_
* The public API, i.e., is any changed class annotated with@Public(Evolving):  _no_
* The serializers: _no_
* The runtime per-record code paths (performance sensitive): _no_
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: _no_
* The S3 file system connector: _no_

## Documentation
* Does this pull request introduce a new feature? no
* If yes, how is the feature documented?  not documented