### PR TITLE
 [FLINK-10569][tests] Remove Instance usages in valid Test

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -41,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * an AllocatedSlot was allocated to the JobManager as soon as the TaskManager registered at the
  * JobManager. All slots had a default unknown resource profile. 
  */
-class AllocatedSlot implements PhysicalSlot {
+public class AllocatedSlot implements PhysicalSlot {
 
 	/** The ID under which the slot is allocated. Uniquely identifies the slot. */
 	private final AllocationID allocationId;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory
 import org.apache.flink.runtime.executiongraph.failover.RestartIndividualStrategy;
 import org.apache.flink.runtime.executiongraph.failover.RestartPipelinedRegionStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -105,7 +105,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -174,7 +174,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -242,7 +242,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -353,7 +353,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		when(taskManagerGateway.submitTask(any(TaskDeploymentDescriptor.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 		when(taskManagerGateway.cancelTask(any(ExecutionAttemptID.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism, taskManagerGateway);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism, taskManagerGateway);
 
 		final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = new CheckpointCoordinatorConfiguration(
 			10L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ConcurrentFailoverStrategyExecutionGraphTest.java
@@ -105,7 +105,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -174,7 +174,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -242,7 +242,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = 2;
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(parallelism);
 
 		final ExecutionGraph graph = createSampleGraph(
 			jid,
@@ -353,7 +353,7 @@ public class ConcurrentFailoverStrategyExecutionGraphTest extends TestLogger {
 		when(taskManagerGateway.submitTask(any(TaskDeploymentDescriptor.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 		when(taskManagerGateway.cancelTask(any(ExecutionAttemptID.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism, taskManagerGateway);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(parallelism, taskManagerGateway);
 
 		final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = new CheckpointCoordinatorConfiguration(
 			10L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.NotCancelAckingTaskGateway;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -568,7 +568,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final JobID jid = new JobID();
 		final JobVertex vertex = createNoOpVertex(parallelism);
 		final NotCancelAckingTaskGateway taskManagerGateway = new NotCancelAckingTaskGateway();
-		final SlotProvider slots = new SimpleSlotProvider(jid, parallelism, taskManagerGateway);
+		final SlotProvider slots = new TestingLogicalSlotProvider(jid, parallelism, taskManagerGateway);
 		final TestRestartStrategy restartStrategy = TestRestartStrategy.manuallyTriggered();
 
 		final ExecutionGraph eg = createSimpleTestGraph(jid, slots, restartStrategy, vertex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -288,7 +288,7 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 		vertex.setInvokableClass(NoOpInvokable.class);
 		vertex.setParallelism(parallelism);
 
-		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, parallelism, gateway);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(parallelism, gateway);
 
 		ExecutionGraph simpleTestGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
 			jobId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
@@ -288,7 +288,7 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 		vertex.setInvokableClass(NoOpInvokable.class);
 		vertex.setParallelism(parallelism);
 
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, parallelism, gateway);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, parallelism, gateway);
 
 		ExecutionGraph simpleTestGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
 			jobId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -476,10 +476,6 @@ public class ExecutionGraphTestUtils {
 	//  utility mocking methods
 	// ------------------------------------------------------------------------
 
-	public static Instance getInstance(final TaskManagerGateway gateway) throws Exception {
-		return getInstance(gateway, 1);
-	}
-
 	public static Instance getInstance(final TaskManagerGateway gateway, final int numberOfSlots) throws Exception {
 		ResourceID resourceID = ResourceID.generate();
 		HardwareDescription hardwareDescription = new HardwareDescription(4, 2L*1024*1024*1024, 1024*1024*1024, 512*1024*1024);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.instance.BaseTestingActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
@@ -410,7 +410,7 @@ public class ExecutionGraphTestUtils {
 			numSlotsNeeded += vertex.getParallelism();
 		}
 
-		SlotProvider slotProvider = new SimpleSlotProvider(jid, numSlotsNeeded, taskManagerGateway);
+		SlotProvider slotProvider = new TestingLogicalSlotProvider(jid, numSlotsNeeded, taskManagerGateway);
 
 		return createSimpleTestGraph(jid, slotProvider, restartStrategy, vertices);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -35,10 +35,6 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
-import org.apache.flink.runtime.instance.BaseTestingActorGateway;
-import org.apache.flink.runtime.instance.HardwareDescription;
-import org.apache.flink.runtime.instance.Instance;
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -50,10 +46,6 @@ import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
-import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.messages.TaskMessages.CancelTask;
-import org.apache.flink.runtime.messages.TaskMessages.FailIntermediateResultPartitions;
-import org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -72,8 +64,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
-
-import scala.concurrent.ExecutionContext;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -410,7 +400,7 @@ public class ExecutionGraphTestUtils {
 			numSlotsNeeded += vertex.getParallelism();
 		}
 
-		SlotProvider slotProvider = new TestingLogicalSlotProvider(jid, numSlotsNeeded, taskManagerGateway);
+		SlotProvider slotProvider = new TestingLogicalSlotProvider(numSlotsNeeded, taskManagerGateway);
 
 		return createSimpleTestGraph(jid, slotProvider, restartStrategy, vertices);
 	}
@@ -476,43 +466,11 @@ public class ExecutionGraphTestUtils {
 	//  utility mocking methods
 	// ------------------------------------------------------------------------
 
-	public static Instance getInstance(final TaskManagerGateway gateway, final int numberOfSlots) throws Exception {
-		ResourceID resourceID = ResourceID.generate();
-		HardwareDescription hardwareDescription = new HardwareDescription(4, 2L*1024*1024*1024, 1024*1024*1024, 512*1024*1024);
-		InetAddress address = InetAddress.getByName("127.0.0.1");
-		TaskManagerLocation connection = new TaskManagerLocation(resourceID, address, 10001);
-
-		return new Instance(gateway, connection, new InstanceID(), hardwareDescription, numberOfSlots);
-	}
-
 	public static JobVertex createJobVertex(String task1, int numTasks, Class<NoOpInvokable> invokable) {
 		JobVertex groupVertex = new JobVertex(task1);
 		groupVertex.setInvokableClass(invokable);
 		groupVertex.setParallelism(numTasks);
 		return groupVertex;
-	}
-
-	@SuppressWarnings("serial")
-	public static class SimpleActorGateway extends BaseTestingActorGateway {
-
-
-		public SimpleActorGateway(ExecutionContext executionContext){
-			super(executionContext);
-		}
-
-		@Override
-		public Object handleMessage(Object message) {
-			if (message instanceof SubmitTask) {
-				SubmitTask submitTask = (SubmitTask) message;
-				return Acknowledge.get();
-			} else if(message instanceof CancelTask) {
-				return Acknowledge.get();
-			} else if(message instanceof FailIntermediateResultPartitions) {
-				return new Object();
-			} else {
-				return null;
-			}
-		}
 	}
 
 	public static final String ERROR_MESSAGE = "test_failure_error_message";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -192,7 +192,7 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, 20);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 20);
 
 		for (JobVertex vertex : orderedVertices) {
 			vertex.setInputDependencyConstraint(inputDependencyConstraint);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
@@ -192,7 +192,7 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
-		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 20);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(20);
 
 		for (JobVertex vertex : orderedVertices) {
 			vertex.setInputDependencyConstraint(inputDependencyConstraint);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.executiongraph.failover.RestartPipelinedRegionSt
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobStatus;
@@ -98,7 +98,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, 20);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 20);
 				
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -215,7 +215,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobId, 16);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 16);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -290,7 +290,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobId, 14);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 14);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -388,7 +388,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jobId, 14);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 14);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -98,7 +98,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final SlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 20);
+		final SlotProvider slotProvider = new TestingLogicalSlotProvider(20);
 				
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -215,7 +215,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 16);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(16);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -290,7 +290,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 14);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(14);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");
@@ -388,7 +388,7 @@ public class FailoverRegionTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final String jobName = "Test Job Sample Name";
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jobId, 14);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(14);
 
 		JobVertex v1 = new JobVertex("vertex1");
 		JobVertex v2 = new JobVertex("vertex2");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -157,7 +157,7 @@ public class GlobalModVersionTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = new Random().nextInt(10) + 1;
 
-		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(parallelism);
 
 		// build a simple execution graph with on job vertex, parallelism 2
 		final ExecutionGraph graph = new ExecutionGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory;
 import org.apache.flink.runtime.executiongraph.restart.InfiniteDelayRestartStrategy;
-import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
+import org.apache.flink.runtime.executiongraph.utils.TestingLogicalSlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -157,7 +157,7 @@ public class GlobalModVersionTest extends TestLogger {
 		final JobID jid = new JobID();
 		final int parallelism = new Random().nextInt(10) + 1;
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final TestingLogicalSlotProvider slotProvider = new TestingLogicalSlotProvider(jid, parallelism);
 
 		// build a simple execution graph with on job vertex, parallelism 2
 		final ExecutionGraph graph = new ExecutionGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/TestingLogicalSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/TestingLogicalSlotProvider.java
@@ -22,11 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
-import org.apache.flink.runtime.instance.Slot;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
@@ -35,10 +33,11 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.AllocatedSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -53,7 +52,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * A testing utility slot provider that simply has a predefined pool of slots.
  */
-public class SimpleSlotProvider implements SlotProvider, SlotOwner {
+public class TestingLogicalSlotProvider implements SlotProvider, SlotOwner {
 
 	private final Object lock = new Object();
 
@@ -61,21 +60,22 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 
 	private final HashMap<SlotRequestId, SlotContext> allocatedSlots;
 
-	public SimpleSlotProvider(JobID jobId, int numSlots) {
+	public TestingLogicalSlotProvider(JobID jobId, int numSlots) {
 		this(jobId, numSlots, new SimpleAckingTaskManagerGateway());
 	}
 
-	public SimpleSlotProvider(JobID jobId, int numSlots, TaskManagerGateway taskManagerGateway) {
+	public TestingLogicalSlotProvider(JobID jobId, int numSlots, TaskManagerGateway taskManagerGateway) {
 		checkNotNull(jobId, "jobId");
 		checkArgument(numSlots >= 0, "numSlots must be >= 0");
 
 		this.slots = new ArrayDeque<>(numSlots);
 
 		for (int i = 0; i < numSlots; i++) {
-			SimpleSlotContext as = new SimpleSlotContext(
+			AllocatedSlot as = new AllocatedSlot(
 				new AllocationID(),
 				new TaskManagerLocation(ResourceID.generate(), InetAddress.getLoopbackAddress(), 10000 + i),
 				0,
+				ResourceProfile.UNKNOWN,
 				taskManagerGateway);
 			slots.add(as);
 		}
@@ -99,7 +99,15 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 				slot = slots.removeFirst();
 			}
 			if (slot != null) {
-				SimpleSlot result = new SimpleSlot(slot, this, 0);
+				TestingLogicalSlot result = new TestingLogicalSlot(
+					slot.getTaskManagerLocation(),
+					slot.getTaskManagerGateway(),
+					slot.getPhysicalSlotNumber(),
+					slot.getAllocationId(),
+					slotRequestId,
+					new SlotSharingGroupId(),
+					null,
+					this);
 				allocatedSlots.put(slotRequestId, slot);
 				return CompletableFuture.completedFuture(result);
 			}
@@ -124,12 +132,15 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 
 	@Override
 	public void returnLogicalSlot(LogicalSlot logicalSlot) {
-		Preconditions.checkArgument(logicalSlot instanceof Slot);
-
-		final Slot slot = ((Slot) logicalSlot);
-
 		synchronized (lock) {
-			slots.add(slot.getSlotContext());
+			AllocatedSlot as = new AllocatedSlot(
+				logicalSlot.getAllocationId(),
+				logicalSlot.getTaskManagerLocation(),
+				logicalSlot.getPhysicalSlotNumber(),
+				ResourceProfile.UNKNOWN,
+				logicalSlot.getTaskManagerGateway());
+
+			slots.add(as);
 			allocatedSlots.remove(logicalSlot.getSlotRequestId());
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -49,6 +49,9 @@ public class TestingLogicalSlot implements LogicalSlot {
 
 	@Nullable
 	private final CompletableFuture<?> customReleaseFuture;
+
+	@Nullable
+	private final SlotOwner slotOwner;
 	
 	private final AllocationID allocationId;
 
@@ -79,6 +82,27 @@ public class TestingLogicalSlot implements LogicalSlot {
 			SlotRequestId slotRequestId,
 			SlotSharingGroupId slotSharingGroupId,
 			@Nullable CompletableFuture<?> customReleaseFuture) {
+		this(
+			taskManagerLocation,
+			taskManagerGateway,
+			slotNumber,
+			allocationId,
+			slotRequestId,
+			slotSharingGroupId,
+			customReleaseFuture,
+			null);
+	}
+
+	public TestingLogicalSlot(
+		TaskManagerLocation taskManagerLocation,
+		TaskManagerGateway taskManagerGateway,
+		int slotNumber,
+		AllocationID allocationId,
+		SlotRequestId slotRequestId,
+		SlotSharingGroupId slotSharingGroupId,
+		@Nullable CompletableFuture<?> customReleaseFuture,
+		@Nullable SlotOwner slotOwner) {
+
 		this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
 		this.taskManagerGateway = Preconditions.checkNotNull(taskManagerGateway);
 		this.payloadReference = new AtomicReference<>();
@@ -88,6 +112,7 @@ public class TestingLogicalSlot implements LogicalSlot {
 		this.slotSharingGroupId = Preconditions.checkNotNull(slotSharingGroupId);
 		this.releaseFuture = new CompletableFuture<>();
 		this.customReleaseFuture = customReleaseFuture;
+		this.slotOwner = slotOwner;
 	}
 
 	@Override
@@ -127,6 +152,10 @@ public class TestingLogicalSlot implements LogicalSlot {
 
 	@Override
 	public CompletableFuture<?> releaseSlot(@Nullable Throwable cause) {
+		if (slotOwner != null) {
+			slotOwner.returnLogicalSlot(this);
+		}
+
 		if (customReleaseFuture != null) {
 			return customReleaseFuture;
 		} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -156,6 +156,12 @@ public class TestingLogicalSlot implements LogicalSlot {
 			slotOwner.returnLogicalSlot(this);
 		}
 
+		Payload payload = payloadReference.get();
+
+		if (payload != null) {
+			payload.fail(cause);
+		}
+
 		if (customReleaseFuture != null) {
 			return customReleaseFuture;
 		} else {


### PR DESCRIPTION
## What is the purpose of the change

**DOT MERGE**

Based on #7809 . The last batch of FLINK-10569.

1. Replace SimpleSlot to TestingLogicalSlot in `ExecutionVertexCancelTest`

2. Add a `releaseAllocatedSlot` method in `TestingLogicalSlotProvider` to simulate `Instance#markDead`

**3** still cannot port the last two tests `testRestartWithSlotSharingAndNotEnoughResources` and `testRestartWithEagerSchedulingAndSlotSharing`. The problem is that it test slot sharing and thus we need a testing slotprovider which support SlotSharing. I haven't successfully implemented it yet. Maybe I need some help from the community.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann @zentol 
