### PR TITLE
[FLINK-11724][core] Add util method to MemorySegment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -1273,6 +1273,14 @@ public abstract class MemorySegment {
 	/**
 	 * Bulk copy method. Copies {@code numBytes} bytes to target unsafe object and pointer.
 	 * NOTE: This is a unsafe method, no check here, please be carefully.
+	 *
+	 * @param offset The position where the bytes are started to be read from in this memory segment.
+	 * @param target The unsafe memory to copy the bytes to.
+	 * @param targetPointer The position in the target unsafe memory to copy the chunk to.
+	 * @param numBytes The number of bytes to copy.
+	 *
+	 * @throws IndexOutOfBoundsException If the source segment does not contain the given number
+	 *           of bytes (starting from offset).
 	 */
 	public final void copyToUnsafe(int offset, Object target, int targetPointer, int numBytes) {
 		final long thisPointer = this.address + offset;
@@ -1287,6 +1295,14 @@ public abstract class MemorySegment {
 	/**
 	 * Bulk copy method. Copies {@code numBytes} bytes from source unsafe object and pointer.
 	 * NOTE: This is a unsafe method, no check here, please be carefully.
+	 *
+	 * @param offset The position where the bytes are started to be write in this memory segment.
+	 * @param source The unsafe memory to copy the bytes from.
+	 * @param sourcePointer The position in the source unsafe memory to copy the chunk from.
+	 * @param numBytes The number of bytes to copy.
+	 *
+	 * @throws IndexOutOfBoundsException If this segment can not contain the given number
+	 *           of bytes (starting from offset).
 	 */
 	public final void copyFromUnsafe(int offset, Object source, int sourcePointer, int numBytes) {
 		final long thisPointer = this.address + offset;
@@ -1389,7 +1405,6 @@ public abstract class MemorySegment {
 	 * @return true if equal, false otherwise
 	 */
 	public final boolean equalTo(MemorySegment seg2, int offset1, int offset2, int length) {
-
 		int i = 0;
 
 		// we assume unaligned accesses are supported.

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -1270,6 +1270,34 @@ public abstract class MemorySegment {
 		}
 	}
 
+	/**
+	 * Bulk copy method. Copies {@code numBytes} bytes to target unsafe object and pointer.
+	 * NOTE: This is a unsafe method, no check here, please be carefully.
+	 */
+	public final void copyToUnsafe(int offset, Object target, int targetPointer, int numBytes) {
+		final long thisPointer = this.address + offset;
+		if (thisPointer + numBytes > addressLimit) {
+			throw new IndexOutOfBoundsException(
+					String.format("offset=%d, numBytes=%d, address=%d",
+							offset, numBytes, this.address));
+		}
+		UNSAFE.copyMemory(this.heapMemory, thisPointer, target, targetPointer, numBytes);
+	}
+
+	/**
+	 * Bulk copy method. Copies {@code numBytes} bytes from source unsafe object and pointer.
+	 * NOTE: This is a unsafe method, no check here, please be carefully.
+	 */
+	public final void copyFromUnsafe(int offset, Object source, int sourcePointer, int numBytes) {
+		final long thisPointer = this.address + offset;
+		if (thisPointer + numBytes > addressLimit) {
+			throw new IndexOutOfBoundsException(
+					String.format("offset=%d, numBytes=%d, address=%d",
+							offset, numBytes, this.address));
+		}
+		UNSAFE.copyMemory(source, sourcePointer, this.heapMemory, thisPointer, numBytes);
+	}
+
 	// -------------------------------------------------------------------------
 	//                      Comparisons & Swapping
 	// -------------------------------------------------------------------------
@@ -1348,5 +1376,39 @@ public abstract class MemorySegment {
 		throw new IndexOutOfBoundsException(
 					String.format("offset1=%d, offset2=%d, len=%d, bufferSize=%d, address1=%d, address2=%d",
 							offset1, offset2, len, tempBuffer.length, this.address, seg2.address));
+	}
+
+	/**
+	 * Equals two memory segment regions.
+	 *
+	 * @param seg2 Segment to equal this segment with
+	 * @param offset1 Offset of this segment to start equaling
+	 * @param offset2 Offset of seg2 to start equaling
+	 * @param length Length of the equaled memory region
+	 *
+	 * @return true if equal, false otherwise
+	 */
+	public final boolean equalTo(MemorySegment seg2, int offset1, int offset2, int length) {
+
+		int i = 0;
+
+		// we assume unaligned accesses are supported.
+		// Compare 8 bytes at a time.
+		while (i <= length - 8) {
+			if (getLong(offset1 + i) != seg2.getLong(offset2 + i)) {
+				return false;
+			}
+			i += 8;
+		}
+
+		// cover the last (length % 8) elements.
+		while (i < length) {
+			if (get(offset1 + i) != seg2.get(offset2 + i)) {
+				return false;
+			}
+			i += 1;
+		}
+
+		return true;
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -304,6 +304,41 @@ public abstract class MemorySegmentTestBase {
 	}
 
 	@Test
+	public void testCopyUnsafeIndexOutOfBounds() {
+		byte[] bytes = new byte[pageSize];
+		MemorySegment segment = createSegment(pageSize);
+
+		try {
+			segment.copyToUnsafe(1, bytes, 0, pageSize);
+			fail("should fail with an IndexOutOfBoundsException");
+		}
+		catch (IndexOutOfBoundsException ignored) {}
+
+		try {
+			segment.copyFromUnsafe(1, bytes, 0, pageSize);
+			fail("should fail with an IndexOutOfBoundsException");
+		}
+		catch (IndexOutOfBoundsException ignored) {}
+	}
+
+	@Test
+	public void testEqualTo() {
+		MemorySegment seg1 = createSegment(pageSize);
+		MemorySegment seg2 = createSegment(pageSize);
+
+		int i = new Random().nextInt(pageSize - 8);
+
+		seg1.put(i, (byte) 10);
+		assertFalse(seg1.equalTo(seg2, i, i, 9));
+
+		seg1.put(i, (byte) 0);
+		assertTrue(seg1.equalTo(seg2, i, i, 9));
+
+		seg1.put(i + 8, (byte) 10);
+		assertFalse(seg1.equalTo(seg2, i, i, 9));
+	}
+
+	@Test
 	public void testCharAccess() {
 		final MemorySegment segment = createSegment(pageSize);
 


### PR DESCRIPTION
## What is the purpose of the change

Improve MemorySegment to provide copyToUnsafe copyFromUnsafe and equalTo.
1.copyUnsafe: If we want to copy int[] data into MemorySegment, we can only use int to set Int one by one, which is inefficient. We can copyFromUnsafe directly.
2.equalTo: Provide an efficient equalTo.

## Brief change log

MemorySegment

## Verifying this change

unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
