### PR TITLE
[FLINK-11773][core] Harden KryoSerializerSnapshot

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/LinkedOptionalMapSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/util/LinkedOptionalMapSerializer.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.BiFunctionWithException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * LinkedOptionalMapSerializer - A serializer of {@link LinkedOptionalMap}.
+ */
+@Internal
+public final class LinkedOptionalMapSerializer {
+
+	private static final long HEADER = 0x4f2c69a3d70L;
+
+	private LinkedOptionalMapSerializer() {
+	}
+
+	public static <K, V> void writeOptionalMap(
+		DataOutputView out,
+		LinkedOptionalMap<K, V> map,
+		BiConsumerWithException<DataOutputView, K, IOException> keyWriter,
+		BiConsumerWithException<DataOutputView, V, IOException> valueWriter) throws IOException {
+
+		out.writeLong(HEADER);
+		out.writeInt(map.size());
+		map.forEach(((keyName, key, value) -> {
+			out.writeUTF(keyName);
+
+			if (key == null) {
+				out.writeBoolean(false);
+			}
+			else {
+				out.writeBoolean(true);
+				writeFramed(out, keyWriter, key);
+			}
+
+			if (value == null) {
+				out.writeBoolean(false);
+			}
+			else {
+				out.writeBoolean(true);
+				writeFramed(out, valueWriter, value);
+			}
+		}));
+	}
+
+	public static <K, V> LinkedOptionalMap<K, V> readOptionalMap(
+		DataInputView in,
+		BiFunctionWithException<DataInputView, String, K, IOException> keyReader,
+		BiFunctionWithException<DataInputView, String, V, IOException> valueReader) throws IOException {
+
+		final long header = in.readLong();
+		checkState(header == HEADER, "Corrupted stream received header %d", header);
+
+		long mapSize = in.readInt();
+		LinkedOptionalMap<K, V> map = new LinkedOptionalMap<>();
+		for (int i = 0; i < mapSize; i++) {
+			String keyName = in.readUTF();
+
+			final K key;
+			if (in.readBoolean()) {
+				key = tryReadFrame(in, keyName, keyReader);
+			}
+			else {
+				key = null;
+			}
+
+			final V value;
+			if (in.readBoolean()) {
+				value = tryReadFrame(in, keyName, valueReader);
+			}
+			else {
+				value = null;
+			}
+
+			map.put(keyName, key, value);
+		}
+		return map;
+	}
+
+	private static <T> void writeFramed(DataOutputView out, BiConsumerWithException<DataOutputView, T, IOException> writter, T item) throws IOException {
+		ByteArrayOutputStreamWithPos streamWithPos = new ByteArrayOutputStreamWithPos();
+		try (DataOutputViewStreamWrapper inMemoryStream = new DataOutputViewStreamWrapper(streamWithPos)) {
+			writter.accept(inMemoryStream, item);
+		}
+		out.writeInt(streamWithPos.getPosition());
+		out.write(streamWithPos.getBuf(), 0, streamWithPos.getPosition());
+	}
+
+	@Nullable
+	private static <T> T tryReadFrame(DataInputView in, String keyName, BiFunctionWithException<DataInputView, String, T, IOException> reader) throws IOException {
+		final int bufferSize = in.readInt();
+		byte[] buf = new byte[bufferSize];
+		in.read(buf, 0, bufferSize);
+		DataInputDeserializer frame = new DataInputDeserializer(buf, 0, bufferSize);
+		return reader.apply(frame, keyName);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerMatchers.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerMatchers.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.function.Predicate;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A Collection of useful {@link Matcher}s for {@link TypeSerializer} and {@link TypeSerializerSchemaCompatibility}.
+ */
+public final class TypeSerializerMatchers {
+
+	private TypeSerializerMatchers() {
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Matcher Factories
+	// -------------------------------------------------------------------------------------------------------------
+
+	/**
+	 * Matches {@code compatibleAsIs} {@link TypeSerializerSchemaCompatibility}.
+	 *
+	 * @param <T> element type
+	 * @return a {@code Matcher} that matches {@code compatibleAsIs} {@link TypeSerializerSchemaCompatibility}.
+	 */
+	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> isCompatibleAsIs() {
+		return propertyMatcher(TypeSerializerSchemaCompatibility::isCompatibleAsIs,
+			"type serializer schema that is a compatible as is");
+	}
+
+	/**
+	 * Matches {@code isIncompatible} {@link TypeSerializerSchemaCompatibility}.
+	 *
+	 * @param <T> element type
+	 * @return a {@code Matcher} that matches {@code isIncompatible} {@link TypeSerializerSchemaCompatibility}.
+	 */
+	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> isIncompatible() {
+		return propertyMatcher(TypeSerializerSchemaCompatibility::isIncompatible,
+			"type serializer schema that is incompatible");
+	}
+
+	/**
+	 * Matches {@code isCompatibleAfterMigration} {@link TypeSerializerSchemaCompatibility}.
+	 *
+	 * @param <T> element type
+	 * @return a {@code Matcher} that matches {@code isCompatibleAfterMigration} {@link TypeSerializerSchemaCompatibility}.
+	 */
+	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> isCompatibleAfterMigration() {
+		return propertyMatcher(TypeSerializerSchemaCompatibility::isCompatibleAfterMigration,
+			"type serializer schema that is compatible after migration");
+	}
+
+	/**
+	 * Matches {@code isCompatibleWithReconfiguredSerializer} {@link TypeSerializerSchemaCompatibility}.
+	 *
+	 * @param <T> element type
+	 * @return a {@code Matcher} that matches {@code isCompatibleWithReconfiguredSerializer} {@link TypeSerializerSchemaCompatibility}.
+	 */
+	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> isCompatibleWithReconfiguredSerializer() {
+		@SuppressWarnings("unchecked") Matcher<TypeSerializer<T>> anything =
+			(Matcher<TypeSerializer<T>>) (Matcher<?>) CoreMatchers.anything();
+
+		return new CompatibleAfterReconfiguration<>(anything);
+	}
+
+	/**
+	 * Matches {@code isCompatibleWithReconfiguredSerializer} {@link TypeSerializerSchemaCompatibility}.
+	 *
+	 * @param reconfiguredSerializerMatcher matches the reconfigured serializer.
+	 * @param <T>                           element type
+	 * @return a {@code Matcher} that matches {@code isCompatibleWithReconfiguredSerializer} {@link TypeSerializerSchemaCompatibility}.
+	 */
+	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> isCompatibleWithReconfiguredSerializer(
+		Matcher<? extends TypeSerializer<T>> reconfiguredSerializerMatcher) {
+
+		return new CompatibleAfterReconfiguration<>(reconfiguredSerializerMatcher);
+	}
+
+	/**
+	 * Matches if the expected {@code TypeSerializerSchemaCompatibility} has the same compatibility as {@code expectedCompatibility}.
+	 *
+	 * @param expectedCompatibility the compatibility to match to.
+	 * @param <T> element type.
+	 * @return a {@code Matcher} that matches if it has the same compatibility as {@code expectedCompatibility}.
+	 */
+	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> hasSameCompatibilityAs(
+		TypeSerializerSchemaCompatibility<T> expectedCompatibility) {
+
+		return new SchemaCompatibilitySameAs<>(expectedCompatibility);
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------------------------------------------
+
+	private static <T> Matcher<T> propertyMatcher(Predicate<T> predicate, String matcherDescription) {
+		return new TypeSafeMatcher<T>() {
+
+			@Override
+			protected boolean matchesSafely(T item) {
+				return predicate.test(item);
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText(matcherDescription);
+			}
+		};
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Matchers
+	// -------------------------------------------------------------------------------------------------------------
+
+	private static final class CompatibleAfterReconfiguration<T>
+			extends TypeSafeDiagnosingMatcher<TypeSerializerSchemaCompatibility<T>> {
+
+		private final Matcher<? extends TypeSerializer<T>> reconfiguredSerializerMatcher;
+
+		private CompatibleAfterReconfiguration(Matcher<? extends TypeSerializer<T>> reconfiguredSerializerMatcher) {
+			this.reconfiguredSerializerMatcher = checkNotNull(reconfiguredSerializerMatcher);
+		}
+
+		@Override
+		protected boolean matchesSafely(TypeSerializerSchemaCompatibility<T> item, Description mismatchDescription) {
+			if (!item.isCompatibleWithReconfiguredSerializer()) {
+				mismatchDescription.appendText("serializer schema is not compatible with a reconfigured serializer");
+				return false;
+			}
+			TypeSerializer<T> reconfiguredSerializer = item.getReconfiguredSerializer();
+			if (!reconfiguredSerializerMatcher.matches(reconfiguredSerializer)) {
+				reconfiguredSerializerMatcher.describeMismatch(reconfiguredSerializer, mismatchDescription);
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("type serializer schema that is compatible after reconfiguration,")
+				.appendText("with a reconfigured serializer matching ")
+				.appendDescriptionOf(reconfiguredSerializerMatcher);
+		}
+	}
+
+	private static class SchemaCompatibilitySameAs<T> extends TypeSafeMatcher<TypeSerializerSchemaCompatibility<T>> {
+
+		private final TypeSerializerSchemaCompatibility<T> expectedCompatibility;
+
+		private SchemaCompatibilitySameAs(TypeSerializerSchemaCompatibility<T> expectedCompatibility) {
+			this.expectedCompatibility = checkNotNull(expectedCompatibility);
+		}
+
+		@Override
+		protected boolean matchesSafely(TypeSerializerSchemaCompatibility<T> testResultCompatibility) {
+			if (expectedCompatibility.isCompatibleAsIs()) {
+				return testResultCompatibility.isCompatibleAsIs();
+			}
+			else if (expectedCompatibility.isIncompatible()) {
+				return testResultCompatibility.isIncompatible();
+			}
+			else if (expectedCompatibility.isCompatibleAfterMigration()) {
+				return testResultCompatibility.isCompatibleAfterMigration();
+			}
+			else if (expectedCompatibility.isCompatibleWithReconfiguredSerializer()) {
+				return testResultCompatibility.isCompatibleWithReconfiguredSerializer();
+			}
+			return false;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("same compatibility as ").appendValue(expectedCompatibility);
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotMigrationTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotMigrationTestBase.java
@@ -25,9 +25,7 @@ import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.TestLogger;
 
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -42,6 +40,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.hasSameCompatibilityAs;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -286,7 +285,7 @@ public abstract class TypeSerializerSnapshotMigrationTestBase<ElementT> extends 
 				Supplier<? extends TypeSerializer<T>> serializerProvider,
 				TypeSerializerSchemaCompatibility<T> expectedCompatibilityResult) {
 			this.serializerProvider = serializerProvider;
-			this.schemaCompatibilityMatcher = hasSameCompatibilityType(expectedCompatibilityResult);
+			this.schemaCompatibilityMatcher = hasSameCompatibilityAs(expectedCompatibilityResult);
 			return this;
 		}
 
@@ -523,33 +522,5 @@ public abstract class TypeSerializerSnapshotMigrationTestBase<ElementT> extends 
 	 */
 	protected interface TestResourceFilenameSupplier {
 		String get(MigrationVersion testVersion);
-	}
-
-	// --------------------------------------------------------------------------------------------------------------
-	// Utilities
-	// --------------------------------------------------------------------------------------------------------------
-
-	public static <T> Matcher<TypeSerializerSchemaCompatibility<T>> hasSameCompatibilityType(TypeSerializerSchemaCompatibility<T> expectedCompatibilty) {
-		return new TypeSafeMatcher<TypeSerializerSchemaCompatibility<T>>() {
-
-			@Override
-			protected boolean matchesSafely(TypeSerializerSchemaCompatibility<T> testResultCompatibility) {
-				if (expectedCompatibilty.isCompatibleAsIs()) {
-					return testResultCompatibility.isCompatibleAsIs();
-				} else if (expectedCompatibilty.isIncompatible()) {
-					return testResultCompatibility.isIncompatible();
-				} else if (expectedCompatibilty.isCompatibleAfterMigration()) {
-					return testResultCompatibility.isCompatibleAfterMigration();
-				} else if (expectedCompatibilty.isCompatibleWithReconfiguredSerializer()) {
-					return testResultCompatibility.isCompatibleWithReconfiguredSerializer();
-				}
-				return false;
-			}
-
-			@Override
-			public void describeTo(Description description) {
-				description.appendText("same compatibility as ").appendValue(expectedCompatibilty);
-			}
-		};
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotMigrationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotMigrationTest.java
@@ -30,6 +30,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.hasSameCompatibilityAs;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -104,7 +105,7 @@ public class PojoSerializerSnapshotMigrationTest extends TypeSerializerSnapshotM
 			PojoSerializer.class,
 			PojoSerializerSnapshot.class,
 			PojoSerializerSnapshotMigrationTest::testPojoWithNewAndRemovedFieldsSerializerSupplier,
-			hasSameCompatibilityType(TypeSerializerSchemaCompatibility.compatibleAfterMigration()));
+			hasSameCompatibilityAs(TypeSerializerSchemaCompatibility.compatibleAfterMigration()));
 
 		return testSpecifications.get();
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime.kryo;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.Animal;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.Dog;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.DogKryoSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.DogV2KryoSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.Parrot;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleAsIs;
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer;
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isIncompatible;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link KryoSerializerSnapshot}.
+ */
+public class KryoSerializerSnapshotTest {
+
+	private ExecutionConfig oldConfig;
+	private ExecutionConfig newConfig;
+
+	@Before
+	public void setup() {
+		oldConfig = new ExecutionConfig();
+		newConfig = new ExecutionConfig();
+	}
+
+	@Test
+	public void sanityTest() {
+		assertThat(resolveKryoCompatibility(oldConfig, newConfig), isCompatibleAsIs());
+	}
+
+	@Test
+	public void addingTypesIsCompatibleAfterReconfiguration() {
+		oldConfig.registerKryoType(Animal.class);
+
+		newConfig.registerKryoType(Animal.class);
+		newConfig.registerTypeWithKryoSerializer(Dog.class, DogKryoSerializer.class);
+
+		assertThat(resolveKryoCompatibility(oldConfig, newConfig),
+			isCompatibleWithReconfiguredSerializer());
+	}
+
+	@Test
+	public void replacingKryoSerializersIsCompatibleAsIs() {
+		oldConfig.registerKryoType(Animal.class);
+		oldConfig.registerTypeWithKryoSerializer(Dog.class, DogKryoSerializer.class);
+
+		newConfig.registerKryoType(Animal.class);
+		newConfig.registerTypeWithKryoSerializer(Dog.class, DogV2KryoSerializer.class);
+
+		// it is compatible as is, since kryo does not expose compatibility API with KryoSerializers
+		// so we can not know if DogKryoSerializer is compatible with DogV2KryoSerializer
+		assertThat(resolveKryoCompatibility(oldConfig, newConfig),
+			isCompatibleAsIs());
+	}
+
+	@Test
+	public void reorderingIsCompatibleAfterReconfiguration() {
+		oldConfig.registerKryoType(Parrot.class);
+		oldConfig.registerKryoType(Dog.class);
+
+		newConfig.registerKryoType(Dog.class);
+		newConfig.registerKryoType(Parrot.class);
+
+		assertThat(resolveKryoCompatibility(oldConfig, newConfig),
+			isCompatibleWithReconfiguredSerializer());
+	}
+
+	@Test
+	public void tryingToRestoreWithNonExistingClassShouldBeIncompatible() throws IOException {
+		TypeSerializerSnapshot<Animal> restoredSnapshot = kryoSnapshotWithMissingClass();
+
+		TypeSerializer<Animal> currentSerializer = new KryoSerializer<>(Animal.class, new ExecutionConfig());
+
+		assertThat(restoredSnapshot.resolveSchemaCompatibility(currentSerializer),
+			isIncompatible());
+	}
+
+	// -------------------------------------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------------------------------------
+
+	private static TypeSerializerSnapshot<Animal> kryoSnapshotWithMissingClass() throws IOException {
+		DataInputView in = new DataInputDeserializer(unLoadableSnapshotBytes());
+
+		return TypeSerializerSnapshot.readVersionedSnapshot(
+			in,
+			KryoSerializerSnapshotTest.class.getClassLoader());
+	}
+
+	/**
+	 * This method returns the bytes of a serialized {@link KryoSerializerSnapshot}, that contains a kryo registration
+	 * of a class that does not exists in the current classpath.
+	 */
+	private static byte[] unLoadableSnapshotBytes() throws IOException {
+		final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+		ClassLoader tempClassLoader =
+			new URLClassLoader(new URL[0], KryoSerializerSnapshotTest.class.getClassLoader());
+		try {
+			Thread.currentThread().setContextClassLoader(tempClassLoader);
+
+			ExecutionConfig conf = registerClassThatIsNotInClassPath(tempClassLoader);
+
+			KryoSerializer<Animal> previousSerializer = new KryoSerializer<>(Animal.class, conf);
+			TypeSerializerSnapshot<Animal> previousSnapshot = previousSerializer.snapshotConfiguration();
+
+			DataOutputSerializer out = new DataOutputSerializer(4096);
+			TypeSerializerSnapshot.writeVersionedSnapshot(out, previousSnapshot);
+			return out.getCopyOfBuffer();
+		}
+		finally {
+			Thread.currentThread().setContextClassLoader(originalClassLoader);
+		}
+	}
+
+	private static ExecutionConfig registerClassThatIsNotInClassPath(ClassLoader tempClassLoader) {
+		Object objectForClassNotInClassPath =
+			CommonTestUtils.createObjectForClassNotInClassPath(tempClassLoader);
+
+		ExecutionConfig conf = new ExecutionConfig();
+		conf.registerKryoType(objectForClassNotInClassPath.getClass());
+		return conf;
+	}
+
+	private static TypeSerializerSchemaCompatibility<Animal> resolveKryoCompatibility(ExecutionConfig previous, ExecutionConfig current) {
+		KryoSerializer<Animal> previousSerializer = new KryoSerializer<>(Animal.class, previous);
+		TypeSerializerSnapshot<Animal> previousSnapshot = previousSerializer.snapshotConfiguration();
+
+		TypeSerializer<Animal> currentSerializer = new KryoSerializer<>(Animal.class, current);
+		return previousSnapshot.resolveSchemaCompatibility(currentSerializer);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/testutils/migration/SchemaCompatibilityTestingSerializer.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/migration/SchemaCompatibilityTestingSerializer.java
@@ -24,273 +24,240 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
-import java.io.IOException;
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * The {@link SchemaCompatibilityTestingSerializer} is a mock serializer that can be used
  * for schema compatibility and serializer upgrade related tests.
  *
- * <p>To use this, tests should always first instantiate an {@link InitialSerializer} serializer
- * instance and then take a snapshot of it. Next, depending on what the new serializer is provided
- * to the taken snapshot, tests can expect the following compatibility results:
+ * <p>To test serializers compatibility we can start by either obtaining a {@link TypeSerializerSnapshot} and restoring
+ * a {@link TypeSerializer} or the other way around, starting with a serializer and calling {@link TypeSerializer#snapshotConfiguration()}
+ * to obtain a snapshot class.
+ *
+ * <p>To start from a snapshot, the class {@link SchemaCompatibilityTestingSnapshot} can be configured to return a predefined
+ * {@link TypeSerializerSchemaCompatibility} result when
+ * {@link TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)} would be called, the following static factory
+ * methods return a pre-configured snapshot class:
  * <ul>
- *     <li>{@link InitialSerializer} as the new serializer: the compatibility result will be
- *         {@link TypeSerializerSchemaCompatibility#compatibleAsIs()}.</li>
- *     <li>{@link UpgradedSchemaSerializer} as the new serializer: the compatibility result will be
- *         {@link TypeSerializerSchemaCompatibility#compatibleAfterMigration()}.</li>
- *     <li>{@link ReconfigurationRequiringSerializer} as the new serializer: the compatibility result
- *         will be {@link TypeSerializerSchemaCompatibility#compatibleWithReconfiguredSerializer(TypeSerializer)},
- *         with a new instance of the {@link InitialSerializer} as the wrapped reconfigured serializer.</li>
- *     <li>{@link IncompatibleSerializer} as the new serializer: the compatibility result will be
- *         {@link TypeSerializerSchemaCompatibility#incompatible()}.</li>
+ * <li>{@code thatIsCompatibleWithNextSerializer}.
+ * <li>{@code thatIsCompatibleWithNextSerializerAfterReconfiguration}</li>
+ * <li>{@code thatIsCompatibleWithNextSerializerAfterMigration}</li>
+ * <li>{@code thatIsIncompatibleWithTheNextSerializer}</li>
  * </ul>
+ *
+ * <p>Here is a simple test example.<pre>{@code
+ * @Test
+ * public void example() {
+ *     TypeSerializerSnapshot<?> snapshot = SchemaCompatibilityTestingSnapshot.thatIsCompatibleWithNextSerializer();
+ *
+ *     TypeSerializerSchemaCompatibility<?> result = snapshot.resolveSchemaCompatibility(new SchemaCompatibilityTestingSerializer());
+ *
+ *     assertTrue(result.compatibleAsIs());
+ * }
+ * }</pre>
+ *
+ * <p>To start from a serializer, simply create a new instance of {@code SchemaCompatibilityTestingSerializer} and call
+ * {@link SchemaCompatibilityTestingSerializer#snapshotConfiguration()} to obtain a {@link SchemaCompatibilityTestingSnapshot}.
+ * To control the behaviour of the returned snapshot it is possible to pass a function from a {@code newSerializer} to a
+ * {@link TypeSerializerSchemaCompatibility}.
+ *
+ * <p>It is also possible to pass in a {@code String} identifier when constructing a snapshot or a serializer to tie a
+ * specific snapshot instance to a specific serializer instance, this might be useful when testing composite serializers.
  */
-public abstract class SchemaCompatibilityTestingSerializer<T> extends TypeSerializer<T> {
+@SuppressWarnings({"WeakerAccess", "serial"})
+public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<Integer> {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2588814752302505240L;
 
-	// ------------------------------------------------------------------------------------------------
-	//  Irrelevant serializer methods
-	// ------------------------------------------------------------------------------------------------
+	private final Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>> resolver;
 
-	@Override
-	public TypeSerializer<T> duplicate() {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
+	@Nullable
+	private final String tokenForEqualityChecks;
+
+	public SchemaCompatibilityTestingSerializer() {
+		this(null, ALWAYS_COMPATIBLE);
+	}
+
+	public SchemaCompatibilityTestingSerializer(String tokenForEqualityChecks) {
+		this(tokenForEqualityChecks, ALWAYS_COMPATIBLE);
+	}
+
+	public SchemaCompatibilityTestingSerializer(
+		@Nullable String tokenForEqualityChecks,
+		Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>> resolver) {
+		this.resolver = resolver;
+		this.tokenForEqualityChecks = tokenForEqualityChecks;
 	}
 
 	@Override
-	public void serialize(T record, DataOutputView target) throws IOException {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
+	public boolean equals(Object obj) {
+		return (obj instanceof SchemaCompatibilityTestingSerializer) &&
+			Objects.equals(tokenForEqualityChecks, ((SchemaCompatibilityTestingSerializer) obj).tokenForEqualityChecks);
 	}
 
 	@Override
-	public T deserialize(T reuse, DataInputView source) throws IOException {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
+	public int hashCode() {
+		return Objects.hash(getClass(), tokenForEqualityChecks);
 	}
 
 	@Override
-	public T deserialize(DataInputView source) throws IOException {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
+	public String toString() {
+		return "StubSerializer{" +
+			"tokenForEqualityChecks='" + tokenForEqualityChecks + '\'' +
+			'}';
 	}
 
 	@Override
-	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
+	public TypeSerializerSnapshot<Integer> snapshotConfiguration() {
+		return new SchemaCompatibilityTestingSnapshot(tokenForEqualityChecks, resolver);
 	}
 
-	@Override
-	public T copy(T from) {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
-	}
-
-	@Override
-	public T copy(T from, T reuse) {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
-	}
-
-	@Override
-	public T createInstance() {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
-	}
+	// -----------------------------------------------------------------------------------------------------------
+	// Serialization related methods are not supported
+	// -----------------------------------------------------------------------------------------------------------
 
 	@Override
 	public boolean isImmutableType() {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
+		throw new UnsupportedOperationException();
+	}
 
+	@Override
+	public TypeSerializer<Integer> duplicate() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Integer createInstance() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Integer copy(Integer from) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Integer copy(Integer from, Integer reuse) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getLength() {
-		throw new UnsupportedOperationException(
-			"this is a SchemaCompatibilityTestingSerializer; should have only been used for snapshotting / compatibility test purposes.");
-
+		throw new UnsupportedOperationException();
 	}
 
-	// ------------------------------------------------------------------------------------------------
-	//  Test serializer variants
-	// ------------------------------------------------------------------------------------------------
-
-	public static class InitialSerializer<T> extends SchemaCompatibilityTestingSerializer<T> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public TypeSerializerSnapshot<T> snapshotConfiguration() {
-			return new InitialSerializerSnapshot();
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj != null && obj.getClass() == InitialSerializer.class;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
+	@Override
+	public void serialize(Integer record, DataOutputView target) {
+		throw new UnsupportedOperationException();
 	}
 
-	public static class UpgradedSchemaSerializer<T> extends SchemaCompatibilityTestingSerializer<T> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public TypeSerializerSnapshot<T> snapshotConfiguration() {
-			return new UpgradedSchemaSerializerSnapshot();
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj != null && obj.getClass() == UpgradedSchemaSerializer.class;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
+	@Override
+	public Integer deserialize(DataInputView source) {
+		throw new UnsupportedOperationException();
 	}
 
-	public static class ReconfigurationRequiringSerializer<T> extends SchemaCompatibilityTestingSerializer<T> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public TypeSerializerSnapshot<T> snapshotConfiguration() {
-			throw new UnsupportedOperationException(
-				"this is a ReconfigurationRequiringSerializer; should not have been snapshotted.");
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj != null && obj.getClass() == ReconfigurationRequiringSerializer.class;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
+	@Override
+	public Integer deserialize(Integer reuse, DataInputView source) {
+		throw new UnsupportedOperationException();
 	}
 
-	public static class IncompatibleSerializer<T> extends SchemaCompatibilityTestingSerializer<T> {
-
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public TypeSerializerSnapshot<T> snapshotConfiguration() {
-			throw new UnsupportedOperationException(
-				"this is a IncompatibleSerializer; should not have been snapshotted.");
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj != null && obj.getClass() == IncompatibleSerializer.class;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
+	@Override
+	public void copy(DataInputView source, DataOutputView target) {
+		throw new UnsupportedOperationException();
 	}
 
-	// ------------------------------------------------------------------------------------------------
-	//  Test serializer snapshots
-	// ------------------------------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------------------------------------
+	// Utils
+	// -----------------------------------------------------------------------------------------------------------
 
-	public class InitialSerializerSnapshot implements TypeSerializerSnapshot<T> {
+	private static final Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>> ALWAYS_COMPATIBLE =
+		unused -> TypeSerializerSchemaCompatibility.compatibleAsIs();
+
+	// -----------------------------------------------------------------------------------------------------------
+	// Snapshot class
+	// -----------------------------------------------------------------------------------------------------------
+
+	/**
+	 * A configurable {@link TypeSerializerSnapshot} for this serializer.
+	 */
+	@SuppressWarnings("WeakerAccess")
+	public static final class SchemaCompatibilityTestingSnapshot implements TypeSerializerSnapshot<Integer> {
+
+		public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializer() {
+			return thatIsCompatibleWithNextSerializer(null);
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializer(String tokenForEqualityChecks) {
+			return new SchemaCompatibilityTestingSnapshot(tokenForEqualityChecks, unused -> TypeSerializerSchemaCompatibility.compatibleAsIs());
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializerAfterReconfiguration() {
+			return thatIsCompatibleWithNextSerializerAfterReconfiguration(null);
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializerAfterReconfiguration(String tokenForEqualityChecks) {
+			SchemaCompatibilityTestingSerializer reconfiguredSerializer = new SchemaCompatibilityTestingSerializer(tokenForEqualityChecks, ALWAYS_COMPATIBLE);
+			return new SchemaCompatibilityTestingSnapshot(tokenForEqualityChecks, unused -> TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(reconfiguredSerializer));
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializerAfterMigration() {
+			return thatIsCompatibleWithNextSerializerAfterMigration(null);
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializerAfterMigration(String tokenForEqualityChecks) {
+			return new SchemaCompatibilityTestingSnapshot(tokenForEqualityChecks, unused -> TypeSerializerSchemaCompatibility.compatibleAfterMigration());
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsIncompatibleWithTheNextSerializer() {
+			return thatIsIncompatibleWithTheNextSerializer(null);
+		}
+
+		public static SchemaCompatibilityTestingSnapshot thatIsIncompatibleWithTheNextSerializer(String tokenForEqualityChecks) {
+			return new SchemaCompatibilityTestingSnapshot(tokenForEqualityChecks, unused -> TypeSerializerSchemaCompatibility.incompatible());
+		}
+
+		@Nullable
+		private final String tokenForEqualityChecks;
+		private final Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>> resolver;
+
+		SchemaCompatibilityTestingSnapshot(@Nullable String tokenForEqualityChecks, Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>> resolver) {
+			this.tokenForEqualityChecks = tokenForEqualityChecks;
+			this.resolver = resolver;
+		}
+
+		@Override
+		public TypeSerializerSchemaCompatibility<Integer> resolveSchemaCompatibility(TypeSerializer<Integer> newSerializer) {
+			if (!(newSerializer instanceof SchemaCompatibilityTestingSerializer)) {
+				return TypeSerializerSchemaCompatibility.incompatible();
+			}
+			SchemaCompatibilityTestingSerializer schemaCompatibilityTestingSerializer = (SchemaCompatibilityTestingSerializer) newSerializer;
+			if (!(Objects.equals(schemaCompatibilityTestingSerializer.tokenForEqualityChecks, tokenForEqualityChecks))) {
+				return TypeSerializerSchemaCompatibility.incompatible();
+			}
+			return resolver.apply(newSerializer);
+		}
 
 		@Override
 		public int getCurrentVersion() {
-			return 1;
+			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void writeSnapshot(DataOutputView out) throws IOException {}
-
-		@Override
-		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {}
-
-		@Override
-		public TypeSerializer<T> restoreSerializer() {
-			return new SchemaCompatibilityTestingSerializer.InitialSerializer<>();
+		public void writeSnapshot(DataOutputView out) {
+			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(TypeSerializer<T> newSerializer) {
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.InitialSerializer) {
-				return TypeSerializerSchemaCompatibility.compatibleAsIs();
-			}
-
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.UpgradedSchemaSerializer) {
-				return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
-			}
-
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.ReconfigurationRequiringSerializer) {
-				return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(new SchemaCompatibilityTestingSerializer.InitialSerializer<T>());
-			}
-
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.IncompatibleSerializer) {
-				return TypeSerializerSchemaCompatibility.incompatible();
-			}
-
-			// reaches here if newSerializer isn't a SchemaCompatibilityTestingSerializer
-			return TypeSerializerSchemaCompatibility.incompatible();
-		}
-	}
-
-	public class UpgradedSchemaSerializerSnapshot implements TypeSerializerSnapshot<T> {
-
-		@Override
-		public int getCurrentVersion() {
-			return 1;
+		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void writeSnapshot(DataOutputView out) throws IOException {}
-
-		@Override
-		public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {}
-
-		@Override
-		public TypeSerializer<T> restoreSerializer() {
-			return new SchemaCompatibilityTestingSerializer.UpgradedSchemaSerializer<>();
-		}
-
-		@Override
-		public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(TypeSerializer<T> newSerializer) {
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.InitialSerializer) {
-				return TypeSerializerSchemaCompatibility.incompatible();
-			}
-
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.UpgradedSchemaSerializer) {
-				return TypeSerializerSchemaCompatibility.compatibleAsIs();
-			}
-
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.ReconfigurationRequiringSerializer) {
-				return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(new SchemaCompatibilityTestingSerializer.UpgradedSchemaSerializer<T>());
-			}
-
-			if (newSerializer instanceof SchemaCompatibilityTestingSerializer.IncompatibleSerializer) {
-				return TypeSerializerSchemaCompatibility.incompatible();
-			}
-
-			// reaches here if newSerializer isn't a SchemaCompatibilityTestingSerializer
-			return TypeSerializerSchemaCompatibility.incompatible();
+		public TypeSerializer<Integer> restoreSerializer() {
+			return new SchemaCompatibilityTestingSerializer(tokenForEqualityChecks, resolver);
 		}
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.formats.avro.typeutils;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataInputView;
@@ -30,16 +29,15 @@ import org.apache.flink.formats.avro.utils.TestDataGenerator;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
-import java.util.function.Function;
 
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleAfterMigration;
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleAsIs;
+import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isIncompatible;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -183,42 +181,6 @@ public class AvroSerializerSnapshotTest {
 		specificSerializer.snapshotConfiguration();
 
 		assertThat(genericSnapshot.resolveSchemaCompatibility(specificSerializer), isCompatibleAsIs());
-	}
-
-	// ---------------------------------------------------------------------------------------------------------------
-	// Matchers
-	// ---------------------------------------------------------------------------------------------------------------
-
-	private Matcher<TypeSerializerSchemaCompatibility> isCompatibleAsIs() {
-		return matcher(TypeSerializerSchemaCompatibility::isCompatibleAsIs, "compatible as is");
-	}
-
-	private Matcher<TypeSerializerSchemaCompatibility> isCompatibleAfterMigration() {
-		return matcher(TypeSerializerSchemaCompatibility::isCompatibleAfterMigration,
-			"compatible after migration");
-	}
-
-	private Matcher<TypeSerializerSchemaCompatibility> isIncompatible() {
-		return matcher(TypeSerializerSchemaCompatibility::isIncompatible,
-			"incompatible");
-	}
-
-	private static <T> Matcher<T> matcher(Function<T, Boolean> predicate, String message) {
-		return new TypeSafeDiagnosingMatcher<T>() {
-
-			@Override
-			protected boolean matchesSafely(T item, Description mismatchDescription) {
-				if (predicate.apply(item)) {
-					return true;
-				}
-				mismatchDescription.appendText("not ").appendText(message);
-				return false;
-			}
-
-			@Override
-			public void describeTo(Description description) {
-			}
-		};
 	}
 
 	// ---------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR builds on top of #7845 .

## What is the purpose of the change

`KryoSerializerSnapshot` would fail in `readSnapshot` if a previously registered `Kryo` type is not accessible by the restored job anymore (either removed from the classpath, or failed to load for some other reason)

The source of this behaviour is an early return at [1], which would skip the consumption at [2] 
 
 [1] https://github.com/apache/flink/blob/cf7b86de436c8714414f563e8637ceb36ea7aabe/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotData.java#L310

[2] https://github.com/apache/flink/blob/cf7b86de436c8714414f563e8637ceb36ea7aabe/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotData.java#L314

## Brief change log
* The first two commits are from  #7845 and they are used by 3224e60 (KryoSnapshotTest)
* 2b95d56 adds an `LinkedOptionalMapSerializer` to robustly read/write `LinkedOptionalMaps`
* b4b47ef uses `LinkedOptionalMapSerializer` by `KryoSnapshotData` and `PojoSnapshotData`

## Verifying this change

* A new unit test for `KryoSerializerSnapshot` was introduced.

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
