### PR TITLE
[FLINK-11777] [docs] Remove and update useless html anchor in hadoop_compatibility.md

### DIFF
--- a/docs/dev/batch/hadoop_compatibility.md
+++ b/docs/dev/batch/hadoop_compatibility.md
@@ -28,7 +28,7 @@ reusing code that was implemented for Hadoop MapReduce.
 
 You can:
 
-- use Hadoop's `Writable` [data types](index.html#data-types) in Flink programs.
+- use Hadoop's `Writable` [data types]({{ site.baseurl }}/dev/api_concepts.html#supported-data-types) in Flink programs.
 - use any Hadoop `InputFormat` as a [DataSource](index.html#data-sources).
 - use any Hadoop `OutputFormat` as a [DataSink](index.html#data-sinks).
 - use a Hadoop `Mapper` as [FlatMapFunction](dataset_transformations.html#flatmap).
@@ -69,7 +69,7 @@ and Reducers.
 Flink supports all Hadoop `Writable` and `WritableComparable` data types
 out-of-the-box. You do not need to include the Hadoop Compatibility dependency,
 if you only want to use your Hadoop data types. See the
-[Programming Guide](index.html#data-types) for more details.
+[Programming Guide](index.html) for more details.
 
 ### Using Hadoop InputFormats
 


### PR DESCRIPTION
Since the html anchor "index.html#data-types" no longer exists, this pull request removes and updates useless html anchor in hadoop_compatibility.md.