### PR TITLE
[FLINK-11698] Add readMapRedTextFile API for HadoopInputs.

### DIFF
--- a/docs/dev/batch/index.md
+++ b/docs/dev/batch/index.md
@@ -877,6 +877,10 @@ DataSet<Person>> csvInput = env.readCsvFile("hdfs:///the/CSV/file")
 // read a file from the specified path of type SequenceFileInputFormat
 DataSet<Tuple2<IntWritable, Text>> tuples =
  env.createInput(HadoopInputs.readSequenceFile(IntWritable.class, Text.class, "hdfs://nnHost:nnPort/path/to/file"));
+ 
+// read a file from the specified path of type org.apache.hadoop.mapred.TextInputFormat
+DataSet<Tuple2<LongWritable, Text>> tuples =
+ env.createInput(HadoopInputs.readMapRedTextFile("hdfs://nnHost:nnPort/path/to/file")); 
 
 // creates a set from some given elements
 DataSet<String> value = env.fromElements("Foo", "bar", "foobar", "fubar");
@@ -967,6 +971,9 @@ File-based:
 
 - `readSequenceFile(Key, Value, path)` / `SequenceFileInputFormat` - Creates a JobConf and reads file from the specified path with
    type SequenceFileInputFormat, Key class and Value class and returns them as Tuple2<Key, Value>.
+     
+- `readMapRedTextFile(path)` / `TextInputFormat` - Creates a JobConf and reads file from the specified path with
+   type org.apache.hadoop.mapred.TextInputFormat, and returns as Tuple2<LongWritable, Text>.
 
 Collection-based:
 
@@ -1030,6 +1037,9 @@ val numbers = env.generateSequence(1, 10000000)
 // read a file from the specified path of type SequenceFileInputFormat
 val tuples = env.createInput(HadoopInputs.readSequenceFile(classOf[IntWritable], classOf[Text],
  "hdfs://nnHost:nnPort/path/to/file"))
+ 
+// read a file from the specified path of type org.apache.hadoop.mapred.TextInputFormat
+val tuples = env.createInput(HadoopInputs.readMapRedTextFile("hdfs://nnHost:nnPort/path/to/file"))
 
 {% endhighlight %}
 

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/HadoopInputs.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/hadoopcompatibility/HadoopInputs.java
@@ -21,6 +21,8 @@ package org.apache.flink.hadoopcompatibility;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.java.hadoop.mapred.HadoopInputFormat;
 
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
 
@@ -70,6 +72,16 @@ public final class HadoopInputs {
 	 */
 	public static <K, V> HadoopInputFormat<K, V> readSequenceFile(Class<K> key, Class<V> value, String inputPath) throws IOException {
 		return readHadoopFile(new org.apache.hadoop.mapred.SequenceFileInputFormat<K, V>(), key, value, inputPath);
+	}
+
+	/**
+	 * Creates a Flink {@link InputFormat} to read a Hadoop Text file for the given inputPath.
+	 *
+	 * @return A Flink InputFormat that wraps a Hadoop {@link org.apache.hadoop.mapred.TextInputFormat}.
+	 */
+	public static HadoopInputFormat<LongWritable, Text> readMapRedTextFile(String inputPath) throws IOException {
+		return readHadoopFile(new org.apache.hadoop.mapred.TextInputFormat(), LongWritable.class,
+			Text.class, inputPath);
 	}
 
 	/**

--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/hadoopcompatibility/scala/HadoopInputs.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/hadoopcompatibility/scala/HadoopInputs.scala
@@ -21,6 +21,7 @@ package org.apache.flink.hadoopcompatibility.scala
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.hadoop.{mapred, mapreduce}
 import org.apache.hadoop.fs.{Path => HadoopPath}
+import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapred.{JobConf, FileInputFormat => MapredFileInputFormat, InputFormat => MapredInputFormat}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => MapreduceFileInputFormat}
 import org.apache.hadoop.mapreduce.{Job, InputFormat => MapreduceInputFormat}
@@ -82,6 +83,23 @@ object HadoopInputs {
       value,
       inputPath
    )
+  }
+
+  /**
+    * Creates a Flink [[org.apache.flink.api.common.io.InputFormat]] that reads a Hadoop Text
+    * file with the given inputPath.
+    *
+    * @return A Flink InputFormat that wraps a Hadoop [[org.apache.hadoop.mapred.TextInputFormat]]
+    */
+  def readMapRedTextFile(inputPath: String)(implicit tpe: TypeInformation[(LongWritable, Text)]):
+  mapred.HadoopInputFormat[LongWritable, Text] = {
+
+    readHadoopFile(
+      new org.apache.hadoop.mapred.TextInputFormat,
+      classOf[LongWritable],
+      classOf[Text],
+      inputPath
+    )
   }
 
   /**

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopTextFormatITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopTextFormatITCase.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.hadoopcompatibility.mapred;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.hadoopcompatibility.HadoopInputs;
+import org.apache.flink.test.testdata.WordCountData;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.util.OperatingSystem;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TextOutputFormat;
+import org.junit.Assume;
+import org.junit.Before;
+
+/**
+ * Test for {@link org.apache.hadoop.mapred.TextInputFormat} and
+ * {@link org.apache.hadoop.mapred.TextOutputFormat}.
+ */
+public class HadoopTextFormatITCase extends JavaProgramTestBase {
+
+	protected String textPath;
+	protected String resultPath;
+
+	@Before
+	public void checkOperatingSystem() {
+		// FLINK-5164 - see https://wiki.apache.org/hadoop/WindowsProblems
+		Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows());
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		textPath = createTempFile("text.txt", WordCountData.TEXT);
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(WordCountData.COUNTS, resultPath, new String[] {".", "_"});
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Tuple2<LongWritable, Text>> input;
+
+		input = env.createInput(HadoopInputs.readMapRedTextFile(textPath));
+
+		DataSet<String> text = input.map(new MapFunction<Tuple2<LongWritable, Text>, String>() {
+			@Override
+			public String map(Tuple2<LongWritable, Text> value) throws Exception {
+				return value.f1.toString();
+			}
+		});
+
+		DataSet<Tuple2<String, Integer>> counts =
+			// split up the lines in pairs (2-tuples) containing: (word,1)
+			text.flatMap(new WordCountMapredITCase.Tokenizer())
+				// group by the tuple field "0" and sum up tuple field "1"
+				.groupBy(0)
+				.sum(1);
+
+		DataSet<Tuple2<Text, LongWritable>> words = counts.map(new MapFunction<Tuple2<String, Integer>, Tuple2<Text, LongWritable>>() {
+
+			@Override
+			public Tuple2<Text, LongWritable> map(Tuple2<String, Integer> value) throws Exception {
+				return new Tuple2<Text, LongWritable>(new Text(value.f0), new LongWritable(value.f1));
+			}
+		});
+
+		// Set up Hadoop Output Format
+		HadoopOutputFormat<Text, LongWritable> hadoopOutputFormat =
+			new HadoopOutputFormat<Text, LongWritable>(new TextOutputFormat<Text, LongWritable>(), new JobConf());
+		hadoopOutputFormat.getJobConf().set("mapred.textoutputformat.separator", " ");
+		TextOutputFormat.setOutputPath(hadoopOutputFormat.getJobConf(), new Path(resultPath));
+
+		// Output & Execute
+		words.output(hadoopOutputFormat);
+		env.execute("Hadoop Compat WordCount");
+		postSubmit();
+	}
+}

--- a/flink-connectors/flink-hadoop-compatibility/src/test/scala/org/apache/flink/api/hadoopcompatibility/scala/HadoopTextFormatMapredITCase.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/scala/org/apache/flink/api/hadoopcompatibility/scala/HadoopTextFormatMapredITCase.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.hadoopcompatibility.scala
+
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.hadoop.mapred.HadoopOutputFormat
+import org.apache.flink.hadoopcompatibility.scala.HadoopInputs
+import org.apache.flink.test.testdata.WordCountData
+import org.apache.flink.test.util.{JavaProgramTestBase, TestBaseUtils}
+import org.apache.flink.util.OperatingSystem
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.{LongWritable, Text}
+import org.apache.hadoop.mapred.{FileOutputFormat, JobConf, TextOutputFormat}
+import org.junit.{Assume, Before}
+
+class HadoopTextFormatMapredITCase extends JavaProgramTestBase {
+  protected var textPath: String = null
+  protected var resultPath: String = null
+
+  @Before
+  def checkOperatingSystem() {
+    // FLINK-5164 - see https://wiki.apache.org/hadoop/WindowsProblems
+    Assume.assumeTrue("This test can't run successfully on Windows.", !OperatingSystem.isWindows)
+  }
+
+  protected override def preSubmit() {
+    textPath = createTempFile("text.txt", WordCountData.TEXT)
+    resultPath = getTempDirPath("result")
+  }
+
+  protected override def postSubmit() {
+    TestBaseUtils.compareResultsByLinesInMemory(WordCountData.COUNTS,
+      resultPath, Array[String](".", "_"))
+  }
+
+  protected def testProgram() {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val input =
+      env.createInput(HadoopInputs.readMapRedTextFile(textPath))
+
+    val counts = input
+      .map(_._2.toString)
+      .flatMap(_.toLowerCase.split("\\W+").filter(_.nonEmpty).map( (_, 1)))
+      .groupBy(0)
+      .sum(1)
+
+    val words = counts
+      .map( t => (new Text(t._1), new LongWritable(t._2)) )
+
+    val hadoopOutputFormat = new HadoopOutputFormat[Text, LongWritable](
+      new TextOutputFormat[Text, LongWritable],
+      new JobConf)
+    hadoopOutputFormat.getJobConf.set("mapred.textoutputformat.separator", " ")
+
+    FileOutputFormat.setOutputPath(hadoopOutputFormat.getJobConf, new Path(resultPath))
+
+    words.output(hadoopOutputFormat)
+
+    env.execute("Hadoop Compat WordCount")
+    postSubmit()
+  }
+}
+


### PR DESCRIPTION
## What is the purpose of the change

 This pull request Add readMapRedTextFile API for HadoopInputs.
https://issues.apache.org/jira/browse/FLINK-11698

## Brief change log
Add readMapRedTextFile both for java and scala API.
Add HadoopTextFormatITCase.java for mapred.
Add HadoopTextFormatMapredITCase.scala.

## Verifying this change

This change is already covered by existing tests, such as HadoopTextFormatITCase and HadoopTextFormatMapredITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented?  docs
