### PR TITLE
[FLINK-10932][ResourceManager] Initial flink-kubernetes module with e…

### DIFF
--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -1,0 +1,64 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.9-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	
+	<artifactId>flink-kubernetes_${scala.binary.version}</artifactId>
+	<name>flink-kubernetes</name>
+	<packaging>jar</packaging>
+	
+	<properties>
+		<kubernetes.version>1.0.1</kubernetes.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- set all Flink dependencies to provided, so they and their transitive  -->
+		<!-- dependencies do not get promoted to direct dependencies during shading -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Parameters that will be used in Flink on k8s cluster.
+ * */
+public class FlinkKubernetesOptions {
+
+	private Configuration configuration;
+
+	public Configuration getConfiguration() {
+		return configuration;
+	}
+
+	public FlinkKubernetesOptions(Configuration configuration) {
+		this.configuration = configuration;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cluster/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cluster/KubernetesClusterDescriptor.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.cluster;
+
+import org.apache.flink.client.deployment.ClusterDeploymentException;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterRetrieveException;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
+import org.apache.flink.kubernetes.kubeclient.KubeClient;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Kubernetes specific {@link ClusterDescriptor} implementation.
+ */
+public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesClusterDescriptor.class);
+
+	private static final String CLUSTER_ID_PREFIX = "flink-session-cluster-";
+
+	private static final String CLUSTER_DESCRIPTION = "Kubernetes cluster";
+
+	private FlinkKubernetesOptions options;
+
+	private KubeClient client;
+
+	public KubernetesClusterDescriptor(@Nonnull FlinkKubernetesOptions options, @Nonnull KubeClient client) {
+		this.options = options;
+		this.client = client;
+	}
+
+	private String generateClusterId() {
+		return CLUSTER_ID_PREFIX + UUID.randomUUID();
+	}
+
+	@Override
+	public String getClusterDescription() {
+		return CLUSTER_DESCRIPTION;
+	}
+
+	private ClusterClient<String> createClusterEndpoint(Endpoint clusterEndpoint, String clusterId) throws Exception {
+
+		Configuration configuration = new Configuration(this.options.getConfiguration());
+		configuration.setString(JobManagerOptions.ADDRESS, clusterEndpoint.getAddress());
+		configuration.setInteger(JobManagerOptions.PORT, clusterEndpoint.getPort());
+		return new RestClusterClient<>(configuration, clusterId);
+	}
+
+	@Override
+	public ClusterClient<String> retrieve(String clusterId) throws ClusterRetrieveException {
+		try {
+			Endpoint clusterEndpoint = this.client.getResetEndpoint(clusterId);
+			return this.createClusterEndpoint(clusterEndpoint, clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			throw new ClusterRetrieveException("Could not create the RestClusterClient.", e);
+		}
+	}
+
+	@Override
+	public ClusterClient<String> deploySessionCluster(ClusterSpecification clusterSpecification)
+		throws ClusterDeploymentException {
+
+		String clusterId = this.generateClusterId();
+
+		//TODO: add arguments
+		final List<String> args = Arrays.asList();
+
+		return this.deployClusterInternal(clusterId, args);
+	}
+
+	@Override
+	public ClusterClient<String> deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph, boolean detached) {
+		throw new NotImplementedException();
+	}
+
+	@Nonnull
+	private ClusterClient<String> deployClusterInternal(String clusterId, List<String> args) throws ClusterDeploymentException {
+		try {
+			Endpoint clusterEndpoint = this.client.createClusterService(clusterId).get();
+			this.client.createClusterPod();
+			return this.createClusterEndpoint(clusterEndpoint, clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			this.tryKillCluster(clusterId);
+			throw new ClusterDeploymentException("Could not create Kubernetes cluster " + clusterId, e);
+		}
+	}
+
+	/**
+	 * Try to kill cluster without throw exception.
+	 */
+	private void tryKillCluster(String clusterId) {
+		try {
+			this.killCluster(clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+		}
+	}
+
+	@Override
+	public void killCluster(String clusterId) throws FlinkException {
+		try {
+			this.client.stopAndCleanupCluster(clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			throw new FlinkException("Could not create Kubernetes cluster " + clusterId);
+		}
+	}
+
+	@Override
+	public void close() {
+		try {
+			this.client.close();
+		} catch (Exception e) {
+			this.client.logException(e);
+			LOG.error("failed to close client, exception {}", e.toString());
+		}
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesSessionClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesSessionClusterEntrypoint.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+
+/**
+ * Entrypoint for a Kubernetes session cluster.
+ */
+public class KubernetesSessionClusterEntrypoint extends SessionClusterEntrypoint {
+
+	public KubernetesSessionClusterEntrypoint(Configuration configuration) {
+		super(configuration);
+	}
+
+	@Override
+	protected DispatcherResourceManagerComponentFactory<?> createDispatcherResourceManagerComponentFactory(Configuration configuration) {
+		return null;
+	}
+
+	public static void main(String[] args) {
+		LOG.info("Started {}.", KubernetesSessionClusterEntrypoint.class.getSimpleName());
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Endpoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Endpoint.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+/**
+ * Represent an endpoint.
+ * */
+public class Endpoint {
+
+	private String address;
+
+	private int port;
+
+	public Endpoint(String address, int port) {
+		this.address = address;
+		this.port = port;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public int getPort() {
+		return port;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The client to talk with kubernetes.
+ * */
+public interface KubeClient extends AutoCloseable {
+
+	/**
+	 * Initialize client.
+	 * */
+	void initialize();
+
+	/**
+	 * Create kubernetes services and expose endpoints for access outside cluster.
+	 */
+	CompletableFuture<Endpoint> createClusterService(String clusterId) throws Exception;
+
+	/**
+	 * Create cluster pod.
+	 */
+	void createClusterPod();
+
+	/**
+	 * stop cluster and clean up all resources, include services, auxiliary services and all running pods.
+	 * */
+	void stopAndCleanupCluster(String clusterId);
+
+	/**
+	 * Log exceptions.
+	 * */
+	void logException(Exception e);
+
+	/**
+	 * retrieval rest endpoint of the giving flink clusterId.
+	 */
+	Endpoint getResetEndpoint(String flinkClusterId);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@ under the License.
 		<module>flink-mesos</module>
 		<module>flink-metrics</module>
 		<module>flink-yarn</module>
+		<module>flink-kubernetes</module>
 		<module>flink-yarn-tests</module>
 		<module>flink-fs-tests</module>
 		<module>flink-docs</module>


### PR DESCRIPTION
## What is the purpose of the change
Initialize the skeleton module to start native k8s integration

## Brief change log
* _Add flink-kubernetes module_
* _Add first Implement of ClusterDescriptor_
* _Add Interface of Kubernetes client_

## Verifying this change
This change is an initial empty implementation, verified by `mvn clean install` and Travis CI.

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
* The serializers: (no )
* The runtime per-record code paths (performance sensitive): ( no )
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
* The S3 file system connector: ( no )

## Documentation
* Does this pull request introduce a new feature? (yes)
* If yes, how is the feature documented? (the document will be introduced in later pull requests)