### PR TITLE
[FLINK-11718][rpc] Add onStart method to RpcEndpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -309,11 +309,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	// Lifecycle management
 	//----------------------------------------------------------------------------------------------
 
-	@Override
-	public void start() {
-		throw new UnsupportedOperationException("Should never call start() without leader ID");
-	}
-
 	/**
 	 * Start the rpc service and begin to run the job.
 	 *
@@ -322,7 +317,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	 */
 	public CompletableFuture<Acknowledge> start(final JobMasterId newJobMasterId) throws Exception {
 		// make sure we receive RPC and async calls
-		super.start();
+		start();
 
 		return callAsyncWithoutFencing(() -> startJobExecution(newJobMasterId), RpcUtils.INF_TIMEOUT);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -120,14 +120,24 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
 	 * Starts the rpc endpoint. This tells the underlying rpc server that the rpc endpoint is ready
 	 * to process remote procedure calls.
 	 *
-	 * <p>IMPORTANT: Whenever you override this method, call the parent implementation to enable
-	 * rpc processing. It is advised to make the parent call last.
-	 *
 	 * @throws Exception indicating that something went wrong while starting the RPC endpoint
 	 */
-	public void start() throws Exception {
+	public void start() {
 		rpcServer.start();
 	}
+
+	/**
+	 * User overridable callback.
+	 *
+	 * <p>This method is called when the RpcEndpoint is being started. The method is guaranteed
+	 * to be executed in the main thread context and can be used to start the rpc endpoint in the
+	 * context of the rpc endpoint's main thread.
+	 *
+	 * <p>IMPORTANT: This method should never be called directly by the user.
+	 * @throws Exception indicating that the rpc endpoint could not be started. If an exception occurs,
+	 * then the rpc endpoint will automatically terminate.
+	 */
+	public void onStart() throws Exception {}
 
 	/**
 	 * Stops the rpc endpoint. This tells the underlying rpc server that the rpc endpoint is

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -122,7 +122,7 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
 	 *
 	 * @throws Exception indicating that something went wrong while starting the RPC endpoint
 	 */
-	public void start() {
+	public final void start() {
 		rpcServer.start();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -271,25 +271,43 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void start() throws Exception {
-		super.start();
-
-		// start by connecting to the ResourceManager
+	public void onStart() throws Exception {
 		try {
-			resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
+			startTaskExecutorServices();
 		} catch (Exception e) {
-			onFatalError(e);
+			final TaskManagerException exception = new TaskManagerException(String.format("Could not start the TaskExecutor %s", getAddress()), e);
+			onFatalError(exception);
+			throw exception;
 		}
 
-		// tell the task slot table who's responsible for the task slot actions
-		taskSlotTable.start(new SlotActionsImpl());
-
-		// start the job leader service
-		jobLeaderService.start(getAddress(), getRpcService(), haServices, new JobLeaderListenerImpl());
-
-		fileCache = new FileCache(taskManagerConfiguration.getTmpDirectories(), blobCacheService.getPermanentBlobService());
-
 		startRegistrationTimeout();
+	}
+
+	private void startTaskExecutorServices() throws Exception {
+		try {
+			// start by connecting to the ResourceManager
+			resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
+
+			// tell the task slot table who's responsible for the task slot actions
+			taskSlotTable.start(new SlotActionsImpl());
+
+			// start the job leader service
+			jobLeaderService.start(getAddress(), getRpcService(), haServices, new JobLeaderListenerImpl());
+
+			fileCache = new FileCache(taskManagerConfiguration.getTmpDirectories(), blobCacheService.getPermanentBlobService());
+		} catch (Exception e) {
+			handleStartTaskExecutorServicesException(e);
+		}
+	}
+
+	private void handleStartTaskExecutorServicesException(Exception e) throws Exception {
+		try {
+			stopTaskExecutorServices();
+		} catch (Exception inner) {
+			e.addSuppressed(inner);
+		}
+
+		throw e;
 	}
 
 	/**
@@ -318,20 +336,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		resourceManagerHeartbeatManager.stop();
 
 		try {
-			resourceManagerLeaderRetriever.stop();
+			stopTaskExecutorServices();
 		} catch (Exception e) {
 			throwable = ExceptionUtils.firstOrSuppressed(e, throwable);
 		}
-
-		try {
-			taskExecutorServices.shutDown();
-			fileCache.shutdown();
-		} catch (Throwable t) {
-			throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
-		}
-
-		// it will call close() recursively from the parent to children
-		taskManagerMetricGroup.close();
 
 		if (throwable != null) {
 			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));
@@ -339,6 +347,41 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			log.info("Stopped TaskExecutor {}.", getAddress());
 			return CompletableFuture.completedFuture(null);
 		}
+	}
+
+	private void stopTaskExecutorServices() throws Exception {
+		Exception exception = null;
+
+		try {
+			jobLeaderService.stop();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		taskSlotTable.stop();
+
+		try {
+			resourceManagerLeaderRetriever.stop();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		try {
+			taskExecutorServices.shutDown();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		try {
+			fileCache.shutdown();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		// it will call close() recursively from the parent to children
+		taskManagerMetricGroup.close();
+
+		ExceptionUtils.tryRethrowException(exception);
 	}
 
 	// ======================================================================

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherHATest.java
@@ -135,6 +135,9 @@ public class DispatcherHATest extends TestLogger {
 		dispatcher.start();
 
 		try {
+			// wait until the election service has been started
+			dispatcherLeaderElectionService.getStartFuture().get();
+
 			final UUID leaderId = UUID.randomUUID();
 			dispatcherLeaderElectionService.isLeader(leaderId);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -545,6 +545,8 @@ public class DispatcherTest extends TestLogger {
 
 		dispatcher = createAndStartDispatcher(heartbeatServices, haServices, new ExpectedJobIdJobManagerRunnerFactory(TEST_JOB_ID, createdJobManagerRunnerLatch));
 
+		dispatcher.waitUntilStarted();
+
 		final SubmittedJobGraph submittedJobGraph = new SubmittedJobGraph(jobGraph);
 		submittedJobGraphStore.putJobGraph(submittedJobGraph);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -266,7 +266,7 @@ public class DispatcherTest extends TestLogger {
 
 		assertTrue(
 			"jobManagerRunner was not started",
-			dispatcherLeaderElectionService.isStarted());
+			dispatcherLeaderElectionService.getStartFuture().isDone());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -344,7 +344,7 @@ public class TaskExecutorTest extends TestLogger {
 			.setTaskStateManager(localStateStoresManager)
 			.build();
 
-		final TaskExecutor taskManager = new TaskExecutor(
+		final TestingTaskExecutor taskManager = new TestingTaskExecutor(
 			rpc,
 			taskManagerConfiguration,
 			haServices,
@@ -357,6 +357,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		try {
 			taskManager.start();
+			taskManager.waitUntilStarted();
 
 			rpc.registerGateway(jobMasterAddress, jobMasterGateway);
 
@@ -1047,7 +1048,7 @@ public class TaskExecutorTest extends TestLogger {
 			.setTaskStateManager(localStateStoresManager)
 			.build();
 
-		final TaskExecutor taskManager = new TaskExecutor(
+		final TestingTaskExecutor taskManager = new TestingTaskExecutor(
 			rpc,
 			taskManagerConfiguration,
 			haServices,
@@ -1060,6 +1061,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		try {
 			taskManager.start();
+			taskManager.waitUntilStarted();
 
 			final TaskExecutorGateway tmGateway = taskManager.getSelfGateway(TaskExecutorGateway.class);
 
@@ -1273,7 +1275,7 @@ public class TaskExecutorTest extends TestLogger {
 			.setTaskStateManager(localStateStoresManager)
 			.build();
 
-		final TaskExecutor taskExecutor = new TaskExecutor(
+		final TestingTaskExecutor taskExecutor = new TestingTaskExecutor(
 			rpc,
 			taskManagerConfiguration,
 			haServices,
@@ -1305,6 +1307,7 @@ public class TaskExecutorTest extends TestLogger {
 			haServices.setJobMasterLeaderRetriever(jobId, jobMasterLeaderRetriever);
 
 			taskExecutor.start();
+			taskExecutor.waitUntilStarted();
 
 			final TaskExecutorGateway taskExecutorGateway = taskExecutor.getSelfGateway(TaskExecutorGateway.class);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link TaskExecutor} extension for testing purposes.
+ */
+class TestingTaskExecutor extends TaskExecutor {
+	private final CompletableFuture<Void> startFuture = new CompletableFuture<>();
+
+	public TestingTaskExecutor(
+			RpcService rpcService,
+			TaskManagerConfiguration taskManagerConfiguration,
+			HighAvailabilityServices haServices,
+			TaskManagerServices taskExecutorServices,
+			HeartbeatServices heartbeatServices,
+			TaskManagerMetricGroup taskManagerMetricGroup,
+			@Nullable String metricQueryServicePath,
+			BlobCacheService blobCacheService,
+			FatalErrorHandler fatalErrorHandler) {
+		super(
+			rpcService,
+			taskManagerConfiguration,
+			haServices,
+			taskExecutorServices,
+			heartbeatServices,
+			taskManagerMetricGroup,
+			metricQueryServicePath,
+			blobCacheService,
+			fatalErrorHandler);
+	}
+
+	@Override
+	public void onStart() throws Exception {
+		try {
+			super.onStart();
+		} catch (Exception e) {
+			startFuture.completeExceptionally(e);
+			throw e;
+		}
+
+		startFuture.complete(null);
+	}
+
+	void waitUntilStarted() {
+		startFuture.join();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a dedicated onStart method to the RpcEndpoint which is called when the RpcEndpoint
is started via the start() method. Due to this change it is no longer necessary for the
user to override the start() method which is error prone because it always requires to
call super.start(). Now this contract is explicitly enforced. Moreover, it allows to
execute the setup logic in the RpcEndpoint's main thread.

## Brief change log

- Add onStart method to `RcpEndpoint`
- Port `start` logic to `onStart` method for `Dispatcher`, `ResourceManager`, `TaskExecutor` and `JobMaster`
- Make `RpcEndpoint#start` final to avoid subclasses to override this method

## Verifying this change

- Added `AkkaRpcActorTest#testOnStartIsCalledWhenRpcEndpointStarts` and `#testOnStartFails`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
