### PR TITLE
[FLINK-11711][table-planner-blink] Add table and column stats

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/stats/ColumnStats.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/stats/ColumnStats.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import java.lang.{Double, Long}
+
+/**
+  * Column statistics.
+  * Note we currently assume that, in Flink, the max and min of ColumnStats will be same type as
+  * the Flink column type. For example, for SHORT and Long columns, the max and min of their
+  * ColumnStats should be of type SHORT and LONG. This assumption might change in the future.
+  *
+  * @param ndv       number of distinct values, the value is null if not available.
+  *                  (when it's not null, it may be an inaccurate value.)
+  * @param nullCount number of nulls, the value is null if not available.
+  *                  (when it's not null, it may be an inaccurate value.)
+  * @param avgLen    average length of column values, the value is null if not available.
+  *                  (when it's not null, it may be an inaccurate value.)
+  * @param maxLen    max length of column values, the value is null if not available.
+  *                  (when it's not null, it may be an inaccurate value.)
+  * @param max       max value of column values, the value is null if not available.
+  *                  (it must be a correct value, and the accurate max value may be
+  *                  less than this value.)
+  * @param min       min value of column values, the value is null if not available.
+  *                  (it must be a correct value, and the accurate min value may be
+  *                  greater than this value.)
+  */
+case class ColumnStats(
+    ndv: Long,
+    nullCount: Long,
+    avgLen: Double,
+    maxLen: Integer,
+    max: Any,
+    min: Any) {
+
+  validateNumber(ndv, "ndv")
+  validateNumber(nullCount, "nullCount")
+  validateNumber(avgLen, "avgLen")
+  validateNumber(maxLen, "maxLen")
+  validateMaxMin(max, min)
+
+  override def toString: String = {
+    val columnStatsStr = Seq(
+      if (ndv != null) s"ndv=$ndv" else "",
+      if (nullCount != null) s"nullCount=$nullCount" else "",
+      if (avgLen != null) s"avgLen=$avgLen" else "",
+      if (maxLen != null) s"maxLen=$maxLen" else "",
+      if (max != null) s"max=$max" else "",
+      if (min != null) s"min=$min" else ""
+    ).filter(_.nonEmpty).mkString(", ")
+
+    s"ColumnStats($columnStatsStr)"
+  }
+
+  private def validateNumber(number: Number, fieldName: String): Unit = {
+    require(number == null || number.doubleValue() >= 0,
+      s"$fieldName should be null or be greater than or equal to 0!")
+  }
+
+  private def validateMaxMin(max: Any, min: Any): Unit = {
+    require(max == null || max.isInstanceOf[Comparable[_]],
+      "max should be null or be a Comparable instance!")
+    require(min == null || min.isInstanceOf[Comparable[_]],
+      "min should be null or be a Comparable instance!")
+    require(min == null || max == null || max.getClass == min.getClass,
+      "the classes of min and max should be same!")
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/stats/FlinkStatistic.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/stats/FlinkStatistic.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import org.apache.calcite.rel.{RelCollation, RelDistribution, RelReferentialConstraint}
+import org.apache.calcite.schema.Statistic
+import org.apache.calcite.util.ImmutableBitSet
+
+import java.lang.{Double => JDouble}
+import java.util
+
+/**
+  * The class provides statistics for a [[org.apache.flink.table.plan.schema.FlinkTable]].
+  *
+  * @param tableStats The table statistics, it cannot be null. Use [[TableStats.UNKNOWN]] if table
+  *                   statistics is not available.
+  */
+class FlinkStatistic private(tableStats: TableStats) extends Statistic {
+
+  require(tableStats != null, "tableStats can not be null!")
+
+  /**
+    * Returns the table statistics.
+    *
+    * @return The table statistics
+    */
+  def getTableStats: TableStats = tableStats
+
+  /**
+    * Returns the stats of the specified the column.
+    *
+    * @param columnName The name of the column for which the stats are requested.
+    * @return The stats of the specified column.
+    */
+  def getColumnStats(columnName: String): ColumnStats = {
+    val columnStats = tableStats.colStats
+    if (columnStats != null) columnStats.get(columnName) else null
+  }
+
+  /**
+    * Returns the number of rows of the table.
+    *
+    * @return The number of rows of the table.
+    */
+  override def getRowCount: JDouble = {
+    val rowCount = tableStats.rowCount
+    if (rowCount != null) rowCount.toDouble else null
+  }
+
+  override def getCollations: util.List[RelCollation] = util.Collections.emptyList()
+
+  /**
+    * Returns whether the given columns are a key or a superset of a unique key
+    * of this table.
+    *
+    * Note: Do not call this method!
+    * Use [[org.apache.calcite.rel.metadata.RelMetadataQuery]].areRowsUnique if need.
+    * Because columns in original uniqueKey may not exist in RowType after project pushDown, however
+    * the RowType cannot be available here.
+    *
+    * @param columns Ordinals of key columns
+    * @return if bit mask represents a unique column set; false if not (or
+    *         if no metadata is available).
+    */
+  override def isKey(columns: ImmutableBitSet): Boolean = false
+
+  override def getDistribution: RelDistribution = null
+
+  override def getReferentialConstraints: util.List[RelReferentialConstraint] =
+    util.Collections.emptyList()
+}
+
+/**
+  * Methods to create FlinkStatistic.
+  */
+object FlinkStatistic {
+
+  /** Represents a FlinkStatistic that knows nothing about a table */
+  val UNKNOWN: FlinkStatistic = new FlinkStatistic(TableStats.UNKNOWN)
+
+  class Builder {
+
+    private var tableStats: TableStats = TableStats.UNKNOWN
+
+    def tableStats(tableStats: TableStats): Builder = {
+      if (tableStats == null) {
+        this.tableStats = TableStats.UNKNOWN
+      } else {
+        this.tableStats = tableStats
+      }
+      this
+    }
+
+    def build(): FlinkStatistic = {
+      if (tableStats == null) {
+        UNKNOWN
+      } else {
+        new FlinkStatistic(tableStats)
+      }
+    }
+  }
+
+  /**
+    * Return a new builder that builds a [[FlinkStatistic]].
+    *
+    * @return a new builder to build a [[FlinkStatistic]]
+    */
+  def builder(): Builder = new Builder
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/stats/TableStats.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/stats/TableStats.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import java.lang.Long
+import java.util
+
+/**
+  * Table statistics
+  *
+  * @param rowCount cardinality of table, the value is null if not available
+  * @param colStats statistics of table columns, the value is empty map if not available.
+  *                 default value is empty map.
+  */
+case class TableStats(
+    rowCount: Long,
+    colStats: util.Map[String, ColumnStats] = new util.HashMap()) {
+
+  require(rowCount == null || rowCount >= 0L, "rowCount cannot be negative!")
+  require(colStats != null, "column statistic cannot be null!")
+
+  override def toString: String = {
+    val rowCountStr = if (rowCount != null) s"rowCount=$rowCount" else ""
+    val colStatsStr = if (!colStats.isEmpty) s"colStats=$colStats" else ""
+
+    s"TableStats{${Seq(rowCountStr, colStatsStr).mkString(", ")}}"
+  }
+
+}
+
+object TableStats {
+
+  val UNKNOWN = new TableStats(null)
+
+  def builder(): Builder = new Builder()
+
+  class Builder {
+    private var rowCount: Long = _
+    private var colStats: util.Map[String, ColumnStats] = new util.HashMap()
+
+    def rowCount(rowCount: Long): Builder = {
+      this.rowCount = rowCount
+      this
+    }
+
+    def colStats(colStats: util.Map[String, ColumnStats]): Builder = {
+      this.colStats = colStats
+      this
+    }
+
+    def tableStats(stats: TableStats): Builder = {
+      require(stats != null, "input TableStats cannot be null!")
+      this.rowCount = stats.rowCount
+      this.colStats = stats.colStats
+      this
+    }
+
+    def build(): TableStats = {
+      new TableStats(rowCount, colStats)
+    }
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stats/ColumnStatsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stats/ColumnStatsTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import org.junit.Test
+
+class ColumnStatsTest {
+
+  @Test
+  def testValidColumnStats(): Unit = {
+    ColumnStats(null, null, null, null, null, null)
+    ColumnStats(0L, 0L, 0D, 0, 0, 0)
+    ColumnStats(100L, 10L, 6.12345, 10, "abc", "xyz")
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testNdvIsNegative(): Unit = {
+    ColumnStats(-1L, null, null, null, null, null)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testNullCountIsNegative(): Unit = {
+    ColumnStats(null, -1L, null, null, null, null)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testAvgLenIsNegative(): Unit = {
+    ColumnStats(null, null, -1D, null, null, null)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMaxLenIsNegative(): Unit = {
+    ColumnStats(null, null, null, -1, null, null)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMaxIsNotComparable(): Unit = {
+    ColumnStats(null, null, null, null, Array(1, 2, 3), null)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMinIsNotComparable(): Unit = {
+    ColumnStats(null, null, null, null, null, Array(1, 2, 3))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testClassOfMaxMinIsDiff(): Unit = {
+    ColumnStats(null, null, null, null, 5L, 2D)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stats/FlinkStatisticTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stats/FlinkStatisticTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.JavaConversions._
+
+class FlinkStatisticTest {
+
+  @Test
+  def testUnknown(): Unit = {
+    assertEquals(TableStats.UNKNOWN, FlinkStatistic.UNKNOWN.getTableStats)
+    assertNull(FlinkStatistic.UNKNOWN.getRowCount)
+    assertNull(FlinkStatistic.UNKNOWN.getColumnStats("a"))
+  }
+
+  @Test
+  def testFlinkStatisticBuilder(): Unit = {
+    val columnStats = Map[String, ColumnStats]("a" -> ColumnStats(100L, 0L, 4D, 4, null, null))
+    val statistic = FlinkStatistic.builder().tableStats(TableStats(100L, columnStats)).build()
+    assertEquals(100.0, statistic.getRowCount)
+    assertEquals(columnStats("a"), statistic.getColumnStats("a"))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stats/TableStatsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stats/TableStatsTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+class TableStatsTest {
+
+  @Test
+  def testValidTableStats(): Unit = {
+    TableStats(null)
+    TableStats(1000L, Map[String, ColumnStats]("a" -> ColumnStats(100L, 0L, 4D, 4, null, null)))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testNdvIsRowCount(): Unit = {
+    TableStats(-1L, new util.HashMap())
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testColumnStatsIsNull(): Unit = {
+    TableStats(1L, null)
+  }
+
+  @Test
+  def testTableStatsBuilder(): Unit = {
+    assertEquals(TableStats.UNKNOWN, TableStats.builder().build())
+    assertEquals(TableStats(100L), TableStats.builder().rowCount(100L).build())
+    val columnStats = Map[String, ColumnStats]("a" -> ColumnStats(100L, 0L, 4D, 4, null, null))
+    assertEquals(TableStats(null, columnStats), TableStats.builder().colStats(columnStats).build())
+    assertEquals(TableStats(100L, columnStats),
+      TableStats.builder().rowCount(100L).colStats(columnStats).build())
+    assertEquals(TableStats(200L, columnStats),
+      TableStats.builder().tableStats(TableStats(1L, columnStats)).rowCount(200L).build())
+  }
+}


### PR DESCRIPTION

## What is the purpose of the change

This commit defines the structure of table and column stats which provide statistics for Calcite cost model.

## Brief change log

  - *add TableStats, ColumnStats and  FlinkStatistic*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for TableStats, ColumnStats and  FlinkStatistic*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
