### PR TITLE
[FLINK-11606][chinese-translation,Documentation] Translate the "Distr…

### DIFF
--- a/docs/concepts/runtime.zh.md
+++ b/docs/concepts/runtime.zh.md
@@ -26,102 +26,73 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-## Tasks and Operator Chains
+## Tasks 和算子链 (Operator Chains)
 
-For distributed execution, Flink *chains* operator subtasks together into *tasks*. Each task is executed by one thread.
-Chaining operators together into tasks is a useful optimization: it reduces the overhead of thread-to-thread
-handover and buffering, and increases overall throughput while decreasing latency.
-The chaining behavior can be configured; see the [chaining docs](../dev/stream/operators/#task-chaining-and-resource-groups) for details.
+分布式计算中，Flink 将算子的 subtasks 串联(chains)成 tasks，每个 task 由一个线程执行。把算子串联为 tasks 是一个非常好的优化：它减少了线程之间的通信和缓冲，而且还能增加吞吐量降低延迟。链化操作的配置详情可参考 [串联文档](../dev/stream/operators/#task-chaining-and-resource-groups)。
 
-The sample dataflow in the figure below is executed with five subtasks, and hence with five parallel threads.
+下图的数据流中有 5 个 subtasks，因此有 5 个线程并发进行处理。
 
-<img src="{{ site.baseurl }}/fig/tasks_chains.svg" alt="Operator chaining into Tasks" class="offset" width="80%" />
+<img src="../fig/tasks_chains.svg" alt="Operator chaining into Tasks" class="offset" width="80%" />
 
 {% top %}
 
 ## Job Managers, Task Managers, Clients
 
-The Flink runtime consists of two types of processes:
+Flink 运行时包含两类进程：
 
-  - The **JobManagers** (also called *masters*) coordinate the distributed execution. They schedule tasks, coordinate
-    checkpoints, coordinate recovery on failures, etc.
+  - **JobManagers** （也称为 *masters*）用来协调分布式计算。负责进行任务调度、协调检查点 (checkpoints)、协调错误恢复等等。
+    
+    至少需要一个 JobManager。高可用部署下会有多个 JobManagers，其中一个作为 leader，其余处于 standby 状态。
 
-    There is always at least one Job Manager. A high-availability setup will have multiple JobManagers, one of
-    which one is always the *leader*, and the others are *standby*.
+  - TaskManagers（也称为 workers）负责执行 dataflow 中的 tasks（更准确的描述是 subtasks），并且对  streams 进行缓存和交换。
+    
+    至少需要一个 TaskManager。
 
-  - The **TaskManagers** (also called *workers*) execute the *tasks* (or more specifically, the subtasks) of a dataflow,
-    and buffer and exchange the data *streams*.
+有多种方式可以启动 JobManagers 和 TaskManagers：作为[独立集群](../ops/deployment/cluster_setup.html)直接在计算机上启动，在容器中或者由资源管理器 [YARN](../ops/deployment/yarn_setup.html) 或 [Mesos](../ops/deployment/mesos.html) 启动。TaskManagers 连接到 JobManagers 后，会通知 JobManagers 自己已可用，接着被分配工作。
 
-    There must always be at least one TaskManager.
+**client** 不作为运行时和程序执行的一部分，只是用于准备和发送 dataflow 作业给 JobManager。 因此客户端可以断开连接，或者保持连接以接收进度报告。客户端可以作为触发执行的Java/Scala 程序的一部分或者运行在命令行进程中 `./bin/flink run ...`。
 
-The JobManagers and TaskManagers can be started in various ways: directly on the machines as a [standalone cluster](../ops/deployment/cluster_setup.html), in
-containers, or managed by resource frameworks like [YARN](../ops/deployment/yarn_setup.html) or [Mesos](../ops/deployment/mesos.html).
-TaskManagers connect to JobManagers, announcing themselves as available, and are assigned work.
-
-The **client** is not part of the runtime and program execution, but is used to prepare and send a dataflow to the JobManager.
-After that, the client can disconnect, or stay connected to receive progress reports. The client runs either as part of the
-Java/Scala program that triggers the execution, or in the command line process `./bin/flink run ...`.
-
-<img src="{{ site.baseurl }}/fig/processes.svg" alt="The processes involved in executing a Flink dataflow" class="offset" width="80%" />
+<img src="../fig/processes.svg" alt="The processes involved in executing a Flink dataflow" class="offset" width="80%" />
 
 {% top %}
 
-## Task Slots and Resources
+## Task 槽和资源
 
-Each worker (TaskManager) is a *JVM process*, and may execute one or more subtasks in separate threads.
-To control how many tasks a worker accepts, a worker has so called **task slots** (at least one).
+每个 worker(TaskManager)都是一个 **JVM 进程**，并且可以在不同的线程中执行一个或多个 subtasks。每个 worker 用  task 槽(至少有一个)来控制可以接收多少个 tasks。
 
-Each *task slot* represents a fixed subset of resources of the TaskManager. A TaskManager with three slots, for example,
-will dedicate 1/3 of its managed memory to each slot. Slotting the resources means that a subtask will not
-compete with subtasks from other jobs for managed memory, but instead has a certain amount of reserved
-managed memory. Note that no CPU isolation happens here; currently slots only separate the managed memory of tasks.
+每个 task 槽代表 TaskManager 中一个固定的资源子集。例如，有 3 个槽位的 TaskManager 会将它的内存资源划分成 3 份分配给每个槽。划分资源意味着 subtask 不会和来自其他作业的 subtasks 竞争资源，但是也意味着它只拥有固定的内存资源。注意划分资源不进行 CPU 隔离，只划分内存资源给不同的 tasks。
 
-By adjusting the number of task slots, users can define how subtasks are isolated from each other.
-Having one slot per TaskManager means each task group runs in a separate JVM (which can be started in a
-separate container, for example). Having multiple slots
-means more subtasks share the same JVM. Tasks in the same JVM share TCP connections (via multiplexing) and
-heartbeat messages. They may also share data sets and data structures, thus reducing the per-task overhead.
+通过调整 task 槽的个数进而可以调整 subtasks 之间的隔离方式。当每个 TaskManager 只有一个槽位时，意味着每个 task group 运行在不同的 JVM 中（例如：可能在不同的 container 中）。当每个 TaskManager 有多个槽时，意味着多个 subtasks 可以共享同一个 JVM。同一个 JVM 中的 tasks 共享 TCP 连接（通过多路复用技术）和心跳消息。可能还会共享数据集和数据结构，从而减少每个 task 的开销。
 
-<img src="{{ site.baseurl }}/fig/tasks_slots.svg" alt="A TaskManager with Task Slots and Tasks" class="offset" width="80%" />
+<img src="../fig/tasks_slots.svg" alt="A TaskManager with Task Slots and Tasks" class="offset" width="80%" />
 
-By default, Flink allows subtasks to share slots even if they are subtasks of different tasks, so long as
-they are from the same job. The result is that one slot may hold an entire pipeline of the
-job. Allowing this *slot sharing* has two main benefits:
+默认情况下，只要 subtasks 是来自同一个作业，Flink 允许不同 tasks 的 subtasks 共享槽位。因此，一个槽可能会负责作业的整个 pipeline。允许槽位共享有两个好处：
 
-  - A Flink cluster needs exactly as many task slots as the highest parallelism used in the job.
-    No need to calculate how many tasks (with varying parallelism) a program contains in total.
+  - Flink 集群需要的槽的数量和 job 的最高并发度相同，不需要计算一个作业总共包含多少个 tasks（具有不同并行度）。
 
-  - It is easier to get better resource utilization. Without slot sharing, the non-intensive
-    *source/map()* subtasks would block as many resources as the resource intensive *window* subtasks.
-    With slot sharing, increasing the base parallelism in our example from two to six yields full utilization of the
-    slotted resources, while making sure that the heavy subtasks are fairly distributed among the TaskManagers.
+  - 更易获取更好的资源利用率。没有槽位共享，非集中型subtasks（source/map()）将会占用和集中型 subtasks（window）一样多的资源。在我们的示例中，允许槽位共享，可以将示例作业的并发度从 2 增加到 6，从而可以充分利用资源，同时保证负载很重的 subtasks 可以在 TaskManagers 中平均分配。
 
-<img src="{{ site.baseurl }}/fig/slot_sharing.svg" alt="TaskManagers with shared Task Slots" class="offset" width="80%" />
+<img src="../fig/slot_sharing.svg" alt="TaskManagers with shared Task Slots" class="offset" width="80%" />
 
-The APIs also include a *[resource group](../dev/stream/operators/#task-chaining-and-resource-groups)* mechanism which can be used to prevent undesirable slot sharing.
+APIs 还包含了一种 *[资源组](../dev/stream/operators/#task-chaining-and-resource-groups)* 机制，用来防止不必要的槽位共享。
 
-As a rule-of-thumb, a good default number of task slots would be the number of CPU cores.
-With hyper-threading, each slot then takes 2 or more hardware thread contexts.
+经验来讲，task 槽的默认值应该与CPU核数一致。在使用超线程下，一个槽将会占用2个或更多的硬件资源。
 
 {% top %}
 
-## State Backends
+## 状态后端（State backends）
 
-The exact data structures in which the key/values indexes are stored depends on the chosen [state backend](../ops/state/state_backends.html). One state backend
-stores data in an in-memory hash map, another state backend uses [RocksDB](http://rocksdb.org) as the key/value store.
-In addition to defining the data structure that holds the state, the state backends also implement the logic to
-take a point-in-time snapshot of the key/value state and store that snapshot as part of a checkpoint.
+key/values 索引存储的准确数据结构取决于选择的状态后端。状态后端可以将数据存储在内存哈希表中，也可以使用 RocksDB 作为 key/value 的存储。 除了定义存储状态的数据结构，状态后端还实现了获取 key/value 状态的时间点快照的逻辑，并将该快照存储为检查点的一部分。
 
-<img src="{{ site.baseurl }}/fig/checkpoints.svg" alt="checkpoints and snapshots" class="offset" width="60%" />
+<img src="../fig/checkpoints.svg" alt="checkpoints and snapshots" class="offset" width="60%" />
 
 {% top %}
 
-## Savepoints
+## 保存点（Savepoints）
+使用 Data Stream API 编写的程序可以从一个**保存点**恢复执行。保存点允许在不丢失任何状态的情况下修改程序和 Flink 集群。
 
-Programs written in the Data Stream API can resume execution from a **savepoint**. Savepoints allow both updating your programs and your Flink cluster without losing any state. 
+[保存点](../ops/state/savepoints.html)是**手动触发的检查点**，它依赖常规的检查点机制，生成程序快照并将其写入到状态后端。在运行期间，worker 节点周期性的生成程序快照并产生检查点。在恢复重启时只会使用最后成功的检查点。并且只要有一个新的检查点生成时，旧的检查点将会被安全地丢弃。
 
-[Savepoints](../ops/state/savepoints.html) are **manually triggered checkpoints**, which take a snapshot of the program and write it out to a state backend. They rely on the regular checkpointing mechanism for this. During execution programs are periodically snapshotted on the worker nodes and produce checkpoints. For recovery only the last completed checkpoint is needed and older checkpoints can be safely discarded as soon as a new one is completed.
-
-Savepoints are similar to these periodic checkpoints except that they are **triggered by the user** and **don't automatically expire** when newer checkpoints are completed. Savepoints can be created from the [command line](../ops/cli.html#savepoints) or when cancelling a job via the [REST API](../monitoring/rest_api.html#cancel-job-with-savepoint).
+保存点与周期性触发的检查点很类似，但是其式**由用户触发**的，且当更新的检查点完成时，老的检查点**不会自动失效**。可以通过[命令行](../ops/cli.html#savepoints)或者在取消一个作业时调用 [REST API](../monitoring/rest_api.html#cancel-job-with-savepoint) 的方式创建保存点。
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

This pull request completes the Chinese translation of "Distributed Runtime Environment" page from official document.

## Brief change log

Translate the "Distributed Runtime Environment" page into Chinese

## Verifying this change

This change is to add a new translated document.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no