### PR TITLE
[FLINK-11779] CLI ignores -m parameter if high-availability is ZOOKEEPER

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.client.ClientUtils;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
@@ -82,6 +83,7 @@ public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<
 			String addressWithPort = commandLine.getOptionValue(addressOption.getOpt());
 			InetSocketAddress jobManagerAddress = ClientUtils.parseHostPortAddress(addressWithPort);
 			setJobManagerAddressInConfig(resultingConfiguration, jobManagerAddress);
+			resultingConfiguration.setBoolean(ConfigConstants.JOB_MANAGER_ADDRESS_SPECIFIED, true);
 		}
 
 		if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -138,6 +138,13 @@ public final class ConfigConstants {
 	public static final String JOB_MANAGER_IPC_PORT_KEY = "jobmanager.rpc.port";
 
 	/**
+	 * The config parameter defining the precedence to use
+	 * {@code StandaloneLeaderRetrievalService} even in ZOOKEEPER mode
+	 * when job manager address specified via -m parameter.
+	 */
+	public static final String JOB_MANAGER_ADDRESS_SPECIFIED = "jobmanager.address.specified";
+
+	/**
 	 * The config parameter defining the network port to connect to
 	 * for communication with the resource manager.
 	 * @deprecated Use {@link ResourceManagerOptions#IPC_PORT} instead.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.highavailability;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -81,6 +82,9 @@ public class HighAvailabilityServicesUtils {
 		AddressResolution addressResolution) throws Exception {
 
 		HighAvailabilityMode highAvailabilityMode = LeaderRetrievalUtils.getRecoveryMode(configuration);
+		highAvailabilityMode = configuration.getBoolean(
+			ConfigConstants.JOB_MANAGER_ADDRESS_SPECIFIED, false) ?
+			HighAvailabilityMode.NONE : highAvailabilityMode;
 
 		switch (highAvailabilityMode) {
 			case NONE:


### PR DESCRIPTION


## What is the purpose of the change

Document CLI ignores -m parameter if high-availability is ZOOKEEPER in flink-conf.yaml.

## Brief change log

Document CLI ignores -m parameter if high-availability is ZOOKEEPER in flink-conf.yaml.




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
