### PR TITLE
[FLINK-11744]  Provide stable/final toHexString for AbstractID

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
@@ -47,7 +47,7 @@ public class AbstractID implements Comparable<AbstractID>, java.io.Serializable 
 	protected final long lowerPart;
 
 	/** The memoized value returned by toString(). */
-	private transient String toString;
+	private transient String hexString;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -127,6 +127,22 @@ public class AbstractID implements Comparable<AbstractID>, java.io.Serializable 
 		return bytes;
 	}
 
+	/**
+	 * Returns pure String representation of the ID in hexadecimal. This method should be used to construct things like
+	 * paths etc., that require a stable representation and is therefore final.
+	 */
+	public final String toHexString() {
+		if (this.hexString == null) {
+			final byte[] ba = new byte[SIZE];
+			longToByteArray(this.lowerPart, ba, 0);
+			longToByteArray(this.upperPart, ba, SIZE_OF_LONG);
+
+			this.hexString = StringUtils.byteToHexString(ba);
+		}
+
+		return this.hexString;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Standard Utilities
 	// --------------------------------------------------------------------------------------------
@@ -153,15 +169,7 @@ public class AbstractID implements Comparable<AbstractID>, java.io.Serializable 
 
 	@Override
 	public String toString() {
-		if (this.toString == null) {
-			final byte[] ba = new byte[SIZE];
-			longToByteArray(this.lowerPart, ba, 0);
-			longToByteArray(this.upperPart, ba, SIZE_OF_LONG);
-
-			this.toString = StringUtils.byteToHexString(ba);
-		}
-
-		return this.toString;
+		return toHexString();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
@@ -52,9 +52,4 @@ public class AllocationID extends AbstractID {
 	public AllocationID(long lowerPart, long upperPart) {
 		super(lowerPart, upperPart);
 	}
-
-	@Override
-	public String toString() {
-		return "AllocationID{" + super.toString() + '}';
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -120,7 +120,7 @@ public class TaskExecutorLocalStateStoresManager {
 
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("Registered new allocation id {} for local state stores for job {}.",
-						allocationID, jobId);
+						allocationID.toHexString(), jobId);
 				}
 			}
 
@@ -232,7 +232,7 @@ public class TaskExecutorLocalStateStoresManager {
 
 	@VisibleForTesting
 	String allocationSubDirString(AllocationID allocationID) {
-		return "aid_" + allocationID;
+		return "aid_" + allocationID.toHexString();
 	}
 
 	private File[] allocationBaseDirectories(AllocationID allocationID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
@@ -357,7 +357,7 @@ public class TaskLocalStateStoreImpl implements OwnedTaskLocalStateStore {
 		return "TaskLocalStateStore{" +
 			"jobID=" + jobID +
 			", jobVertexID=" + jobVertexID +
-			", allocationID=" + allocationID +
+			", allocationID=" + allocationID.toHexString() +
 			", subtaskIndex=" + subtaskIndex +
 			", localRecoveryConfig=" + localRecoveryConfig +
 			", storedCheckpointIDs=" + storedTaskStateByCheckpointID.keySet() +


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a final method into `AbstractID` that gives a stable respresentation of the ID as a Hex-String. Before, user had to rely on `toString` for this, which could be overriden in subclasses. Code that relies on stable string representations (e.g. using the id to create a file path) can silently break when `toString` is overriden later. Such code can rely on the newly introduced method.

The PR also includes a hotfix to revert overriding ot `toString` in `AllocationID`

## Brief change log

- Introduce `final AbstractID::toHexString`.
- Use of this new stable method for local recovery, instead of plain `toString`
- Revert overriding of `toString` in `AllocationID`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
