### PR TITLE
[FLINK-10881] Fix SavepointITCase test instability.

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -192,7 +192,7 @@ public class SavepointITCase extends TestLogger {
 
 			StatefulCounter.getProgressLatch().await();
 
-			return client.triggerSavepoint(jobId, null).get();
+			return client.cancelWithSavepoint(jobId, null);
 		} finally {
 			cluster.after();
 			StatefulCounter.resetForTest(parallelism);


### PR DESCRIPTION
This is a trivial test-stability fix.
When running the test in a loop locally, we were not cancelling the job and it was, consequently, not freeing up some resources. The result was the test to fail with an `OOM`. 

This seems to be fixing the instability.