### PR TITLE
[FLINK-11787] Update Kubernetes resources: workaround to make TM reachable from JM in Kubernetes

### DIFF
--- a/docs/ops/deployment/kubernetes.md
+++ b/docs/ops/deployment/kubernetes.md
@@ -147,6 +147,7 @@ spec:
         image: flink:latest
         args:
         - taskmanager
+        - "-Dtaskmanager.host=$(K8S_POD_IP)"
         ports:
         - containerPort: 6121
           name: data
@@ -157,6 +158,10 @@ spec:
         env:
         - name: JOB_MANAGER_RPC_ADDRESS
           value: flink-jobmanager
+        - name: K8S_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
 {% endhighlight %}
 
 `jobmanager-service.yaml`

--- a/flink-container/kubernetes/task-manager-deployment.yaml.template
+++ b/flink-container/kubernetes/task-manager-deployment.yaml.template
@@ -31,4 +31,9 @@ spec:
       containers:
       - name: flink-task-manager
         image: ${FLINK_IMAGE_NAME}
-        args: ["task-manager", "-Djobmanager.rpc.address=flink-job-cluster"]
+        args: ["task-manager", "-Djobmanager.rpc.address=flink-job-cluster", "-Dtaskmanager.host=$(K8S_POD_IP)"]
+        env:
+        - name: K8S_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP


### PR DESCRIPTION
## What is the purpose of the change

* This PR adds configuration update (Kubernetes resource definitions) as workaround for [[FLINK-11127]](https://issues.apache.org/jira/browse/FLINK-11127) for Flink `1.7` release branch. With this change, the TMs should be advertising themselves to JM using their k8s pods' ip addresses instead of (by default) hostnames.

**NB:** this patch is supposed only for Flink `1.7` release branch. Flink `1.8` and higher have introduced a new configuration option to mitigate this (`taskmanager.network.bind-policy`).

## Brief change log

  - Example Kubernetes resources are updated to use pods ip address as TMs host address

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

  - Manually verified the change by running a cluser with 1 JobManagers and 2 TaskManagers in a minikube.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
