### PR TITLE
[FLINK-11752] [dist] Move flink-python to opt

### DIFF
--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -227,17 +227,7 @@ under the License.
 				<include>flink-gelly-examples_${scala.binary.version}-${project.version}.jar</include>
 			</includes>
 		</fileSet>
-
-		<!-- copy python jar -->
-		<fileSet>
-			<directory>../flink-libraries/flink-python/target</directory>
-			<outputDirectory>lib</outputDirectory>
-			<fileMode>0644</fileMode>
-			<includes>
-				<include>flink-python_${scala.binary.version}-${project.version}.jar</include>
-			</includes>
-		</fileSet>
-
+		
 		<!-- copy python example to examples of dist -->
 		<fileSet>
 			<directory>../flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/example</directory>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -162,6 +162,14 @@
 			<fileMode>0644</fileMode>
 		</file>
 
+		<!-- Batch Python API -->
+		<file>
+			<source>../flink-libraries/flink-python/target/flink-python_${scala.binary.version}-${project.version}.jar</source>
+			<outputDirectory>opt</outputDirectory>
+			<destName>flink-python_${scala.binary.version}-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
 		<!-- Streaming Python API -->
 		<file>
 			<source>../flink-libraries/flink-streaming-python/target/flink-streaming-python_${scala.binary.version}-${project.version}.jar</source>

--- a/flink-dist/src/main/flink-bin/bin/pyflink.bat
+++ b/flink-dist/src/main/flink-bin/bin/pyflink.bat
@@ -22,4 +22,4 @@ setlocal EnableDelayedExpansion
 SET bin=%~dp0
 SET FLINK_ROOT_DIR=%bin%..
 
-"%FLINK_ROOT_DIR%\bin\flink" run -v "%FLINK_ROOT_DIR%"\lib\flink-python*.jar %*
+"%FLINK_ROOT_DIR%\bin\flink" run -v "%FLINK_ROOT_DIR%"\opt\flink-python*.jar %*

--- a/flink-dist/src/main/flink-bin/bin/pyflink.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink.sh
@@ -22,4 +22,4 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/lib/flink-python*.jar "$@"
+"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/opt/flink-python*.jar "$@"


### PR DESCRIPTION
## What is the purpose of the change

Move `flink-python` from `/lib` to `/opt` directory of distribution.

## Verifying this change

```bash
$ find lib opt
lib
lib/log4j-1.2.17.jar
lib/slf4j-log4j12-1.7.15.jar
lib/flink-dist_2.11-1.9-SNAPSHOT.jar
opt
opt/flink-metrics-prometheus-1.9-SNAPSHOT.jar
opt/flink-cep-scala_2.11-1.9-SNAPSHOT.jar
opt/flink-sql-client_2.11-1.9-SNAPSHOT.jar
opt/flink-oss-fs-hadoop-1.9-SNAPSHOT.jar
opt/flink-swift-fs-hadoop-1.9-SNAPSHOT.jar
opt/flink-queryable-state-runtime_2.11-1.9-SNAPSHOT.jar
opt/flink-gelly-scala_2.11-1.9-SNAPSHOT.jar
opt/flink-metrics-statsd-1.9-SNAPSHOT.jar
opt/flink-metrics-datadog-1.9-SNAPSHOT.jar
opt/flink-ml_2.11-1.9-SNAPSHOT.jar
opt/flink-metrics-influxdb-1.9-SNAPSHOT.jar
opt/flink-s3-fs-presto-1.9-SNAPSHOT.jar
opt/flink-gelly_2.11-1.9-SNAPSHOT.jar
opt/flink-streaming-python_2.11-1.9-SNAPSHOT.jar
opt/flink-cep_2.11-1.9-SNAPSHOT.jar
opt/flink-metrics-slf4j-1.9-SNAPSHOT.jar
opt/flink-table_2.11-1.9-SNAPSHOT.jar
opt/flink-s3-fs-hadoop-1.9-SNAPSHOT.jar
opt/flink-metrics-graphite-1.9-SNAPSHOT.jar
opt/flink-python_2.11-1.9-SNAPSHOT.jar
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no** (but moves dependency in distribution)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**
