### PR TITLE
[DO NOT MERGE][FLINK-11710][tests] Refactor SimpleSlotProvider to TestingLogicalSlo…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SettableSlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SettableSlotContext.java
@@ -26,9 +26,9 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.Preconditions;
 
 /**
- * Simple implementation of the {@link SlotContext} interface for the legacy code.
+ * A settable implementation of the {@link SlotContext} interface.
  */
-public class SimpleSlotContext implements SlotContext {
+public class SettableSlotContext implements SlotContext {
 
 	private final AllocationID allocationId;
 
@@ -40,7 +40,7 @@ public class SimpleSlotContext implements SlotContext {
 
 	private final ResourceProfile resourceProfile;
 
-	public SimpleSlotContext(
+	public SettableSlotContext(
 			AllocationID allocationId,
 			TaskManagerLocation taskManagerLocation,
 			int physicalSlotNumber,
@@ -48,7 +48,7 @@ public class SimpleSlotContext implements SlotContext {
 		this(allocationId, taskManagerLocation, physicalSlotNumber, taskManagerGateway, ResourceProfile.UNKNOWN);
 	}
 
-	public SimpleSlotContext(
+	public SettableSlotContext(
 			AllocationID allocationId,
 			TaskManagerLocation taskManagerLocation,
 			int physicalSlotNumber,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlot.java
@@ -97,7 +97,7 @@ public class SimpleSlot extends Slot implements LogicalSlot {
 		super(
 			parent != null ?
 				parent.getSlotContext() :
-				new SimpleSlotContext(
+				new SettableSlotContext(
 					NO_ALLOCATION_ID,
 					location,
 					slotNumber,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Slot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Slot.java
@@ -113,7 +113,7 @@ public abstract class Slot {
 		checkArgument(slotNumber >= 0);
 
 		// create a simple slot context
-		this.slotContext = new SimpleSlotContext(
+		this.slotContext = new SettableSlotContext(
 			NO_ALLOCATION_ID,
 			location,
 			slotNumber,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.instance.SettableSlotContext;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
@@ -51,10 +51,10 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
 
 	protected final TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
 
-	protected final SimpleSlotContext ssc1 = new SimpleSlotContext(aid1, tml1, 1, taskManagerGateway, resourceProfile);
-	protected final SimpleSlotContext ssc2 = new SimpleSlotContext(aid2, tml2, 2, taskManagerGateway, biggerResourceProfile);
-	protected final SimpleSlotContext ssc3 = new SimpleSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile);
-	protected final SimpleSlotContext ssc4 = new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile);
+	protected final SettableSlotContext ssc1 = new SettableSlotContext(aid1, tml1, 1, taskManagerGateway, resourceProfile);
+	protected final SettableSlotContext ssc2 = new SettableSlotContext(aid2, tml2, 2, taskManagerGateway, biggerResourceProfile);
+	protected final SettableSlotContext ssc3 = new SettableSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile);
+	protected final SettableSlotContext ssc4 = new SettableSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile);
 
 	protected final Set<SlotContext> candidates = Collections.unmodifiableSet(createCandidates());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory
 import org.apache.flink.runtime.executiongraph.failover.RestartIndividualStrategy;
 import org.apache.flink.runtime.executiongraph.failover.RestartPipelinedRegionStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -105,7 +105,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -174,7 +174,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -242,7 +242,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -353,7 +353,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		when(taskManagerGateway.submitTask(any(TaskDeploymentDescriptor.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 		when(taskManagerGateway.cancelTask(any(ExecutionAttemptID.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism, taskManagerGateway);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism, taskManagerGateway);
 
 		final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = new CheckpointCoordinatorConfiguration(
 			10L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.NotCancelAckingTaskGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -568,7 +568,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final JobID jid = new JobID();
 		final JobVertex vertex = createNoOpVertex(parallelism);
 		final NotCancelAckingTaskGateway taskManagerGateway = new NotCancelAckingTaskGateway();
-		final SlotProvider slots = new SimpleSlotProvider(jid, parallelism, taskManagerGateway);
+		final SlotProvider slots = new TestingLogicalSlotProvider(jid, parallelism, taskManagerGateway);
 		final TestRestartStrategy restartStrategy = TestRestartStrategy.manuallyTriggered();
 
 		final ExecutionGraph eg = createSimpleTestGraph(jid, slots, restartStrategy, vertex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.instance.SettableSlotContext;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -600,7 +600,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		TaskManagerLocation location = new TaskManagerLocation(
 				ResourceID.generate(), InetAddress.getLoopbackAddress(), 12345);
 
-		SimpleSlotContext slot = new SimpleSlotContext(
+		SettableSlotContext slot = new SettableSlotContext(
 			new AllocationID(),
 			location,
 			0,
@@ -614,7 +614,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		TaskManagerLocation location = new TaskManagerLocation(
 			ResourceID.generate(), InetAddress.getLoopbackAddress(), 12345);
 
-		SimpleSlotContext slotContext = new SimpleSlotContext(
+		SettableSlotContext slotContext = new SettableSlotContext(
 			new AllocationID(),
 			location,
 			0,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
@@ -289,7 +289,7 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 		vertex.setInvokableClass(NoOpInvokable.class);
 		vertex.setParallelism(parallelism);
 
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, parallelism, gateway);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, parallelism, gateway);
 
 		ExecutionGraph simpleTestGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
 			jobId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -40,7 +40,7 @@ import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.instance.SettableSlotContext;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -355,7 +355,7 @@ public class ExecutionGraphTestUtils {
 		final TaskManagerLocation location = new TaskManagerLocation(
 				ResourceID.generate(), InetAddress.getLoopbackAddress(), 6572);
 
-		final SimpleSlotContext allocatedSlot = new SimpleSlotContext(
+		final SettableSlotContext allocatedSlot = new SettableSlotContext(
 			new AllocationID(),
 			location,
 			0,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.instance.BaseTestingActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
@@ -411,7 +411,7 @@ public class ExecutionGraphTestUtils {
 			numSlotsNeeded += vertex.getParallelism();
 		}
 
-		SlotProvider slotProvider = new SimpleSlotProvider(jid, numSlotsNeeded, taskManagerGateway);
+		SlotProvider slotProvider = new TestingLogicalSlotProvider(jid, numSlotsNeeded, taskManagerGateway);
 
 		return createSimpleTestGraph(jid, slotProvider, restartStrategy, vertices);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -192,7 +192,7 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, 20);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 20);
 
 		for (JobVertex vertex : orderedVertices) {
 			vertex.setInputDependencyConstraint(inputDependencyConstraint);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.instance.SettableSlotContext;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -233,7 +233,7 @@ public class ExecutionVertexLocalityTest extends TestLogger {
 		//  - mocking the scheduler created fragile tests that break whenever the scheduler is adjusted
 		//  - exposing test methods in the ExecutionVertex leads to undesirable setters 
 
-		SlotContext slot = new SimpleSlotContext(
+		SlotContext slot = new SettableSlotContext(
 			new AllocationID(),
 			location,
 			0,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.executiongraph.failover.RestartPipelinedRegionSt
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobStatus;
@@ -98,7 +98,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, 20);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 20);
 				
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -215,7 +215,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobId, 16);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 16);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -290,7 +290,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobId, 14);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 14);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -388,7 +388,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobId, 14);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 14);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory;
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -157,7 +157,7 @@ public class GlobalModVersionTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = new Random().nextInt(10) + 1;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		// build a simple execution graph with on job vertex, parallelism 2
 		final ExecutionGraph graph = new ExecutionGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -49,6 +49,9 @@ public class TestingLogicalSlot implements LogicalSlot {
 
 	@Nullable
 	private final CompletableFuture<?> customReleaseFuture;
+
+	@Nullable
+	private final SlotOwner slotOwner;
 	
 	private final AllocationID allocationId;
 
@@ -79,6 +82,27 @@ public class TestingLogicalSlot implements LogicalSlot {
 			SlotRequestId slotRequestId,
 			SlotSharingGroupId slotSharingGroupId,
 			@Nullable CompletableFuture<?> customReleaseFuture) {
+		this(
+			taskManagerLocation,
+			taskManagerGateway,
+			slotNumber,
+			allocationId,
+			slotRequestId,
+			slotSharingGroupId,
+			customReleaseFuture,
+			null);
+	}
+
+	public TestingLogicalSlot(
+		TaskManagerLocation taskManagerLocation,
+		TaskManagerGateway taskManagerGateway,
+		int slotNumber,
+		AllocationID allocationId,
+		SlotRequestId slotRequestId,
+		SlotSharingGroupId slotSharingGroupId,
+		@Nullable CompletableFuture<?> customReleaseFuture,
+		@Nullable SlotOwner slotOwner) {
+
 		this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
 		this.taskManagerGateway = Preconditions.checkNotNull(taskManagerGateway);
 		this.payloadReference = new AtomicReference<>();
@@ -88,6 +112,7 @@ public class TestingLogicalSlot implements LogicalSlot {
 		this.slotSharingGroupId = Preconditions.checkNotNull(slotSharingGroupId);
 		this.releaseFuture = new CompletableFuture<>();
 		this.customReleaseFuture = customReleaseFuture;
+		this.slotOwner = slotOwner;
 	}
 
 	@Override
@@ -127,6 +152,10 @@ public class TestingLogicalSlot implements LogicalSlot {
 
 	@Override
 	public CompletableFuture<?> releaseSlot(@Nullable Throwable cause) {
+		if (slotOwner != null) {
+			slotOwner.returnLogicalSlot(this);
+		}
+
 		if (customReleaseFuture != null) {
 			return customReleaseFuture;
 		} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
@@ -22,15 +22,14 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.instance.SettableSlotContext;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmanager.slots.DummySlotOwner;
-import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
@@ -73,9 +72,16 @@ public class SingleLogicalSlotTest extends TestLogger {
 	}
 
 	private SingleLogicalSlot createSingleLogicalSlot(SlotOwner slotOwner) {
+		SlotContext slotContext = new SettableSlotContext(
+			new AllocationID(),
+			new LocalTaskManagerLocation(),
+			0,
+			new SimpleAckingTaskManagerGateway(),
+			ResourceProfile.UNKNOWN);
+
 		return new SingleLogicalSlot(
 			new SlotRequestId(),
-			new DummySlotContext(),
+			slotContext,
 			null,
 			Locality.LOCAL,
 			slotOwner);
@@ -282,46 +288,6 @@ public class SingleLogicalSlotTest extends TestLogger {
 		@Override
 		public void returnLogicalSlot(LogicalSlot logicalSlot) {
 			returnAllocatedSlotFuture.complete(logicalSlot);
-		}
-	}
-
-	private static final class DummySlotContext implements SlotContext {
-
-		private final AllocationID allocationId;
-
-		private final TaskManagerLocation taskManagerLocation;
-
-		private final TaskManagerGateway taskManagerGateway;
-
-		DummySlotContext() {
-			allocationId = new AllocationID();
-			taskManagerLocation = new LocalTaskManagerLocation();
-			taskManagerGateway = new SimpleAckingTaskManagerGateway();
-		}
-
-		@Override
-		public AllocationID getAllocationId() {
-			return allocationId;
-		}
-
-		@Override
-		public TaskManagerLocation getTaskManagerLocation() {
-			return taskManagerLocation;
-		}
-
-		@Override
-		public int getPhysicalSlotNumber() {
-			return 0;
-		}
-
-		@Override
-		public ResourceProfile getResourceProfile() {
-			return ResourceProfile.UNKNOWN;
-		}
-
-		@Override
-		public TaskManagerGateway getTaskManagerGateway() {
-			return taskManagerGateway;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.instance.SettableSlotContext;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmanager.slots.DummySlotOwner;
@@ -269,7 +269,7 @@ public class SlotSharingManagerTest extends TestLogger {
 			allocatedSlotActions,
 			SLOT_OWNER);
 
-		final SlotContext slotContext = new SimpleSlotContext(
+		final SlotContext slotContext = new SettableSlotContext(
 			new AllocationID(),
 			new LocalTaskManagerLocation(),
 			0,
@@ -384,7 +384,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		// now complete the slotContextFuture
 		slotContextFuture.complete(
-			new SimpleSlotContext(
+			new SettableSlotContext(
 				new AllocationID(),
 				new LocalTaskManagerLocation(),
 				0,
@@ -409,7 +409,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotSharingManager.MultiTaskSlot rootSlot = slotSharingManager.createRootSlot(
 			new SlotRequestId(),
 			CompletableFuture.completedFuture(
-				new SimpleSlotContext(
+				new SettableSlotContext(
 					new AllocationID(),
 					new LocalTaskManagerLocation(),
 					0,
@@ -457,7 +457,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotSharingManager.MultiTaskSlot rootSlot1 = slotSharingManager.createRootSlot(
 			new SlotRequestId(),
 			CompletableFuture.completedFuture(
-				new SimpleSlotContext(
+				new SettableSlotContext(
 					new AllocationID(),
 					new LocalTaskManagerLocation(),
 					0,
@@ -468,7 +468,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		SlotSharingManager.MultiTaskSlot rootSlot2 = slotSharingManager.createRootSlot(
 			new SlotRequestId(),
 			CompletableFuture.completedFuture(
-				new SimpleSlotContext(
+				new SettableSlotContext(
 					new AllocationID(),
 					taskManagerLocation,
 					0,


### PR DESCRIPTION
This change originally for FLINK-10569 and now I can see @leesf took over the successors like FLINK-12181. **DO NOT MERGE** since this issue possibly become invalid soon.

## What is the purpose of the change

Refactor `SimpleSlotProvider` to `TestingLogicalSlotProvider`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann @zentol @GJL 