### PR TITLE
[FLINK-11651][tests] Upgrade jepsen dependency to 0.1.11

### DIFF
--- a/flink-jepsen/project.clj
+++ b/flink-jepsen/project.clj
@@ -22,7 +22,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"],
                  [cheshire "5.8.0"]
                  [clj-http "3.8.0"]
-                 [jepsen "0.1.10"],
+                 [jepsen "0.1.11"],
                  [jepsen.zookeeper "0.1.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [zookeeper-clj "0.9.4" :exclusions [org.slf4j/slf4j-log4j12]]]


### PR DESCRIPTION
## What is the purpose of the change

*This upgrades the jepsen dependency to 0.1.11*


## Brief change log

  - *Upgrade jepsen dependency to 0.1.11*

## Verifying this change

This change is already covered by existing tests, such as *flink-jepsen*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
