### PR TITLE
[FLINK-11379] Fix OutOfMemoryError caused by Files.readAllBytes() when TM loads a large size TDD

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -28,11 +28,15 @@ import org.apache.flink.util.function.ThrowingConsumer;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Random;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -55,6 +59,15 @@ public final class FileUtils {
 
 	/** The length of the random part of the filename. */
 	private static final int RANDOM_FILE_NAME_LENGTH = 12;
+
+	/**
+	 * The maximum size of array to allocate for reading. See
+	 * {@link java.nio.file.Files#MAX_BUFFER_SIZE} for more.
+	 */
+	private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+
+	/** The size of the buffer used for reading. */
+	private static final int BUFFER_SIZE = 4096;
 
 	// ------------------------------------------------------------------------
 
@@ -90,7 +103,7 @@ public final class FileUtils {
 	// ------------------------------------------------------------------------
 
 	public static String readFile(File file, String charsetName) throws IOException {
-		byte[] bytes = Files.readAllBytes(file.toPath());
+		byte[] bytes = readAllBytes(file.toPath());
 		return new String(bytes, charsetName);
 	}
 
@@ -105,6 +118,92 @@ public final class FileUtils {
 
 	public static void writeFileUtf8(File file, String contents) throws IOException {
 		writeFile(file, contents, "UTF-8");
+	}
+
+	/**
+	 * Reads all the bytes from a file. The method ensures that the file is
+	 * closed when all bytes have been read or an I/O error, or other runtime
+	 * exception, is thrown.
+	 *
+	 * <p>This is an implementation that follow {@link java.nio.file.Files#readAllBytes(java.nio.file.Path)},
+	 * and the difference is that it limits the size of the direct buffer to avoid
+	 * direct-buffer OutOfMemoryError. When {@link java.nio.file.Files#readAllBytes(java.nio.file.Path)}
+	 * or other interfaces in java API can do this in the future, we should remove it.
+	 *
+	 * @param path
+	 *        the path to the file
+	 * @return a byte array containing the bytes read from the file
+	 *
+	 * @throws IOException
+	 *         if an I/O error occurs reading from the stream
+	 * @throws OutOfMemoryError
+	 *         if an array of the required size cannot be allocated, for
+	 *         example the file is larger that {@code 2GB}
+	 */
+	public static byte[] readAllBytes(java.nio.file.Path path) throws IOException {
+		try (SeekableByteChannel channel = Files.newByteChannel(path);
+			InputStream in = Channels.newInputStream(channel)) {
+
+			long size = channel.size();
+			if (size > (long) MAX_BUFFER_SIZE) {
+				throw new OutOfMemoryError("Required array size too large");
+			}
+
+			return read(in, (int) size, BUFFER_SIZE);
+		}
+	}
+
+	/**
+	 * Reads all the bytes from an input stream. Uses {@code initialSize} as a hint
+	 * about how many bytes the stream will have and uses {@code directBufferSize}
+	 * to limit the size of the direct buffer used to read.
+	 *
+	 * @param source
+	 *        the input stream to read from
+	 * @param initialSize
+	 *        the initial size of the byte array to allocate
+	 * @param maxDirectBufferSize
+	 *        the maximum size of the direct buffer used to read
+	 * @return a byte array containing the bytes read from the file
+	 *
+	 * @throws IOException
+	 *         if an I/O error occurs reading from the stream
+	 * @throws OutOfMemoryError
+	 *         if an array of the required size cannot be allocated
+	 */
+	private static byte[] read(InputStream source, int initialSize, int maxDirectBufferSize) throws IOException {
+		int capacity = initialSize;
+		byte[] buf = new byte[capacity];
+		int nread = 0;
+		int n;
+
+		maxDirectBufferSize = (maxDirectBufferSize <= 0) ? BUFFER_SIZE : maxDirectBufferSize;
+		for (; ;) {
+			// read to EOF which may read more or less than initialSize (eg: file
+			// is truncated while we are reading)
+			while ((n = source.read(buf, nread, Math.min(capacity - nread, maxDirectBufferSize))) > 0) {
+				nread += n;
+			}
+
+			// if last call to source.read() returned -1, we are done
+			// otherwise, try to read one more byte; if that failed we're done too
+			if (n < 0 || (n = source.read()) < 0) {
+				break;
+			}
+
+			// one more byte was read; need to allocate a larger buffer
+			if (capacity <= MAX_BUFFER_SIZE - capacity) {
+				capacity = Math.max(capacity << 1, BUFFER_SIZE);
+			} else {
+				if (capacity == MAX_BUFFER_SIZE) {
+					throw new OutOfMemoryError("Required array size too large");
+				}
+				capacity = MAX_BUFFER_SIZE;
+			}
+			buf = Arrays.copyOf(buf, capacity);
+			buf[nread++] = (byte) n;
+		}
+		return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -149,7 +149,7 @@ public final class FileUtils {
 				throw new OutOfMemoryError("Required array size too large");
 			}
 
-			return read(in, (int) size, BUFFER_SIZE);
+			return read(in, (int) size);
 		}
 	}
 
@@ -162,8 +162,6 @@ public final class FileUtils {
 	 *        the input stream to read from
 	 * @param initialSize
 	 *        the initial size of the byte array to allocate
-	 * @param maxDirectBufferSize
-	 *        the maximum size of the direct buffer used to read
 	 * @return a byte array containing the bytes read from the file
 	 *
 	 * @throws IOException
@@ -171,17 +169,16 @@ public final class FileUtils {
 	 * @throws OutOfMemoryError
 	 *         if an array of the required size cannot be allocated
 	 */
-	private static byte[] read(InputStream source, int initialSize, int maxDirectBufferSize) throws IOException {
+	private static byte[] read(InputStream source, int initialSize) throws IOException {
 		int capacity = initialSize;
 		byte[] buf = new byte[capacity];
 		int nread = 0;
 		int n;
 
-		maxDirectBufferSize = (maxDirectBufferSize <= 0) ? BUFFER_SIZE : maxDirectBufferSize;
 		for (; ;) {
 			// read to EOF which may read more or less than initialSize (eg: file
 			// is truncated while we are reading)
-			while ((n = source.read(buf, nread, Math.min(capacity - nread, maxDirectBufferSize))) > 0) {
+			while ((n = source.read(buf, nread, Math.min(capacity - nread, BUFFER_SIZE))) > 0) {
 				nread += n;
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
@@ -34,7 +35,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.file.Files;
 import java.util.Collection;
 
 /**
@@ -300,7 +300,7 @@ public final class TaskDeploymentDescriptor implements Serializable {
 			//       (it is deleted automatically on the BLOB server and cache when the job
 			//       enters a terminal state)
 			SerializedValue<JobInformation> serializedValue =
-				SerializedValue.fromBytes(Files.readAllBytes(dataFile.toPath()));
+				SerializedValue.fromBytes(FileUtils.readAllBytes(dataFile.toPath()));
 			serializedJobInformation = new NonOffloaded<>(serializedValue);
 		}
 
@@ -315,7 +315,7 @@ public final class TaskDeploymentDescriptor implements Serializable {
 			//       (it is deleted automatically on the BLOB server and cache when the job
 			//       enters a terminal state)
 			SerializedValue<TaskInformation> serializedValue =
-				SerializedValue.fromBytes(Files.readAllBytes(dataFile.toPath()));
+				SerializedValue.fromBytes(FileUtils.readAllBytes(dataFile.toPath()));
 			serializedTaskInformation = new NonOffloaded<>(serializedValue);
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes TM do not throw a "java.lang.OutOfMemoryError: Direct Buffer Memory" error In the case of loading a offloaded TDD with large size.  The loading uses NIO's Files.readAllBytes() to read serialized TDD, and in the call stack of Files.readAllBytes() , it will allocate a direct memory buffer which's size is equal to the length of the file. This will cause OutOfMemoryError when the file is very large.


## Brief change log

  - A new method readAllBytes() which limits the used size of the direct buffer is added to the FileUtils class.
    - *The reason for adding this new method is that no an available method of Java API or third-party interface has been found. The available method should be not only as efficient and scalable (auto-scaling allocated byte array) as NIO's Files.available() , but also limits the used size of the direct buffer.*
    - *The new method is an implementation that follow nio's Files.readAllBytes(),  and the only difference is that it limits the used size of the direct buffer.*
  - When TM loads a offloaded TDD, FileUtils.readAllBytes() is called to replace nio's Files.readAllBytes().


## Verifying this change

This change added tests and can be verified as follows:
  -  Added test that validates that the results of FileUtils.readAllBytes() are correct in the following cases:
    - The file size (1K) is smaller than the direct-buffer size (4K).
    -  The file size (4K) is equal to the direct-buffer size (4K).
    -  The file size (5K) is greater than the direct-buffer size (4K).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
