### PR TITLE
[FLINK-11185] Fix StreamSourceOperatorWatermarksTest instability.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -97,7 +97,6 @@ public class StreamSourceOperatorWatermarksTest {
 	public void testNoMaxWatermarkOnAsyncCancel() throws Exception {
 
 		final List<StreamElement> output = new ArrayList<>();
-		final Thread runner = Thread.currentThread();
 
 		// regular stream source operator
 		final StreamSource<String, InfiniteSource<String>> operator =
@@ -113,7 +112,6 @@ public class StreamSourceOperatorWatermarksTest {
 					Thread.sleep(200);
 				} catch (InterruptedException ignored) {}
 				operator.cancel();
-				runner.interrupt();
 			}
 		}.start();
 


### PR DESCRIPTION
The change removes the `mainThread.interrupt()` call from the `StreamSourceOperatorWatermarksTest.testNoMaxWatermarkOnAsyncCancel()` test.

The cause of the instability seems to be that due to a not-so-rare timing, the thread that calls the `interrupt()` on the main thread, runs still after its original test finishes and call `interrupt()` during execution of the next test. This causes the normal execution (or `sleep()` in this case) to be interrupted.