### PR TITLE
[FLINK-11750][network] Replace IntermediateResultPartitionID with ResultPartitionID in ResultPartitionDeploymentDescriptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.deployment;
 
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 
 import java.io.Serializable;
@@ -43,7 +43,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 	private final IntermediateDataSetID resultId;
 
 	/** The ID of the partition. */
-	private final IntermediateResultPartitionID partitionId;
+	private final ResultPartitionID partitionId;
 
 	/** The type of the partition. */
 	private final ResultPartitionType partitionType;
@@ -59,7 +59,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 
 	public ResultPartitionDeploymentDescriptor(
 			IntermediateDataSetID resultId,
-			IntermediateResultPartitionID partitionId,
+			ResultPartitionID partitionId,
 			ResultPartitionType partitionType,
 			int numberOfSubpartitions,
 			int maxParallelism,
@@ -80,7 +80,7 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 		return resultId;
 	}
 
-	public IntermediateResultPartitionID getPartitionId() {
+	public ResultPartitionID getPartitionId() {
 		return partitionId;
 	}
 
@@ -113,7 +113,8 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
 			IntermediateResultPartition partition, int maxParallelism, boolean lazyScheduling) {
 
 		final IntermediateDataSetID resultId = partition.getIntermediateResult().getId();
-		final IntermediateResultPartitionID partitionId = partition.getPartitionId();
+		final ResultPartitionID partitionId = new ResultPartitionID(
+			partition.getPartitionId(), partition.getProducer().getCurrentExecutionAttempt().getAttemptId());
 		final ResultPartitionType partitionType = partition.getIntermediateResult().getResultType();
 
 		// The produced data is partitioned among a number of subpartitions.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -364,13 +364,11 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 		int counter = 0;
 
 		for (ResultPartitionDeploymentDescriptor desc: resultPartitionDeploymentDescriptors) {
-			ResultPartitionID partitionId = new ResultPartitionID(desc.getPartitionId(), executionId);
-
 			this.producedPartitions[counter] = new ResultPartition(
 				taskNameWithSubtaskAndId,
 				this,
 				jobId,
-				partitionId,
+				desc.getPartitionId(),
 				desc.getPartitionType(),
 				desc.getNumberOfSubpartitions(),
 				desc.getMaxParallelism(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.deployment;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -40,7 +42,7 @@ public class ResultPartitionDeploymentDescriptorTest {
 	public void testSerialization() throws Exception {
 		// Expected values
 		IntermediateDataSetID resultId = new IntermediateDataSetID();
-		IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
+		ResultPartitionID partitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 		ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
 		int numberOfSubpartitions = 24;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1253,7 +1253,7 @@ public class JobMasterTest extends TestLogger {
 			jobMasterGateway.updateTaskExecutionState(new TaskExecutionState(producerConsumerJobGraph.getJobID(), executionAttemptId, ExecutionState.FINISHED)).get();
 
 			// request the state of the result partition of the producer
-			final ResultPartitionID partitionId = new ResultPartitionID(partition.getPartitionId(), copiedExecutionAttemptId);
+			final ResultPartitionID partitionId = new ResultPartitionID(partition.getPartitionId().getPartitionId(), copiedExecutionAttemptId);
 			CompletableFuture<ExecutionState> partitionStateFuture = jobMasterGateway.requestPartitionState(partition.getResultId(), partitionId);
 
 			assertThat(partitionStateFuture.get(), equalTo(ExecutionState.FINISHED));
@@ -1279,7 +1279,8 @@ public class JobMasterTest extends TestLogger {
 			}
 
 			// ask for "old" execution
-			partitionStateFuture = jobMasterGateway.requestPartitionState(partition.getResultId(), new ResultPartitionID(partition.getPartitionId(), new ExecutionAttemptID()));
+			partitionStateFuture = jobMasterGateway.requestPartitionState(
+				partition.getResultId(), new ResultPartitionID(partition.getPartitionId().getPartitionId(), new ExecutionAttemptID()));
 
 			try {
 				partitionStateFuture.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -680,7 +680,8 @@ public class TaskManagerTest extends TestLogger {
 				IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 
 				List<ResultPartitionDeploymentDescriptor> irpdd = new ArrayList<ResultPartitionDeploymentDescriptor>();
-				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, 1, true));
+				irpdd.add(new ResultPartitionDeploymentDescriptor(
+					new IntermediateDataSetID(), new ResultPartitionID(partitionId, eid1), ResultPartitionType.PIPELINED, 1, 1, true));
 
 				InputGateDeploymentDescriptor ircdd =
 						new InputGateDeploymentDescriptor(
@@ -829,7 +830,8 @@ public class TaskManagerTest extends TestLogger {
 				IntermediateResultPartitionID partitionId = new IntermediateResultPartitionID();
 
 				List<ResultPartitionDeploymentDescriptor> irpdd = new ArrayList<ResultPartitionDeploymentDescriptor>();
-				irpdd.add(new ResultPartitionDeploymentDescriptor(new IntermediateDataSetID(), partitionId, ResultPartitionType.PIPELINED, 1, 1, true));
+				irpdd.add(new ResultPartitionDeploymentDescriptor(
+					new IntermediateDataSetID(), new ResultPartitionID(partitionId, eid1), ResultPartitionType.PIPELINED, 1, 1, true));
 
 				InputGateDeploymentDescriptor ircdd =
 						new InputGateDeploymentDescriptor(
@@ -1580,7 +1582,7 @@ public class TaskManagerTest extends TestLogger {
 
 			final ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor = new ResultPartitionDeploymentDescriptor(
 				new IntermediateDataSetID(),
-				new IntermediateResultPartitionID(),
+				new ResultPartitionID(new IntermediateResultPartitionID(), eid),
 				ResultPartitionType.PIPELINED,
 				1,
 				1,


### PR DESCRIPTION
## What is the purpose of the change

*The motivation of task is for preparing the creation of `ResultPartition` via `ShuffleService` future.
Currently during the creation of `ResultPartition` we need the `ExecutionAttemptID` info to generate `ResultPartitionID`. To make the interface of `ShuffleService#createResultPartitionWriter` clean, it is better to get `ResultPartitionID` directly from `ResultPartitionDeploymentDescriptor` instead of explicitly passing additional `ExecutionAttemptID`.*

*We could create this `ResultPartitionID` during generating `ResultPartitionDeploymentDescriptor` to replace the field of `IntermediateResultPartitionID`.*

## Brief change log

  - *Creates `ResultPartitionID` during generating `ResultPartitionDeploymentDescriptor`*
  - *Gets `ResultPartitionID` directly from `ResultPartitionDeploymentDescriptor` in `Task` class*

## Verifying this change

This change is already covered by existing tests, such as *ResultPartitionDeploymentDescriptorTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)