### PR TITLE
[FLINK-11723][network] Remove KvState related components from Network…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.queryablestate.network.stats.DisabledKvStateRequestStats;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.query.KvStateClientProxy;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.query.KvStateServer;
+import org.apache.flink.runtime.query.QueryableStateUtils;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KvState related components of each {@link TaskExecutor} instance. This service can
+ * create the kvState registration for a single task.
+ */
+public class KvStateService {
+	private static final Logger LOG = LoggerFactory.getLogger(KvStateService.class);
+
+	/** Registry for {@link InternalKvState} instances. */
+	private final KvStateRegistry kvStateRegistry;
+
+	/** Server for {@link InternalKvState} requests. */
+	private KvStateServer kvStateServer;
+
+	/** Proxy for the queryable state client. */
+	private KvStateClientProxy kvStateClientProxy;
+
+	KvStateService(KvStateRegistry kvStateRegistry, KvStateServer kvStateServer, KvStateClientProxy kvStateClientProxy) {
+		this.kvStateRegistry = Preconditions.checkNotNull(kvStateRegistry);
+		this.kvStateServer = kvStateServer;
+		this.kvStateClientProxy = kvStateClientProxy;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Getter/Setter
+	// --------------------------------------------------------------------------------------------
+
+	public KvStateRegistry getKvStateRegistry() {
+		return kvStateRegistry;
+	}
+
+	public KvStateServer getKvStateServer() {
+		return kvStateServer;
+	}
+
+	public KvStateClientProxy getKvStateClientProxy() {
+		return kvStateClientProxy;
+	}
+
+	public TaskKvStateRegistry createKvStateTaskRegistry(JobID jobId, JobVertexID jobVertexId) {
+		return kvStateRegistry.createTaskRegistry(jobId, jobVertexId);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Start and shut down methods
+	// --------------------------------------------------------------------------------------------
+
+	public void start() {
+		if (kvStateServer != null) {
+			try {
+				kvStateServer.start();
+			} catch (Throwable ie) {
+				kvStateServer.shutdown();
+				kvStateServer = null;
+				LOG.error("Failed to start the Queryable State Data Server.", ie);
+			}
+		}
+
+		if (kvStateClientProxy != null) {
+			try {
+				kvStateClientProxy.start();
+			} catch (Throwable ie) {
+				kvStateClientProxy.shutdown();
+				kvStateClientProxy = null;
+				LOG.error("Failed to start the Queryable State Client Proxy.", ie);
+			}
+		}
+	}
+
+	public void shutdown() {
+		if (kvStateClientProxy != null) {
+			try {
+				LOG.debug("Shutting down Queryable State Client Proxy.");
+				kvStateClientProxy.shutdown();
+			} catch (Throwable t) {
+				LOG.warn("Cannot shut down Queryable State Client Proxy.", t);
+			}
+		}
+
+		if (kvStateServer != null) {
+			try {
+				LOG.debug("Shutting down Queryable State Data Server.");
+				kvStateServer.shutdown();
+			} catch (Throwable t) {
+				LOG.warn("Cannot shut down Queryable State Data Server.", t);
+			}
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Static factory methods for kvState service
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Creates and returns the KvState service.
+	 *
+	 * @param taskManagerServicesConfiguration task manager configuration
+	 * @return service for kvState related components
+	 */
+	public static KvStateService fromConfiguration(TaskManagerServicesConfiguration taskManagerServicesConfiguration) {
+		KvStateRegistry kvStateRegistry = new KvStateRegistry();
+
+		QueryableStateConfiguration qsConfig = taskManagerServicesConfiguration.getQueryableStateConfig();
+
+		KvStateClientProxy kvClientProxy = null;
+		KvStateServer kvStateServer = null;
+
+		if (qsConfig != null) {
+			int numProxyServerNetworkThreads = qsConfig.numProxyServerThreads() == 0 ?
+				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numProxyServerThreads();
+			int numProxyServerQueryThreads = qsConfig.numProxyQueryThreads() == 0 ?
+				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numProxyQueryThreads();
+			kvClientProxy = QueryableStateUtils.createKvStateClientProxy(
+				taskManagerServicesConfiguration.getTaskManagerAddress(),
+				qsConfig.getProxyPortRange(),
+				numProxyServerNetworkThreads,
+				numProxyServerQueryThreads,
+				new DisabledKvStateRequestStats());
+
+			int numStateServerNetworkThreads = qsConfig.numStateServerThreads() == 0 ?
+				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numStateServerThreads();
+			int numStateServerQueryThreads = qsConfig.numStateQueryThreads() == 0 ?
+				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numStateQueryThreads();
+			kvStateServer = QueryableStateUtils.createKvStateServer(
+				taskManagerServicesConfiguration.getTaskManagerAddress(),
+				qsConfig.getStateServerPortRange(),
+				numStateServerNetworkThreads,
+				numStateServerQueryThreads,
+				kvStateRegistry,
+				new DisabledKvStateRequestStats());
+		}
+
+		return new KvStateService(kvStateRegistry, kvStateServer, kvClientProxy);
+	}
+
+	public static KvStateService build() {
+		return new KvStateService(new KvStateRegistry(), null, null);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
@@ -52,7 +52,7 @@ public class KvStateService {
 
 	private boolean isShutdown;
 
-	KvStateService(KvStateRegistry kvStateRegistry, KvStateServer kvStateServer, KvStateClientProxy kvStateClientProxy) {
+	public KvStateService(KvStateRegistry kvStateRegistry, KvStateServer kvStateServer, KvStateClientProxy kvStateClientProxy) {
 		this.kvStateRegistry = Preconditions.checkNotNull(kvStateRegistry);
 		this.kvStateServer = kvStateServer;
 		this.kvStateClientProxy = kvStateClientProxy;
@@ -184,9 +184,5 @@ public class KvStateService {
 		}
 
 		return new KvStateService(kvStateRegistry, kvStateServer, kvClientProxy);
-	}
-
-	public static KvStateService build() {
-		return new KvStateService(new KvStateRegistry(), null, null);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
@@ -140,6 +140,12 @@ public class KvStateService {
 		}
 	}
 
+	public boolean isShutdown() {
+		synchronized (lock) {
+			return isShutdown;
+		}
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Static factory methods for kvState service
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
-import org.apache.flink.queryablestate.network.stats.DisabledKvStateRequestStats;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -40,10 +39,6 @@ import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.query.KvStateClientProxy;
-import org.apache.flink.runtime.query.KvStateRegistry;
-import org.apache.flink.runtime.query.KvStateServer;
-import org.apache.flink.runtime.query.QueryableStateUtils;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
@@ -82,6 +77,7 @@ public class TaskManagerServices {
 	private final MemoryManager memoryManager;
 	private final IOManager ioManager;
 	private final NetworkEnvironment networkEnvironment;
+	private final KvStateService kvStateService;
 	private final BroadcastVariableManager broadcastVariableManager;
 	private final TaskSlotTable taskSlotTable;
 	private final JobManagerTable jobManagerTable;
@@ -89,20 +85,22 @@ public class TaskManagerServices {
 	private final TaskExecutorLocalStateStoresManager taskManagerStateStore;
 
 	TaskManagerServices(
-		TaskManagerLocation taskManagerLocation,
-		MemoryManager memoryManager,
-		IOManager ioManager,
-		NetworkEnvironment networkEnvironment,
-		BroadcastVariableManager broadcastVariableManager,
-		TaskSlotTable taskSlotTable,
-		JobManagerTable jobManagerTable,
-		JobLeaderService jobLeaderService,
-		TaskExecutorLocalStateStoresManager taskManagerStateStore) {
+			TaskManagerLocation taskManagerLocation,
+			MemoryManager memoryManager,
+			IOManager ioManager,
+			NetworkEnvironment networkEnvironment,
+			KvStateService kvStateService,
+			BroadcastVariableManager broadcastVariableManager,
+			TaskSlotTable taskSlotTable,
+			JobManagerTable jobManagerTable,
+			JobLeaderService jobLeaderService,
+			TaskExecutorLocalStateStoresManager taskManagerStateStore) {
 
 		this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
 		this.memoryManager = Preconditions.checkNotNull(memoryManager);
 		this.ioManager = Preconditions.checkNotNull(ioManager);
 		this.networkEnvironment = Preconditions.checkNotNull(networkEnvironment);
+		this.kvStateService = Preconditions.checkNotNull(kvStateService);
 		this.broadcastVariableManager = Preconditions.checkNotNull(broadcastVariableManager);
 		this.taskSlotTable = Preconditions.checkNotNull(taskSlotTable);
 		this.jobManagerTable = Preconditions.checkNotNull(jobManagerTable);
@@ -124,6 +122,10 @@ public class TaskManagerServices {
 
 	public NetworkEnvironment getNetworkEnvironment() {
 		return networkEnvironment;
+	}
+
+	public KvStateService getKvStateService() {
+		return kvStateService;
 	}
 
 	public TaskManagerLocation getTaskManagerLocation() {
@@ -186,6 +188,12 @@ public class TaskManagerServices {
 		}
 
 		try {
+			kvStateService.shutdown();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		try {
 			taskSlotTable.stop();
 		} catch (Exception e) {
 			exception = ExceptionUtils.firstOrSuppressed(e, exception);
@@ -229,6 +237,9 @@ public class TaskManagerServices {
 
 		final NetworkEnvironment network = createNetworkEnvironment(taskManagerServicesConfiguration, maxJvmHeapMemory);
 		network.start();
+
+		final KvStateService kvStateService = KvStateService.fromConfiguration(taskManagerServicesConfiguration);
+		kvStateService.start();
 
 		final TaskManagerLocation taskManagerLocation = new TaskManagerLocation(
 			resourceID,
@@ -277,6 +288,7 @@ public class TaskManagerServices {
 			memoryManager,
 			ioManager,
 			network,
+			kvStateService,
 			broadcastVariableManager,
 			taskSlotTable,
 			jobManagerTable,
@@ -415,51 +427,12 @@ public class TaskManagerServices {
 		ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
 		TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 
-		KvStateRegistry kvStateRegistry = new KvStateRegistry();
-
-		QueryableStateConfiguration qsConfig = taskManagerServicesConfiguration.getQueryableStateConfig();
-
-		KvStateClientProxy kvClientProxy = null;
-		KvStateServer kvStateServer = null;
-
-		if (qsConfig != null) {
-			int numProxyServerNetworkThreads = qsConfig.numProxyServerThreads() == 0 ?
-				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numProxyServerThreads();
-
-			int numProxyServerQueryThreads = qsConfig.numProxyQueryThreads() == 0 ?
-				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numProxyQueryThreads();
-
-			kvClientProxy = QueryableStateUtils.createKvStateClientProxy(
-				taskManagerServicesConfiguration.getTaskManagerAddress(),
-				qsConfig.getProxyPortRange(),
-				numProxyServerNetworkThreads,
-				numProxyServerQueryThreads,
-				new DisabledKvStateRequestStats());
-
-			int numStateServerNetworkThreads = qsConfig.numStateServerThreads() == 0 ?
-				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numStateServerThreads();
-
-			int numStateServerQueryThreads = qsConfig.numStateQueryThreads() == 0 ?
-				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numStateQueryThreads();
-
-			kvStateServer = QueryableStateUtils.createKvStateServer(
-				taskManagerServicesConfiguration.getTaskManagerAddress(),
-				qsConfig.getStateServerPortRange(),
-				numStateServerNetworkThreads,
-				numStateServerQueryThreads,
-				kvStateRegistry,
-				new DisabledKvStateRequestStats());
-		}
-
 		// we start the network first, to make sure it can allocate its buffers first
 		return new NetworkEnvironment(
 			networkBufferPool,
 			connectionManager,
 			resultPartitionManager,
 			taskEventDispatcher,
-			kvStateRegistry,
-			kvStateServer,
-			kvClientProxy,
 			networkEnvironmentConfiguration.partitionRequestInitialBackoff(),
 			networkEnvironmentConfiguration.partitionRequestMaxBackoff(),
 			networkEnvironmentConfiguration.networkBuffersPerChannel(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -85,16 +85,16 @@ public class TaskManagerServices {
 	private final TaskExecutorLocalStateStoresManager taskManagerStateStore;
 
 	TaskManagerServices(
-			TaskManagerLocation taskManagerLocation,
-			MemoryManager memoryManager,
-			IOManager ioManager,
-			NetworkEnvironment networkEnvironment,
-			KvStateService kvStateService,
-			BroadcastVariableManager broadcastVariableManager,
-			TaskSlotTable taskSlotTable,
-			JobManagerTable jobManagerTable,
-			JobLeaderService jobLeaderService,
-			TaskExecutorLocalStateStoresManager taskManagerStateStore) {
+		TaskManagerLocation taskManagerLocation,
+		MemoryManager memoryManager,
+		IOManager ioManager,
+		NetworkEnvironment networkEnvironment,
+		KvStateService kvStateService,
+		BroadcastVariableManager broadcastVariableManager,
+		TaskSlotTable taskSlotTable,
+		JobManagerTable jobManagerTable,
+		JobLeaderService jobLeaderService,
+		TaskExecutorLocalStateStoresManager taskManagerStateStore) {
 
 		this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
 		this.memoryManager = Preconditions.checkNotNull(memoryManager);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -68,7 +68,7 @@ import org.apache.flink.runtime.metrics.{MetricRegistryConfiguration, MetricRegi
 import org.apache.flink.runtime.process.ProcessReaper
 import org.apache.flink.runtime.security.{SecurityConfiguration, SecurityUtils}
 import org.apache.flink.runtime.state.{TaskExecutorLocalStateStoresManager, TaskStateManagerImpl}
-import org.apache.flink.runtime.taskexecutor.{TaskExecutor, TaskManagerConfiguration, TaskManagerServices, TaskManagerServicesConfiguration}
+import org.apache.flink.runtime.taskexecutor.{KvStateService, TaskExecutor, TaskManagerConfiguration, TaskManagerServices, TaskManagerServicesConfiguration}
 import org.apache.flink.runtime.util._
 import org.apache.flink.runtime.{FlinkActor, LeaderSessionMessageFilter, LogMessages}
 import org.apache.flink.util.NetUtils
@@ -127,6 +127,7 @@ class TaskManager(
     protected val memoryManager: MemoryManager,
     protected val ioManager: IOManager,
     protected val network: NetworkEnvironment,
+    protected val kvStateService: KvStateService,
     protected val taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
     protected val numberOfSlots: Int,
     protected val highAvailabilityServices: HighAvailabilityServices,
@@ -941,10 +942,10 @@ class TaskManager(
         taskManagerConnection))
 
 
-    val kvStateServer = network.getKvStateServer()
+    val kvStateServer = kvStateService.getKvStateServer()
 
     if (kvStateServer != null) {
-      val kvStateRegistry = network.getKvStateRegistry()
+      val kvStateRegistry = kvStateService.getKvStateRegistry()
 
       kvStateRegistry.registerListener(
         HighAvailabilityServices.DEFAULT_JOB_ID,
@@ -953,7 +954,7 @@ class TaskManager(
           kvStateServer.getServerAddress))
     }
 
-    val proxy = network.getKvStateProxy
+    val proxy = kvStateService.getKvStateClientProxy
 
     if (proxy != null) {
       proxy.updateKvStateLocationOracle(
@@ -1071,11 +1072,11 @@ class TaskManager(
     // disassociate the slot environment
     connectionUtils = None
 
-    if (network.getKvStateRegistry != null) {
-      network.getKvStateRegistry.unregisterListener(HighAvailabilityServices.DEFAULT_JOB_ID)
+    if (kvStateService.getKvStateRegistry != null) {
+      kvStateService.getKvStateRegistry.unregisterListener(HighAvailabilityServices.DEFAULT_JOB_ID)
     }
 
-    val proxy = network.getKvStateProxy
+    val proxy = kvStateService.getKvStateClientProxy
 
     if (proxy != null) {
       // clear the key-value location oracle
@@ -1235,6 +1236,7 @@ class TaskManager(
         memoryManager,
         ioManager,
         network,
+        kvStateService,
         bcVarManager,
         taskStateManager,
         taskManagerConnection,
@@ -2031,6 +2033,7 @@ object TaskManager {
       taskManagerServices.getMemoryManager(),
       taskManagerServices.getIOManager(),
       taskManagerServices.getNetworkEnvironment(),
+      taskManagerServices.getKvStateService,
       taskManagerServices.getTaskManagerStateStore(),
       highAvailabilityServices,
       taskManagerMetricGroup)
@@ -2049,6 +2052,7 @@ object TaskManager {
     memoryManager: MemoryManager,
     ioManager: IOManager,
     networkEnvironment: NetworkEnvironment,
+    kvStateService: KvStateService,
     taskStateManager: TaskExecutorLocalStateStoresManager,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup: TaskManagerMetricGroup
@@ -2061,6 +2065,7 @@ object TaskManager {
       memoryManager,
       ioManager,
       networkEnvironment,
+      kvStateService,
       taskStateManager,
       taskManagerConfig.getNumberSlots(),
       highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -71,7 +71,6 @@ import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
@@ -267,11 +266,15 @@ public class TaskExecutorTest extends TestLogger {
 			true);
 		networkEnvironment.start();
 
+		final KvStateService kvStateService = KvStateService.build();
+		kvStateService.start();
+
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskManagerLocation(taskManagerLocation)
 			.setMemoryManager(memoryManager)
 			.setIoManager(ioManager)
 			.setNetworkEnvironment(networkEnvironment)
+			.setKvStateService(kvStateService)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobLeaderService(jobLeaderService)
 			.setTaskStateManager(localStateStoresManager)
@@ -748,13 +751,13 @@ public class TaskExecutorTest extends TestLogger {
 		TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 		final NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
 
-		when(networkEnvironment.createKvStateTaskRegistry(eq(jobId), eq(jobVertexId))).thenReturn(mock(TaskKvStateRegistry.class));
 		when(networkEnvironment.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setNetworkEnvironment(networkEnvironment)
+			.setKvStateService(KvStateService.build())
 			.setTaskSlotTable(taskSlotTable)
 			.setJobManagerTable(jobManagerTable)
 			.setTaskStateManager(localStateStoresManager)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -71,6 +71,7 @@ import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
@@ -266,7 +267,7 @@ public class TaskExecutorTest extends TestLogger {
 			true);
 		networkEnvironment.start();
 
-		final KvStateService kvStateService = KvStateService.build();
+		final KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);
 		kvStateService.start();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
@@ -755,9 +756,11 @@ public class TaskExecutorTest extends TestLogger {
 
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
+		final KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);
+
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setNetworkEnvironment(networkEnvironment)
-			.setKvStateService(KvStateService.build())
+			.setKvStateService(kvStateService)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobManagerTable(jobManagerTable)
 			.setTaskStateManager(localStateStoresManager)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -305,6 +305,7 @@ public class TaskExecutorTest extends TestLogger {
 		assertThat(memoryManager.isShutdown(), is(true));
 		assertThat(networkEnvironment.isShutdown(), is(true));
 		assertThat(ioManager.isProperlyShutDown(), is(true));
+		assertThat(kvStateService.isShutdown(), is(true));
 	}
 
 	@Test
@@ -756,11 +757,8 @@ public class TaskExecutorTest extends TestLogger {
 
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
-		final KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);
-
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setNetworkEnvironment(networkEnvironment)
-			.setKvStateService(kvStateService)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobManagerTable(jobManagerTable)
 			.setTaskStateManager(localStateStoresManager)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -41,6 +41,7 @@ public class TaskManagerServicesBuilder {
 	private MemoryManager memoryManager;
 	private IOManager ioManager;
 	private NetworkEnvironment networkEnvironment;
+	private KvStateService kvStateService;
 	private BroadcastVariableManager broadcastVariableManager;
 	private TaskSlotTable taskSlotTable;
 	private JobManagerTable jobManagerTable;
@@ -57,6 +58,7 @@ public class TaskManagerServicesBuilder {
 			false);
 		ioManager = mock(IOManager.class);
 		networkEnvironment = mock(NetworkEnvironment.class);
+		kvStateService = KvStateService.build();
 		broadcastVariableManager = new BroadcastVariableManager();
 		taskSlotTable = mock(TaskSlotTable.class);
 		jobManagerTable = new JobManagerTable();
@@ -81,6 +83,11 @@ public class TaskManagerServicesBuilder {
 
 	public TaskManagerServicesBuilder setNetworkEnvironment(NetworkEnvironment networkEnvironment) {
 		this.networkEnvironment = networkEnvironment;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setKvStateService(KvStateService kvStateService) {
+		this.kvStateService = kvStateService;
 		return this;
 	}
 
@@ -115,6 +122,7 @@ public class TaskManagerServicesBuilder {
 			memoryManager,
 			ioManager,
 			networkEnvironment,
+			kvStateService,
 			broadcastVariableManager,
 			taskSlotTable,
 			jobManagerTable,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -58,7 +59,7 @@ public class TaskManagerServicesBuilder {
 			false);
 		ioManager = mock(IOManager.class);
 		networkEnvironment = mock(NetworkEnvironment.class);
-		kvStateService = KvStateService.build();
+		kvStateService = new KvStateService(new KvStateRegistry(), null, null);
 		broadcastVariableManager = new BroadcastVariableManager();
 		taskSlotTable = mock(TaskSlotTable.class);
 		jobManagerTable = new JobManagerTable();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -53,7 +53,6 @@ import org.apache.flink.runtime.jobgraph.tasks.StoppableTask;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
@@ -224,8 +223,6 @@ public class TaskAsyncCallTest extends TestLogger {
 		TaskEventDispatcher taskEventDispatcher = mock(TaskEventDispatcher.class);
 		NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
 		when(networkEnvironment.getResultPartitionManager()).thenReturn(partitionManager);
-		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
-				.thenReturn(mock(TaskKvStateRegistry.class));
 		when(networkEnvironment.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		TaskMetricGroup taskMetricGroup = mock(TaskMetricGroup.class);
@@ -260,6 +257,7 @@ public class TaskAsyncCallTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,
+			KvStateService.build(),
 			mock(BroadcastVariableManager.class),
 			new TestTaskStateManager(),
 			mock(TaskManagerActions.class),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -53,7 +53,9 @@ import org.apache.flink.runtime.jobgraph.tasks.StoppableTask;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.SerializedValue;
@@ -257,7 +259,7 @@ public class TaskAsyncCallTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,
-			KvStateService.build(),
+			new KvStateService(new KvStateRegistry(), null, null),
 			mock(BroadcastVariableManager.class),
 			new TestTaskStateManager(),
 			mock(TaskManagerActions.class),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
@@ -608,7 +609,7 @@ public class TaskTest extends TestLogger {
 			final Task task =  new TaskBuilder()
 				.setInvokable(InvokableBlockingInInvoke.class)
 				.setNetworkEnvironment(network)
-				.setKvStateService(KvStateService.build())
+				.setKvStateService(new KvStateService(new KvStateRegistry(), null, null))
 				.setConsumableNotifier(consumableNotifier)
 				.setPartitionProducerStateChecker(partitionChecker)
 				.setExecutor(Executors.directExecutor())
@@ -950,7 +951,7 @@ public class TaskTest extends TestLogger {
 			when(networkEnvironment.getResultPartitionManager()).thenReturn(partitionManager);
 			when(networkEnvironment.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
-			kvStateService = KvStateService.build();
+			kvStateService = new KvStateService(new KvStateRegistry(), null, null);
 
 			executor = TestingUtils.defaultExecutor();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -60,8 +60,8 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
@@ -575,8 +575,6 @@ public class TaskTest extends TestLogger {
 		final ResultPartitionConsumableNotifier consumableNotifier = new NoOpResultPartitionConsumableNotifier();
 		final NetworkEnvironment network = mock(NetworkEnvironment.class);
 		when(network.getResultPartitionManager()).thenReturn(mock(ResultPartitionManager.class));
-		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
-			.thenReturn(mock(TaskKvStateRegistry.class));
 		when(network.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		// Test all branches of trigger partition state check
@@ -610,6 +608,7 @@ public class TaskTest extends TestLogger {
 			final Task task =  new TaskBuilder()
 				.setInvokable(InvokableBlockingInInvoke.class)
 				.setNetworkEnvironment(network)
+				.setKvStateService(KvStateService.build())
 				.setConsumableNotifier(consumableNotifier)
 				.setPartitionProducerStateChecker(partitionChecker)
 				.setExecutor(Executors.directExecutor())
@@ -929,6 +928,7 @@ public class TaskTest extends TestLogger {
 		private ResultPartitionConsumableNotifier consumableNotifier;
 		private PartitionProducerStateChecker partitionProducerStateChecker;
 		private NetworkEnvironment networkEnvironment;
+		private KvStateService kvStateService;
 		private Executor executor;
 		private Configuration taskManagerConfig;
 		private ExecutionConfig executionConfig;
@@ -948,9 +948,9 @@ public class TaskTest extends TestLogger {
 			final TaskEventDispatcher taskEventDispatcher = mock(TaskEventDispatcher.class);
 			networkEnvironment = mock(NetworkEnvironment.class);
 			when(networkEnvironment.getResultPartitionManager()).thenReturn(partitionManager);
-			when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
-				.thenReturn(mock(TaskKvStateRegistry.class));
 			when(networkEnvironment.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
+
+			kvStateService = KvStateService.build();
 
 			executor = TestingUtils.defaultExecutor();
 
@@ -987,6 +987,11 @@ public class TaskTest extends TestLogger {
 
 		TaskBuilder setNetworkEnvironment(NetworkEnvironment networkEnvironment) {
 			this.networkEnvironment = networkEnvironment;
+			return this;
+		}
+
+		TaskBuilder setKvStateService(KvStateService kvStateService) {
+			this.kvStateService = kvStateService;
 			return this;
 		}
 
@@ -1053,6 +1058,7 @@ public class TaskTest extends TestLogger {
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				networkEnvironment,
+				kvStateService,
 				mock(BroadcastVariableManager.class),
 				new TestTaskStateManager(),
 				taskManagerActions,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -609,7 +609,6 @@ public class TaskTest extends TestLogger {
 			final Task task =  new TaskBuilder()
 				.setInvokable(InvokableBlockingInInvoke.class)
 				.setNetworkEnvironment(network)
-				.setKvStateService(new KvStateService(new KvStateRegistry(), null, null))
 				.setConsumableNotifier(consumableNotifier)
 				.setPartitionProducerStateChecker(partitionChecker)
 				.setExecutor(Executors.directExecutor())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -54,12 +54,12 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
@@ -167,7 +167,6 @@ public class JvmExitOnFatalErrorTest {
 				final IOManager ioManager = new IOManagerAsync();
 
 				final NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
-				when(networkEnvironment.createKvStateTaskRegistry(jid, jobVertexId)).thenReturn(mock(TaskKvStateRegistry.class));
 				TaskEventDispatcher taskEventDispatcher = mock(TaskEventDispatcher.class);
 				when(networkEnvironment.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
@@ -208,6 +207,7 @@ public class JvmExitOnFatalErrorTest {
 						memoryManager,
 						ioManager,
 						networkEnvironment,
+						KvStateService.build(),
 						new BroadcastVariableManager(),
 						slotStateManager,
 						new NoOpTaskManagerActions(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
@@ -207,7 +208,7 @@ public class JvmExitOnFatalErrorTest {
 						memoryManager,
 						ioManager,
 						networkEnvironment,
-						KvStateService.build(),
+						new KvStateService(new KvStateRegistry(), null, null),
 						new BroadcastVariableManager(),
 						slotStateManager,
 						new NoOpTaskManagerActions(),

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.memory.MemoryManager
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager
-import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration
+import org.apache.flink.runtime.taskexecutor.{KvStateService, TaskManagerConfiguration}
 import org.apache.flink.runtime.taskmanager.{TaskManager, TaskManagerLocation}
 
 import scala.language.postfixOps
@@ -39,6 +39,7 @@ class TestingTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    kvStateService: KvStateService,
     taskManagerStateStore: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
@@ -50,6 +51,7 @@ class TestingTaskManager(
     memoryManager,
     ioManager,
     network,
+    kvStateService,
     taskManagerStateStore,
     numberOfSlots,
     highAvailabilityServices,
@@ -62,6 +64,7 @@ class TestingTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    kvStateService: KvStateService,
     taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
@@ -73,6 +76,7 @@ class TestingTaskManager(
       memoryManager,
       ioManager,
       network,
+      kvStateService,
       taskManagerLocalStateStoresManager,
       numberOfSlots,
       highAvailabilityServices,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -49,7 +49,6 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.taskmanager.NoOpTaskActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -218,9 +217,6 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 			nettyConnectionManager,
 			new ResultPartitionManager(),
 			new TaskEventDispatcher(),
-			new KvStateRegistry(),
-			null,
-			null,
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL.defaultValue(),
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX.defaultValue(),
 			TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -52,7 +52,6 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -65,6 +64,7 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -92,7 +92,6 @@ import java.util.concurrent.Executor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -183,8 +182,6 @@ public class InterruptSensitiveRestoreTest {
 
 		TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 		NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
-		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
-				.thenReturn(mock(TaskKvStateRegistry.class));
 		when(networkEnvironment.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		Collection<KeyedStateHandle> keyedStateFromBackend = Collections.emptyList();
@@ -275,6 +272,7 @@ public class InterruptSensitiveRestoreTest {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,
+			KvStateService.build(),
 			mock(BroadcastVariableManager.class),
 			taskStateManager,
 			mock(TaskManagerActions.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -272,7 +273,7 @@ public class InterruptSensitiveRestoreTest {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,
-			KvStateService.build(),
+			new KvStateService(new KvStateRegistry(), null, null),
 			mock(BroadcastVariableManager.class),
 			taskStateManager,
 			mock(TaskManagerActions.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
@@ -168,7 +169,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			new MemoryManager(32L * 1024L, 1),
 			new IOManagerAsync(),
 			networkEnv,
-			KvStateService.build(),
+			new KvStateService(new KvStateRegistry(), null, null),
 			mock(BroadcastVariableManager.class),
 			new TestTaskStateManager(),
 			mock(TaskManagerActions.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -66,6 +66,7 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -149,7 +150,6 @@ public class StreamTaskTerminationTest extends TestLogger {
 
 		TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 		final NetworkEnvironment networkEnv = mock(NetworkEnvironment.class);
-		when(networkEnv.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class))).thenReturn(mock(TaskKvStateRegistry.class));
 		when(networkEnv.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		BlobCacheService blobService =
@@ -168,6 +168,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			new MemoryManager(32L * 1024L, 1),
 			new IOManagerAsync(),
 			networkEnv,
+			KvStateService.build(),
 			mock(BroadcastVariableManager.class),
 			new TestTaskStateManager(),
 			mock(TaskManagerActions.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -64,7 +64,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
@@ -85,6 +84,7 @@ import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
@@ -901,8 +901,6 @@ public class StreamTaskTest extends TestLogger {
 
 		NetworkEnvironment network = mock(NetworkEnvironment.class);
 		when(network.getResultPartitionManager()).thenReturn(partitionManager);
-		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
-				.thenReturn(mock(TaskKvStateRegistry.class));
 		when(network.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		JobInformation jobInformation = new JobInformation(
@@ -934,6 +932,7 @@ public class StreamTaskTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			network,
+			KvStateService.build(),
 			mock(BroadcastVariableManager.class),
 			taskStateManager,
 			taskManagerActions,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
@@ -932,7 +933,7 @@ public class StreamTaskTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			network,
-			KvStateService.build(),
+			new KvStateService(new KvStateRegistry(), null, null),
 			mock(BroadcastVariableManager.class),
 			taskStateManager,
 			taskManagerActions,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -54,7 +54,6 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractSnapshotStrategy;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -71,6 +70,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.BackendForTestStream;
+import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -99,7 +99,6 @@ import java.util.concurrent.RunnableFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -224,10 +223,8 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 				TestStreamTask.class.getName(),
 				taskConfig);
 
-		TaskKvStateRegistry mockKvRegistry = mock(TaskKvStateRegistry.class);
 		TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 		NetworkEnvironment network = mock(NetworkEnvironment.class);
-		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class))).thenReturn(mockKvRegistry);
 		when(network.getTaskEventDispatcher()).thenReturn(taskEventDispatcher);
 
 		BlobCacheService blobService =
@@ -246,6 +243,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				network,
+				KvStateService.build(),
 				mock(BroadcastVariableManager.class),
 				new TestTaskStateManager(),
 				mock(TaskManagerActions.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.AbstractSnapshotStrategy;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -243,7 +244,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				network,
-				KvStateService.build(),
+				new KvStateService(new KvStateRegistry(), null, null),
 				mock(BroadcastVariableManager.class),
 				new TestTaskStateManager(),
 				mock(TaskManagerActions.class),


### PR DESCRIPTION
## What is the purpose of the change

*The `NetworkEnvironment` would be refactored into `NetworkShuffleService` created by `ShuffleManager` future. So the `NetworkEnvironment` should only cover shuffle related components to make the preparation.*

*Currently `KvStateRegistry`, `KvStateServer`, `KvStateClientProxy` are not related to shuffle process and mainly used to be got in `TaskExecutor`. So it is reasonable to remove them from `NetworkEnvironment`.*

*And then we could introduce a new `KvStateService` for wrapping these three components and pass it into `TaskManagerService`. This new service can also be passed into `TaskExecutor`, `Task` for use and avoid spreading in messy.*

## Brief change log

  - *Remove `KvStateRegistry`, `KvStateServer`, `KvStateClientProxy` from `NetworkEnvironment`*
  - *Introduce `KvStateService` as a component of task manager services*
  - *Pass `KvStateService` into `TaskExecutor` and `Task`*

## Verifying this change

This change is already covered by existing tests, such as *NetworkEnvironmentTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)