### PR TITLE
[FLINK-10712] Support to restore state when using RestartPipelinedRegionStrategy

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
@@ -77,8 +77,8 @@ public class RollingSinkFaultToleranceITCase extends StreamFaultToleranceTestBas
 
 	private static String outPath;
 
-	@BeforeClass
-	public static void createHDFS() throws IOException {
+	@Before
+	public void createHDFS() throws IOException {
 		Configuration conf = new Configuration();
 
 		File dataDir = tempFolder.newFolder();
@@ -94,8 +94,8 @@ public class RollingSinkFaultToleranceITCase extends StreamFaultToleranceTestBas
 				+ "/string-non-rolling-out";
 	}
 
-	@AfterClass
-	public static void destroyHDFS() {
+	@After
+	public void destroyHDFS() {
 		if (hdfsCluster != null) {
 			hdfsCluster.shutdown();
 		}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFaultToleranceITCase.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
@@ -77,8 +77,8 @@ public class BucketingSinkFaultToleranceITCase extends StreamFaultToleranceTestB
 
 	private static String outPath;
 
-	@BeforeClass
-	public static void createHDFS() throws IOException {
+	@Before
+	public void createHDFS() throws IOException {
 		Configuration conf = new Configuration();
 
 		File dataDir = tempFolder.newFolder();
@@ -94,8 +94,8 @@ public class BucketingSinkFaultToleranceITCase extends StreamFaultToleranceTestB
 				+ "/string-non-rolling-out";
 	}
 
-	@AfterClass
-	public static void destroyHDFS() {
+	@After
+	public void destroyHDFS() {
 		if (hdfsCluster != null) {
 			hdfsCluster.shutdown();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1202,12 +1202,15 @@ public class CheckpointCoordinator {
 				currentPeriodicTrigger = null;
 			}
 
-			for (PendingCheckpoint p : pendingCheckpoints.values()) {
-				p.abortError(new Exception("Checkpoint Coordinator is suspending."));
-			}
+			abortPendingCheckpoints();
 
-			pendingCheckpoints.clear();
 			numUnsuccessfulCheckpointsTriggers.set(0);
+		}
+	}
+
+	public void cancelPendingCheckpoints() {
+		synchronized (lock) {
+			abortPendingCheckpoints();
 		}
 	}
 
@@ -1312,5 +1315,16 @@ public class CheckpointCoordinator {
 				}
 			});
 		}
+	}
+
+	/**
+	 * Aborts all the pending checkpoints.
+	 */
+	private void abortPendingCheckpoints() {
+		for (PendingCheckpoint p : pendingCheckpoints.values()) {
+			p.abortError(new Exception("Checkpoint Coordinator is suspending."));
+		}
+
+		pendingCheckpoints.clear();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1202,15 +1202,23 @@ public class CheckpointCoordinator {
 				currentPeriodicTrigger = null;
 			}
 
-			abortPendingCheckpoints();
+			abortPendingCheckpoints(new Exception("Checkpoint Coordinator is suspending."));
 
 			numUnsuccessfulCheckpointsTriggers.set(0);
 		}
 	}
 
-	public void cancelPendingCheckpoints() {
+	/**
+	 * Aborts all the pending checkpoints due to en exception.
+	 * @param exception The exception.
+	 */
+	public void abortPendingCheckpoints(Exception exception) {
 		synchronized (lock) {
-			abortPendingCheckpoints();
+			for (PendingCheckpoint p : pendingCheckpoints.values()) {
+				p.abortError(exception);
+			}
+
+			pendingCheckpoints.clear();
 		}
 	}
 
@@ -1315,16 +1323,5 @@ public class CheckpointCoordinator {
 				}
 			});
 		}
-	}
-
-	/**
-	 * Aborts all the pending checkpoints.
-	 */
-	private void abortPendingCheckpoints() {
-		for (PendingCheckpoint p : pendingCheckpoints.values()) {
-			p.abortError(new Exception("Checkpoint Coordinator is suspending."));
-		}
-
-		pendingCheckpoints.clear();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -89,7 +89,6 @@ import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 import static org.apache.flink.runtime.execution.ExecutionState.RUNNING;
 import static org.apache.flink.runtime.execution.ExecutionState.SCHEDULED;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A single execution of a vertex. While an {@link ExecutionVertex} can be executed multiple times
@@ -365,7 +364,6 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @param taskRestore information to restore the state
 	 */
 	public void setInitialState(@Nullable JobManagerTaskRestore taskRestore) {
-		checkState(state == CREATED, "Can only assign operator state when execution attempt is in CREATED");
 		this.taskRestore = taskRestore;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -126,18 +126,7 @@ public class FailoverRegion {
 		return state;
 	}
 
-	public Map<JobVertexID, ExecutionJobVertex> getTasks() {
-		return tasks;
-	}
-
-	/**
-	 * get all execution vertexes contained in this region
-	 */
-	public List<ExecutionVertex> getAllExecutionVertexes() {
-		return connectedExecutionVertexes;
-	}
-
-	// Notice the region to failover, 
+	// Notice the region to failover,
 	private void failover(long globalModVersionOfFailover) {
 		if (!executionGraph.getRestartStrategy().canRestart()) {
 			executionGraph.failGlobal(new FlinkException("RestartStrategy validate fail"));
@@ -232,7 +221,7 @@ public class FailoverRegion {
 					// we restart the checkpoint scheduler for
 					// i) enable new checkpoint could be triggered without waiting for last checkpoint expired.
 					// ii) ensure the EXACTLY_ONCE semantics if needed.
-					executionGraph.getCheckpointCoordinator().cancelPendingCheckpoints();
+					executionGraph.getCheckpointCoordinator().abortPendingCheckpoints(new Exception("FailoverRegion is restarting."));
 
 					executionGraph.getCheckpointCoordinator().restoreLatestCheckpointedState(
 						tasks, false, true);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -38,8 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -76,23 +74,14 @@ public class FailoverRegion {
 
 	public FailoverRegion(
 		ExecutionGraph executionGraph,
-		List<ExecutionVertex> connectedExecutions) {
+		List<ExecutionVertex> connectedExecutions,
+		Map<JobVertexID, ExecutionJobVertex> tasks) {
 
 		this.executionGraph = checkNotNull(executionGraph);
 		this.connectedExecutionVertexes = checkNotNull(connectedExecutions);
-		this.tasks = initTasks(connectedExecutionVertexes);
+		this.tasks = checkNotNull(tasks);
 
 		LOG.debug("Created failover region {} with vertices: {}", id, connectedExecutions);
-	}
-
-	private Map<JobVertexID, ExecutionJobVertex> initTasks(List<ExecutionVertex> connectedExecutionVertexes) {
-		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>(connectedExecutionVertexes.size());
-		for (ExecutionVertex executionVertex : connectedExecutionVertexes) {
-			JobVertexID jobvertexId = executionVertex.getJobvertexId();
-			ExecutionJobVertex jobVertex = executionVertex.getJobVertex();
-			tasks.putIfAbsent(jobvertexId, jobVertex);
-		}
-		return Collections.unmodifiableMap(tasks);
 	}
 
 	public void onExecutionFail(Execution taskExecution, Throwable cause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartPipelinedRegionStrategy.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -36,6 +37,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -222,7 +224,19 @@ public class RestartPipelinedRegionStrategy extends FailoverStrategy {
 
 	@VisibleForTesting
 	protected FailoverRegion createFailoverRegion(ExecutionGraph eg, List<ExecutionVertex> connectedExecutions) {
-		return new FailoverRegion(eg, connectedExecutions);
+		Map<JobVertexID, ExecutionJobVertex> tasks = initTasks(connectedExecutions);
+		return new FailoverRegion(eg, connectedExecutions, tasks);
+	}
+
+	@VisibleForTesting
+	protected Map<JobVertexID, ExecutionJobVertex> initTasks(List<ExecutionVertex> connectedExecutions) {
+		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>(connectedExecutions.size());
+		for (ExecutionVertex executionVertex : connectedExecutions) {
+			JobVertexID jobvertexId = executionVertex.getJobvertexId();
+			ExecutionJobVertex jobVertex = executionVertex.getJobVertex();
+			tasks.putIfAbsent(jobvertexId, jobVertex);
+		}
+		return tasks;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartPipelinedRegionStrategy.java
@@ -40,7 +40,7 @@ import java.util.List;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * A failover strategy that restarts regions of the ExecutionGraph. A region is defined
+ * A failover strategy that restarts regions of the ExecutionGraph with state. A region is defined
  * by this strategy as the weakly connected component of tasks that communicate via pipelined
  * data exchange.
  */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
@@ -521,7 +522,8 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 
 		@Override
 		protected FailoverRegion createFailoverRegion(ExecutionGraph eg, List<ExecutionVertex> connectedExecutions) {
-			return new FailoverRegion(eg, connectedExecutions) {
+			Map<JobVertexID, ExecutionJobVertex> tasks = initTasks(connectedExecutions);
+			return new FailoverRegion(eg, connectedExecutions, tasks) {
 				@Override
 				protected CompletableFuture<Void> createTerminationFutureOverAllConnectedVertexes() {
 					ArrayList<CompletableFuture<?>> terminationAndBlocker = new ArrayList<>(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -60,7 +60,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstrain
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -565,7 +565,7 @@ public class FailoverRegionTest extends TestLogger {
 
 		CheckpointCoordinator checkpointCoordinator = eg.getCheckpointCoordinator();
 		assertNotNull(checkpointCoordinator);
-		CheckpointStorage checkpointStorage = checkpointCoordinator.getCheckpointStorage();
+		CheckpointStorageCoordinatorView checkpointStorage = checkpointCoordinator.getCheckpointStorage();
 		pendingCheckpoints.put(checkpointId, new PendingCheckpoint(
 			eg.getJobID(),
 			checkpointId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -19,14 +19,25 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.mock.Whitebox;
+import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTest;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointProperties;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
+import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.PendingCheckpoint;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory;
@@ -34,68 +45,56 @@ import org.apache.flink.runtime.executiongraph.failover.RestartPipelinedRegionSt
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
-import org.apache.flink.runtime.instance.Instance;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
-import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
-import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
-import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilExecutionState;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilFailoverRegionState;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 public class FailoverRegionTest extends TestLogger {
 
-	private CheckpointCoordinator spyCheckpointCoordinator;
-
-	@After
-	public void cleanup() throws Exception {
-		resetCheckpointCoordinator();
-	}
-
-	private void resetCheckpointCoordinator() throws Exception {
-		if (spyCheckpointCoordinator != null) {
-			spyCheckpointCoordinator.shutdown(JobStatus.FINISHED);
-			spyCheckpointCoordinator = null;
-		}
-	}
+	private static final long checkpointId = 42L;
 
 	/**
-	 * Tests that a job only has one failover region and can recover from task failure successfully
-	 * @throws Exception
+	 * Tests that a job only has one failover region and can recover from task failure successfully with state.
+	 * @throws Exception if fail to create the single region execution graph or fail to acknowledge all checkpoints.
 	 */
 	@Test
 	public void testSingleRegionFailover() throws Exception {
@@ -105,7 +104,16 @@ public class FailoverRegionTest extends TestLogger {
 
 		ExecutionVertex ev = eg.getAllExecutionVertices().iterator().next();
 
+		assertNotNull(eg.getCheckpointCoordinator());
+		assertFalse(eg.getCheckpointCoordinator().getPendingCheckpoints().isEmpty());
+
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev).getState());
+
+		acknowledgeAllCheckpoints(eg.getCheckpointCoordinator(), eg.getAllExecutionVertices().iterator());
+
+		// verify checkpoint has been completed successfully.
+		assertEquals(1, eg.getCheckpointCoordinator().getCheckpointStore().getNumberOfRetainedCheckpoints());
+		assertEquals(checkpointId, eg.getCheckpointCoordinator().getCheckpointStore().getLatestCheckpoint().getCheckpointID());
 
 		ev.getCurrentExecutionAttempt().fail(new Exception("Test Exception"));
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev).getState());
@@ -113,11 +121,8 @@ public class FailoverRegionTest extends TestLogger {
 		for (ExecutionVertex evs : eg.getAllExecutionVertices()) {
 			evs.getCurrentExecutionAttempt().completeCancelling();
 		}
-		// start checkpoint scheduler would trigger to stop checkpoint scheduler again.
-		verify(spyCheckpointCoordinator, times(2)).stopCheckpointScheduler();
-		verify(spyCheckpointCoordinator, times(1)).startCheckpointScheduler();
-		verify(spyCheckpointCoordinator, times(1))
-			.restoreLatestCheckpointedState(ArgumentMatchers.anyMap(), any(Boolean.class), any(Boolean.class));
+
+		verifyCheckpointRestoredAsExpected(eg);
 
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev).getState());
 	}
@@ -141,8 +146,9 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, 20);
-				
+		final Map<ExecutionAttemptID, JobManagerTaskRestore> attemptIDInitStateMap = new HashMap<>();
+		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, 20, new CollectTddTaskManagerGateway(attemptIDInitStateMap));
+
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
 		JobVertex v3 = new JobVertex("vertex3");
@@ -176,7 +182,6 @@ public class FailoverRegionTest extends TestLogger {
 			slotProvider);
 
 		eg.attachJobGraph(ordered);
-		eg.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		RestartPipelinedRegionStrategy strategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
 
@@ -193,17 +198,19 @@ public class FailoverRegionTest extends TestLogger {
 		ExecutionVertex ev32 = eg.getJobVertex(v3.getID()).getTaskVertices()[1];
 		ExecutionVertex ev4 = eg.getJobVertex(v4.getID()).getTaskVertices()[0];
 
-		Map<JobVertexID, ExecutionJobVertex> region12Tasks = strategy.getFailoverRegion(ev11).getTasks();
-
-		Map<JobVertexID, ExecutionJobVertex> region3Tasks = strategy.getFailoverRegion(ev32).getTasks();
-
 		enableCheckpointing(eg);
-		spyCheckpointCoordinator = spy(eg.getCheckpointCoordinator());
-		Whitebox.setInternalState(eg, "checkpointCoordinator", spyCheckpointCoordinator);
 
+		eg.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
 		eg.scheduleForExecution();
+		assertEquals(JobStatus.RUNNING, eg.getState());
+
+		attachPendingCheckpoints(eg);
 
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
+		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev21).getState());
+		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
+
+		acknowledgeAllCheckpoints(eg.getCheckpointCoordinator(), Arrays.asList(ev11, ev21, ev12, ev22, ev31, ev32, ev4).iterator());
 
 		ev21.scheduleForExecution(slotProvider, true, LocationPreferenceConstraint.ALL, Collections.emptySet());
 		ev21.getCurrentExecutionAttempt().fail(new Exception("New fail"));
@@ -212,14 +219,11 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
 
 		ev11.getCurrentExecutionAttempt().completeCancelling();
+		verifyCheckpointRestoredAsExpected(eg);
+
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
-
-		verify(spyCheckpointCoordinator, times(1))
-			.restoreLatestCheckpointedState(eq(region12Tasks), any(Boolean.class), any(Boolean.class));
-		verify(spyCheckpointCoordinator, never())
-			.restoreLatestCheckpointedState(eq(region3Tasks), any(Boolean.class), any(Boolean.class));
 
 		ev11.getCurrentExecutionAttempt().markFinished();
 		ev21.getCurrentExecutionAttempt().markFinished();
@@ -238,22 +242,18 @@ public class FailoverRegionTest extends TestLogger {
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev31).getState());
 
 		ev32.getCurrentExecutionAttempt().completeCancelling();
+		verifyCheckpointRestoredAsExpected(eg);
+
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev11).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev22).getState());
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev31).getState());
 
 		assertEquals(JobStatus.RUNNING, strategy.getFailoverRegion(ev4).getState());
-
-		// triggered before
-		verify(spyCheckpointCoordinator, times(1))
-			.restoreLatestCheckpointedState(eq(region12Tasks), any(Boolean.class), any(Boolean.class));
-		verify(spyCheckpointCoordinator, times(1))
-			.restoreLatestCheckpointedState(eq(region3Tasks), any(Boolean.class), any(Boolean.class));
 	}
 
 	/**
-	 * Tests that when a task fail, and restart strategy doesn't support restarting, the job will go to failed
-	 * @throws Exception
+	 * Tests that when a task fail, and restart strategy doesn't support restarting, the job will go to failed.
+	 * @throws Exception if fail to create the single region execution graph.
 	 */
 	@Test
 	public void testNoManualRestart() throws Exception {
@@ -268,14 +268,12 @@ public class FailoverRegionTest extends TestLogger {
 			evs.getCurrentExecutionAttempt().completeCancelling();
 		}
 		assertEquals(JobStatus.FAILED, eg.getState());
-		verify(spyCheckpointCoordinator, never()).startCheckpointScheduler();
-		verify(spyCheckpointCoordinator, never())
-			.restoreLatestCheckpointedState(ArgumentMatchers.anyMap(), any(Boolean.class), any(Boolean.class));
 	}
 
 	/**
-	 * Tests that two failover regions failover at the same time, they will not influence each other
-	 * @throws Exception
+	 * Tests that two regions failover at the same time, they will not influence each other.
+	 * @throws Exception if fail to create dummy job information, fail to schedule for execution
+	 * or timeout before region switches to expected status.
 	 */
 	@Test
 	public void testMultiRegionFailoverAtSameTime() throws Exception {
@@ -349,7 +347,7 @@ public class FailoverRegionTest extends TestLogger {
 	 * Tests that if a task reports the result of its preceding task is failed,
 	 * its preceding task will be considered as failed, and start to failover
 	 * TODO: as the report part is not finished yet, this case is ignored temporarily
-	 * @throws Exception
+	 * @throws Exception if fail to create dummy job information or fail to schedule for execution.
 	 */
 	@Ignore
 	@Test
@@ -402,8 +400,8 @@ public class FailoverRegionTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that a new failure comes while the failover region is in CANCELLING
-	 * @throws Exception
+	 * Tests that a new failure comes while the failover region is in CANCELLING.
+	 * @throws Exception if fail to create the single region execution graph.
 	 */
 	@Test
 	public void testFailWhileCancelling() throws Exception {
@@ -418,30 +416,22 @@ public class FailoverRegionTest extends TestLogger {
 
 		ev1.getCurrentExecutionAttempt().fail(new Exception("new fail"));
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev1).getState());
-		verify(spyCheckpointCoordinator, never())
-			.restoreLatestCheckpointedState(ArgumentMatchers.anyMap(), any(Boolean.class), any(Boolean.class));
 
 		ExecutionVertex ev2 = iter.next();
 		ev2.getCurrentExecutionAttempt().fail(new Exception("new fail"));
 		assertEquals(JobStatus.RUNNING, eg.getState());
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev1).getState());
-		for (ExecutionVertex evs : eg.getAllExecutionVertices()) {
-			evs.getCurrentExecutionAttempt().completeCancelling();
-		}
-		verify(spyCheckpointCoordinator, times(1))
-			.restoreLatestCheckpointedState(ArgumentMatchers.anyMap(), any(Boolean.class), any(Boolean.class));
-
 	}
 
 	/**
-	 * Tests that a new failure comes while the failover region is restarting
-	 * @throws Exception
+	 * Tests that a new failure comes while the failover region is restarting.
+	 * @throws Exception if fail to create the single region execution graph.
 	 */
 	@Test
 	public void testFailWhileRestarting() throws Exception {
 		RestartStrategy restartStrategy = new InfiniteDelayRestartStrategy();
 		ExecutionGraph eg = createSingleRegionExecutionGraph(restartStrategy);
-		RestartPipelinedRegionStrategy strategy = (RestartPipelinedRegionStrategy) eg.getFailoverStrategy();
+		RestartPipelinedRegionStrategy strategy = (RestartPipelinedRegionStrategy)eg.getFailoverStrategy();
 
 		Iterator<ExecutionVertex> iter = eg.getAllExecutionVertices().iterator();
 		ExecutionVertex ev1 = iter.next();
@@ -457,34 +447,21 @@ public class FailoverRegionTest extends TestLogger {
 
 		ev1.getCurrentExecutionAttempt().fail(new Exception("new fail"));
 		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev1).getState());
-		verify(spyCheckpointCoordinator, times(1)).startCheckpointScheduler();
-		verify(spyCheckpointCoordinator, times(2)).stopCheckpointScheduler();
-		verify(spyCheckpointCoordinator, times(1))
-			.restoreLatestCheckpointedState(ArgumentMatchers.anyMap(), any(Boolean.class), any(Boolean.class));
+	}
 
-		ExecutionVertex ev2 = iter.next();
-		ev2.getCurrentExecutionAttempt().fail(new Exception("new fail"));
-		assertEquals(JobStatus.RUNNING, eg.getState());
-		assertEquals(JobStatus.CANCELLING, strategy.getFailoverRegion(ev1).getState());
-		for (ExecutionVertex evs : eg.getAllExecutionVertices()) {
-			evs.getCurrentExecutionAttempt().completeCancelling();
-		}
-		verify(spyCheckpointCoordinator, times(2)).startCheckpointScheduler();
-		verify(spyCheckpointCoordinator, times(4)).stopCheckpointScheduler();
-		verify(spyCheckpointCoordinator, times(2))
-			.restoreLatestCheckpointedState(ArgumentMatchers.anyMap(), any(Boolean.class), any(Boolean.class));
+	// --------------------------------------------------------------------------------------------
 
+	private void verifyCheckpointRestoredAsExpected(ExecutionGraph eg) throws Exception {
+		// pending checkpoints have already been cancelled.
+		assertNotNull(eg.getCheckpointCoordinator());
+		assertTrue(eg.getCheckpointCoordinator().getPendingCheckpoints().isEmpty());
+
+		// verify checkpoint has been restored successfully.
+		assertEquals(1, eg.getCheckpointCoordinator().getCheckpointStore().getNumberOfRetainedCheckpoints());
+		assertEquals(checkpointId, eg.getCheckpointCoordinator().getCheckpointStore().getLatestCheckpoint().getCheckpointID());
 	}
 
 	private ExecutionGraph createSingleRegionExecutionGraph(RestartStrategy restartStrategy) throws Exception {
-		Instance instance = ExecutionGraphTestUtils.getInstance(
-				new ActorTaskManagerGateway(
-						new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.directExecutionContext())),
-				14);
-
-		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
-		scheduler.newInstanceAvailable(instance);
-
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
@@ -527,11 +504,11 @@ public class FailoverRegionTest extends TestLogger {
 		}
 
 		enableCheckpointing(eg);
-		spyCheckpointCoordinator = spy(eg.getCheckpointCoordinator());
-		Whitebox.setInternalState(eg, "checkpointCoordinator", spyCheckpointCoordinator);
 
 		eg.start(TestingComponentMainThreadExecutorServiceAdapter.forMainThread());
 		eg.scheduleForExecution();
+
+		attachPendingCheckpoints(eg);
 		return eg;
 	}
 
@@ -549,11 +526,10 @@ public class FailoverRegionTest extends TestLogger {
 		}
 	}
 
-	private static void enableCheckpointing(ExecutionGraph executionGraph) throws Exception {
-		ArrayList<ExecutionJobVertex> jobVertices = new ArrayList<>(executionGraph.getAllVertices().values());
-		executionGraph
-			.enableCheckpointing(
-				100,
+	private static void enableCheckpointing(ExecutionGraph eg) {
+		ArrayList<ExecutionJobVertex> jobVertices = new ArrayList<>(eg.getAllVertices().values());
+		eg.enableCheckpointing(
+				1000,
 				100,
 				0,
 				1,
@@ -570,6 +546,85 @@ public class FailoverRegionTest extends TestLogger {
 					jobVertices,
 					mock(CheckpointCoordinatorConfiguration.class),
 					new UnregisteredMetricsGroup()));
+	}
+
+	/**
+	 * Attach pending checkpoints of chk-42 and chk-43 to the execution graph.
+	 * If {@link #acknowledgeAllCheckpoints(CheckpointCoordinator, Iterator)} called then,
+	 * chk-42 would become the completed checkpoint.
+	 */
+	private void attachPendingCheckpoints(ExecutionGraph eg) throws IOException {
+		final Map<Long, PendingCheckpoint> pendingCheckpoints = new HashMap<>();
+		final Map<ExecutionAttemptID, ExecutionVertex> verticesToConfirm = new HashMap<>();
+		eg.getAllExecutionVertices().forEach(e -> {
+			Execution ee = e.getCurrentExecutionAttempt();
+			if (ee != null) {
+				verticesToConfirm.put(ee.getAttemptId(), e);
+			}
+		});
+
+		CheckpointCoordinator checkpointCoordinator = eg.getCheckpointCoordinator();
+		assertNotNull(checkpointCoordinator);
+		CheckpointStorage checkpointStorage = checkpointCoordinator.getCheckpointStorage();
+		pendingCheckpoints.put(checkpointId, new PendingCheckpoint(
+			eg.getJobID(),
+			checkpointId,
+			0L,
+			verticesToConfirm,
+			CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.RETAIN_ON_FAILURE),
+			checkpointStorage.initializeLocationForCheckpoint(checkpointId),
+			eg.getFutureExecutor()));
+
+		long newCheckpointId = checkpointId + 1;
+		pendingCheckpoints.put(newCheckpointId, new PendingCheckpoint(
+			eg.getJobID(),
+			newCheckpointId,
+			0L,
+			verticesToConfirm,
+			CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.RETAIN_ON_FAILURE),
+			checkpointStorage.initializeLocationForCheckpoint(newCheckpointId),
+			eg.getFutureExecutor()));
+		Whitebox.setInternalState(checkpointCoordinator, "pendingCheckpoints", pendingCheckpoints);
+	}
+
+	/**
+	 * Let the checkpoint coordinator to receive all acknowledges from given executionVertexes so that to complete the expected checkpoint.
+	 */
+	private void acknowledgeAllCheckpoints(CheckpointCoordinator checkpointCoordinator, Iterator<ExecutionVertex> executionVertexes) throws IOException, CheckpointException {
+		while (executionVertexes.hasNext()) {
+			ExecutionVertex executionVertex = executionVertexes.next();
+			for (int index = 0; index < executionVertex.getJobVertex().getParallelism(); index++) {
+				JobVertexID jobVertexID = executionVertex.getJobvertexId();
+				OperatorStateHandle opStateBackend = CheckpointCoordinatorTest.generatePartitionableStateHandle(jobVertexID, index, 2, 8, false);
+				OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, null, null, null);
+				TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
+				taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID), operatorSubtaskState);
+
+				AcknowledgeCheckpoint acknowledgeCheckpoint = new AcknowledgeCheckpoint(
+					executionVertex.getJobId(),
+					executionVertex.getJobVertex().getTaskVertices()[index].getCurrentExecutionAttempt().getAttemptId(),
+					checkpointId,
+					new CheckpointMetrics(),
+					taskOperatorSubtaskStates);
+
+				checkpointCoordinator.receiveAcknowledgeMessage(acknowledgeCheckpoint);
+			}
+		}
+	}
+
+	private static class CollectTddTaskManagerGateway extends SimpleAckingTaskManagerGateway {
+
+		private final Map<ExecutionAttemptID, JobManagerTaskRestore> attemptIDInitStateMap;
+
+		CollectTddTaskManagerGateway(Map<ExecutionAttemptID, JobManagerTaskRestore> attemptIDInitStateMap) {
+			this.attemptIDInitStateMap = attemptIDInitStateMap;
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> submitTask(TaskDeploymentDescriptor tdd, Time timeout) {
+			attemptIDInitStateMap.put(tdd.getExecutionAttemptId(), tdd.getTaskRestore());
+			return super.submitTask(tdd, timeout);
+		}
 	}
 
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Tests for region failover with multi regions.
+ */
+public class RegionFailoverITCase extends TestLogger {
+
+	private static final int FAIL_BASE = 1000;
+	private static final int NUM_OF_REGIONS = 3;
+	private static final Set<Integer> EXPECTED_INDICES = IntStream.range(0, NUM_OF_REGIONS).boxed().collect(Collectors.toSet());
+	private static final int NUM_OF_RESTARTS = 3;
+	private static final int NUM_ELEMENTS = FAIL_BASE * 10;
+
+	private static volatile long lastCompletedCheckpointId = 0;
+	private static volatile int numCompletedCheckpoints = 0;
+	private static volatile AtomicInteger jobFailedCnt = new AtomicInteger(0);
+
+	private static Map<Long, Integer> snapshotIndicesOfSubTask = new HashMap<>();
+
+	private static MiniClusterWithClientResource cluster;
+
+	private static boolean restoredState = false;
+
+	@ClassRule
+	public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+	@Before
+	public void setup() throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
+
+		cluster = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+				.setConfiguration(configuration)
+				.setNumberTaskManagers(2)
+				.setNumberSlotsPerTaskManager(2).build());
+		cluster.before();
+		jobFailedCnt.set(0);
+		numCompletedCheckpoints = 0;
+	}
+
+	@AfterClass
+	public static void shutDownExistingCluster() {
+		if (cluster != null) {
+			cluster.after();
+			cluster = null;
+		}
+	}
+
+	/**
+	 * Tests that a simple job (Source -> Map) with multi regions could restore with operator state.
+	 *
+	 * <p>The last subtask of Map function in the 1st stream graph would fail {@code NUM_OF_RESTARTS} times,
+	 * and it will verify whether the restored state is identical to last completed checkpoint's.
+	 */
+	@Test(timeout = 60000)
+	public void testMultiRegionFailover() {
+		try {
+			JobGraph jobGraph = createJobGraph();
+			ClusterClient<?> client = cluster.getClusterClient();
+			client.submitJob(jobGraph, RegionFailoverITCase.class.getClassLoader());
+			Assert.assertTrue("The test multi-region job has never ever restored state.", restoredState);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	private JobGraph createJobGraph() {
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(NUM_OF_REGIONS);
+		env.enableCheckpointing(200, CheckpointingMode.EXACTLY_ONCE);
+		env.getCheckpointConfig().enableExternalizedCheckpoints(CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+		env.disableOperatorChaining();
+		env.getConfig().setRestartStrategy(RestartStrategies.fixedDelayRestart(NUM_OF_RESTARTS, 0L));
+		env.getConfig().disableSysoutLogging();
+
+		// there exists num of 'NUM_OF_REGIONS' individual regions.
+		env.addSource(new StringGeneratingSourceFunction(NUM_ELEMENTS, NUM_ELEMENTS / NUM_OF_RESTARTS))
+			.setParallelism(NUM_OF_REGIONS)
+			.map(new FailingMapperFunction(NUM_OF_RESTARTS))
+			.setParallelism(NUM_OF_REGIONS);
+
+		// another stream graph totally disconnected with the above one.
+		env.addSource(new StringGeneratingSourceFunction(NUM_ELEMENTS, NUM_ELEMENTS / NUM_OF_RESTARTS)).setParallelism(1)
+			.map((MapFunction<Integer, Object>) value -> value).setParallelism(1);
+
+		return env.getStreamGraph().getJobGraph();
+	}
+
+	private static class StringGeneratingSourceFunction extends RichParallelSourceFunction<Integer>
+		implements CheckpointListener, CheckpointedFunction {
+		private static final long serialVersionUID = 1L;
+
+		private final long numElements;
+		private final long checkpointLatestAt;
+
+		private int index = -1;
+
+		private int lastRegionIndex = -1;
+
+		private volatile boolean isRunning = true;
+
+		private ListState<Integer> listState;
+
+		private static final ListStateDescriptor<Integer> stateDescriptor = new ListStateDescriptor<>("list-1", Integer.class);
+
+		private ListState<Integer> unionListState;
+
+		private static final ListStateDescriptor<Integer> unionStateDescriptor = new ListStateDescriptor<>("list-2", Integer.class);
+
+		StringGeneratingSourceFunction(long numElements, long checkpointLatestAt) {
+			this.numElements = numElements;
+			this.checkpointLatestAt = checkpointLatestAt;
+		}
+
+		@Override
+		public void run(SourceContext<Integer> ctx) throws Exception {
+			if (index < 0) {
+				// not been restored, so initialize
+				index = 0;
+			}
+
+			while (isRunning && index < numElements) {
+				//noinspection SynchronizationOnLocalVariableOrMethodParameter
+				synchronized (ctx.getCheckpointLock()) {
+					index += 1;
+					ctx.collect(index);
+				}
+
+				if (numCompletedCheckpoints < 3) {
+					// not yet completed enough checkpoints, so slow down
+					if (index < checkpointLatestAt) {
+						// mild slow down
+						Thread.sleep(1);
+					} else {
+						// wait until the checkpoints are completed
+						while (isRunning && numCompletedCheckpoints < 3) {
+							Thread.sleep(300);
+						}
+					}
+				}
+				if (jobFailedCnt.get() < NUM_OF_RESTARTS) {
+					// slow down if job has not failed for 'NUM_OF_RESTARTS' times.
+					Thread.sleep(1);
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) throws Exception {
+			if (getRuntimeContext().getIndexOfThisSubtask() == NUM_OF_REGIONS - 1) {
+				lastCompletedCheckpointId = checkpointId;
+				snapshotIndicesOfSubTask.put(checkpointId, lastRegionIndex);
+				numCompletedCheckpoints++;
+			}
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
+			if (indexOfThisSubtask != 0) {
+				listState.clear();
+				listState.add(index);
+				if (indexOfThisSubtask == NUM_OF_REGIONS - 1) {
+					lastRegionIndex = index;
+				}
+			}
+			unionListState.clear();
+			unionListState.add(indexOfThisSubtask);
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
+			if (context.isRestored()) {
+				restoredState = true;
+
+				unionListState = context.getOperatorStateStore().getUnionListState(unionStateDescriptor);
+				Set<Integer> actualIndices = StreamSupport.stream(unionListState.get().spliterator(), false).collect(Collectors.toSet());
+				Assert.assertTrue(CollectionUtils.isEqualCollection(EXPECTED_INDICES, actualIndices));
+
+				if (indexOfThisSubtask == 0) {
+					listState = context.getOperatorStateStore().getListState(stateDescriptor);
+					Assert.assertTrue("list state should be empty for subtask-0",
+						((List<Integer>) listState.get()).isEmpty());
+				} else {
+					listState = context.getOperatorStateStore().getListState(stateDescriptor);
+					Assert.assertTrue("list state should not be empty for subtask-" + indexOfThisSubtask,
+						((List<Integer>) listState.get()).size() > 0);
+
+					if (indexOfThisSubtask == NUM_OF_REGIONS - 1) {
+						index = listState.get().iterator().next();
+						if (index != snapshotIndicesOfSubTask.get(lastCompletedCheckpointId)) {
+							throw new RuntimeException("Test failed due to unexpected recovered index: " + index +
+								", while last completed checkpoint record index: " + snapshotIndicesOfSubTask.get(lastCompletedCheckpointId));
+						}
+					}
+				}
+			} else {
+				unionListState = context.getOperatorStateStore().getUnionListState(unionStateDescriptor);
+
+				if (indexOfThisSubtask != 0) {
+					listState = context.getOperatorStateStore().getListState(stateDescriptor);
+				}
+			}
+
+		}
+	}
+
+	private static class FailingMapperFunction extends RichMapFunction<Integer, Integer> {
+		private final int restartTimes;
+
+		FailingMapperFunction(int restartTimes) {
+			this.restartTimes = restartTimes;
+		}
+
+		@Override
+		public Integer map(Integer input) throws Exception {
+			int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
+
+			if (input > FAIL_BASE * (jobFailedCnt.get() + 1)) {
+
+				// we would let region-0 to failover first
+				if (jobFailedCnt.get() < 1 && indexOfThisSubtask == 0) {
+					jobFailedCnt.incrementAndGet();
+					throw new TestException();
+				}
+
+				// then let last region to failover
+				if (jobFailedCnt.get() < restartTimes && indexOfThisSubtask == NUM_OF_REGIONS - 1) {
+					jobFailedCnt.incrementAndGet();
+					throw new TestException();
+				}
+			}
+			return input;
+		}
+	}
+
+	private static class TestException extends IOException{
+		private static final long serialVersionUID = 1L;
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -379,7 +379,7 @@ public class RegionFailoverITCase extends TestLogger {
 
 		@Override
 		public void restoreState(List<HashMap<Integer, Integer>> state) throws Exception {
-			if (state.isEmpty() || state.size() > 1) {
+			if (state.size() != 1) {
 				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
 			}
 			this.counts.putAll(state.get(0));

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -19,33 +19,84 @@
 package org.apache.flink.test.checkpointing;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.test.util.TestUtils;
+import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.fail;
 
 /**
  * Test base for fault tolerant streaming programs.
  */
+@RunWith(Parameterized.class)
 public abstract class StreamFaultToleranceTestBase extends TestLogger {
+
+	@Parameterized.Parameters(name = "FailoverStrategy: {0}")
+	public static Collection<FailoverStrategy> parameters() {
+		return Arrays.asList(FailoverStrategy.RestartAllStrategy, FailoverStrategy.RestartPipelinedRegionStrategy);
+	}
+
+	/**
+	 * The failover strategy to use.
+	 */
+	public enum FailoverStrategy{
+		RestartAllStrategy,
+		RestartPipelinedRegionStrategy
+	}
+
+	@Parameterized.Parameter
+	public FailoverStrategy failoverStrategy;
 
 	protected static final int NUM_TASK_MANAGERS = 3;
 	protected static final int NUM_TASK_SLOTS = 4;
 	protected static final int PARALLELISM = NUM_TASK_MANAGERS * NUM_TASK_SLOTS;
 
-	@ClassRule
-	public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE = new MiniClusterWithClientResource(
-		new MiniClusterResourceConfiguration.Builder()
-			.setNumberTaskManagers(NUM_TASK_MANAGERS)
-			.setNumberSlotsPerTaskManager(NUM_TASK_SLOTS)
-			.build());
+	private static MiniClusterWithClientResource cluster;
+
+	@Before
+	public void setup() throws Exception {
+		Configuration configuration = new Configuration();
+		switch (failoverStrategy) {
+			case RestartPipelinedRegionStrategy:
+				configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
+				break;
+			case RestartAllStrategy:
+				configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
+		}
+
+		cluster = new MiniClusterWithClientResource(
+			new MiniClusterResourceConfiguration.Builder()
+				.setConfiguration(configuration)
+				.setNumberTaskManagers(NUM_TASK_MANAGERS)
+				.setNumberSlotsPerTaskManager(NUM_TASK_SLOTS)
+				.build());
+		cluster.before();
+	}
+
+	@After
+	public void shutDownExistingCluster() {
+		if (cluster != null) {
+			cluster.after();
+			cluster = null;
+		}
+	}
 
 	/**
 	 * Implementations are expected to assemble the test topology in this function
@@ -73,7 +124,25 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
 
 			testProgram(env);
 
-			TestUtils.tryExecute(env, "Fault Tolerance Test");
+			JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+			try {
+				cluster.getClusterClient().submitJob(jobGraph, getClass().getClassLoader()).getJobExecutionResult();
+			}
+			catch (ProgramInvocationException root) {
+				Throwable cause = root.getCause();
+
+				// search for nested SuccessExceptions
+				int depth = 0;
+				while (!(cause instanceof SuccessException)) {
+					if (cause == null || depth++ == 20) {
+						root.printStackTrace();
+						fail("Test failed: " + root.getMessage());
+					}
+					else {
+						cause = cause.getCause();
+					}
+				}
+			}
 
 			postSubmit();
 		}


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-11618](https://issues.apache.org/jira/browse/FLINK-11618) merged, previous [PR-7009](https://github.com/apache/flink/pull/7009) seems a bit outdated, just create this new PR based on previous discussion to replace the older one.

Currently, `RestartPipelinedRegionStrategy` does not perform any state restore. This is big problem because all restored regions will be restarted with empty state. This PR supports to restore state when using `RestartPipelinedRegionStrategy`.

## Brief change log
  - Reload checkpointed state when `FailoverRegion` called `restart` method.

## Verifying this change
This change added tests and can be verified as follows:

  - Added unit tests for `FailoverRegion` to ensure the failover region ever called new `restoreLatestCheckpointedState` API within `CheckpointCoordinator`.
  - Added new integration test `RegionFailoverITCase` to verify split redistribution and union state could be restored properly when the job consists multi regions.
  - Refactored `StreamFaultToleranceTestBase` to let all sub-classes ITs could failover with state using RestartPipelinedRegionStrategy.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**, restore state when failover using RestartPipelinedRegionStrategy.
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs**
