### PR TITLE
[FLINK-11713][docs] Remove legacy mode from documentation

### DIFF
--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -13,19 +13,9 @@
             <td>The failover timeout in seconds for the Mesos scheduler, after which running tasks are automatically shut down.</td>
         </tr>
         <tr>
-            <td><h5>mesos.initial-tasks</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>The initial workers to bring up when the master starts. This option is ignored unless Flink is in <a href="#legacy">legacy mode</a>.</td>
-        </tr>
-        <tr>
             <td><h5>mesos.master</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>The Mesos master URL. The value should be in one of the following forms: <ul><li>host:port</li><li>zk://host1:port1,host2:port2,.../path</li><li>zk://username:password@host1:port1,host2:port2,.../path</li><li>file:///path/to/file</li></ul></td>
-        </tr>
-        <tr>
-            <td><h5>mesos.maximum-failed-tasks</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>The maximum number of failed workers before the cluster fails. May be set to -1 to disable this feature. This option is ignored unless Flink is in <a href="#legacy">legacy mode</a>.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.artifactserver.port</h5></td>

--- a/docs/monitoring/rest_api.md
+++ b/docs/monitoring/rest_api.md
@@ -61,8 +61,6 @@ If no version is specified Flink will default to the *oldest* version supporting
 
 Querying unsupported/non-existing versions will return a 404 error.
 
-<span class="label label-danger">Attention</span> REST API versioning is *not* active if the cluster runs in [legacy mode](../ops/config.html#mode). For this case please refer to the legacy API below.
-
 <div class="codetabs" markdown="1">
 
 <div data-lang="v1" markdown="1">

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -189,12 +189,6 @@ For example:
         -Dtaskmanager.numberOfTaskSlots=2 \
         -Dparallelism.default=10
 
-<div class="alert alert-info">
-  <strong>Note:</strong> If Flink is in <a href="{{ site.baseurl }}/ops/config.html#legacy">legacy mode</a>,
-  you should additionally define the number of task managers that are started by Mesos via
-  <a href="{{ site.baseurl }}/ops/config.html#mesos-initial-tasks"><code>mesos.initial-tasks</code></a>.
-</div>
-
 ### High Availability
 
 You will need to run a service like Marathon or Apache Aurora which takes care of restarting the Flink master process in case of node or process failures.

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -332,6 +332,4 @@ if a task manager is no longer available, a task that cannot return to its previ
 that the previous slot can only disappear when a task manager is no longer available, and in this case *some* tasks have to request a new slot anyways. With our scheduling strategy
 we give the maximum number of tasks a chance to recover from their local state and avoid the cascading effect of tasks stealing their previous slots from one another.
 
-Allocation-preserving scheduling does not work with Flink's legacy mode.
-
 {% top %}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
@@ -20,7 +20,6 @@ package org.apache.flink.mesos.configuration;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.description.Description;
-import org.apache.flink.configuration.description.LinkElement;
 import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -29,31 +28,6 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * The set of configuration options relating to mesos settings.
  */
 public class MesosOptions {
-
-	/**
-	 * The initial number of Mesos tasks to allocate.
-	 */
-	public static final ConfigOption<Integer> INITIAL_TASKS =
-		key("mesos.initial-tasks")
-			.defaultValue(0)
-			.withDescription(Description.builder()
-				.text("The initial workers to bring up when the master starts. ")
-				.text("This option is ignored unless Flink is in %s.", LinkElement.link("#legacy", "legacy mode"))
-				.build());
-
-	/**
-	 * The maximum number of failed Mesos tasks before entirely stopping
-	 * the Mesos session / job on Mesos.
-	 *
-	 * <p>By default, we take the number of initially requested tasks.
-	 */
-	public static final ConfigOption<Integer> MAX_FAILED_TASKS =
-		key("mesos.maximum-failed-tasks")
-			.defaultValue(-1)
-			.withDescription(Description.builder()
-				.text("The maximum number of failed workers before the cluster fails. May be set to -1 to disable this feature. ")
-				.text("This option is ignored unless Flink is in %s.", LinkElement.link("#legacy", "legacy mode"))
-				.build());
 
 	/**
 	 * The Mesos master URL.


### PR DESCRIPTION
## What is the purpose of the change

*This removes references to the legacy mode from the Flink documentation.*


## Brief change log

  - *Remove legacy mode from Flink docs.*
  
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
