### PR TITLE
[FLINK-11716] Add new config option for TaskManager automatic address binding

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -8,12 +8,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>network.taskmanager.bind-policy</h5></td>
-            <td style="word-wrap: break-word;">"ip"</td>
-            <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
-<ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>task.cancellation.interval</h5></td>
             <td style="word-wrap: break-word;">30000</td>
             <td>Time interval between two successive task cancellation attempts in milliseconds.</td>
@@ -97,6 +91,12 @@
             <td><h5>taskmanager.memory.size</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>Amount of memory to be allocated by the task manager's memory manager. If not set, a relative fraction will be allocated.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.bind-policy</h5></td>
+            <td style="word-wrap: break-word;">"ip"</td>
+            <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
+<ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -64,9 +64,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.host.bind-policy</h5></td>
-            <td style="word-wrap: break-word;">"auto-detect-hostname"</td>
+            <td style="word-wrap: break-word;">"ip"</td>
             <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
-<ul><li>"hostname" - uses host's hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li><li>"auto-detect-hostname" - searches for network interfaces that can connect to the JobManager</li></ul></td>
+<ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -8,6 +8,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>network.taskmanager.bind-policy</h5></td>
+            <td style="word-wrap: break-word;">"ip"</td>
+            <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
+<ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>task.cancellation.interval</h5></td>
             <td style="word-wrap: break-word;">30000</td>
             <td>Time interval between two successive task cancellation attempts in milliseconds.</td>
@@ -61,12 +67,6 @@
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.host.bind-policy</h5></td>
-            <td style="word-wrap: break-word;">"ip"</td>
-            <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
-<ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -60,7 +60,13 @@
         <tr>
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>The hostname of the network interface that the TaskManager binds to. By default, the TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers. This option can be used to define a hostname if that strategy fails for some reason. Because different TaskManagers need different values for this option, it usually is specified in an additional non-shared TaskManager-specific config file.</td>
+            <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.host.bind-policy</h5></td>
+            <td style="word-wrap: break-word;">"auto-detect-hostname"</td>
+            <td>The automatic address binding policy used by the TaskManager if "taskmanager.host" is not set. The value should be one of the following:
+<ul><li>"hostname" - uses host's hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li><li>"auto-detect-hostname" - searches for network interfaces that can connect to the JobManager</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -96,14 +96,13 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<String> HOST_BIND_POLICY =
 		key("taskmanager.host.bind-policy")
-		.defaultValue("auto-detect-hostname")
+		.defaultValue("ip")
 		.withDescription(Description.builder()
 			.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +
 				" The value should be one of the following:\n")
 			.list(
-				text("\"hostname\" - uses host's hostname as binding address"),
-				text("\"ip\" - uses host's ip address as binding address"),
-				text("\"auto-detect-hostname\" - searches for network interfaces that can connect to the JobManager"))
+				text("\"name\" - uses hostname as binding address"),
+				text("\"ip\" - uses host's ip address as binding address"))
 			.build());
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -81,6 +81,7 @@ public class TaskManagerOptions {
 
 	/**
 	 * The config parameter defining the task manager's hostname.
+	 * Overrides {@link #HOST_BIND_POLICY} automatic address binding.
 	 */
 	public static final ConfigOption<String> HOST =
 		key("taskmanager.host")
@@ -89,21 +90,6 @@ public class TaskManagerOptions {
 				" This option can be used to define explicitly a binding address. Because" +
 				" different TaskManagers need different values for this option, usually it is specified in an" +
 				" additional non-shared TaskManager-specific config file.");
-
-	/**
-	 * The config parameter for automatically defining the TaskManager's binding address,
-	 * if {@link #HOST} configuration option is not set.
-	 */
-	public static final ConfigOption<String> HOST_BIND_POLICY =
-		key("network.taskmanager.bind-policy")
-		.defaultValue("ip")
-		.withDescription(Description.builder()
-			.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +
-				" The value should be one of the following:\n")
-			.list(
-				text("\"name\" - uses hostname as binding address"),
-				text("\"ip\" - uses host's ip address as binding address"))
-			.build());
 
 	/**
 	 * The default network port range the task manager expects incoming IPC connections. The {@code "0"} means that
@@ -258,6 +244,22 @@ public class TaskManagerOptions {
 	// ------------------------------------------------------------------------
 	//  Network Options
 	// ------------------------------------------------------------------------
+
+	/**
+	 * The config parameter for automatically defining the TaskManager's binding address,
+	 * if {@link #HOST} configuration option is not set.
+	 */
+	public static final ConfigOption<String> HOST_BIND_POLICY =
+		key("taskmanager.network.bind-policy")
+			.defaultValue("ip")
+			.withDescription(Description.builder()
+				.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +
+					" The value should be one of the following:\n")
+				.list(
+					text("\"name\" - uses hostname as binding address"),
+					text("\"ip\" - uses host's ip address as binding address"))
+				.build());
+
 
 	/**
 	 * Number of buffers used in the network stack. This defines the number of possible tasks and

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -20,8 +20,10 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * The set of configuration options relating to TaskManager and Task settings.
@@ -83,11 +85,26 @@ public class TaskManagerOptions {
 	public static final ConfigOption<String> HOST =
 		key("taskmanager.host")
 			.noDefaultValue()
-			.withDescription("The hostname of the network interface that the TaskManager binds to. By default, the" +
-				" TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers." +
-				" This option can be used to define a hostname if that strategy fails for some reason. Because" +
-				" different TaskManagers need different values for this option, it usually is specified in an" +
+			.withDescription("The address of the network interface that the TaskManager binds to." +
+				" This option can be used to define explicitly a binding address. Because" +
+				" different TaskManagers need different values for this option, usually it is specified in an" +
 				" additional non-shared TaskManager-specific config file.");
+
+	/**
+	 * The config parameter for automatically defining the TaskManager's binding address,
+	 * if {@link #HOST} configuration option is not set.
+	 */
+	public static final ConfigOption<String> HOST_BIND_POLICY =
+		key("taskmanager.host.bind-policy")
+		.defaultValue("auto-detect-hostname")
+		.withDescription(Description.builder()
+			.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +
+				" The value should be one of the following:\n")
+			.list(
+				text("\"hostname\" - uses host's hostname as binding address"),
+				text("\"ip\" - uses host's ip address as binding address"),
+				text("\"auto-detect-hostname\" - searches for network interfaces that can connect to the JobManager"))
+			.build());
 
 	/**
 	 * The default network port range the task manager expects incoming IPC connections. The {@code "0"} means that

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -95,7 +95,7 @@ public class TaskManagerOptions {
 	 * if {@link #HOST} configuration option is not set.
 	 */
 	public static final ConfigOption<String> HOST_BIND_POLICY =
-		key("taskmanager.host.bind-policy")
+		key("network.taskmanager.bind-policy")
 		.defaultValue("ip")
 		.withDescription(Description.builder()
 			.text("The automatic address binding policy used by the TaskManager if \"" + HOST.key() + "\" is not set." +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/HostBindPolicy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/HostBindPolicy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+/**
+ * A host binding address mechanism policy.
+ */
+enum HostBindPolicy {
+	HOSTNAME,
+	IP,
+	AUTO_DETECT_HOSTNAME;
+
+	@Override
+	public String toString() {
+		return name().toLowerCase().replace('_', '-');
+	}
+
+	public static HostBindPolicy fromString(String configValue) {
+		switch (configValue) {
+			case "hostname":
+				return HOSTNAME;
+			case "ip":
+				return IP;
+			case "auto-detect-hostname":
+				return AUTO_DETECT_HOSTNAME;
+			default:
+				throw new IllegalArgumentException("Unknown host bind policy: " + configValue);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/HostBindPolicy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/HostBindPolicy.java
@@ -22,25 +22,19 @@ package org.apache.flink.runtime.taskexecutor;
  * A host binding address mechanism policy.
  */
 enum HostBindPolicy {
-	HOSTNAME,
-	IP,
-	AUTO_DETECT_HOSTNAME;
+	NAME,
+	IP;
 
 	@Override
 	public String toString() {
-		return name().toLowerCase().replace('_', '-');
+		return name().toLowerCase();
 	}
 
 	public static HostBindPolicy fromString(String configValue) {
-		switch (configValue) {
-			case "hostname":
-				return HOSTNAME;
-			case "ip":
-				return IP;
-			case "auto-detect-hostname":
-				return AUTO_DETECT_HOSTNAME;
-			default:
-				throw new IllegalArgumentException("Unknown host bind policy: " + configValue);
+		try {
+			return HostBindPolicy.valueOf(configValue.toUpperCase());
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException("Unknown host bind policy: " + configValue);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -422,21 +422,11 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			LOG.info("Using configured hostname/address for TaskManager: {}.", configuredTaskManagerHostname);
 			return configuredTaskManagerHostname;
 		} else {
-			HostBindPolicy bindPolicy = HostBindPolicy.fromString(configuration.getString(TaskManagerOptions.HOST_BIND_POLICY));
-			switch (bindPolicy) {
-				case HOSTNAME:
-					return InetAddress.getLocalHost().getHostName();
-				case IP:
-					return InetAddress.getLocalHost().getHostAddress();
-				case AUTO_DETECT_HOSTNAME:
-					return determineTaskManagerHostnameByConnectingToResourceManager(configuration, haServices);
-				default:
-					throw new IllegalArgumentException("Unknown " + TaskManagerOptions.HOST_BIND_POLICY.key() + ": " + bindPolicy);
-			}
+			return determineTaskManagerBindAddressByConnectingToResourceManager(configuration, haServices);
 		}
 	}
 
-	private static String determineTaskManagerHostnameByConnectingToResourceManager(
+	private static String determineTaskManagerBindAddressByConnectingToResourceManager(
 			final Configuration configuration,
 			final HighAvailabilityServices haServices) throws LeaderRetrievalException {
 
@@ -449,6 +439,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		LOG.info("TaskManager will use hostname/address '{}' ({}) for communication.",
 			taskManagerAddress.getHostName(), taskManagerAddress.getHostAddress());
 
-		return taskManagerAddress.getHostName();
+		HostBindPolicy bindPolicy = HostBindPolicy.fromString(configuration.getString(TaskManagerOptions.HOST_BIND_POLICY));
+		return bindPolicy == HostBindPolicy.IP ? taskManagerAddress.getHostAddress() : taskManagerAddress.getHostName();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
@@ -94,8 +94,8 @@ public class TaskManagerRunnerConfigurationTest extends TestLogger {
 	}
 
 	@Test
-	public void testTaskManagerRpcServiceShouldBindToHostname() throws Exception {
-		final Configuration config = createFlinkConfigWithHostBindPolicy(HostBindPolicy.HOSTNAME);
+	public void testTaskManagerRpcServiceShouldBindToHostnameAddress() throws Exception {
+		final Configuration config = createFlinkConfigWithHostBindPolicy(HostBindPolicy.NAME);
 		final HighAvailabilityServices highAvailabilityServices = createHighAvailabilityServices(config);
 
 		RpcService taskManagerRpcService = null;
@@ -109,22 +109,7 @@ public class TaskManagerRunnerConfigurationTest extends TestLogger {
 	}
 
 	@Test
-	public void testTaskManagerRpcServiceShouldBindToIp() throws Exception {
-		final Configuration config = createFlinkConfigWithHostBindPolicy(HostBindPolicy.IP);
-		final HighAvailabilityServices highAvailabilityServices = createHighAvailabilityServices(config);
-
-		RpcService taskManagerRpcService = null;
-		try {
-			taskManagerRpcService = TaskManagerRunner.createRpcService(config, highAvailabilityServices);
-			assertThat(taskManagerRpcService.getAddress(), isIpAddress());
-		} finally {
-			maybeCloseRpcService(taskManagerRpcService);
-			highAvailabilityServices.closeAndCleanupAllData();
-		}
-	}
-
-	@Test
-	public void testTaskManagerRpcServiceShouldBindToAddressDeterminedByConnectingToResourceManager() throws Exception {
+	public void testTaskManagerRpcServiceShouldBindToIpAddressDeterminedByConnectingToResourceManager() throws Exception {
 		final ServerSocket testJobManagerSocket = openServerSocket();
 		final Configuration config = createFlinkConfigWithJobManagerPort(testJobManagerSocket.getLocalPort());
 		final HighAvailabilityServices highAvailabilityServices = createHighAvailabilityServices(config);
@@ -132,7 +117,7 @@ public class TaskManagerRunnerConfigurationTest extends TestLogger {
 		RpcService taskManagerRpcService = null;
 		try {
 			taskManagerRpcService = TaskManagerRunner.createRpcService(config, highAvailabilityServices);
-			assertThat(taskManagerRpcService.getAddress(), not(isEmptyOrNullString()));
+			assertThat(taskManagerRpcService.getAddress(), is(ipAddress()));
 		} finally {
 			maybeCloseRpcService(taskManagerRpcService);
 			highAvailabilityServices.closeAndCleanupAllData();
@@ -225,7 +210,7 @@ public class TaskManagerRunnerConfigurationTest extends TestLogger {
 		}
 	}
 
-	private static TypeSafeMatcher<String> isIpAddress() {
+	private static TypeSafeMatcher<String> ipAddress() {
 		return new TypeSafeMatcher<String>() {
 			@Override
 			protected boolean matchesSafely(String value) {


### PR DESCRIPTION
## What is the purpose of the change

This PR allows to configure TMs automatic address binding by introducing a new `flink-config.yaml` configuration option `taskmanager.host.bind-policy`.

## Brief change log

  - introduce new automatic  address binding methods for TM via `taskmanager.host.bind-policy` configuration;
  - add simple unit tests.

## Verifying this change

This change is a trivial rework.

  - Added simple unit tests to `TaskManagerRunnerConfigurationTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
