### PR TITLE
[FLINK-11091][table] Clear the use of deprecated `process(ProcessFunc…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.api
 import _root_.java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.calcite.plan.RelOptUtil
-import org.apache.calcite.plan.hep.HepMatchOrder
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.sql2rel.RelDecorrelator

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.runtime.aggregate
 
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 import org.apache.flink.api.common.state._
@@ -43,13 +43,13 @@ import org.apache.flink.table.util.Logging
   * @param aggregatesTypeInfo       row type info of aggregation
   * @param inputType                row type info of input row
   */
-class ProcTimeBoundedRangeOver(
+class ProcTimeBoundedRangeOver[K](
     genAggregations: GeneratedAggregationsFunction,
     precedingTimeBoundary: Long,
     aggregatesTypeInfo: RowTypeInfo,
     inputType: TypeInformation[CRow],
     queryConfig: StreamQueryConfig)
-  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+  extends ProcessFunctionWithCleanupState[K, CRow, CRow](queryConfig)
     with Compiler[GeneratedAggregations]
     with Logging {
 
@@ -90,7 +90,7 @@ class ProcTimeBoundedRangeOver(
 
   override def processElement(
     input: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     val currentTime = ctx.timerService.currentProcessingTime
@@ -114,7 +114,7 @@ class ProcTimeBoundedRangeOver(
 
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     if (stateCleaningEnabled) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRowsOver.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRowsOver.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueSta
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.{ListTypeInfo, RowTypeInfo}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.{Compiler, GeneratedAggregationsFunction}
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -40,13 +40,13 @@ import org.apache.flink.util.{Collector, Preconditions}
   * @param aggregatesTypeInfo   row type info of aggregation
   * @param inputType            row type info of input row
   */
-class ProcTimeBoundedRowsOver(
+class ProcTimeBoundedRowsOver[K](
     genAggregations: GeneratedAggregationsFunction,
     precedingOffset: Long,
     aggregatesTypeInfo: RowTypeInfo,
     inputType: TypeInformation[CRow],
     queryConfig: StreamQueryConfig)
-  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+  extends ProcessFunctionWithCleanupState[K, CRow, CRow](queryConfig)
     with Compiler[GeneratedAggregations]
     with Logging {
 
@@ -102,7 +102,7 @@ class ProcTimeBoundedRowsOver(
 
   override def processElement(
     inputC: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     val input = inputC.row
@@ -184,7 +184,7 @@ class ProcTimeBoundedRowsOver(
 
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     if (stateCleaningEnabled) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeSortProcessFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeSortProcessFunction.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.runtime.aggregate
 
 import org.apache.flink.api.common.state.{ListState, ListStateDescriptor}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.types.Row
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.util.{Collector, Preconditions}
@@ -35,10 +35,10 @@ import org.apache.flink.streaming.api.operators.TimestampedCollector
  * @param inputRowType The data type of the input data.
  * @param rowComparator A comparator to sort rows.
  */
-class ProcTimeSortProcessFunction(
+class ProcTimeSortProcessFunction[K](
     private val inputRowType: CRowTypeInfo,
     private val rowComparator: CollectionRowComparator)
-  extends ProcessFunction[CRow, CRow] {
+  extends KeyedProcessFunction[K, CRow, CRow] {
 
   Preconditions.checkNotNull(rowComparator)
 
@@ -58,7 +58,7 @@ class ProcTimeSortProcessFunction(
 
   override def processElement(
     inputC: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     val input = inputC.row
@@ -74,7 +74,7 @@ class ProcTimeSortProcessFunction(
   
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     // remove timestamp set outside of ProcessFunction.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeUnboundedOver.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeUnboundedOver.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.aggregate
 import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.{Compiler, GeneratedAggregationsFunction}
 import org.apache.flink.table.runtime.types.CRow
@@ -34,11 +34,11 @@ import org.apache.flink.util.Collector
   * @param genAggregations Generated aggregate helper function
   * @param aggregationStateType     row type info of aggregation
   */
-class ProcTimeUnboundedOver(
+class ProcTimeUnboundedOver[K](
     genAggregations: GeneratedAggregationsFunction,
     aggregationStateType: RowTypeInfo,
     queryConfig: StreamQueryConfig)
-  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+  extends ProcessFunctionWithCleanupState[K, CRow, CRow](queryConfig)
     with Compiler[GeneratedAggregations]
     with Logging {
 
@@ -67,7 +67,7 @@ class ProcTimeUnboundedOver(
 
   override def processElement(
     inputC: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     // register state-cleanup timer
@@ -92,7 +92,7 @@ class ProcTimeUnboundedOver(
 
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     if (stateCleaningEnabled) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcessFunctionWithCleanupState.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcessFunctionWithCleanupState.scala
@@ -22,11 +22,11 @@ import java.lang.{Long => JLong}
 import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
 import org.apache.flink.api.common.state.State
 import org.apache.flink.streaming.api.TimeDomain
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.table.api.{StreamQueryConfig, Types}
 
-abstract class ProcessFunctionWithCleanupState[IN,OUT](queryConfig: StreamQueryConfig)
-  extends ProcessFunction[IN, OUT]
+abstract class ProcessFunctionWithCleanupState[KEY, IN,OUT](queryConfig: StreamQueryConfig)
+  extends KeyedProcessFunction[KEY, IN, OUT]
   with CleanupState {
 
   protected val minRetentionTime: Long = queryConfig.getMinIdleStateRetentionTime
@@ -45,7 +45,7 @@ abstract class ProcessFunctionWithCleanupState[IN,OUT](queryConfig: StreamQueryC
   }
 
   protected def processCleanupTimer(
-    ctx: ProcessFunction[IN, OUT]#Context,
+    ctx: KeyedProcessFunction[KEY, IN, OUT]#Context,
     currentTime: Long): Unit = {
     if (stateCleaningEnabled) {
       registerProcessingCleanupTimer(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRangeOver.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRangeOver.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state._
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.{ListTypeInfo, RowTypeInfo}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.{Compiler, GeneratedAggregationsFunction}
@@ -40,14 +40,14 @@ import org.apache.flink.util.{Collector, Preconditions}
   * @param inputRowType             row type info of input row
   * @param precedingOffset          preceding offset
  */
-class RowTimeBoundedRangeOver(
+class RowTimeBoundedRangeOver[K](
     genAggregations: GeneratedAggregationsFunction,
     aggregationStateType: RowTypeInfo,
     inputRowType: CRowTypeInfo,
     precedingOffset: Long,
     rowTimeIdx: Int,
     queryConfig: StreamQueryConfig)
-  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+  extends ProcessFunctionWithCleanupState[K, CRow, CRow](queryConfig)
     with Compiler[GeneratedAggregations]
     with Logging {
   Preconditions.checkNotNull(aggregationStateType)
@@ -108,7 +108,7 @@ class RowTimeBoundedRangeOver(
 
   override def processElement(
     inputC: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     val input = inputC.row
@@ -139,7 +139,7 @@ class RowTimeBoundedRangeOver(
 
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     if (isProcessingTimeTimer(ctx.asInstanceOf[OnTimerContext])) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRowsOver.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRowsOver.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.state._
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.{ListTypeInfo, RowTypeInfo}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.{Compiler, GeneratedAggregationsFunction}
@@ -41,14 +41,14 @@ import org.apache.flink.util.{Collector, Preconditions}
   * @param inputRowType             row type info of input row
   * @param precedingOffset          preceding offset
  */
-class RowTimeBoundedRowsOver(
+class RowTimeBoundedRowsOver[K](
     genAggregations: GeneratedAggregationsFunction,
     aggregationStateType: RowTypeInfo,
     inputRowType: CRowTypeInfo,
     precedingOffset: Long,
     rowTimeIdx: Int,
     queryConfig: StreamQueryConfig)
-  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+  extends ProcessFunctionWithCleanupState[K, CRow, CRow](queryConfig)
     with Compiler[GeneratedAggregations]
     with Logging {
 
@@ -117,7 +117,7 @@ class RowTimeBoundedRowsOver(
 
   override def processElement(
     inputC: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     val input = inputC.row
@@ -148,7 +148,7 @@ class RowTimeBoundedRowsOver(
 
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     if (isProcessingTimeTimer(ctx.asInstanceOf[OnTimerContext])) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state.{MapState, MapStateDescriptor, ValueSta
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.ListTypeInfo
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.types.Row
@@ -36,11 +36,11 @@ import org.apache.flink.util.{Collector, Preconditions}
   * @param rowtimeIdx The index of the rowtime field.
   * @param rowComparator A comparator to sort rows.
  */
-class RowTimeSortProcessFunction(
+class RowTimeSortProcessFunction[K](
     private val inputRowType: CRowTypeInfo,
     private val rowtimeIdx: Int,
     private val rowComparator: Option[CollectionRowComparator])
-  extends ProcessFunction[CRow, CRow] {
+  extends KeyedProcessFunction[K, CRow, CRow] {
 
   Preconditions.checkNotNull(rowComparator)
 
@@ -77,7 +77,7 @@ class RowTimeSortProcessFunction(
   
   override def processElement(
     inputC: CRow,
-    ctx: ProcessFunction[CRow, CRow]#Context,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#Context,
     out: Collector[CRow]): Unit = {
 
     val input = inputC.row
@@ -107,7 +107,7 @@ class RowTimeSortProcessFunction(
 
   override def onTimer(
     timestamp: Long,
-    ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+    ctx: KeyedProcessFunction[K, CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
     // remove timestamp set outside of ProcessFunction.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.table.runtime.aggregate
 
+import java.lang.{Byte => JByte}
+
 import org.apache.calcite.rel.`type`._
 import org.apache.calcite.rel.RelCollation
 import org.apache.calcite.rel.RelFieldCollation
@@ -25,7 +27,7 @@ import org.apache.flink.types.Row
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.api.common.typeutils.TypeComparator
 import org.apache.flink.api.java.typeutils.runtime.RowComparator
 import org.apache.flink.api.common.typeutils.TypeSerializer
@@ -59,7 +61,7 @@ object SortUtil {
     collationSort: RelCollation,
     inputType: RelDataType,
     inputTypeInfo: TypeInformation[Row],
-    execCfg: ExecutionConfig): ProcessFunction[CRow, CRow] = {
+    execCfg: ExecutionConfig): KeyedProcessFunction[JByte, CRow, CRow] = {
 
     Preconditions.checkArgument(collationSort.getFieldCollations.size() > 0)
     val rowtimeIdx = collationSort.getFieldCollations.get(0).getFieldIndex
@@ -78,7 +80,7 @@ object SortUtil {
 
     val inputCRowType = CRowTypeInfo(inputTypeInfo)
  
-    new RowTimeSortProcessFunction(
+    new RowTimeSortProcessFunction[JByte](
       inputCRowType,
       rowtimeIdx,
       collectionRowComparator)
@@ -97,7 +99,7 @@ object SortUtil {
     collationSort: RelCollation,
     inputType: RelDataType,
     inputTypeInfo: TypeInformation[Row],
-    execCfg: ExecutionConfig): ProcessFunction[CRow, CRow] = {
+    execCfg: ExecutionConfig): KeyedProcessFunction[JByte, CRow, CRow] = {
 
     val rowComp = createRowComparator(
       inputType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/AggFunctionHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/AggFunctionHarnessTest.scala
@@ -71,7 +71,7 @@ class AggFunctionHarnessTest extends HarnessTestBase {
     val state = getState(
       operator,
       "function",
-      classOf[GroupAggProcessFunction],
+      classOf[GroupAggProcessFunction[Row]],
       "acc0_map_dataview").asInstanceOf[MapView[JInt, JInt]]
     assertTrue(state.isInstanceOf[StateMapView[_, _]])
     assertTrue(operator.getKeyedStateBackend.isInstanceOf[RocksDBKeyedStateBackend[_]])
@@ -136,12 +136,12 @@ class AggFunctionHarnessTest extends HarnessTestBase {
     val minState = getState(
       operator,
       "function",
-      classOf[GroupAggProcessFunction],
+      classOf[GroupAggProcessFunction[Row]],
       "acc0_map_dataview").asInstanceOf[MapView[JInt, JInt]]
     val maxState = getState(
       operator,
       "function",
-      classOf[GroupAggProcessFunction],
+      classOf[GroupAggProcessFunction[Row]],
       "acc1_map_dataview").asInstanceOf[MapView[JInt, JInt]]
     assertTrue(minState.isInstanceOf[StateMapView[_, _]])
     assertTrue(maxState.isInstanceOf[StateMapView[_, _]])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/GroupAggregateHarnessTest.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.scala._
@@ -45,8 +45,8 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
   @Test
   def testAggregate(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new GroupAggProcessFunction(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new GroupAggProcessFunction[String](
         genSumAggFunction,
         sumAggregationStateType,
         false,
@@ -104,8 +104,8 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
   @Test
   def testAggregateWithRetract(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new GroupAggProcessFunction(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new GroupAggProcessFunction[String](
         genSumAggFunction,
         sumAggregationStateType,
         true,
@@ -211,7 +211,7 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
     val fields = getGeneratedAggregationFields(
       operator,
       "function",
-      classOf[GroupAggProcessFunction])
+      classOf[GroupAggProcessFunction[Row]])
 
     // check only one DistinctAccumulator is used
     assertTrue(fields.count(_.getName.endsWith("distinctValueMap_dataview")) == 1)
@@ -301,7 +301,7 @@ class GroupAggregateHarnessTest extends HarnessTestBase {
     val fields = getGeneratedAggregationFields(
       operator,
       "function",
-      classOf[GroupAggProcessFunction])
+      classOf[GroupAggProcessFunction[Row]])
 
     // check only one DistinctAccumulator is used
     assertTrue(fields.count(_.getName.endsWith("distinctValueMap_dataview")) == 1)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
-import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.{StreamQueryConfig, Types}
 import org.apache.flink.table.runtime.aggregate._
@@ -40,8 +40,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testProcTimeBoundedRowsOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new ProcTimeBoundedRowsOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new ProcTimeBoundedRowsOver[String](
         genMinMaxAggFunction,
         2,
         minMaxAggregationStateType,
@@ -141,8 +141,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testProcTimeBoundedRangeOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new ProcTimeBoundedRangeOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new ProcTimeBoundedRangeOver[String](
         genMinMaxAggFunction,
         4000,
         minMaxAggregationStateType,
@@ -269,8 +269,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testProcTimeUnboundedOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new ProcTimeUnboundedOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new ProcTimeUnboundedOver[String](
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         queryConfig))
@@ -361,8 +361,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testRowTimeBoundedRangeOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new RowTimeBoundedRangeOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new RowTimeBoundedRangeOver[String](
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         minMaxCRowType,
@@ -511,8 +511,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testRowTimeBoundedRowsOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new RowTimeBoundedRowsOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new RowTimeBoundedRowsOver[String](
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         minMaxCRowType,
@@ -659,8 +659,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testRowTimeUnboundedRangeOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new RowTimeUnboundedRangeOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new RowTimeUnboundedRangeOver[String](
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         minMaxCRowType,
@@ -795,8 +795,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
   @Test
   def testRowTimeUnboundedRowsOver(): Unit = {
 
-    val processFunction = new LegacyKeyedProcessOperator[String, CRow, CRow](
-      new RowTimeUnboundedRowsOver(
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new RowTimeUnboundedRowsOver[String](
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         minMaxCRowType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/SortProcessFunctionHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/harness/SortProcessFunctionHarnessTest.scala
@@ -28,7 +28,7 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.java.typeutils.runtime.RowComparator
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.{KeyedOneInputStreamOperatorTestHarness, TestHarnessUtil}
@@ -71,8 +71,8 @@ class SortProcessFunctionHarnessTest {
     
     val inputCRowType = CRowTypeInfo(rT)
     
-    val processFunction = new LegacyKeyedProcessOperator[Integer,CRow,CRow](
-      new ProcTimeSortProcessFunction(
+    val processFunction = new KeyedProcessOperator[Integer,CRow,CRow](
+      new ProcTimeSortProcessFunction[Integer](
         inputCRowType,
         collectionRowComparator))
   
@@ -170,8 +170,8 @@ class SortProcessFunctionHarnessTest {
 
     val inputCRowType = CRowTypeInfo(rT)
 
-    val processFunction = new LegacyKeyedProcessOperator[Integer,CRow,CRow](
-      new RowTimeSortProcessFunction(
+    val processFunction = new KeyedProcessOperator[Integer,CRow,CRow](
+      new RowTimeSortProcessFunction[Integer](
         inputCRowType,
         4,
         Some(collectionRowComparator)))


### PR DESCRIPTION
## What is the purpose of the change

This pull request clear the use of deprecated method `process(ProcessFunction)` of KeyedStream in table operators.


## Brief change log
  - Replace `ProcessFunction` with `KeyedProcessFunction` which using in`DataStreamGroupAggregate`, `DataStreamOverAggregate` and `DataStreamSort`
  - Modify `ProcessFunctionWithCleanupState` to extend `KeyedProcessFunction`
  - Fix a number of corresponding test cases


## Verifying this change
This change is already covered by existing tests, such as *(GroupAggregateHarnessTest
,OverWindowHarnessTest, SortProcessFunctionHarnessTest, etc.)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
