### PR TITLE
[FLINK-9003][E2E] Add operators with input type that goes through custom, stateful serialization

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/SingleThreadAccessCheckingTypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/SingleThreadAccessCheckingTypeSerializer.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class SingleThreadAccessCheckingTypeSerializer<T> extends TypeSerializer<T> {
+	private static final long serialVersionUID = 131020282727167064L;
+
+	private final SingleThreadAccessChecker singleThreadAccessChecker;
+	private final TypeSerializer<T> originalSerializer;
+
+	public SingleThreadAccessCheckingTypeSerializer(TypeSerializer<T> originalSerializer) {
+		this.singleThreadAccessChecker = new SingleThreadAccessChecker();
+		this.originalSerializer = originalSerializer;
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.isImmutableType();
+	}
+
+	@Override
+	public TypeSerializer<T> duplicate() {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return new SingleThreadAccessCheckingTypeSerializer<>(originalSerializer.duplicate());
+	}
+
+	@Override
+	public T createInstance() {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.createInstance();
+	}
+
+	@Override
+	public T copy(T from) {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.copy(from);
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.copy(from, reuse);
+	}
+
+	@Override
+	public int getLength() {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.getLength();
+	}
+
+	@Override
+	public void serialize(T record, DataOutputView target) throws IOException {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		originalSerializer.serialize(record, target);
+	}
+
+	@Override
+	public T deserialize(DataInputView source) throws IOException {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.deserialize(source);
+	}
+
+	@Override
+	public T deserialize(T reuse, DataInputView source) throws IOException {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.deserialize(reuse, source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		originalSerializer.copy(source, target);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return obj == this ||
+			(obj != null && obj.getClass() == getClass() &&
+				originalSerializer.equals(obj));
+	}
+
+	@Override
+	public int hashCode() {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.hashCode();
+	}
+
+	@Override
+	public TypeSerializerSnapshot<T> snapshotConfiguration() {
+		singleThreadAccessChecker.checkSingleThreadAccess();
+		return originalSerializer.snapshotConfiguration();
+	}
+
+	public static class SingleThreadAccessChecker implements Serializable {
+		private static final long serialVersionUID = 131020282727167064L;
+
+		private transient Thread currentThread = null;
+
+		public void checkSingleThreadAccess() {
+			if (currentThread == null) {
+				currentThread = Thread.currentThread();
+			} else {
+				Preconditions.checkArgument(
+					Thread.currentThread().equals(currentThread), "Concurrent access from another thread");
+			}
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -29,9 +29,8 @@ import java.io.Serializable;
  * This interface describes the methods that are required for a data type to be handled by the Flink
  * runtime. Specifically, this interface contains the serialization and copying methods.
  *
- * <p>The methods in this class are assumed to be stateless, such that it is effectively thread safe. Stateful
- * implementations of the methods may lead to unpredictable side effects and will compromise both stability and
- * correctness of the program.
+ * <p>The methods in this class are not necessarily thread safe. To avoid unpredictable side effects,
+ * it is recommended to call {@code duplicate()} method and use one serializer instance per thread.
  *
  * <p><b>Upgrading TypeSerializers to the new TypeSerializerSnapshot model</b>
  *

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/CustomEventTypeInformation.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/CustomEventTypeInformation.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.SingleThreadAccessCheckingTypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.Objects;
+
+public class CustomEventTypeInformation extends TypeInformation<Event> {
+	private final TypeInformation<Event> originalTypeInformation = TypeInformation.of(Event.class);
+
+	@Override
+	public boolean isBasicType() {
+		return originalTypeInformation.isBasicType();
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return originalTypeInformation.isTupleType();
+	}
+
+	@Override
+	public int getArity() {
+		return originalTypeInformation.getArity();
+	}
+
+	@Override
+	public int getTotalFields() {
+		return originalTypeInformation.getTotalFields();
+	}
+
+	@Override
+	public Class<Event> getTypeClass() {
+		return originalTypeInformation.getTypeClass();
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return originalTypeInformation.isKeyType();
+	}
+
+	@Override
+	public TypeSerializer<Event> createSerializer(ExecutionConfig config) {
+		return new SingleThreadAccessCheckingTypeSerializer<>(originalTypeInformation.createSerializer(config));
+	}
+
+	@Override
+	public String toString() {
+		return originalTypeInformation.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		CustomEventTypeInformation that = (CustomEventTypeInformation) o;
+		return Objects.equals(originalTypeInformation, that.originalTypeInformation);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(originalTypeInformation);
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof CustomEventTypeInformation;
+	}
+}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/CustomEventTypeInformation.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/CustomEventTypeInformation.java
@@ -26,8 +26,16 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import java.util.Objects;
 
 /** Custom {@link TypeInformation} to test custom {@link TypeSerializer}. */
-public class CustomEventTypeInformation extends TypeInformation<Event> {
-	private final TypeInformation<Event> originalTypeInformation = TypeInformation.of(Event.class);
+public class CustomEventTypeInformation<T> extends TypeInformation<T> {
+	private final TypeInformation<T> originalTypeInformation;
+
+	public CustomEventTypeInformation(Class<T> clazz) {
+		this(TypeInformation.of(clazz));
+	}
+
+	public CustomEventTypeInformation(TypeInformation<T> originalTypeInformation) {
+		this.originalTypeInformation = originalTypeInformation;
+	}
 
 	@Override
 	public boolean isBasicType() {
@@ -50,7 +58,7 @@ public class CustomEventTypeInformation extends TypeInformation<Event> {
 	}
 
 	@Override
-	public Class<Event> getTypeClass() {
+	public Class<T> getTypeClass() {
 		return originalTypeInformation.getTypeClass();
 	}
 
@@ -60,7 +68,7 @@ public class CustomEventTypeInformation extends TypeInformation<Event> {
 	}
 
 	@Override
-	public TypeSerializer<Event> createSerializer(ExecutionConfig config) {
+	public TypeSerializer<T> createSerializer(ExecutionConfig config) {
 		return new SingleThreadAccessCheckingTypeSerializer<>(originalTypeInformation.createSerializer(config));
 	}
 

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/CustomEventTypeInformation.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/CustomEventTypeInformation.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.Objects;
 
+/** Custom {@link TypeInformation} to test custom {@link TypeSerializer}. */
 public class CustomEventTypeInformation extends TypeInformation<Event> {
 	private final TypeInformation<Event> originalTypeInformation = TypeInformation.of(Event.class);
 
@@ -70,8 +71,12 @@ public class CustomEventTypeInformation extends TypeInformation<Event> {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o){
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		CustomEventTypeInformation that = (CustomEventTypeInformation) o;
 		return Objects.equals(originalTypeInformation, that.originalTypeInformation);
 	}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -268,13 +269,13 @@ public class DataStreamAllroundTestJobFactory {
 				STATE_BACKEND_FILE_ASYNC.key(),
 				STATE_BACKEND_FILE_ASYNC.defaultValue());
 
-			env.setStateBackend(new FsStateBackend(checkpointDir, asyncCheckpoints));
+			env.setStateBackend((StateBackend) new FsStateBackend(checkpointDir, asyncCheckpoints));
 		} else if ("rocks".equalsIgnoreCase(stateBackend)) {
 			boolean incrementalCheckpoints = pt.getBoolean(
 				STATE_BACKEND_ROCKS_INCREMENTAL.key(),
 				STATE_BACKEND_ROCKS_INCREMENTAL.defaultValue());
 
-			env.setStateBackend(new RocksDBStateBackend(checkpointDir, incrementalCheckpoints));
+			env.setStateBackend((StateBackend) new RocksDBStateBackend(checkpointDir, incrementalCheckpoints));
 		} else {
 			throw new IllegalArgumentException("Unknown backend requested: " + stateBackend);
 		}
@@ -441,7 +442,7 @@ public class DataStreamAllroundTestJobFactory {
 		return new ArtificalOperatorStateMapper<>(mapFunction);
 	}
 
-	static <IN, STATE> ArtificialStateBuilder<IN> createValueStateBuilder(
+	private static <IN, STATE> ArtificialStateBuilder<IN> createValueStateBuilder(
 		JoinFunction<IN, STATE, STATE> inputAndOldStateToNewState,
 		ValueStateDescriptor<STATE> valueStateDescriptor) {
 
@@ -451,7 +452,7 @@ public class DataStreamAllroundTestJobFactory {
 			valueStateDescriptor);
 	}
 
-	static <IN, STATE> ArtificialStateBuilder<IN> createListStateBuilder(
+	private static <IN, STATE> ArtificialStateBuilder<IN> createListStateBuilder(
 		JoinFunction<IN, STATE, STATE> inputAndOldStateToNewState,
 		ListStateDescriptor<STATE> listStateDescriptor) {
 

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -508,7 +508,7 @@ public class DataStreamAllroundTestJobFactory {
 			.keyBy(new EventKeySelectorWithCustomKeyTypeInformation())
 
 			.map(e -> e)
-			.returns(new CustomEventTypeInformation<>(Event.class))
+			.returns(new SingleThreadAccessCheckingTypeInfo<>(Event.class))
 			.name(MAPPER_RETURNS_OUT_WITH_CUSTOM_SER.getName())
 			.uid(MAPPER_RETURNS_OUT_WITH_CUSTOM_SER.getUid())
 			// apply a keyBy so that we have a non-chained operator with Event as input type that goes through serialization
@@ -522,7 +522,7 @@ public class DataStreamAllroundTestJobFactory {
 	private static class EventIdentityFunctionWithCustomEventTypeInformation
 		implements MapFunction<Event, Event>, ResultTypeQueryable<Event> {
 
-		private final CustomEventTypeInformation<Event> typeInformation = new CustomEventTypeInformation<>(Event.class);
+		private final SingleThreadAccessCheckingTypeInfo<Event> typeInformation = new SingleThreadAccessCheckingTypeInfo<>(Event.class);
 
 		@Override
 		public Event map(Event value) {
@@ -538,7 +538,7 @@ public class DataStreamAllroundTestJobFactory {
 	private static class EventKeySelectorWithCustomKeyTypeInformation
 		implements KeySelector<Event, Integer>, ResultTypeQueryable<Integer> {
 
-		private final CustomEventTypeInformation<Integer> typeInformation = new CustomEventTypeInformation<>(Integer.class);
+		private final SingleThreadAccessCheckingTypeInfo<Integer> typeInformation = new SingleThreadAccessCheckingTypeInfo<>(Integer.class);
 
 		@Override
 		public Integer getKey(Event value) {

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestProgram.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestProgram.java
@@ -52,7 +52,17 @@ import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createTimestampExtractor;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.isSimulateFailures;
 import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.setupEnvironment;
-import static org.apache.flink.streaming.tests.TestOperatorEnum.*;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.EVENT_SOURCE;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.FAILURE_MAPPER_NAME;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.KEYED_STATE_OPER_WITH_AVRO_SER;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.KEYED_STATE_OPER_WITH_KRYO_AND_CUSTOM_SER;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.OPERATOR_STATE_OPER;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.SEMANTICS_CHECK_MAPPER;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.SEMANTICS_CHECK_PRINT_SINK;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.SLIDING_WINDOW_AGG;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.SLIDING_WINDOW_CHECK_MAPPER;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.SLIDING_WINDOW_CHECK_PRINT_SINK;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.TIME_WINDOW_OPER;
 
 /**
  * A general purpose test job for Flink's DataStream API operators and primitives.

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestProgram.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestProgram.java
@@ -141,10 +141,11 @@ public class DataStreamAllroundTestProgram {
 
 		// apply a tumbling window that simply passes forward window elements;
 		// this allows the job to cover timers state
+		@SuppressWarnings("Convert2Lambda")
 		DataStream<Event> eventStream3 = applyTumblingWindows(eventStream2.keyBy(Event::getKey), pt)
 			.apply(new WindowFunction<Event, Event, Integer, TimeWindow>() {
 				@Override
-				public void apply(Integer integer, TimeWindow window, Iterable<Event> input, Collector<Event> out) throws Exception {
+				public void apply(Integer integer, TimeWindow window, Iterable<Event> input, Collector<Event> out) {
 					for (Event e : input) {
 						out.collect(e);
 					}
@@ -175,7 +176,7 @@ public class DataStreamAllroundTestProgram {
 				@Override
 				public void apply(
 					Integer key, TimeWindow window, Iterable<Event> input,
-					Collector<Tuple2<Integer, List<Event>>> out) throws Exception {
+					Collector<Tuple2<Integer, List<Event>>> out) {
 
 					out.collect(Tuple2.of(key, StreamSupport.stream(input.spliterator(), false).collect(Collectors.toList())));
 				}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SemanticsCheckMapper.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SemanticsCheckMapper.java
@@ -60,7 +60,7 @@ public class SemanticsCheckMapper extends RichFlatMapFunction<Event, String> {
 	}
 
 	@Override
-	public void open(Configuration parameters) throws Exception {
+	public void open(Configuration parameters) {
 		ValueStateDescriptor<Long> sequenceStateDescriptor =
 			new ValueStateDescriptor<>("sequenceState", Long.class);
 

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SequenceGeneratorSource.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SequenceGeneratorSource.java
@@ -28,9 +28,6 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,8 +39,6 @@ import java.util.Random;
 public class SequenceGeneratorSource extends RichParallelSourceFunction<Event> implements CheckpointedFunction {
 
 	private static final long serialVersionUID = -3986989644799442178L;
-
-	private static final Logger LOG = LoggerFactory.getLogger(SequenceGeneratorSource.class);
 
 	/** Length of the artificial payload string generated for each event. */
 	private final int payloadLength;
@@ -145,7 +140,7 @@ public class SequenceGeneratorSource extends RichParallelSourceFunction<Event> i
 		}
 	}
 
-	private void runIdle(SourceContext<Event> ctx) throws Exception {
+	private void runIdle(SourceContext<Event> ctx) {
 		ctx.markAsTemporarilyIdle();
 
 		// just wait until this source is canceled

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SingleThreadAccessCheckingTypeInfo.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SingleThreadAccessCheckingTypeInfo.java
@@ -26,14 +26,14 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import java.util.Objects;
 
 /** Custom {@link TypeInformation} to test custom {@link TypeSerializer}. */
-public class CustomEventTypeInformation<T> extends TypeInformation<T> {
+public class SingleThreadAccessCheckingTypeInfo<T> extends TypeInformation<T> {
 	private final TypeInformation<T> originalTypeInformation;
 
-	public CustomEventTypeInformation(Class<T> clazz) {
+	SingleThreadAccessCheckingTypeInfo(Class<T> clazz) {
 		this(TypeInformation.of(clazz));
 	}
 
-	public CustomEventTypeInformation(TypeInformation<T> originalTypeInformation) {
+	private SingleThreadAccessCheckingTypeInfo(TypeInformation<T> originalTypeInformation) {
 		this.originalTypeInformation = originalTypeInformation;
 	}
 
@@ -85,7 +85,7 @@ public class CustomEventTypeInformation<T> extends TypeInformation<T> {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		CustomEventTypeInformation that = (CustomEventTypeInformation) o;
+		SingleThreadAccessCheckingTypeInfo that = (SingleThreadAccessCheckingTypeInfo) o;
 		return Objects.equals(originalTypeInformation, that.originalTypeInformation);
 	}
 
@@ -96,6 +96,6 @@ public class CustomEventTypeInformation<T> extends TypeInformation<T> {
 
 	@Override
 	public boolean canEqual(Object obj) {
-		return obj instanceof CustomEventTypeInformation;
+		return obj instanceof SingleThreadAccessCheckingTypeInfo;
 	}
 }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/TestOperatorEnum.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/TestOperatorEnum.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests;
+
+public enum TestOperatorEnum {
+	EVENT_SOURCE("EventSource", 1),
+	KEYED_STATE_OPER_WITH_KRYO_AND_CUSTOM_SER("ArtificalKeyedStateMapper_Kryo_and_Custom_Stateful", 2),
+	KEYED_STATE_OPER_WITH_AVRO_SER("ArtificalKeyedStateMapper_Avro", 3),
+	OPERATOR_STATE_OPER("ArtificalOperatorStateMapper", 4),
+	TIME_WINDOW_OPER("TumblingWindowOperator", 5),
+	SEMANTICS_CHECK_MAPPER("SemanticsCheckMapper", 6),
+	SEMANTICS_CHECK_PRINT_SINK("SemanticsCheckPrintSink", 7),
+	FAILURE_MAPPER_NAME("FailureMapper", 8),
+	SLIDING_WINDOW_AGG("SlidingWindowOperator", 9),
+	SLIDING_WINDOW_CHECK_MAPPER("SlidingWindowCheckMapper", 10),
+	SLIDING_WINDOW_CHECK_PRINT_SINK("SlidingWindowCheckPrintSink", 11),
+	RESULT_TYPE_QUERYABLE_MAPPER_WITH_CUSTOM_SER("ResultTypeQueryableMapWithCustomStatefulTypeSerializer", 12),
+	MAPPER_RETURNS_OUT_WITH_CUSTOM_SER("MapReturnsOutputWithCustomStatefulTypeSerializer", 13),
+	EVENT_IDENTITY_MAPPER("EventIdentityMapper", 14);
+
+	private final String name;
+	private final String uid;
+
+	TestOperatorEnum(String name, int uid) {
+		this.name = name;
+		this.uid = String.format("%04d", uid);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getUid() {
+		return uid;
+	}
+}

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/TestOperatorEnum.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/TestOperatorEnum.java
@@ -18,15 +18,16 @@
 
 package org.apache.flink.streaming.tests;
 
+/** Enum of names and uids of all test operators used in {@link DataStreamAllroundTestProgram}. */
 public enum TestOperatorEnum {
 	EVENT_SOURCE("EventSource", 1),
 	KEYED_STATE_OPER_WITH_KRYO_AND_CUSTOM_SER("ArtificalKeyedStateMapper_Kryo_and_Custom_Stateful", 2),
 	KEYED_STATE_OPER_WITH_AVRO_SER("ArtificalKeyedStateMapper_Avro", 3),
 	OPERATOR_STATE_OPER("ArtificalOperatorStateMapper", 4),
 	TIME_WINDOW_OPER("TumblingWindowOperator", 5),
-	SEMANTICS_CHECK_MAPPER("SemanticsCheckMapper", 6),
-	SEMANTICS_CHECK_PRINT_SINK("SemanticsCheckPrintSink", 7),
-	FAILURE_MAPPER_NAME("FailureMapper", 8),
+	FAILURE_MAPPER_NAME("FailureMapper", 6),
+	SEMANTICS_CHECK_MAPPER("SemanticsCheckMapper", 7),
+	SEMANTICS_CHECK_PRINT_SINK("SemanticsCheckPrintSink", 8),
 	SLIDING_WINDOW_AGG("SlidingWindowOperator", 9),
 	SLIDING_WINDOW_CHECK_MAPPER("SlidingWindowCheckMapper", 10),
 	SLIDING_WINDOW_CHECK_PRINT_SINK("SlidingWindowCheckPrintSink", 11),

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/StatefulComplexPayloadSerializer.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/StatefulComplexPayloadSerializer.java
@@ -140,14 +140,6 @@ public class StatefulComplexPayloadSerializer extends TypeSerializer<ComplexPayl
 		return new Snapshot();
 	}
 
-	private boolean isCompatibleSerializationFormatIdentifier(String identifier) {
-		return identifier.equals(getSerializationFormatIdentifier());
-	}
-
-	private String getSerializationFormatIdentifier() {
-		return getClass().getCanonicalName();
-	}
-
 	// ----------------------------------------------------------------------------------------
 
 	/**

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/builder/ArtificialStateBuilder.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/builder/ArtificialStateBuilder.java
@@ -30,9 +30,9 @@ public abstract class ArtificialStateBuilder<T> implements Serializable {
 
 	private static final long serialVersionUID = -5887676929924485788L;
 
-	protected final String stateName;
+	final String stateName;
 
-	public ArtificialStateBuilder(String stateName) {
+	ArtificialStateBuilder(String stateName) {
 		this.stateName = stateName;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -21,29 +21,23 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.api.common.typeutils.SingleThreadAccessCheckingTypeSerializer;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.RunnableFuture;
-
-import static org.junit.Assert.assertEquals;
 
 class StateSnapshotTransformerTest {
 	private final AbstractKeyedStateBackend<Integer> backend;
@@ -130,7 +124,7 @@ class StateSnapshotTransformerTest {
 		private TestListState() throws Exception {
 			this.state = backend.createInternalState(
 				VoidNamespaceSerializer.INSTANCE,
-				new ListStateDescriptor<>("TestListState", new SingleThreadAccessCheckingTypeSerializer()),
+				new ListStateDescriptor<>("TestListState", new SingleThreadAccessCheckingTypeSerializer<>(StringSerializer.INSTANCE)),
 				snapshotTransformFactory);
 			state.setCurrentNamespace(VoidNamespace.INSTANCE);
 		}
@@ -167,7 +161,7 @@ class StateSnapshotTransformerTest {
 	private static class SingleThreadAccessCheckingSnapshotTransformFactory<T>
 		implements StateSnapshotTransformFactory<T> {
 
-		private final SingleThreadAccessChecker singleThreadAccessChecker = new SingleThreadAccessChecker();
+		private final SingleThreadAccessCheckingTypeSerializer.SingleThreadAccessChecker singleThreadAccessChecker = new SingleThreadAccessCheckingTypeSerializer.SingleThreadAccessChecker();
 
 		static <T> StateSnapshotTransformFactory<T> create() {
 			return new SingleThreadAccessCheckingSnapshotTransformFactory<>();
@@ -187,7 +181,7 @@ class StateSnapshotTransformerTest {
 
 		private <T1> Optional<StateSnapshotTransformer<T1>> createStateSnapshotTransformer() {
 			return Optional.of(new StateSnapshotTransformer<T1>() {
-				private final SingleThreadAccessChecker singleThreadAccessChecker = new SingleThreadAccessChecker();
+				private final SingleThreadAccessCheckingTypeSerializer.SingleThreadAccessChecker singleThreadAccessChecker = new SingleThreadAccessCheckingTypeSerializer.SingleThreadAccessChecker();
 
 				@Nullable
 				@Override
@@ -196,103 +190,6 @@ class StateSnapshotTransformerTest {
 					return value;
 				}
 			});
-		}
-	}
-
-	private static class SingleThreadAccessCheckingTypeSerializer extends TypeSerializer<String> {
-		private final SingleThreadAccessChecker singleThreadAccessChecker = new SingleThreadAccessChecker();
-
-		@Override
-		public boolean isImmutableType() {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.isImmutableType();
-		}
-
-		@Override
-		public TypeSerializer<String> duplicate() {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return new SingleThreadAccessCheckingTypeSerializer();
-		}
-
-		@Override
-		public String createInstance() {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.createInstance();
-		}
-
-		@Override
-		public String copy(String from) {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.copy(from);
-		}
-
-		@Override
-		public String copy(String from, String reuse) {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.copy(from, reuse);
-		}
-
-		@Override
-		public int getLength() {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.getLength();
-		}
-
-		@Override
-		public void serialize(String record, DataOutputView target) throws IOException {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			StringSerializer.INSTANCE.serialize(record, target);
-		}
-
-		@Override
-		public String deserialize(DataInputView source) throws IOException {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.deserialize(source);
-		}
-
-		@Override
-		public String deserialize(String reuse, DataInputView source) throws IOException {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.deserialize(reuse, source);
-		}
-
-		@Override
-		public void copy(DataInputView source, DataOutputView target) throws IOException {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			StringSerializer.INSTANCE.copy(source, target);
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return obj == this ||
-				(obj != null && obj.getClass() == getClass() &&
-					StringSerializer.INSTANCE.equals(obj));
-		}
-
-		@Override
-		public int hashCode() {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.hashCode();
-		}
-
-		@Override
-		public TypeSerializerSnapshot<String> snapshotConfiguration() {
-			singleThreadAccessChecker.checkSingleThreadAccess();
-			return StringSerializer.INSTANCE.snapshotConfiguration();
-		}
-	}
-
-	private static class SingleThreadAccessChecker {
-		private Thread currentThread = null;
-
-		void checkSingleThreadAccess() {
-			if (currentThread == null) {
-				currentThread = Thread.currentThread();
-			} else {
-				assertEquals("Concurrent access from another thread",
-					currentThread, Thread.currentThread());
-			}
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Introduces testing of stateful custom serialisation used in shuffling for generic streaming all around end-to-end test job.

## Brief change log

  - move SingleThreadAccessCheckingTypeSerializer to core typeutils to use it in the job
  - CustomEventTypeInformation which produces stateful type serializer to check that it is accessed in single thread
  - add map/keyBy operator chains in DataStreamAllroundTestProgram to test ResultTypeQueryable and operator.returns approaches to assign custom serialisation for shuffled records.

## Verifying this change

Run any e2e test which uses DataStreamAllroundTestProgram, e.g.:
cd flink-end-to-end-tests
FLINK_DIR=../build-target ./run-single-test.sh test-scripts/test_resume_savepoint.sh 22 file true

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (only in tests)
  - The runtime per-record code paths (performance sensitive): (only in tests)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
