### PR TITLE
[FLINK-11728] [table] Deprecate CalciteConfig temporarily

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableConfig.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableConfig.scala
@@ -81,13 +81,29 @@ class TableConfig {
 
   /**
     * Returns the current configuration of Calcite for Table API and SQL queries.
+    *
+    * @deprecated This method will be removed temporarily while the API is uncoupled
+    *             from Calcite. An alternative might be provided in the future. See FLINK-11728
+    *             for more information.
     */
+  @Deprecated
+  @deprecated(
+    "This method will be removed temporarily while the API is uncoupled from Calcite.",
+    "1.8.0")
   def getCalciteConfig: CalciteConfig = calciteConfig
 
   /**
     * Sets the configuration of Calcite for Table API and SQL queries.
     * Changing the configuration has no effect after the first query has been defined.
+    *
+    * @deprecated This method will be removed temporarily while the API is uncoupled
+    *             from Calcite. An alternative might be provided in the future. See FLINK-11728
+    *             for more information.
     */
+  @Deprecated
+  @deprecated(
+    "This method will be removed temporarily while the API is uncoupled from Calcite.",
+    "1.8.0")
   def setCalciteConfig(calciteConfig: CalciteConfig): Unit = {
     this.calciteConfig = calciteConfig
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/CalciteConfig.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/CalciteConfig.scala
@@ -33,7 +33,15 @@ import scala.collection.JavaConverters._
 
 /**
   * Builder for creating a Calcite configuration.
+  *
+  * @deprecated This class will be removed temporarily while the API is uncoupled
+  *             from Calcite. An alternative might be provided in the future. See FLINK-11728
+  *             for more information.
   */
+@Deprecated
+@deprecated(
+  "This method will be removed temporarily while the API is uncoupled from Calcite.",
+  "1.8.0")
 class CalciteConfigBuilder {
 
   /**
@@ -255,7 +263,15 @@ class CalciteConfigBuilder {
 
 /**
   * Calcite configuration for defining a custom Calcite configuration for Table and SQL API.
+  *
+  * @deprecated This class will be removed temporarily while the API is uncoupled
+  *             from Calcite. An alternative might be provided in the future. See FLINK-11728
+  *             for more information.
   */
+@Deprecated
+@deprecated(
+  "This method will be removed temporarily while the API is uncoupled from Calcite.",
+  "1.8.0")
 trait CalciteConfig {
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

Deprecates the CalciteConfig to unblock FLINK-11067.

## Brief change log

- Deprecation added.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
