### PR TITLE
[FLINK-11772] [DataStream] InternalTimerServiceSerializationProxy should be using the new serialization compatibility abstractions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -80,7 +80,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <S> The type of the originating serializer.
  */
 @PublicEvolving
-public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerializer> implements TypeSerializerSnapshot<T> {
+public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerializer<T>> implements TypeSerializerSnapshot<T> {
 
 	/** Magic number for integrity checks during deserialization. */
 	private static final int MAGIC_NUMBER = 911108;
@@ -111,8 +111,9 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
 	 *
 	 * @param correspondingSerializerClass the expected class of the new serializer.
 	 */
-	public CompositeTypeSerializerSnapshot(Class<S> correspondingSerializerClass) {
-		this.correspondingSerializerClass = checkNotNull(correspondingSerializerClass);
+	@SuppressWarnings("unchecked")
+	public CompositeTypeSerializerSnapshot(Class<? extends TypeSerializer> correspondingSerializerClass) {
+		this.correspondingSerializerClass = (Class<S>) checkNotNull(correspondingSerializerClass);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerUtils.java
@@ -45,7 +45,7 @@ public final class TypeSerializerUtils {
 	 * is set up properly (with its originating serializer) such that the backwards
 	 * compatible code paths work.
 	 */
-	public static TypeSerializerSnapshot<?> snapshotBackwardsCompatible(TypeSerializer<?> originatingSerializer) {
+	public static <T> TypeSerializerSnapshot<T> snapshotBackwardsCompatible(TypeSerializer<T> originatingSerializer) {
 		return configureForBackwardsCompatibility(originatingSerializer.snapshotConfiguration(), originatingSerializer);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  *
  * @param <C> The component type.
  */
-public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerializerSnapshot<C[], GenericArraySerializer> {
+public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerializerSnapshot<C[], GenericArraySerializer<C>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -56,6 +56,7 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
 	 * Constructor that the legacy {@link GenericArraySerializerConfigSnapshot} uses
 	 * to delegate compatibility checks to this class.
 	 */
+	@SuppressWarnings("deprecation")
 	GenericArraySerializerSnapshot(Class<C> componentClass) {
 		super(GenericArraySerializer.class);
 		this.componentClass = componentClass;
@@ -77,19 +78,19 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
 	}
 
 	@Override
-	protected boolean isOuterSnapshotCompatible(GenericArraySerializer newSerializer) {
+	protected boolean isOuterSnapshotCompatible(GenericArraySerializer<C> newSerializer) {
 		return this.componentClass == newSerializer.getComponentClass();
 	}
 
 	@Override
-	protected GenericArraySerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected GenericArraySerializer<C> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<C> componentSerializer = (TypeSerializer<C>) nestedSerializers[0];
 		return new GenericArraySerializer<>(componentClass, componentSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(GenericArraySerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(GenericArraySerializer<C> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getComponentSerializer() };
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerSnapshot.java
@@ -20,12 +20,13 @@ package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+
 import java.util.List;
 
 /**
  * Snapshot class for the {@link ListSerializer}.
  */
-public class ListSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<List<T>, ListSerializer> {
+public class ListSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<List<T>, ListSerializer<T>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -49,14 +50,14 @@ public class ListSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<L
 	}
 
 	@Override
-	protected ListSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected ListSerializer<T> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<T> elementSerializer = (TypeSerializer<T>) nestedSerializers[0];
 		return new ListSerializer<>(elementSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(ListSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(ListSerializer<T> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getElementSerializer() };
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerSnapshot.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * Snapshot class for the {@link MapSerializer}.
  */
-public class MapSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot<Map<K, V>, MapSerializer> {
+public class MapSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot<Map<K, V>, MapSerializer<K, V>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -50,7 +50,7 @@ public class MapSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot
 	}
 
 	@Override
-	protected MapSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected MapSerializer<K, V> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<K> keySerializer = (TypeSerializer<K>) nestedSerializers[0];
 
@@ -61,7 +61,7 @@ public class MapSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(MapSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(MapSerializer<K, V> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getKeySerializer(), outerSerializer.getValueSerializer() };
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/TypeSerializerSingleton.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 
 @Internal
-public abstract class TypeSerializerSingleton<T> extends TypeSerializer<T>{
+public abstract class TypeSerializerSingleton<T> extends TypeSerializer<T> {
 
 	private static final long serialVersionUID = 8766687317209282373L;
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/JavaEitherSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/JavaEitherSerializerSnapshot.java
@@ -25,7 +25,7 @@ import org.apache.flink.types.Either;
 /**
  * Snapshot class for the {@link EitherSerializer}.
  */
-public class JavaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializerSnapshot<Either<L, R>, EitherSerializer> {
+public class JavaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializerSnapshot<Either<L, R>, EitherSerializer<L, R>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -50,12 +50,18 @@ public class JavaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializerS
 	}
 
 	@Override
-	protected EitherSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
-		return new EitherSerializer<>(nestedSerializers[0], nestedSerializers[1]);
+	protected EitherSerializer<L, R> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+		@SuppressWarnings("unchecked")
+		TypeSerializer<L> leftSerializer = (TypeSerializer<L>) nestedSerializers[0];
+
+		@SuppressWarnings("unchecked")
+		TypeSerializer<R> rightSerializer = (TypeSerializer<R>) nestedSerializers[1];
+
+		return new EitherSerializer<>(leftSerializer, rightSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(EitherSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(EitherSerializer<L, R> outerSerializer) {
 		return new TypeSerializer<?>[]{ outerSerializer.getLeftSerializer(), outerSerializer.getRightSerializer() };
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -299,7 +299,7 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 
 		@SuppressWarnings("unused")
 		public NullableSerializerSnapshot() {
-			super(serializerClass());
+			super(NullableSerializer.class);
 		}
 
 		public NullableSerializerSnapshot(NullableSerializer<T> serializerInstance) {
@@ -308,7 +308,7 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 		}
 
 		private NullableSerializerSnapshot(int nullPaddingLength) {
-			super(serializerClass());
+			super(NullableSerializer.class);
 			checkArgument(nullPaddingLength >= 0,
 				"Computed NULL padding can not be negative. %d",
 				nullPaddingLength);
@@ -350,10 +350,6 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 		@Override
 		protected boolean isOuterSnapshotCompatible(NullableSerializer<T> newSerializer) {
 			return nullPaddingLength == newSerializer.nullPaddingLength();
-		}
-
-		private static <T> Class<NullableSerializer<T>> serializerClass() {
-			return (Class<NullableSerializer<T>>) (Class<?>) NullableSerializer.class;
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerSnapshot.java
@@ -44,7 +44,7 @@ public final class TupleSerializerSnapshot<T extends Tuple>
 
 	@SuppressWarnings("unused")
 	public TupleSerializerSnapshot() {
-		super(correspondingSerializerClass());
+		super(TupleSerializer.class);
 	}
 
 	TupleSerializerSnapshot(TupleSerializer<T> serializerInstance) {
@@ -57,7 +57,7 @@ public final class TupleSerializerSnapshot<T extends Tuple>
 	 * {@link TupleSerializer#resolveSchemaCompatibilityViaRedirectingToNewSnapshotClass}.
 	 */
 	TupleSerializerSnapshot(Class<T> tupleClass) {
-		super(correspondingSerializerClass());
+		super(TupleSerializer.class);
 		this.tupleClass = checkNotNull(tupleClass, "tuple class can not be NULL");
 	}
 
@@ -86,10 +86,5 @@ public final class TupleSerializerSnapshot<T extends Tuple>
 	@Override
 	protected void readOuterSnapshot(int readOuterSnapshotVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
 		this.tupleClass = InstantiationUtil.resolveClassByName(in, userCodeClassLoader);
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T extends Tuple> Class<TupleSerializer<T>> correspondingSerializerClass() {
-		return (Class<TupleSerializer<T>>) (Class<?>) TupleSerializer.class;
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerSnapshot.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerSnapshot.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
  * A {@link TypeSerializerSnapshot} for the {@link Lockable.LockableTypeSerializer}.
  */
 @Internal
-public class LockableTypeSerializerSnapshot<E> extends CompositeTypeSerializerSnapshot<Lockable<E>, Lockable.LockableTypeSerializer> {
+public class LockableTypeSerializerSnapshot<E> extends CompositeTypeSerializerSnapshot<Lockable<E>, Lockable.LockableTypeSerializer<E>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -51,14 +51,14 @@ public class LockableTypeSerializerSnapshot<E> extends CompositeTypeSerializerSn
 	}
 
 	@Override
-	protected Lockable.LockableTypeSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected Lockable.LockableTypeSerializer<E> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<E> elementSerializer = (TypeSerializer<E>) nestedSerializers[0];
 		return new Lockable.LockableTypeSerializer<>(elementSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(Lockable.LockableTypeSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(Lockable.LockableTypeSerializer<E> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getElementSerializer() };
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializerSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializerSnapshot.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 /**
  * Snapshot class for the {@link ArrayListSerializer}.
  */
-public class ArrayListSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<ArrayList<T>, ArrayListSerializer> {
+public class ArrayListSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<ArrayList<T>, ArrayListSerializer<T>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -50,14 +50,14 @@ public class ArrayListSerializerSnapshot<T> extends CompositeTypeSerializerSnaps
 	}
 
 	@Override
-	protected ArrayListSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected ArrayListSerializer<T> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<T> elementSerializer = (TypeSerializer<T>) nestedSerializers[0];
 		return new ArrayListSerializer<>(elementSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(ArrayListSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(ArrayListSerializer<T> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getElementSerializer() };
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -312,7 +312,7 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS extends S> {
 
 		@SuppressWarnings({"WeakerAccess", "unused"})
 		public TtlSerializerSnapshot() {
-			super(correspondingSerializerClass());
+			super(TtlSerializer.class);
 		}
 
 		TtlSerializerSnapshot(TtlSerializer<T> serializerInstance) {
@@ -336,11 +336,6 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS extends S> {
 			TypeSerializer<T> valueSerializer = (TypeSerializer<T>) nestedSerializers[1];
 
 			return new TtlSerializer<>(timestampSerializer, valueSerializer);
-		}
-
-		@SuppressWarnings("unchecked")
-		private static <T> Class<TtlSerializer<T>> correspondingSerializerClass() {
-			return (Class<TtlSerializer<T>>) (Class<?>) TtlSerializer.class;
 		}
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
@@ -49,7 +49,7 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 	 */
 	@SuppressWarnings("unused")
 	public ScalaCaseClassSerializerSnapshot() {
-		super(correspondingSerializerClass());
+		super(ScalaCaseClassSerializer.class);
 	}
 
 	/**
@@ -63,7 +63,7 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 	 */
 	@Internal
 	ScalaCaseClassSerializerSnapshot(Class<T> type) {
-		super(correspondingSerializerClass());
+		super(ScalaCaseClassSerializer.class);
 		this.type = checkNotNull(type, "type can not be NULL");
 	}
 
@@ -105,10 +105,5 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 	@Override
 	protected boolean isOuterSnapshotCompatible(ScalaCaseClassSerializer<T> newSerializer) {
 		return Objects.equals(type, newSerializer.getTupleClass());
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T extends scala.Product> Class<ScalaCaseClassSerializer<T>> correspondingSerializerClass() {
-		return (Class<ScalaCaseClassSerializer<T>>) (Class<?>) ScalaCaseClassSerializer.class;
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerSnapshot.java
@@ -27,7 +27,7 @@ import scala.util.Either;
  * Configuration snapshot for serializers of Scala's {@link Either} type,
  * containing configuration snapshots of the Left and Right serializers.
  */
-public class ScalaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializerSnapshot<Either<L, R>, EitherSerializer> {
+public class ScalaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializerSnapshot<Either<L, R>, EitherSerializer<L, R>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -51,7 +51,7 @@ public class ScalaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializer
 	}
 
 	@Override
-	protected EitherSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected EitherSerializer<L, R> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<L> leftSerializer = (TypeSerializer<L>) nestedSerializers[0];
 
@@ -62,7 +62,7 @@ public class ScalaEitherSerializerSnapshot<L, R> extends CompositeTypeSerializer
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(EitherSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(EitherSerializer<L, R> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getLeftSerializer(), outerSerializer.getRightSerializer() };
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaOptionSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaOptionSerializerSnapshot.java
@@ -33,7 +33,7 @@ public final class ScalaOptionSerializerSnapshot<E> extends CompositeTypeSeriali
 
 	@SuppressWarnings("WeakerAccess")
 	public ScalaOptionSerializerSnapshot() {
-		super(underlyingClass());
+		super(OptionSerializer.class);
 	}
 
 	public ScalaOptionSerializerSnapshot(OptionSerializer<E> serializerInstance) {
@@ -54,10 +54,5 @@ public final class ScalaOptionSerializerSnapshot<E> extends CompositeTypeSeriali
 	protected OptionSerializer<E> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked") TypeSerializer<E> nestedSerializer = (TypeSerializer<E>) nestedSerializers[0];
 		return new OptionSerializer<>(nestedSerializer);
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <E> Class<OptionSerializer<E>> underlyingClass() {
-		return (Class<OptionSerializer<E>>) (Class<?>) OptionSerializer.class;
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerSnapshot.java
@@ -38,7 +38,7 @@ public class ScalaTrySerializerSnapshot<E> extends CompositeTypeSerializerSnapsh
 	/** This empty nullary constructor is required for deserializing the configuration. */
 	@SuppressWarnings("unused")
 	public ScalaTrySerializerSnapshot() {
-		super(correspondingSerializerClass());
+		super(TrySerializer.class);
 	}
 
 	public ScalaTrySerializerSnapshot(TrySerializer<E> trySerializer) {
@@ -62,10 +62,5 @@ public class ScalaTrySerializerSnapshot<E> extends CompositeTypeSerializerSnapsh
 		TypeSerializer<Throwable> valueSerializer = (TypeSerializer<Throwable>) nestedSerializers[1];
 
 		return new TrySerializer<>(elementSerializer, valueSerializer);
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <E> Class<TrySerializer<E>> correspondingSerializerClass() {
-		return (Class<TrySerializer<E>>) (Class<?>) TrySerializer.class;
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
@@ -47,7 +47,7 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
 
 	@SuppressWarnings("unused")
 	public TraversableSerializerSnapshot() {
-		super(serializerClass());
+		super(TraversableSerializer.class);
 	}
 
 	public TraversableSerializerSnapshot(TraversableSerializer<T, E> serializerInstance) {
@@ -56,7 +56,7 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
 	}
 
 	TraversableSerializerSnapshot(String cbfCode) {
-		super(serializerClass());
+		super(TraversableSerializer.class);
 		checkArgument(cbfCode != null, "cbfCode cannot be null");
 
 		this.cbfCode = cbfCode;
@@ -100,10 +100,5 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
 	@Override
 	protected boolean isOuterSnapshotCompatible(TraversableSerializer<T, E> newSerializer) {
 		return cbfCode.equals(newSerializer.cbfCode());
-	}
-
-	@SuppressWarnings({"unchecked"})
-	private static <T extends TraversableOnce<E>, E> Class<TraversableSerializer<T, E>> serializerClass() {
-		return (Class<TraversableSerializer<T, E>>) (Class<?>) TraversableSerializer.class;
 	}
 }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
@@ -48,7 +48,7 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
 
 	@SuppressWarnings("unused")
 	public Tuple2CaseClassSerializerSnapshot() {
-		super(correspondingSerializerClass());
+		super(package$.MODULE$.tuple2ClassForJava());
 	}
 
 	public Tuple2CaseClassSerializerSnapshot(ScalaCaseClassSerializer<Tuple2<T1, T2>> serializerInstance) {
@@ -61,7 +61,7 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
 	 * {@code Tuple2CaseClassSerializer#resolveSchemaCompatibilityViaRedirectingToNewSnapshotClass(TypeSerializerConfigSnapshot)}.
 	 */
 	public Tuple2CaseClassSerializerSnapshot(Class<Tuple2<T1, T2>> tupleClass) {
-		super(correspondingSerializerClass());
+		super(package$.MODULE$.tuple2ClassForJava());
 		this.type = checkNotNull(tupleClass, "tuple class can not be NULL");
 	}
 
@@ -97,10 +97,5 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
 	@Override
 	protected boolean isOuterSnapshotCompatible(ScalaCaseClassSerializer<Tuple2<T1, T2>> newSerializer) {
 		return Objects.equals(type, newSerializer.getTupleClass());
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T1, T2> Class<ScalaCaseClassSerializer<Tuple2<T1, T2>>> correspondingSerializerClass() {
-		return (Class<ScalaCaseClassSerializer<Tuple2<T1, T2>>>) (Class<?>) package$.MODULE$.tuple2ClassForJava();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -669,7 +669,7 @@ public class CoGroupedStreams<T1, T2> {
 
 		@SuppressWarnings("WeakerAccess")
 		public UnionSerializerSnapshot() {
-			super(correspondingSerializerClass());
+			super(UnionSerializer.class);
 		}
 
 		UnionSerializerSnapshot(UnionSerializer<T1, T2> serializerInstance) {
@@ -690,11 +690,6 @@ public class CoGroupedStreams<T1, T2> {
 		@Override
 		protected UnionSerializer<T1, T2> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 			return new UnionSerializer<>((TypeSerializer<T1>) nestedSerializers[0], (TypeSerializer<T2>) nestedSerializers[1]);
-		}
-
-		@SuppressWarnings("unchecked")
-		private static <T1, T2> Class<UnionSerializer<T1, T2>> correspondingSerializerClass() {
-			return (Class<UnionSerializer<T1, T2>>) (Class<?>) UnionSerializer.class;
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -844,7 +844,7 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 
 		@SuppressWarnings("WeakerAccess")
 		public StateSerializerSnapshot() {
-			super(correspondingSerializerClass());
+			super(StateSerializer.class);
 		}
 
 		StateSerializerSnapshot(StateSerializer<TXN, CONTEXT> serializerInstance) {
@@ -870,11 +870,6 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT>
 		@Override
 		protected TypeSerializer<?>[] getNestedSerializers(StateSerializer<TXN, CONTEXT> outerSerializer) {
 			return new TypeSerializer<?>[] { outerSerializer.transactionSerializer, outerSerializer.contextSerializer };
-		}
-
-		@SuppressWarnings("unchecked")
-		private static <TXN, CONTEXT> Class<StateSerializer<TXN, CONTEXT>> correspondingSerializerClass() {
-			return (Class<StateSerializer<TXN, CONTEXT>>) (Class<?>) StateSerializer.class;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -19,9 +19,8 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.runtime.state.InternalPriorityQueue;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
@@ -142,26 +141,31 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, 
 
 			// the following is the case where we restore
 			if (restoredTimersSnapshot != null) {
-				CompatibilityResult<K> keySerializerCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					this.keyDeserializer,
-					null,
-					restoredTimersSnapshot.getKeySerializerSnapshot(),
-					keySerializer);
+				TypeSerializerSchemaCompatibility<K> keySerializerCompatibility =
+					restoredTimersSnapshot.getKeySerializerSnapshot().resolveSchemaCompatibility(keySerializer);
 
-				CompatibilityResult<N> namespaceSerializerCompatibility = CompatibilityUtil.resolveCompatibilityResult(
-					this.namespaceDeserializer,
-					null,
-					restoredTimersSnapshot.getNamespaceSerializerSnapshot(),
-					namespaceSerializer);
-
-				if (keySerializerCompatibility.isRequiresMigration() || namespaceSerializerCompatibility.isRequiresMigration()) {
-					throw new IllegalStateException("Tried to initialize restored TimerService " +
-						"with incompatible serializers than those used to snapshot its state.");
+				if (keySerializerCompatibility.isIncompatible() || keySerializerCompatibility.isCompatibleAfterMigration()) {
+					throw new IllegalStateException(
+						"Tried to initialize restored TimerService with new key serializer that requires migration or is incompatible.");
 				}
+
+				TypeSerializerSchemaCompatibility<N> namespaceSerializerCompatibility =
+					restoredTimersSnapshot.getNamespaceSerializerSnapshot().resolveSchemaCompatibility(namespaceSerializer);
+
+				if (namespaceSerializerCompatibility.isIncompatible() || namespaceSerializerCompatibility.isCompatibleAfterMigration()) {
+					throw new IllegalStateException(
+						"Tried to initialize restored TimerService with new namespace serializer that requires migration or is incompatible.");
+				}
+
+				this.keySerializer = keySerializerCompatibility.isCompatibleAsIs()
+					? keySerializer : keySerializerCompatibility.getReconfiguredSerializer();
+				this.namespaceSerializer = keySerializerCompatibility.isCompatibleAsIs()
+					? namespaceSerializer : namespaceSerializerCompatibility.getReconfiguredSerializer();
+			} else {
+				this.keySerializer = keySerializer;
+				this.namespaceSerializer = namespaceSerializer;
 			}
 
-			this.keySerializer = keySerializer;
-			this.namespaceSerializer = namespaceSerializer;
 			this.keyDeserializer = null;
 			this.namespaceDeserializer = null;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -145,13 +145,13 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N>, 
 				CompatibilityResult<K> keySerializerCompatibility = CompatibilityUtil.resolveCompatibilityResult(
 					this.keyDeserializer,
 					null,
-					restoredTimersSnapshot.getKeySerializerConfigSnapshot(),
+					restoredTimersSnapshot.getKeySerializerSnapshot(),
 					keySerializer);
 
 				CompatibilityResult<N> namespaceSerializerCompatibility = CompatibilityUtil.resolveCompatibilityResult(
 					this.namespaceDeserializer,
 					null,
-					restoredTimersSnapshot.getNamespaceSerializerConfigSnapshot(),
+					restoredTimersSnapshot.getNamespaceSerializerSnapshot(),
 					namespaceSerializer);
 
 				if (keySerializerCompatibility.isRequiresMigration() || namespaceSerializerCompatibility.isRequiresMigration()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshot.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshot.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerUtils;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -32,9 +33,7 @@ import java.util.Set;
  */
 public class InternalTimersSnapshot<K, N> {
 
-	private TypeSerializer<K> keySerializer;
 	private TypeSerializerSnapshot<K> keySerializerSnapshot;
-	private TypeSerializer<N> namespaceSerializer;
 	private TypeSerializerSnapshot<N> namespaceSerializerSnapshot;
 
 	private Set<TimerHeapInternalTimer<K, N>> eventTimeTimers;
@@ -46,26 +45,17 @@ public class InternalTimersSnapshot<K, N> {
 	/** Constructor to use when snapshotting the timers. */
 	public InternalTimersSnapshot(
 			TypeSerializer<K> keySerializer,
-			TypeSerializerSnapshot<K> keySerializerSnapshot,
 			TypeSerializer<N> namespaceSerializer,
-			TypeSerializerSnapshot<N> namespaceSerializerSnapshot,
 			@Nullable Set<TimerHeapInternalTimer<K, N>> eventTimeTimers,
 			@Nullable Set<TimerHeapInternalTimer<K, N>> processingTimeTimers) {
 
-		this.keySerializer = Preconditions.checkNotNull(keySerializer);
-		this.keySerializerSnapshot = Preconditions.checkNotNull(keySerializerSnapshot);
-		this.namespaceSerializer = Preconditions.checkNotNull(namespaceSerializer);
-		this.namespaceSerializerSnapshot = Preconditions.checkNotNull(namespaceSerializerSnapshot);
+		Preconditions.checkNotNull(keySerializer);
+		this.keySerializerSnapshot = TypeSerializerUtils.snapshotBackwardsCompatible(keySerializer);
+		Preconditions.checkNotNull(namespaceSerializer);
+		this.namespaceSerializerSnapshot = TypeSerializerUtils.snapshotBackwardsCompatible(namespaceSerializer);
+
 		this.eventTimeTimers = eventTimeTimers;
 		this.processingTimeTimers = processingTimeTimers;
-	}
-
-	public TypeSerializer<K> getKeySerializer() {
-		return keySerializer;
-	}
-
-	public void setKeySerializer(TypeSerializer<K> keySerializer) {
-		this.keySerializer = keySerializer;
 	}
 
 	public TypeSerializerSnapshot<K> getKeySerializerSnapshot() {
@@ -74,14 +64,6 @@ public class InternalTimersSnapshot<K, N> {
 
 	public void setKeySerializerSnapshot(TypeSerializerSnapshot<K> keySerializerConfigSnapshot) {
 		this.keySerializerSnapshot = keySerializerConfigSnapshot;
-	}
-
-	public TypeSerializer<N> getNamespaceSerializer() {
-		return namespaceSerializer;
-	}
-
-	public void setNamespaceSerializer(TypeSerializer<N> namespaceSerializer) {
-		this.namespaceSerializer = namespaceSerializer;
 	}
 
 	public TypeSerializerSnapshot<N> getNamespaceSerializerSnapshot() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshot.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshot.java
@@ -33,9 +33,9 @@ import java.util.Set;
 public class InternalTimersSnapshot<K, N> {
 
 	private TypeSerializer<K> keySerializer;
-	private TypeSerializerSnapshot<K> keySerializerConfigSnapshot;
+	private TypeSerializerSnapshot<K> keySerializerSnapshot;
 	private TypeSerializer<N> namespaceSerializer;
-	private TypeSerializerSnapshot<N> namespaceSerializerConfigSnapshot;
+	private TypeSerializerSnapshot<N> namespaceSerializerSnapshot;
 
 	private Set<TimerHeapInternalTimer<K, N>> eventTimeTimers;
 	private Set<TimerHeapInternalTimer<K, N>> processingTimeTimers;
@@ -46,16 +46,16 @@ public class InternalTimersSnapshot<K, N> {
 	/** Constructor to use when snapshotting the timers. */
 	public InternalTimersSnapshot(
 			TypeSerializer<K> keySerializer,
-			TypeSerializerSnapshot<K> keySerializerConfigSnapshot,
+			TypeSerializerSnapshot<K> keySerializerSnapshot,
 			TypeSerializer<N> namespaceSerializer,
-			TypeSerializerSnapshot<N> namespaceSerializerConfigSnapshot,
+			TypeSerializerSnapshot<N> namespaceSerializerSnapshot,
 			@Nullable Set<TimerHeapInternalTimer<K, N>> eventTimeTimers,
 			@Nullable Set<TimerHeapInternalTimer<K, N>> processingTimeTimers) {
 
 		this.keySerializer = Preconditions.checkNotNull(keySerializer);
-		this.keySerializerConfigSnapshot = Preconditions.checkNotNull(keySerializerConfigSnapshot);
+		this.keySerializerSnapshot = Preconditions.checkNotNull(keySerializerSnapshot);
 		this.namespaceSerializer = Preconditions.checkNotNull(namespaceSerializer);
-		this.namespaceSerializerConfigSnapshot = Preconditions.checkNotNull(namespaceSerializerConfigSnapshot);
+		this.namespaceSerializerSnapshot = Preconditions.checkNotNull(namespaceSerializerSnapshot);
 		this.eventTimeTimers = eventTimeTimers;
 		this.processingTimeTimers = processingTimeTimers;
 	}
@@ -68,12 +68,12 @@ public class InternalTimersSnapshot<K, N> {
 		this.keySerializer = keySerializer;
 	}
 
-	public TypeSerializerSnapshot<K> getKeySerializerConfigSnapshot() {
-		return keySerializerConfigSnapshot;
+	public TypeSerializerSnapshot<K> getKeySerializerSnapshot() {
+		return keySerializerSnapshot;
 	}
 
-	public void setKeySerializerConfigSnapshot(TypeSerializerSnapshot<K> keySerializerConfigSnapshot) {
-		this.keySerializerConfigSnapshot = keySerializerConfigSnapshot;
+	public void setKeySerializerSnapshot(TypeSerializerSnapshot<K> keySerializerConfigSnapshot) {
+		this.keySerializerSnapshot = keySerializerConfigSnapshot;
 	}
 
 	public TypeSerializer<N> getNamespaceSerializer() {
@@ -84,12 +84,12 @@ public class InternalTimersSnapshot<K, N> {
 		this.namespaceSerializer = namespaceSerializer;
 	}
 
-	public TypeSerializerSnapshot<N> getNamespaceSerializerConfigSnapshot() {
-		return namespaceSerializerConfigSnapshot;
+	public TypeSerializerSnapshot<N> getNamespaceSerializerSnapshot() {
+		return namespaceSerializerSnapshot;
 	}
 
-	public void setNamespaceSerializerConfigSnapshot(TypeSerializerSnapshot<N> namespaceSerializerConfigSnapshot) {
-		this.namespaceSerializerConfigSnapshot = namespaceSerializerConfigSnapshot;
+	public void setNamespaceSerializerSnapshot(TypeSerializerSnapshot<N> namespaceSerializerConfigSnapshot) {
+		this.namespaceSerializerSnapshot = namespaceSerializerConfigSnapshot;
 	}
 
 	public Set<TimerHeapInternalTimer<K, N>> getEventTimeTimers() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -56,16 +56,24 @@ public class InternalTimersSnapshotReaderWriters {
 	//  Writers
 	//   - pre-versioned: Flink 1.4.0
 	//   - v1: Flink 1.4.1
+	//   - v2: Flink 1.8.0
 	// -------------------------------------------------------------------------------
 
-	public static <K, N> InternalTimersSnapshotWriter getWriterForVersion(int version, InternalTimersSnapshot<K, N> timersSnapshot) {
+	public static <K, N> InternalTimersSnapshotWriter getWriterForVersion(
+			int version,
+			InternalTimersSnapshot<K, N> timersSnapshot,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer) {
 
 		switch (version) {
 			case NO_VERSION:
-				return new InternalTimersSnapshotWriterPreVersioned<>(timersSnapshot);
+				return new InternalTimersSnapshotWriterPreVersioned<>(timersSnapshot, keySerializer, namespaceSerializer);
+
+			case 1:
+				return new InternalTimersSnapshotWriterV1<>(timersSnapshot, keySerializer, namespaceSerializer);
 
 			case InternalTimerServiceSerializationProxy.VERSION:
-				return new InternalTimersSnapshotWriterV1<>(timersSnapshot);
+				return new InternalTimersSnapshotWriterV2<>(timersSnapshot, keySerializer, namespaceSerializer);
 
 			default:
 				// guard for future
@@ -92,8 +100,16 @@ public class InternalTimersSnapshotReaderWriters {
 
 		protected final InternalTimersSnapshot<K, N> timersSnapshot;
 
-		public AbstractInternalTimersSnapshotWriter(InternalTimersSnapshot<K, N> timersSnapshot) {
+		protected final TypeSerializer<K> keySerializer;
+		protected final TypeSerializer<N> namespaceSerializer;
+
+		public AbstractInternalTimersSnapshotWriter(
+				InternalTimersSnapshot<K, N> timersSnapshot,
+				TypeSerializer<K> keySerializer,
+				TypeSerializer<N> namespaceSerializer) {
 			this.timersSnapshot = checkNotNull(timersSnapshot);
+			this.keySerializer = checkNotNull(keySerializer);
+			this.namespaceSerializer = checkNotNull(namespaceSerializer);
 		}
 
 		protected abstract void writeKeyAndNamespaceSerializers(DataOutputView out) throws IOException;
@@ -103,8 +119,8 @@ public class InternalTimersSnapshotReaderWriters {
 			writeKeyAndNamespaceSerializers(out);
 
 			LegacyTimerSerializer<K, N> timerSerializer = new LegacyTimerSerializer<>(
-				timersSnapshot.getKeySerializer(),
-				timersSnapshot.getNamespaceSerializer());
+				keySerializer,
+				namespaceSerializer);
 
 			// write the event time timers
 			Set<TimerHeapInternalTimer<K, N>> eventTimers = timersSnapshot.getEventTimeTimers();
@@ -132,16 +148,19 @@ public class InternalTimersSnapshotReaderWriters {
 
 	private static class InternalTimersSnapshotWriterPreVersioned<K, N> extends AbstractInternalTimersSnapshotWriter<K, N> {
 
-		public InternalTimersSnapshotWriterPreVersioned(InternalTimersSnapshot<K, N> timersSnapshot) {
-			super(timersSnapshot);
+		public InternalTimersSnapshotWriterPreVersioned(
+				InternalTimersSnapshot<K, N> timersSnapshot,
+				TypeSerializer<K> keySerializer,
+				TypeSerializer<N> namespaceSerializer) {
+			super(timersSnapshot, keySerializer, namespaceSerializer);
 		}
 
 		@Override
 		protected void writeKeyAndNamespaceSerializers(DataOutputView out) throws IOException {
 			// the pre-versioned format only serializes the serializers, without their configuration snapshots
 			try (ByteArrayOutputStreamWithPos stream = new ByteArrayOutputStreamWithPos()) {
-				InstantiationUtil.serializeObject(stream, timersSnapshot.getKeySerializer());
-				InstantiationUtil.serializeObject(stream, timersSnapshot.getNamespaceSerializer());
+				InstantiationUtil.serializeObject(stream, keySerializer);
+				InstantiationUtil.serializeObject(stream, namespaceSerializer);
 
 				out.write(stream.getBuf(), 0, stream.getPosition());
 			}
@@ -150,8 +169,11 @@ public class InternalTimersSnapshotReaderWriters {
 
 	private static class InternalTimersSnapshotWriterV1<K, N> extends AbstractInternalTimersSnapshotWriter<K, N> {
 
-		public InternalTimersSnapshotWriterV1(InternalTimersSnapshot<K, N> timersSnapshot) {
-			super(timersSnapshot);
+		public InternalTimersSnapshotWriterV1(
+				InternalTimersSnapshot<K, N> timersSnapshot,
+				TypeSerializer<K> keySerializer,
+				TypeSerializer<N> namespaceSerializer) {
+			super(timersSnapshot, keySerializer, namespaceSerializer);
 		}
 
 		@Override
@@ -160,8 +182,24 @@ public class InternalTimersSnapshotReaderWriters {
 			TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience(
 				out,
 				Arrays.asList(
-					Tuple2.of(timersSnapshot.getKeySerializer(), timersSnapshot.getKeySerializerSnapshot()),
-					Tuple2.of(timersSnapshot.getNamespaceSerializer(), timersSnapshot.getNamespaceSerializerSnapshot())));
+					Tuple2.of(keySerializer, timersSnapshot.getKeySerializerSnapshot()),
+					Tuple2.of(namespaceSerializer, timersSnapshot.getNamespaceSerializerSnapshot())));
+		}
+	}
+
+	private static class InternalTimersSnapshotWriterV2<K, N> extends AbstractInternalTimersSnapshotWriter<K, N> {
+
+		public InternalTimersSnapshotWriterV2(
+				InternalTimersSnapshot<K, N> timersSnapshot,
+				TypeSerializer<K> keySerializer,
+				TypeSerializer<N> namespaceSerializer) {
+			super(timersSnapshot, keySerializer, namespaceSerializer);
+		}
+
+		@Override
+		protected void writeKeyAndNamespaceSerializers(DataOutputView out) throws IOException {
+			TypeSerializerSnapshot.writeVersionedSnapshot(out, timersSnapshot.getKeySerializerSnapshot());
+			TypeSerializerSnapshot.writeVersionedSnapshot(out, timersSnapshot.getNamespaceSerializerSnapshot());
 		}
 	}
 
@@ -178,8 +216,11 @@ public class InternalTimersSnapshotReaderWriters {
 			case NO_VERSION:
 				return new InternalTimersSnapshotReaderPreVersioned<>(userCodeClassLoader);
 
-			case InternalTimerServiceSerializationProxy.VERSION:
+			case 1:
 				return new InternalTimersSnapshotReaderV1<>(userCodeClassLoader);
+
+			case InternalTimerServiceSerializationProxy.VERSION:
+				return new InternalTimersSnapshotReaderV2<>(userCodeClassLoader);
 
 			default:
 				// guard for future
@@ -223,8 +264,8 @@ public class InternalTimersSnapshotReaderWriters {
 
 			LegacyTimerSerializer<K, N> timerSerializer =
 				new LegacyTimerSerializer<>(
-					restoredTimersSnapshot.getKeySerializer(),
-					restoredTimersSnapshot.getNamespaceSerializer());
+					restoredTimersSnapshot.getKeySerializerSnapshot().restoreSerializer(),
+					restoredTimersSnapshot.getNamespaceSerializerSnapshot().restoreSerializer());
 
 			// read the event time timers
 			int sizeOfEventTimeTimers = in.readInt();
@@ -269,9 +310,7 @@ public class InternalTimersSnapshotReaderWriters {
 				final TypeSerializer<K> keySerializer = InstantiationUtil.deserializeObject(dis, userCodeClassLoader, true);
 				final TypeSerializer<N> namespaceSerializer = InstantiationUtil.deserializeObject(dis, userCodeClassLoader, true);
 
-				restoredTimersSnapshot.setKeySerializer(keySerializer);
 				restoredTimersSnapshot.setKeySerializerSnapshot(new BackwardsCompatibleSerializerSnapshot<>(keySerializer));
-				restoredTimersSnapshot.setNamespaceSerializer(namespaceSerializer);
 				restoredTimersSnapshot.setNamespaceSerializerSnapshot(new BackwardsCompatibleSerializerSnapshot<>(namespaceSerializer));
 			} catch (ClassNotFoundException exception) {
 				throw new IOException(exception);
@@ -294,10 +333,25 @@ public class InternalTimersSnapshotReaderWriters {
 			List<Tuple2<TypeSerializer<?>, TypeSerializerSnapshot<?>>> serializersAndConfigs =
 				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(in, userCodeClassLoader);
 
-			restoredTimersSnapshot.setKeySerializer((TypeSerializer<K>) serializersAndConfigs.get(0).f0);
 			restoredTimersSnapshot.setKeySerializerSnapshot((TypeSerializerSnapshot<K>) serializersAndConfigs.get(0).f1);
-			restoredTimersSnapshot.setNamespaceSerializer((TypeSerializer<N>) serializersAndConfigs.get(1).f0);
 			restoredTimersSnapshot.setNamespaceSerializerSnapshot((TypeSerializerSnapshot<N>) serializersAndConfigs.get(1).f1);
+		}
+	}
+
+	private static class InternalTimersSnapshotReaderV2<K, N> extends AbstractInternalTimersSnapshotReader<K, N> {
+
+		public InternalTimersSnapshotReaderV2(ClassLoader userCodeClassLoader) {
+			super(userCodeClassLoader);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		protected void restoreKeyAndNamespaceSerializers(
+			InternalTimersSnapshot<K, N> restoredTimersSnapshot,
+			DataInputView in) throws IOException {
+
+			restoredTimersSnapshot.setKeySerializerSnapshot(TypeSerializerSnapshot.readVersionedSnapshot(in, userCodeClassLoader));
+			restoredTimersSnapshot.setNamespaceSerializerSnapshot(TypeSerializerSnapshot.readVersionedSnapshot(in, userCodeClassLoader));
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -159,8 +159,8 @@ public class InternalTimersSnapshotReaderWriters {
 			TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience(
 				out,
 				Arrays.asList(
-					Tuple2.of(timersSnapshot.getKeySerializer(), timersSnapshot.getKeySerializerConfigSnapshot()),
-					Tuple2.of(timersSnapshot.getNamespaceSerializer(), timersSnapshot.getNamespaceSerializerConfigSnapshot())));
+					Tuple2.of(timersSnapshot.getKeySerializer(), timersSnapshot.getKeySerializerSnapshot()),
+					Tuple2.of(timersSnapshot.getNamespaceSerializer(), timersSnapshot.getNamespaceSerializerSnapshot())));
 		}
 	}
 
@@ -289,9 +289,9 @@ public class InternalTimersSnapshotReaderWriters {
 				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(in, userCodeClassLoader);
 
 			restoredTimersSnapshot.setKeySerializer((TypeSerializer<K>) serializersAndConfigs.get(0).f0);
-			restoredTimersSnapshot.setKeySerializerConfigSnapshot((TypeSerializerSnapshot<K>) serializersAndConfigs.get(0).f1);
+			restoredTimersSnapshot.setKeySerializerSnapshot((TypeSerializerSnapshot<K>) serializersAndConfigs.get(0).f1);
 			restoredTimersSnapshot.setNamespaceSerializer((TypeSerializer<N>) serializersAndConfigs.get(1).f0);
-			restoredTimersSnapshot.setNamespaceSerializerConfigSnapshot((TypeSerializerSnapshot<N>) serializersAndConfigs.get(1).f1);
+			restoredTimersSnapshot.setNamespaceSerializerSnapshot((TypeSerializerSnapshot<N>) serializersAndConfigs.get(1).f1);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.BackwardsCompatibleSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
@@ -265,8 +266,13 @@ public class InternalTimersSnapshotReaderWriters {
 
 			DataInputViewStream dis = new DataInputViewStream(in);
 			try {
-				restoredTimersSnapshot.setKeySerializer(InstantiationUtil.deserializeObject(dis, userCodeClassLoader, true));
-				restoredTimersSnapshot.setNamespaceSerializer(InstantiationUtil.deserializeObject(dis, userCodeClassLoader, true));
+				final TypeSerializer<K> keySerializer = InstantiationUtil.deserializeObject(dis, userCodeClassLoader, true);
+				final TypeSerializer<N> namespaceSerializer = InstantiationUtil.deserializeObject(dis, userCodeClassLoader, true);
+
+				restoredTimersSnapshot.setKeySerializer(keySerializer);
+				restoredTimersSnapshot.setKeySerializerSnapshot(new BackwardsCompatibleSerializerSnapshot<>(keySerializer));
+				restoredTimersSnapshot.setNamespaceSerializer(namespaceSerializer);
+				restoredTimersSnapshot.setNamespaceSerializerSnapshot(new BackwardsCompatibleSerializerSnapshot<>(namespaceSerializer));
 			} catch (ClassNotFoundException exception) {
 				throw new IOException(exception);
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializerSnapshot.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializerSnapshot.java
@@ -31,7 +31,7 @@ public class TimerSerializerSnapshot<K, N> extends CompositeTypeSerializerSnapsh
 	private static final int VERSION = 2;
 
 	public TimerSerializerSnapshot() {
-		super(correspondingSerializerClass());
+		super(TimerSerializer.class);
 	}
 
 	public TimerSerializerSnapshot(TimerSerializer<K, N> timerSerializer) {
@@ -51,16 +51,11 @@ public class TimerSerializerSnapshot<K, N> extends CompositeTypeSerializerSnapsh
 		@SuppressWarnings("unchecked")
 		final TypeSerializer<N> namespaceSerializer = (TypeSerializer<N>) nestedSerializers[1];
 
-		return new TimerSerializer<K, N>(keySerializer, namespaceSerializer);
+		return new TimerSerializer<>(keySerializer, namespaceSerializer);
 	}
 
 	@Override
 	protected TypeSerializer<?>[] getNestedSerializers(TimerSerializer<K, N> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getKeySerializer(), outerSerializer.getNamespaceSerializer() };
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <K, N> Class<TimerSerializer<K, N>> correspondingSerializerClass() {
-		return (Class<TimerSerializer<K, N>>) (Class<?>) TimerSerializer.class;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -509,7 +509,7 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 
 		@SuppressWarnings({"unused", "WeakerAccess"})
 		public BufferEntrySerializerSnapshot() {
-			super(correspondingSerializerClass());
+			super(BufferEntrySerializer.class);
 		}
 
 		BufferEntrySerializerSnapshot(BufferEntrySerializer<T> serializerInstance) {
@@ -530,11 +530,6 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 		@SuppressWarnings("unchecked")
 		protected BufferEntrySerializer<T> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 			return new BufferEntrySerializer<>((TypeSerializer<T>) nestedSerializers[0]);
-		}
-
-		@SuppressWarnings("unchecked")
-		private static <T> Class<BufferEntrySerializer<T>> correspondingSerializerClass() {
-			return (Class<BufferEntrySerializer<T>>) (Class<?>) BufferEntrySerializer.class;
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
@@ -314,7 +314,7 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 
 		@SuppressWarnings("WeakerAccess")
 		public StreamElementSerializerSnapshot() {
-			super(serializerClass());
+			super(StreamElementSerializer.class);
 		}
 
 		StreamElementSerializerSnapshot(StreamElementSerializer<T> serializerInstance) {
@@ -337,12 +337,6 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 			TypeSerializer<T> casted = (TypeSerializer<T>) nestedSerializers[0];
 
 			return new StreamElementSerializer<>(casted);
-		}
-
-		@SuppressWarnings("unchecked")
-		private static <T> Class<StreamElementSerializer<T>> serializerClass() {
-			Class<?> streamElementSerializerClass = StreamElementSerializer.class;
-			return (Class<StreamElementSerializer<T>>) streamElementSerializerClass;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
@@ -620,10 +620,14 @@ public class InternalTimerServiceImplTest {
 		Map<Integer, byte[]> snapshot = new HashMap<>();
 		for (Integer keyGroupIndex : testKeyGroupRange) {
 			try (ByteArrayOutputStream outStream = new ByteArrayOutputStream()) {
-				InternalTimersSnapshot<?, ?> timersSnapshot = timerService.snapshotTimersForKeyGroup(keyGroupIndex);
+				InternalTimersSnapshot<Integer, String> timersSnapshot = timerService.snapshotTimersForKeyGroup(keyGroupIndex);
 
 				InternalTimersSnapshotReaderWriters
-					.getWriterForVersion(snapshotVersion, timersSnapshot)
+					.getWriterForVersion(
+						snapshotVersion,
+						timersSnapshot,
+						timerService.getKeySerializer(),
+						timerService.getNamespaceSerializer())
 					.writeTimersSnapshot(new DataOutputViewStreamWrapper(outStream));
 
 				snapshot.put(keyGroupIndex, outStream.toByteArray());
@@ -701,10 +705,14 @@ public class InternalTimerServiceImplTest {
 		Map<Integer, byte[]> snapshot2 = new HashMap<>();
 		for (Integer keyGroupIndex : testKeyGroupRange) {
 			try (ByteArrayOutputStream outStream = new ByteArrayOutputStream()) {
-				InternalTimersSnapshot<?, ?> timersSnapshot = timerService.snapshotTimersForKeyGroup(keyGroupIndex);
+				InternalTimersSnapshot<Integer, String> timersSnapshot = timerService.snapshotTimersForKeyGroup(keyGroupIndex);
 
 				InternalTimersSnapshotReaderWriters
-					.getWriterForVersion(snapshotVersion, timersSnapshot)
+					.getWriterForVersion(
+						snapshotVersion,
+						timersSnapshot,
+						timerService.getKeySerializer(),
+						timerService.getNamespaceSerializer())
 					.writeTimersSnapshot(new DataOutputViewStreamWrapper(outStream));
 
 				if (subKeyGroupRange1.contains(keyGroupIndex)) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/dataview/ListViewSerializerSnapshot.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/dataview/ListViewSerializerSnapshot.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @param <T> the type of the list elements.
  */
-public final class ListViewSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<ListView<T>, ListViewSerializer> {
+public final class ListViewSerializerSnapshot<T> extends CompositeTypeSerializerSnapshot<ListView<T>, ListViewSerializer<T>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -54,14 +54,14 @@ public final class ListViewSerializerSnapshot<T> extends CompositeTypeSerializer
 	}
 
 	@Override
-	protected ListViewSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected ListViewSerializer<T> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<List<T>> listSerializer = (TypeSerializer<List<T>>) nestedSerializers[0];
 		return new ListViewSerializer<>(listSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(ListViewSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(ListViewSerializer<T> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getListSerializer() };
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/dataview/MapViewSerializerSnapshot.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/dataview/MapViewSerializerSnapshot.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * @param <K> the key type of the map entries.
  * @param <V> the value type of the map entries.
  */
-public class MapViewSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot<MapView<K, V>, MapViewSerializer> {
+public class MapViewSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot<MapView<K, V>, MapViewSerializer<K, V>> {
 
 	private static final int CURRENT_VERSION = 1;
 
@@ -55,14 +55,14 @@ public class MapViewSerializerSnapshot<K, V> extends CompositeTypeSerializerSnap
 	}
 
 	@Override
-	protected MapViewSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
+	protected MapViewSerializer<K, V> createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
 		@SuppressWarnings("unchecked")
 		TypeSerializer<Map<K, V>> mapSerializer = (TypeSerializer<Map<K, V>>) nestedSerializers[0];
 		return new MapViewSerializer<>(mapSerializer);
 	}
 
 	@Override
-	protected TypeSerializer<?>[] getNestedSerializers(MapViewSerializer outerSerializer) {
+	protected TypeSerializer<?>[] getNestedSerializers(MapViewSerializer<K, V> outerSerializer) {
 		return new TypeSerializer<?>[] { outerSerializer.getMapSerializer() };
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on #7818. The first commit is not relevant.

All of the changes done to managed state surrounding:
- how we no longer Java-serialize serializers anymore, and only write the serializer
snapshot
- All schema compatibility checks of serializers go through `TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)`
were not reflected to the timers, due to the fact that timers were not handled by state backends (and were therefore not managed state) in the past, and were handled in an
isolated manner by the {{InternalTimerServiceSerializationProxy}}.

This PR updates the {{InternalTimerServiceSerializationProxy}} accordingly.

## Brief change log

- ad7222e: Minor code cleanup related to method / field names
- 543b3ce: This commit fixes compatibility checks of key / namespace serializers to go through `TypeSerializerSnapshot#resolveSchemaCompatibility`, instead of the broken `CompatibilityUtil`. It also handles serializer reconfiguration properly.
- acb9238: This commit upticks the version of {{InternalTimerServiceSerializationProxy}} to 2, and also introduces new `InternalTimersSnapshotWriter` and `InternalTimersSnapshotReader` for version 2, that correctly only writes serializer snapshots as state.

## Verifying this change

Existing migration IT cases that use timers, such as `WindowOperatorMigrationTest` and `CEPMigrationTest` should cover this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? N/A
