### PR TITLE
[FLINK-11679][table] Create Blink SQL planner and runtime modules

### DIFF
--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -51,13 +51,13 @@ under the License.
 			<dependency>
 				<groupId>org.codehaus.janino</groupId>
 				<artifactId>commons-compiler</artifactId>
-				<version>3.0.7</version>
+				<version>${janino.version}</version>
 			</dependency>
 			<!-- Common dependency of calcite-core and flink-table-runtime-blink -->
 			<dependency>
 				<groupId>org.codehaus.janino</groupId>
 				<artifactId>janino</artifactId>
-				<version>3.0.7</version>
+				<version>${janino.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-table</artifactId>
+		<version>1.8-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+	<name>flink-table-planner-blink</name>
+	<description>
+		This module bridges Table/SQL API and runtime. It contains
+		all resources that are required during pre-flight and runtime
+		phase. The content of this module is work-in-progress. It will
+		replace flink-table-planner once it is stable. See FLINK-11439
+		and FLIP-32 for more details.
+	</description>
+
+	<packaging>jar</packaging>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Common dependency of calcite-core and flink-* -->
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>19.0</version>
+			</dependency>
+			<!-- Common dependency of calcite-core and flink-table-runtime-blink -->
+			<dependency>
+				<groupId>org.codehaus.janino</groupId>
+				<artifactId>commons-compiler</artifactId>
+				<version>3.0.7</version>
+			</dependency>
+			<!-- Common dependency of calcite-core and flink-table-runtime-blink -->
+			<dependency>
+				<groupId>org.codehaus.janino</groupId>
+				<artifactId>janino</artifactId>
+				<version>3.0.7</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+
+		<!-- core dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime-blink</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-jackson</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Used for translation of table programs -->
+		<dependency>
+			<groupId>org.apache.calcite</groupId>
+			<artifactId>calcite-core</artifactId>
+			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
+			<version>1.17.0</version>
+			<exclusions>
+				<!-- Dependencies that are not needed for how we use Calcite right now -->
+				<exclusion>
+					<groupId>org.apache.calcite.avatica</groupId>
+					<artifactId>avatica-metrics</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-dbcp</groupId>
+					<artifactId>commons-dbcp</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.esri.geometry</groupId>
+					<artifactId>esri-geometry-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+						scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>add-source</goal>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+						 scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<configuration>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<!-- Excluded all these files for a clean flink-table-planner-blink JAR -->
+										<exclude>org-apache-calcite-jdbc.properties</exclude>
+										<exclude>common.proto</exclude>
+										<exclude>requests.proto</exclude>
+										<exclude>responses.proto</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>codegen/**</exclude>
+										<exclude>google/**</exclude>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+										<exclude>META-INF/services/java.sql.Driver</exclude>
+										<exclude>properties.dtd</exclude>
+										<exclude>PropertyList-1.0.dtd</exclude>
+										<exclude>digesterRules.xml</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<artifactSet>
+								<includes combine.children="append">
+									<include>org.apache.calcite:*</include>
+									<include>org.apache.calcite.avatica:*</include>
+
+									<!-- Calcite's dependencies -->
+									<include>com.google.guava:guava</include>
+									<include>net.hydromatic:*</include>
+
+									<!-- flink-table-runtime-blink dependencies -->
+									<include>org.codehaus.janino:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<!-- Calcite's dependencies -->
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.pentaho</pattern>
+									<shadedPattern>org.apache.flink.calcite.shaded.org.pentaho</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Scala Code Style, most of the configuration done via plugin management -->
+			<plugin>
+				<groupId>org.scalastyle</groupId>
+				<artifactId>scalastyle-maven-plugin</artifactId>
+				<configuration>
+					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,19 @@
+flink-table-planner-blink
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:19.0
+- net.hydromatic:aggdesigner-algorithm:6.0
+- org.apache.calcite:calcite-core:1.17.0
+- org.apache.calcite:calcite-linq4j:1.17.0
+- org.apache.calcite.avatica:avatica-core:1.12.0
+
+This project bundles the following dependencies under the BSD license.
+See bundled license files for details
+
+- org.codehaus.janino:janino:3.0.7
+- org.codehaus.janino:commons-compiler:3.0.7

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/licenses/LICENSE.janino
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/licenses/LICENSE.janino
@@ -1,0 +1,31 @@
+Janino - An embedded Java[TM] compiler
+
+Copyright (c) 2001-2016, Arno Unkrig
+Copyright (c) 2015-2016  TIBCO Software Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+   3. Neither the name of JANINO nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -149,6 +149,10 @@ under the License.
 					<groupId>commons-dbcp</groupId>
 					<artifactId>commons-dbcp</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.esri.geometry</groupId>
+					<artifactId>esri-geometry-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -284,7 +288,6 @@ under the License.
 									<!-- Calcite's dependencies -->
 									<include>com.google.guava:guava</include>
 									<include>net.hydromatic:*</include>
-									<include>com.esri.geometry:*</include>
 
 									<!-- flink-table-planner dependencies -->
 									<include>org.codehaus.janino:*</include>
@@ -306,10 +309,6 @@ under the License.
 								<relocation>
 									<pattern>org.pentaho</pattern>
 									<shadedPattern>org.apache.flink.calcite.shaded.org.pentaho</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.esri</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.esri</shadedPattern>
 								</relocation>
 
 								<!-- flink-table dependencies -->

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -49,13 +49,13 @@ under the License.
 			<dependency>
 				<groupId>org.codehaus.janino</groupId>
 				<artifactId>commons-compiler</artifactId>
-				<version>3.0.7</version>
+				<version>${janino.version}</version>
 			</dependency>
 			<!-- Common dependency of calcite-core and flink-table-planner -->
 			<dependency>
 				<groupId>org.codehaus.janino</groupId>
 				<artifactId>janino</artifactId>
-				<version>3.0.7</version>
+				<version>${janino.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.esri.geometry:esri-geometry-api:2.0.0
 - com.google.guava:guava:19.0
 - joda-time:joda-time:2.5
 - net.hydromatic:aggdesigner-algorithm:6.0

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -58,7 +58,7 @@ under the License.
 		<dependency>
 			<groupId>org.codehaus.janino</groupId>
 			<artifactId>janino</artifactId>
-			<version>3.0.7</version>
+			<version>${janino.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -22,26 +22,43 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-parent</artifactId>
+		<artifactId>flink-table</artifactId>
 		<version>1.8-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-table</artifactId>
-	<name>flink-table</name>
+	<artifactId>flink-table-runtime-blink</artifactId>
+	<name>flink-table-runtime-blink</name>
+	<description>
+		This module contains classes that are required by a task manager for
+		execution of table programs. The content of this module is work-in-progress.
+		It will replace the runtime classes contained in flink-table-planner once
+		it is stable. See FLINK-11439 and FLIP-32 for more details.
+	</description>
 
-	<packaging>pom</packaging>
+	<packaging>jar</packaging>
 
-	<modules>
-		<module>flink-table-common</module>
-		<module>flink-table-api-java</module>
-		<module>flink-table-api-scala</module>
-		<module>flink-table-api-java-bridge</module>
-		<module>flink-table-api-scala-bridge</module>
-		<module>flink-table-planner</module>
-		<module>flink-table-planner-blink</module>
-		<module>flink-table-runtime-blink</module>
-		<module>flink-table-uber</module>
-		<module>flink-sql-client</module>
-	</modules>
+	<dependencies>
+
+		<!-- core dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+			<version>3.0.7</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,5 @@
+flink-table-runtime-blink
+Copyright 2014-2018 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -44,4 +44,9 @@ under the License.
 		<module>flink-table-uber</module>
 		<module>flink-sql-client</module>
 	</modules>
+
+	<properties>
+		<!-- When updating Janino, make sure that Calcite supports it as well. -->
+		<janino.version>3.0.7</janino.version>
+	</properties>
 </project>

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -53,6 +53,8 @@ flink-table/flink-table-api-scala,\
 flink-table/flink-table-api-java-bridge,\
 flink-table/flink-table-api-scala-bridge,\
 flink-table/flink-table-planner,\
+flink-table/flink-table-planner-blink,\
+flink-table/flink-table-runtime-blink,\
 flink-table/flink-sql-client,\
 flink-queryable-state/flink-queryable-state-runtime,\
 flink-queryable-state/flink-queryable-state-client-java"


### PR DESCRIPTION
## What is the purpose of the change

This commit adds flink-table-planner-blink and flink-table-runtime-blink
modules. Those modules are work-in-progress and are not connected to the
API yet. This happens at a later stage (see FLINK-11452). We aim to make
the runtime module Scala-free.

Initial dependencies have been added. Optimization with Calcite, code
generation, and translation to operators are performed in the planner
module.

Actual execution classes and code compilation are performed in the runtime
module.

## Brief change log

- New modules added

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
