### PR TITLE
[FLINK-11780] Change version scheme of Hadoop-based modules to conform to SNAPSHOT guidelines

### DIFF
--- a/flink-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-connectors/flink-connector-filesystem/pom.xml
@@ -53,7 +53,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -111,7 +111,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -69,7 +69,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-connectors/flink-orc/pom.xml
+++ b/flink-connectors/flink-orc/pom.xml
@@ -80,7 +80,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -408,7 +408,7 @@ under the License.
 				<dependency>
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-shaded-hadoop2-uber</artifactId>
-					<version>${project.version}-${hadoop.version}</version>
+					<version>${hadoop.version}-${project.version}</version>
 					<!--
                         Exclusion of flink-shaded-hadoop2 not necessary, dependencies
                         are shaded away properly by flink-shaded-hadoop2-uber.

--- a/flink-dist/src/main/assemblies/hadoop.xml
+++ b/flink-dist/src/main/assemblies/hadoop.xml
@@ -31,7 +31,7 @@ under the License.
 	<files>
 		<!-- copy the Hadoop uber jar -->
 		<file>
-			<source>../flink-shaded-hadoop/flink-shaded-hadoop2-uber/target/flink-shaded-hadoop2-uber-${project.version}-${hadoop.version}.jar</source>
+			<source>../flink-shaded-hadoop/flink-shaded-hadoop2-uber/target/flink-shaded-hadoop2-uber-${hadoop.version}-${project.version}.jar</source>
 			<outputDirectory>lib/</outputDirectory>
 			<destName>flink-shaded-hadoop2-uber-${project.version}-${hadoop.version}.jar</destName>
 			<fileMode>0644</fileMode>

--- a/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 			<exclusions>
 				<!-- Needed for proper dependency convergence -->

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -45,7 +45,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -61,7 +61,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -47,7 +47,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -39,7 +39,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -70,7 +70,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/flink-shaded-hadoop/flink-shaded-hadoop2-uber/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2-uber/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<name>flink-shaded-hadoop2-uber</name>
 
 	<packaging>jar</packaging>
-	<version>1.9-SNAPSHOT-${hadoop.version}</version>
+	<version>${hadoop.version}-1.9-SNAPSHOT</version>
 
 	<!--
 		the only dependency of the 'flink-shaded-hadoop2' artifact, out

--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<name>flink-shaded-hadoop2</name>
 
 	<packaging>jar</packaging>
-	<version>1.9-SNAPSHOT-${hadoop.version}</version>
+	<version>${hadoop.version}-1.9-SNAPSHOT</version>
 
 	<dependencies>
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -55,7 +55,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -119,14 +119,14 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2-uber</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -392,7 +392,7 @@ under the License.
 						<artifactItem>
 							<groupId>org.apache.flink</groupId>
 							<artifactId>flink-shaded-hadoop2-uber</artifactId>
-							<version>${project.version}-${hadoop.version}</version>
+							<version>${hadoop.version}-${project.version}</version>
 							<type>jar</type>
 							<overWrite>true</overWrite>
 							<outputDirectory>${project.build.directory}/shaded-hadoop</outputDirectory>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -56,7 +56,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
-			<version>${project.version}-${hadoop.version}</version>
+			<version>${hadoop.version}-${project.version}</version>
 		</dependency>
 
 		<dependency>

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -49,7 +49,7 @@ fi
 cd ..
 
 #change version in all pom files
-find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>'$OLD_VERSION'(.*)</version>#<version>'$NEW_VERSION'\1</version>#' {} \;
+find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>(.*)'$OLD_VERSION'(.*)</version>#<version>\1'$NEW_VERSION'\2</version>#' {} \;
 
 #change version of documentation
 cd docs


### PR DESCRIPTION
Currently, modules that depend on Hadoop have the version scheme `${project.version}-${hadoop.version}`. With this, however, the version does not have SNAPSHOT at the end, meaning we cannot deploy snapshot releases.

The change proposed by @zentol  is to use `${hadoop.version}-${project.version}`.

I didn't yet see if this is green on Travis, just opening it early for review.