### PR TITLE
[FLINK-11730] [State Backends] Make HeapKeyedStateBackend follow the builder pattern

### DIFF
--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -31,6 +32,8 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -75,7 +78,8 @@ final class StubStateBackend implements StateBackend {
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		Collection<KeyedStateHandle> stateHandles) throws Exception {
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) throws Exception {
 
 		return backend.createKeyedStateBackend(
 			env,
@@ -87,7 +91,8 @@ final class StubStateBackend implements StateBackend {
 			kvStateRegistry,
 			this.ttlTimeProvider,
 			metricGroup,
-			stateHandles);
+			stateHandles,
+			cancelStreamRegistry);
 	}
 
 	@Override

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.contrib.streaming.state.PredefinedOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
@@ -87,7 +88,8 @@ public final class KVStateRequestSerializerRocksDBTest {
 				TtlTimeProvider.DEFAULT,
 				new UnregisteredMetricsGroup(),
 				Collections.emptyList(),
-				RocksDBStateBackend.getCompressionDecorator(executionConfig)
+				RocksDBStateBackend.getCompressionDecorator(executionConfig),
+				new CloseableRegistry()
 			).build();
 		longHeapKeyedStateBackend.setCurrentKey(key);
 
@@ -130,7 +132,8 @@ public final class KVStateRequestSerializerRocksDBTest {
 				TtlTimeProvider.DEFAULT,
 				new UnregisteredMetricsGroup(),
 				Collections.emptyList(),
-				RocksDBStateBackend.getCompressionDecorator(executionConfig)
+				RocksDBStateBackend.getCompressionDecorator(executionConfig),
+				new CloseableRegistry()
 			).build();
 		longHeapKeyedStateBackend.setCurrentKey(key);
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.internal.InternalListState;
@@ -88,7 +89,7 @@ public final class KVStateRequestSerializerRocksDBTest {
 				TtlTimeProvider.DEFAULT,
 				new UnregisteredMetricsGroup(),
 				Collections.emptyList(),
-				RocksDBStateBackend.getCompressionDecorator(executionConfig),
+				AbstractStateBackend.getCompressionDecorator(executionConfig),
 				new CloseableRegistry()
 			).build();
 		longHeapKeyedStateBackend.setCurrentKey(key);
@@ -132,7 +133,7 @@ public final class KVStateRequestSerializerRocksDBTest {
 				TtlTimeProvider.DEFAULT,
 				new UnregisteredMetricsGroup(),
 				Collections.emptyList(),
-				RocksDBStateBackend.getCompressionDecorator(executionConfig),
+				AbstractStateBackend.getCompressionDecorator(executionConfig),
 				new CloseableRegistry()
 			).build();
 		longHeapKeyedStateBackend.setCurrentKey(key);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
@@ -200,8 +201,8 @@ public class KvStateRequestSerializerTest {
 				new ExecutionConfig(),
 				TestLocalRecoveryConfig.disabled(),
 				new HeapPriorityQueueSetFactory(keyGroupRange, keyGroupRange.getNumberOfKeyGroups(), 128),
-				TtlTimeProvider.DEFAULT
-			);
+				TtlTimeProvider.DEFAULT,
+				new CloseableRegistry());
 		longHeapKeyedStateBackend.setCurrentKey(key);
 
 		final InternalListState<Long, VoidNamespace, Long> listState = longHeapKeyedStateBackend.createInternalState(
@@ -309,8 +310,8 @@ public class KvStateRequestSerializerTest {
 				new ExecutionConfig(),
 				TestLocalRecoveryConfig.disabled(),
 				new HeapPriorityQueueSetFactory(keyGroupRange, keyGroupRange.getNumberOfKeyGroups(), 128),
-				TtlTimeProvider.DEFAULT
-			);
+				TtlTimeProvider.DEFAULT,
+				new CloseableRegistry());
 		longHeapKeyedStateBackend.setCurrentKey(key);
 
 		final InternalMapState<Long, VoidNamespace, Long, String> mapState =

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.queryablestate.client.VoidNamespace;
@@ -771,6 +772,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 			registry.createTaskRegistry(dummyEnv.getJobID(), dummyEnv.getJobVertexId()),
 			TtlTimeProvider.DEFAULT,
 			new UnregisteredMetricsGroup(),
-			null);
+			Collections.emptyList(),
+			new CloseableRegistry());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
@@ -42,6 +43,7 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
 	protected final TtlTimeProvider ttlTimeProvider;
 	protected final StreamCompressionDecorator keyGroupCompressionDecorator;
 	protected final Collection<KeyedStateHandle> restoreStateHandles;
+	protected final CloseableRegistry cancelStreamRegistry;
 
 	public AbstractKeyedStateBackendBuilder(
 		TaskKvStateRegistry kvStateRegistry,
@@ -52,7 +54,8 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider,
 		@Nonnull Collection<KeyedStateHandle> stateHandles,
-		StreamCompressionDecorator keyGroupCompressionDecorator) {
+		StreamCompressionDecorator keyGroupCompressionDecorator,
+		CloseableRegistry cancelStreamRegistry) {
 		this.kvStateRegistry = kvStateRegistry;
 		this.keySerializer = keySerializer;
 		this.keySerializerProvider = StateSerializerProvider.fromNewRegisteredSerializer(keySerializer);
@@ -63,5 +66,6 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
 		this.ttlTimeProvider = ttlTimeProvider;
 		this.keyGroupCompressionDecorator = keyGroupCompressionDecorator;
 		this.restoreStateHandles = stateHandles;
+		this.cancelStreamRegistry = cancelStreamRegistry;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -56,7 +57,8 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		@Nonnull Collection<KeyedStateHandle> stateHandles) throws IOException;
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) throws IOException;
 
 	@Override
 	public abstract OperatorStateBackend createOperatorStateBackend(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -41,6 +42,14 @@ import java.util.Collection;
 public abstract class AbstractStateBackend implements StateBackend, java.io.Serializable {
 
 	private static final long serialVersionUID = 4620415814639230247L;
+
+	public static StreamCompressionDecorator getCompressionDecorator(ExecutionConfig executionConfig) {
+		if (executionConfig != null && executionConfig.isUseSnapshotCompression()) {
+			return SnappyStreamCompressionDecorator.INSTANCE;
+		} else {
+			return UncompressedStreamCompressionDecorator.INSTANCE;
+		}
+	}
 
 	// ------------------------------------------------------------------------
 	//  State Backend - State-Holding Backends

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RestoreOperation.java
@@ -16,16 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.contrib.streaming.state.restore;
-
-import org.apache.flink.runtime.state.RestoreOperation;
+package org.apache.flink.runtime.state;
 
 /**
- * Interface for RocksDB restore.
+ * Interface for restore operation.
+ *
+ * @param <R> Generic type of the restore result.
  */
-public interface RocksDBRestoreOperation extends RestoreOperation<RocksDBRestoreResult> {
+public interface RestoreOperation<R> {
 	/**
 	 * Restores state that was previously snapshot-ed from the provided state handles.
 	 */
-	RocksDBRestoreResult restore() throws Exception;
+	R restore() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -186,7 +187,8 @@ public interface StateBackend extends java.io.Serializable {
 			kvStateRegistry,
 			ttlTimeProvider,
 			new UnregisteredMetricsGroup(),
-			Collections.emptyList());
+			Collections.emptyList(),
+			new CloseableRegistry());
 	}
 
 	/**
@@ -220,7 +222,8 @@ public interface StateBackend extends java.io.Serializable {
 			kvStateRegistry,
 			ttlTimeProvider,
 			new UnregisteredMetricsGroup(),
-			stateHandles);
+			stateHandles,
+			new CloseableRegistry());
 	}
 
 	/**
@@ -245,7 +248,8 @@ public interface StateBackend extends java.io.Serializable {
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		@Nonnull Collection<KeyedStateHandle> stateHandles) throws Exception;
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) throws Exception;
 	
 	/**
 	 * Creates a new {@link OperatorStateBackend} that can be used for storing operator state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
@@ -461,7 +462,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		Collection<KeyedStateHandle> stateHandles) {
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) {
 
 		TaskStateManager taskStateManager = env.getTaskStateManager();
 		LocalRecoveryConfig localRecoveryConfig = taskStateManager.createLocalRecoveryConfig();
@@ -478,7 +480,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 				env.getExecutionConfig(),
 				localRecoveryConfig,
 				priorityQueueSetFactory,
-				ttlTimeProvider);
+				ttlTimeProvider,
+			cancelStreamRegistry);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -30,15 +30,17 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.BackendBuildingException;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
-import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.TaskStateManager;
-import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.TernaryBoolean;
@@ -463,25 +465,27 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
 		@Nonnull Collection<KeyedStateHandle> stateHandles,
-		CloseableRegistry cancelStreamRegistry) {
+		CloseableRegistry cancelStreamRegistry) throws BackendBuildingException {
 
 		TaskStateManager taskStateManager = env.getTaskStateManager();
 		LocalRecoveryConfig localRecoveryConfig = taskStateManager.createLocalRecoveryConfig();
 		HeapPriorityQueueSetFactory priorityQueueSetFactory =
 			new HeapPriorityQueueSetFactory(keyGroupRange, numberOfKeyGroups, 128);
 
-		return new HeapKeyedStateBackend<>(
-				kvStateRegistry,
-				keySerializer,
-				env.getUserClassLoader(),
-				numberOfKeyGroups,
-				keyGroupRange,
-				isUsingAsynchronousSnapshots(),
-				env.getExecutionConfig(),
-				localRecoveryConfig,
-				priorityQueueSetFactory,
-				ttlTimeProvider,
-			cancelStreamRegistry);
+		return new HeapKeyedStateBackendBuilder<>(
+			kvStateRegistry,
+			keySerializer,
+			env.getUserClassLoader(),
+			numberOfKeyGroups,
+			keyGroupRange,
+			env.getExecutionConfig(),
+			ttlTimeProvider,
+			stateHandles,
+			AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
+			localRecoveryConfig,
+			priorityQueueSetFactory,
+			isUsingAsynchronousSnapshots(),
+			cancelStreamRegistry).build();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AsyncSnapshotStrategySynchronicityBehavior.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AsyncSnapshotStrategySynchronicityBehavior.java
@@ -16,16 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.contrib.streaming.state.restore;
+package org.apache.flink.runtime.state.heap;
 
-import org.apache.flink.runtime.state.RestoreOperation;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 
 /**
- * Interface for RocksDB restore.
+ * Asynchronous behavior for heap snapshot strategy.
+ *
+ * @param <K> The data type that the serializer serializes.
  */
-public interface RocksDBRestoreOperation extends RestoreOperation<RocksDBRestoreResult> {
-	/**
-	 * Restores state that was previously snapshot-ed from the provided state handles.
-	 */
-	RocksDBRestoreResult restore() throws Exception;
+class AsyncSnapshotStrategySynchronicityBehavior<K> implements SnapshotStrategySynchronicityBehavior<K> {
+
+	@Override
+	public boolean isAsynchronous() {
+		return true;
+	}
+
+	@Override
+	public <N, V> StateTable<K, N, V> newStateTable(
+		InternalKeyContext<K> keyContext,
+		RegisteredKeyValueStateBackendMetaInfo<N, V> newMetaInfo) {
+		return new CopyOnWriteStateTable<>(keyContext, newMetaInfo);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -140,16 +140,17 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private final HeapPriorityQueueSetFactory priorityQueueSetFactory;
 
 	public HeapKeyedStateBackend(
-			TaskKvStateRegistry kvStateRegistry,
-			TypeSerializer<K> keySerializer,
-			ClassLoader userCodeClassLoader,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			boolean asynchronousSnapshots,
-			ExecutionConfig executionConfig,
-			LocalRecoveryConfig localRecoveryConfig,
-			HeapPriorityQueueSetFactory priorityQueueSetFactory,
-			TtlTimeProvider ttlTimeProvider) {
+		TaskKvStateRegistry kvStateRegistry,
+		TypeSerializer<K> keySerializer,
+		ClassLoader userCodeClassLoader,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		boolean asynchronousSnapshots,
+		ExecutionConfig executionConfig,
+		LocalRecoveryConfig localRecoveryConfig,
+		HeapPriorityQueueSetFactory priorityQueueSetFactory,
+		TtlTimeProvider ttlTimeProvider,
+		CloseableRegistry cancelStreamRegistry) {
 
 		super(kvStateRegistry, keySerializer, userCodeClassLoader,
 			numberOfKeyGroups, keyGroupRange, executionConfig, ttlTimeProvider, new CloseableRegistry());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackendBuilder;
+import org.apache.flink.runtime.state.BackendBuildingException;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builder class for {@link HeapKeyedStateBackend} which handles all necessary initializations and clean ups.
+ *
+ * @param <K> The data type that the key serializer serializes.
+ */
+public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBuilder<K> {
+	/**
+	 * The configuration of local recovery.
+	 */
+	private final LocalRecoveryConfig localRecoveryConfig;
+	/**
+	 * Factory for state that is organized as priority queue.
+	 */
+	private final HeapPriorityQueueSetFactory priorityQueueSetFactory;
+	/**
+	 * Whether asynchronous snapshot is enabled.
+	 */
+	private final boolean asynchronousSnapshots;
+
+
+	public HeapKeyedStateBackendBuilder(
+		TaskKvStateRegistry kvStateRegistry,
+		TypeSerializer<K> keySerializer,
+		ClassLoader userCodeClassLoader,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		ExecutionConfig executionConfig,
+		TtlTimeProvider ttlTimeProvider,
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		StreamCompressionDecorator keyGroupCompressionDecorator,
+		LocalRecoveryConfig localRecoveryConfig,
+		HeapPriorityQueueSetFactory priorityQueueSetFactory,
+		boolean asynchronousSnapshots,
+		CloseableRegistry cancelStreamRegistry) {
+		super(
+			kvStateRegistry,
+			keySerializer,
+			userCodeClassLoader,
+			numberOfKeyGroups,
+			keyGroupRange,
+			executionConfig,
+			ttlTimeProvider,
+			stateHandles,
+			keyGroupCompressionDecorator,
+			cancelStreamRegistry);
+		this.localRecoveryConfig = localRecoveryConfig;
+		this.priorityQueueSetFactory = priorityQueueSetFactory;
+		this.asynchronousSnapshots = asynchronousSnapshots;
+	}
+
+	@Override
+	public HeapKeyedStateBackend<K> build() throws BackendBuildingException {
+		// Map of registered Key/Value states
+		Map<String, StateTable<K, ?, ?>> registeredKVStates = new HashMap<>();
+		// Map of registered priority queue set states
+		Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates = new HashMap<>();
+		CloseableRegistry cancelStreamRegistryForBackend = new CloseableRegistry();
+		HeapSnapshotStrategy<K> snapshotStrategy = initSnapshotStrategy(
+			asynchronousSnapshots, registeredKVStates, registeredPQStates, cancelStreamRegistryForBackend);
+		HeapKeyedStateBackend<K> backend = new HeapKeyedStateBackend<>(
+			kvStateRegistry,
+			keySerializerProvider,
+			userCodeClassLoader,
+			numberOfKeyGroups,
+			keyGroupRange,
+			executionConfig,
+			ttlTimeProvider,
+			cancelStreamRegistryForBackend,
+			keyGroupCompressionDecorator,
+			registeredKVStates,
+			registeredPQStates,
+			localRecoveryConfig,
+			priorityQueueSetFactory,
+			snapshotStrategy
+		);
+		HeapRestoreOperation<K> restoreOperation = new HeapRestoreOperation<>(
+			restoreStateHandles,
+			keySerializerProvider,
+			userCodeClassLoader,
+			registeredKVStates,
+			registeredPQStates,
+			cancelStreamRegistry,
+			priorityQueueSetFactory,
+			keyGroupRange,
+			numberOfKeyGroups,
+			snapshotStrategy,
+			backend);
+		try {
+			restoreOperation.restore();
+		} catch (Exception e) {
+			throw new BackendBuildingException("Failed when trying to restore heap backend", e);
+		}
+		return backend;
+	}
+
+	private HeapSnapshotStrategy<K> initSnapshotStrategy(
+		boolean asynchronousSnapshots,
+		Map<String, StateTable<K, ?, ?>> registeredKVStates,
+		Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates,
+		CloseableRegistry cancelStreamRegistry) {
+		SnapshotStrategySynchronicityBehavior<K> synchronicityTrait = asynchronousSnapshots ?
+			new AsyncSnapshotStrategySynchronicityBehavior<>() :
+			new SyncSnapshotStrategySynchronicityBehavior<>();
+		return new HeapSnapshotStrategy<>(
+			synchronicityTrait,
+			registeredKVStates,
+			registeredPQStates,
+			keyGroupCompressionDecorator,
+			localRecoveryConfig,
+			keyGroupRange,
+			cancelStreamRegistry,
+			keySerializerProvider);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.runtime.state.KeyExtractorFunction;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.RestoreOperation;
+import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.StateSnapshotKeyGroupReader;
+import org.apache.flink.runtime.state.StateSnapshotRestore;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StateMigrationException;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of heap restore operation.
+ *
+ * @param <K> The data type that the serializer serializes.
+ */
+public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
+	private final Collection<KeyedStateHandle> restoreStateHandles;
+	private final StateSerializerProvider<K> keySerializerProvider;
+	private final ClassLoader userCodeClassLoader;
+	private final Map<String, StateTable<K, ?, ?>> registeredKVStates;
+	private final Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates;
+	private final CloseableRegistry cancelStreamRegistry;
+	private final HeapPriorityQueueSetFactory priorityQueueSetFactory;
+	@Nonnull
+	private final KeyGroupRange keyGroupRange;
+	@Nonnegative
+	private final int numberOfKeyGroups;
+	private final HeapSnapshotStrategy<K> snapshotStrategy;
+	private final HeapKeyedStateBackend<K> backend;
+
+	HeapRestoreOperation(
+		@Nonnull Collection<KeyedStateHandle> restoreStateHandles,
+		StateSerializerProvider<K> keySerializerProvider,
+		ClassLoader userCodeClassLoader,
+		Map<String, StateTable<K, ?, ?>> registeredKVStates,
+		Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates,
+		CloseableRegistry cancelStreamRegistry,
+		HeapPriorityQueueSetFactory priorityQueueSetFactory,
+		@Nonnull KeyGroupRange keyGroupRange,
+		int numberOfKeyGroups,
+		HeapSnapshotStrategy<K> snapshotStrategy,
+		HeapKeyedStateBackend<K> backend) {
+		this.restoreStateHandles = restoreStateHandles;
+		this.keySerializerProvider = keySerializerProvider;
+		this.userCodeClassLoader = userCodeClassLoader;
+		this.registeredKVStates = registeredKVStates;
+		this.registeredPQStates = registeredPQStates;
+		this.cancelStreamRegistry = cancelStreamRegistry;
+		this.priorityQueueSetFactory = priorityQueueSetFactory;
+		this.keyGroupRange = keyGroupRange;
+		this.numberOfKeyGroups = numberOfKeyGroups;
+		this.snapshotStrategy = snapshotStrategy;
+		this.backend = backend;
+	}
+
+	@Override
+	public Void restore() throws Exception {
+
+		final Map<Integer, StateMetaInfoSnapshot> kvStatesById = new HashMap<>();
+		registeredKVStates.clear();
+		registeredPQStates.clear();
+
+		boolean keySerializerRestored = false;
+
+		for (KeyedStateHandle keyedStateHandle : restoreStateHandles) {
+
+			if (keyedStateHandle == null) {
+				continue;
+			}
+
+			if (!(keyedStateHandle instanceof KeyGroupsStateHandle)) {
+				throw new IllegalStateException("Unexpected state handle type, " +
+					"expected: " + KeyGroupsStateHandle.class +
+					", but found: " + keyedStateHandle.getClass());
+			}
+
+			KeyGroupsStateHandle keyGroupsStateHandle = (KeyGroupsStateHandle) keyedStateHandle;
+			FSDataInputStream fsDataInputStream = keyGroupsStateHandle.openInputStream();
+			cancelStreamRegistry.registerCloseable(fsDataInputStream);
+
+			try {
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(fsDataInputStream);
+
+				KeyedBackendSerializationProxy<K> serializationProxy =
+					new KeyedBackendSerializationProxy<>(userCodeClassLoader);
+
+				serializationProxy.read(inView);
+
+				if (!keySerializerRestored) {
+					// check for key serializer compatibility; this also reconfigures the
+					// key serializer to be compatible, if it is required and is possible
+					TypeSerializerSchemaCompatibility<K> keySerializerSchemaCompat =
+						keySerializerProvider.setPreviousSerializerSnapshotForRestoredState(serializationProxy.getKeySerializerSnapshot());
+					if (keySerializerSchemaCompat.isCompatibleAfterMigration() || keySerializerSchemaCompat.isIncompatible()) {
+						throw new StateMigrationException("The new key serializer must be compatible.");
+					}
+
+					keySerializerRestored = true;
+				}
+
+				List<StateMetaInfoSnapshot> restoredMetaInfos =
+					serializationProxy.getStateMetaInfoSnapshots();
+
+				createOrCheckStateForMetaInfo(restoredMetaInfos, kvStatesById);
+
+				readStateHandleStateData(
+					fsDataInputStream,
+					inView,
+					keyGroupsStateHandle.getGroupRangeOffsets(),
+					kvStatesById, restoredMetaInfos.size(),
+					serializationProxy.getReadVersion(),
+					serializationProxy.isUsingKeyGroupCompression());
+			} finally {
+				if (cancelStreamRegistry.unregisterCloseable(fsDataInputStream)) {
+					IOUtils.closeQuietly(fsDataInputStream);
+				}
+			}
+		}
+		return null;
+	}
+
+	private void createOrCheckStateForMetaInfo(
+		List<StateMetaInfoSnapshot> restoredMetaInfo,
+		Map<Integer, StateMetaInfoSnapshot> kvStatesById) {
+
+		for (StateMetaInfoSnapshot metaInfoSnapshot : restoredMetaInfo) {
+			final StateSnapshotRestore registeredState;
+
+			switch (metaInfoSnapshot.getBackendStateType()) {
+				case KEY_VALUE:
+					registeredState = registeredKVStates.get(metaInfoSnapshot.getName());
+					if (registeredState == null) {
+						RegisteredKeyValueStateBackendMetaInfo<?, ?> registeredKeyedBackendStateMetaInfo =
+							new RegisteredKeyValueStateBackendMetaInfo<>(metaInfoSnapshot);
+						registeredKVStates.put(
+							metaInfoSnapshot.getName(),
+							snapshotStrategy.newStateTable(backend, registeredKeyedBackendStateMetaInfo));
+					}
+					break;
+				case PRIORITY_QUEUE:
+					registeredState = registeredPQStates.get(metaInfoSnapshot.getName());
+					if (registeredState == null) {
+						createInternal(new RegisteredPriorityQueueStateBackendMetaInfo<>(metaInfoSnapshot));
+					}
+					break;
+				default:
+					throw new IllegalStateException("Unexpected state type: " +
+						metaInfoSnapshot.getBackendStateType() + ".");
+			}
+
+			if (registeredState == null) {
+				kvStatesById.put(kvStatesById.size(), metaInfoSnapshot);
+			}
+		}
+	}
+
+	private <T extends HeapPriorityQueueElement & PriorityComparable & Keyed> void createInternal(
+		RegisteredPriorityQueueStateBackendMetaInfo<T> metaInfo) {
+
+		final String stateName = metaInfo.getName();
+		final HeapPriorityQueueSet<T> priorityQueue = priorityQueueSetFactory.create(
+			stateName,
+			metaInfo.getElementSerializer());
+
+		HeapPriorityQueueSnapshotRestoreWrapper<T> wrapper =
+			new HeapPriorityQueueSnapshotRestoreWrapper<>(
+				priorityQueue,
+				metaInfo,
+				KeyExtractorFunction.forKeyedObjects(),
+				keyGroupRange,
+				numberOfKeyGroups);
+
+		registeredPQStates.put(stateName, wrapper);
+	}
+
+	private void readStateHandleStateData(
+		FSDataInputStream fsDataInputStream,
+		DataInputViewStreamWrapper inView,
+		KeyGroupRangeOffsets keyGroupOffsets,
+		Map<Integer, StateMetaInfoSnapshot> kvStatesById,
+		int numStates,
+		int readVersion,
+		boolean isCompressed) throws IOException {
+
+		final StreamCompressionDecorator streamCompressionDecorator = isCompressed ?
+			SnappyStreamCompressionDecorator.INSTANCE : UncompressedStreamCompressionDecorator.INSTANCE;
+
+		for (Tuple2<Integer, Long> groupOffset : keyGroupOffsets) {
+			int keyGroupIndex = groupOffset.f0;
+			long offset = groupOffset.f1;
+
+			// Check that restored key groups all belong to the backend.
+			Preconditions.checkState(keyGroupRange.contains(keyGroupIndex), "The key group must belong to the backend.");
+
+			fsDataInputStream.seek(offset);
+
+			int writtenKeyGroupIndex = inView.readInt();
+			Preconditions.checkState(writtenKeyGroupIndex == keyGroupIndex,
+				"Unexpected key-group in restore.");
+
+			try (InputStream kgCompressionInStream =
+					 streamCompressionDecorator.decorateWithCompression(fsDataInputStream)) {
+
+				readKeyGroupStateData(
+					kgCompressionInStream,
+					kvStatesById,
+					keyGroupIndex,
+					numStates,
+					readVersion);
+			}
+		}
+	}
+
+	private void readKeyGroupStateData(
+		InputStream inputStream,
+		Map<Integer, StateMetaInfoSnapshot> kvStatesById,
+		int keyGroupIndex,
+		int numStates,
+		int readVersion) throws IOException {
+
+		DataInputViewStreamWrapper inView =
+			new DataInputViewStreamWrapper(inputStream);
+
+		for (int i = 0; i < numStates; i++) {
+
+			final int kvStateId = inView.readShort();
+			final StateMetaInfoSnapshot stateMetaInfoSnapshot = kvStatesById.get(kvStateId);
+			final StateSnapshotRestore registeredState;
+
+			switch (stateMetaInfoSnapshot.getBackendStateType()) {
+				case KEY_VALUE:
+					registeredState = registeredKVStates.get(stateMetaInfoSnapshot.getName());
+					break;
+				case PRIORITY_QUEUE:
+					registeredState = registeredPQStates.get(stateMetaInfoSnapshot.getName());
+					break;
+				default:
+					throw new IllegalStateException("Unexpected state type: " +
+						stateMetaInfoSnapshot.getBackendStateType() + ".");
+			}
+
+			StateSnapshotKeyGroupReader keyGroupReader = registeredState.keyGroupReader(readVersion);
+			keyGroupReader.readMappingsInKeyGroup(inView, keyGroupIndex);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.AbstractSnapshotStrategy;
+import org.apache.flink.runtime.state.AsyncSnapshotCallable;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.DoneFuture;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.StateSnapshotRestore;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.SupplierWithException;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+
+/**
+ * Base class for the snapshots of the heap backend that outlines the algorithm and offers some hooks to realize
+ * the concrete strategies. Subclasses must be threadsafe.
+ */
+class HeapSnapshotStrategy<K>
+	extends AbstractSnapshotStrategy<KeyedStateHandle> implements SnapshotStrategySynchronicityBehavior<K> {
+
+	private final SnapshotStrategySynchronicityBehavior<K> snapshotStrategySynchronicityTrait;
+	private final Map<String, StateTable<K, ?, ?>> registeredKVStates;
+	private final Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates;
+	private final StreamCompressionDecorator keyGroupCompressionDecorator;
+	private final LocalRecoveryConfig localRecoveryConfig;
+	private final KeyGroupRange keyGroupRange;
+	private final CloseableRegistry cancelStreamRegistry;
+	private final StateSerializerProvider<K> keySerializerProvider;
+
+	HeapSnapshotStrategy(
+		SnapshotStrategySynchronicityBehavior<K> snapshotStrategySynchronicityTrait,
+		Map<String, StateTable<K, ?, ?>> registeredKVStates,
+		Map<String, HeapPriorityQueueSnapshotRestoreWrapper> registeredPQStates,
+		StreamCompressionDecorator keyGroupCompressionDecorator,
+		LocalRecoveryConfig localRecoveryConfig,
+		KeyGroupRange keyGroupRange,
+		CloseableRegistry cancelStreamRegistry,
+		StateSerializerProvider<K> keySerializerProvider) {
+		super("Heap backend snapshot");
+		this.snapshotStrategySynchronicityTrait = snapshotStrategySynchronicityTrait;
+		this.registeredKVStates = registeredKVStates;
+		this.registeredPQStates = registeredPQStates;
+		this.keyGroupCompressionDecorator = keyGroupCompressionDecorator;
+		this.localRecoveryConfig = localRecoveryConfig;
+		this.keyGroupRange = keyGroupRange;
+		this.cancelStreamRegistry = cancelStreamRegistry;
+		this.keySerializerProvider = keySerializerProvider;
+	}
+
+	@Nonnull
+	@Override
+	public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+		long checkpointId,
+		long timestamp,
+		@Nonnull CheckpointStreamFactory primaryStreamFactory,
+		@Nonnull CheckpointOptions checkpointOptions) throws IOException {
+
+		if (!hasRegisteredState()) {
+			return DoneFuture.of(SnapshotResult.empty());
+		}
+
+		int numStates = registeredKVStates.size() + registeredPQStates.size();
+
+		Preconditions.checkState(numStates <= Short.MAX_VALUE,
+			"Too many states: " + numStates +
+				". Currently at most " + Short.MAX_VALUE + " states are supported");
+
+		final List<StateMetaInfoSnapshot> metaInfoSnapshots = new ArrayList<>(numStates);
+		final Map<StateUID, Integer> stateNamesToId =
+			new HashMap<>(numStates);
+		final Map<StateUID, StateSnapshot> cowStateStableSnapshots =
+			new HashMap<>(numStates);
+
+		processSnapshotMetaInfoForAllStates(
+			metaInfoSnapshots,
+			cowStateStableSnapshots,
+			stateNamesToId,
+			registeredKVStates,
+			StateMetaInfoSnapshot.BackendStateType.KEY_VALUE);
+
+		processSnapshotMetaInfoForAllStates(
+			metaInfoSnapshots,
+			cowStateStableSnapshots,
+			stateNamesToId,
+			registeredPQStates,
+			StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE);
+
+		final KeyedBackendSerializationProxy<K> serializationProxy =
+			new KeyedBackendSerializationProxy<>(
+				// TODO: this code assumes that writing a serializer is threadsafe, we should support to
+				// get a serialized form already at state registration time in the future
+				getKeySerializer(),
+				metaInfoSnapshots,
+				!Objects.equals(UncompressedStreamCompressionDecorator.INSTANCE, keyGroupCompressionDecorator));
+
+		final SupplierWithException<CheckpointStreamWithResultProvider, Exception> checkpointStreamSupplier =
+
+			localRecoveryConfig.isLocalRecoveryEnabled() ?
+
+				() -> CheckpointStreamWithResultProvider.createDuplicatingStream(
+					checkpointId,
+					CheckpointedStateScope.EXCLUSIVE,
+					primaryStreamFactory,
+					localRecoveryConfig.getLocalStateDirectoryProvider()) :
+
+				() -> CheckpointStreamWithResultProvider.createSimpleStream(
+					CheckpointedStateScope.EXCLUSIVE,
+					primaryStreamFactory);
+
+		//--------------------------------------------------- this becomes the end of sync part
+
+		final AsyncSnapshotCallable<SnapshotResult<KeyedStateHandle>> asyncSnapshotCallable =
+			new AsyncSnapshotCallable<SnapshotResult<KeyedStateHandle>>() {
+				@Override
+				protected SnapshotResult<KeyedStateHandle> callInternal() throws Exception {
+
+					final CheckpointStreamWithResultProvider streamWithResultProvider =
+						checkpointStreamSupplier.get();
+
+					snapshotCloseableRegistry.registerCloseable(streamWithResultProvider);
+
+					final CheckpointStreamFactory.CheckpointStateOutputStream localStream =
+						streamWithResultProvider.getCheckpointOutputStream();
+
+					final DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(localStream);
+					serializationProxy.write(outView);
+
+					final long[] keyGroupRangeOffsets = new long[keyGroupRange.getNumberOfKeyGroups()];
+
+					for (int keyGroupPos = 0; keyGroupPos < keyGroupRange.getNumberOfKeyGroups(); ++keyGroupPos) {
+						int keyGroupId = keyGroupRange.getKeyGroupId(keyGroupPos);
+						keyGroupRangeOffsets[keyGroupPos] = localStream.getPos();
+						outView.writeInt(keyGroupId);
+
+						for (Map.Entry<StateUID, StateSnapshot> stateSnapshot :
+							cowStateStableSnapshots.entrySet()) {
+							StateSnapshot.StateKeyGroupWriter partitionedSnapshot =
+
+								stateSnapshot.getValue().getKeyGroupWriter();
+							try (
+								OutputStream kgCompressionOut =
+									keyGroupCompressionDecorator.decorateWithCompression(localStream)) {
+								DataOutputViewStreamWrapper kgCompressionView =
+									new DataOutputViewStreamWrapper(kgCompressionOut);
+								kgCompressionView.writeShort(stateNamesToId.get(stateSnapshot.getKey()));
+								partitionedSnapshot.writeStateInKeyGroup(kgCompressionView, keyGroupId);
+							} // this will just close the outer compression stream
+						}
+					}
+
+					if (snapshotCloseableRegistry.unregisterCloseable(streamWithResultProvider)) {
+						KeyGroupRangeOffsets kgOffs = new KeyGroupRangeOffsets(keyGroupRange, keyGroupRangeOffsets);
+						SnapshotResult<StreamStateHandle> result =
+							streamWithResultProvider.closeAndFinalizeCheckpointStreamResult();
+						return CheckpointStreamWithResultProvider.toKeyedStateHandleSnapshotResult(result, kgOffs);
+					} else {
+						throw new IOException("Stream already unregistered.");
+					}
+				}
+
+				@Override
+				protected void cleanupProvidedResources() {
+					for (StateSnapshot tableSnapshot : cowStateStableSnapshots.values()) {
+						tableSnapshot.release();
+					}
+				}
+
+				@Override
+				protected void logAsyncSnapshotComplete(long startTime) {
+					if (snapshotStrategySynchronicityTrait.isAsynchronous()) {
+						logAsyncCompleted(primaryStreamFactory, startTime);
+					}
+				}
+			};
+
+		final FutureTask<SnapshotResult<KeyedStateHandle>> task =
+			asyncSnapshotCallable.toAsyncSnapshotFutureTask(cancelStreamRegistry);
+		finalizeSnapshotBeforeReturnHook(task);
+
+		return task;
+	}
+
+	@Override
+	public void finalizeSnapshotBeforeReturnHook(Runnable runnable) {
+		snapshotStrategySynchronicityTrait.finalizeSnapshotBeforeReturnHook(runnable);
+	}
+
+	@Override
+	public boolean isAsynchronous() {
+		return snapshotStrategySynchronicityTrait.isAsynchronous();
+	}
+
+	@Override
+	public <N, V> StateTable<K, N, V> newStateTable(
+		InternalKeyContext<K> keyContext,
+		RegisteredKeyValueStateBackendMetaInfo<N, V> newMetaInfo) {
+		return snapshotStrategySynchronicityTrait.newStateTable(keyContext, newMetaInfo);
+	}
+
+	private void processSnapshotMetaInfoForAllStates(
+		List<StateMetaInfoSnapshot> metaInfoSnapshots,
+		Map<StateUID, StateSnapshot> cowStateStableSnapshots,
+		Map<StateUID, Integer> stateNamesToId,
+		Map<String, ? extends StateSnapshotRestore> registeredStates,
+		StateMetaInfoSnapshot.BackendStateType stateType) {
+
+		for (Map.Entry<String, ? extends StateSnapshotRestore> kvState : registeredStates.entrySet()) {
+			final StateUID stateUid = StateUID.of(kvState.getKey(), stateType);
+			stateNamesToId.put(stateUid, stateNamesToId.size());
+			StateSnapshotRestore state = kvState.getValue();
+			if (null != state) {
+				final StateSnapshot stateSnapshot = state.stateSnapshot();
+				metaInfoSnapshots.add(stateSnapshot.getMetaInfoSnapshot());
+				cowStateStableSnapshots.put(stateUid, stateSnapshot);
+			}
+		}
+	}
+
+	private boolean hasRegisteredState() {
+		return !(registeredKVStates.isEmpty() && registeredPQStates.isEmpty());
+	}
+
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializerProvider.currentSchemaSerializer();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/SnapshotStrategySynchronicityBehavior.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/SnapshotStrategySynchronicityBehavior.java
@@ -16,16 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.contrib.streaming.state.restore;
+package org.apache.flink.runtime.state.heap;
 
-import org.apache.flink.runtime.state.RestoreOperation;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 
 /**
- * Interface for RocksDB restore.
+ * Interface for synchronicity behavior of heap snapshot strategy.
+ *
+ * @param <K> The data type that the serializer serializes.
  */
-public interface RocksDBRestoreOperation extends RestoreOperation<RocksDBRestoreResult> {
-	/**
-	 * Restores state that was previously snapshot-ed from the provided state handles.
-	 */
-	RocksDBRestoreResult restore() throws Exception;
+interface SnapshotStrategySynchronicityBehavior<K> {
+
+	default void finalizeSnapshotBeforeReturnHook(Runnable runnable) {
+
+	}
+
+	boolean isAsynchronous();
+
+	<N, V> StateTable<K, N, V> newStateTable(
+		InternalKeyContext<K> keyContext,
+		RegisteredKeyValueStateBackendMetaInfo<N, V> newMetaInfo);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateUID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateUID.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Unique identifier for registered state in this backend.
+ */
+final class StateUID {
+
+	@Nonnull
+	private final String stateName;
+
+	@Nonnull
+	private final StateMetaInfoSnapshot.BackendStateType stateType;
+
+	StateUID(@Nonnull String stateName, @Nonnull StateMetaInfoSnapshot.BackendStateType stateType) {
+		this.stateName = stateName;
+		this.stateType = stateType;
+	}
+
+	@Nonnull
+	public String getStateName() {
+		return stateName;
+	}
+
+	@Nonnull
+	public StateMetaInfoSnapshot.BackendStateType getStateType() {
+		return stateType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		StateUID uid = (StateUID) o;
+		return Objects.equals(getStateName(), uid.getStateName()) &&
+			getStateType() == uid.getStateType();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getStateName(), getStateType());
+	}
+
+	public static StateUID of(@Nonnull String stateName, @Nonnull StateMetaInfoSnapshot.BackendStateType stateType) {
+		return new StateUID(stateName, stateType);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -41,6 +42,7 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.TernaryBoolean;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -316,7 +318,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		Collection<KeyedStateHandle> stateHandles) {
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) {
 
 		TaskStateManager taskStateManager = env.getTaskStateManager();
 		HeapPriorityQueueSetFactory priorityQueueSetFactory =
@@ -331,7 +334,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 				env.getExecutionConfig(),
 				taskStateManager.createLocalRecoveryConfig(),
 				priorityQueueSetFactory,
-				ttlTimeProvider);
+				ttlTimeProvider,
+			cancelStreamRegistry);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -50,6 +51,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
@@ -175,7 +177,8 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 			TaskKvStateRegistry kvStateRegistry,
 			TtlTimeProvider ttlTimeProvider,
 			MetricGroup metricGroup,
-			Collection<KeyedStateHandle> stateHandles) throws Exception {
+			@Nonnull Collection<KeyedStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry) throws Exception {
 			throw new UnsupportedOperationException();
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1000,7 +1000,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getTaskKvStateRegistry());
-		backend.restore(Collections.emptyList());
 		return backend;
 	}
 
@@ -1036,7 +1035,6 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 			env.getTaskKvStateRegistry()
 			, TtlTimeProvider.DEFAULT,
 			state);
-		backend.restore(new StateObjectCollection<>(state));
 		return backend;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -60,7 +60,6 @@ import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
@@ -81,6 +80,7 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.StateMigrationException;
 import org.apache.flink.util.TestLogger;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -109,6 +109,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -179,8 +181,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				env.getTaskKvStateRegistry(),
 				TtlTimeProvider.DEFAULT);
 
-		backend.restore(Collections.emptyList());
-
 		return backend;
 	}
 
@@ -217,8 +217,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			env.getTaskKvStateRegistry(),
 			TtlTimeProvider.DEFAULT,
 			state);
-
-		backend.restore(new StateObjectCollection<>(state));
 
 		return backend;
 	}
@@ -666,7 +664,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			// on the second restore, since the custom serializer will be used for
 			// deserialization, we expect the deliberate failure to be thrown
-			expectedException.expect(ExpectedKryoTestException.class);
+			expectedException.expect(anyOf(isA(ExpectedKryoTestException.class),
+				Matchers.<Throwable>hasProperty("cause", isA(ExpectedKryoTestException.class))));
 
 			// state backends that eagerly deserializes (such as the memory state backend) will fail here
 			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot2, env);
@@ -768,7 +767,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			// on the second restore, since the custom serializer will be used for
 			// deserialization, we expect the deliberate failure to be thrown
-			expectedException.expect(ExpectedKryoTestException.class);
+			expectedException.expect(anyOf(isA(ExpectedKryoTestException.class),
+				Matchers.<Throwable>hasProperty("cause", isA(ExpectedKryoTestException.class))));
 
 			// state backends that eagerly deserializes (such as the memory state backend) will fail here
 			backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot2, env);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -57,7 +58,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
 			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT);
+			TtlTimeProvider.DEFAULT,
+			new CloseableRegistry());
 
 		try {
 			Assert.assertTrue(
@@ -81,7 +83,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
 			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT);
+			TtlTimeProvider.DEFAULT,
+			new CloseableRegistry());
 
 		try {
 			Assert.assertTrue(
@@ -123,7 +126,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
 			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT);
+			TtlTimeProvider.DEFAULT,
+			new CloseableRegistry());
 
 		try {
 
@@ -166,7 +170,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			executionConfig,
 			TestLocalRecoveryConfig.disabled(),
 			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT);
+			TtlTimeProvider.DEFAULT,
+			new CloseableRegistry());
 		try {
 
 			stateBackend.restore(StateObjectCollection.singleton(stateHandle));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
@@ -26,16 +27,18 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.TestLogger;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.RunnableFuture;
 
 import static org.mockito.Mockito.mock;
@@ -43,23 +46,12 @@ import static org.mockito.Mockito.mock;
 public class StateSnapshotCompressionTest extends TestLogger {
 
 	@Test
-	public void testCompressionConfiguration() {
+	public void testCompressionConfiguration() throws BackendBuildingException {
 
 		ExecutionConfig executionConfig = new ExecutionConfig();
 		executionConfig.setUseSnapshotCompression(true);
 
-		AbstractKeyedStateBackend<String> stateBackend = new HeapKeyedStateBackend<>(
-			mock(TaskKvStateRegistry.class),
-			StringSerializer.INSTANCE,
-			StateSnapshotCompressionTest.class.getClassLoader(),
-			16,
-			new KeyGroupRange(0, 15),
-			true,
-			executionConfig,
-			TestLocalRecoveryConfig.disabled(),
-			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT,
-			new CloseableRegistry());
+		AbstractKeyedStateBackend<String> stateBackend = getStringHeapKeyedStateBackend(executionConfig);
 
 		try {
 			Assert.assertTrue(
@@ -73,18 +65,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
 		executionConfig = new ExecutionConfig();
 		executionConfig.setUseSnapshotCompression(false);
 
-		stateBackend = new HeapKeyedStateBackend<>(
-			mock(TaskKvStateRegistry.class),
-			StringSerializer.INSTANCE,
-			StateSnapshotCompressionTest.class.getClassLoader(),
-			16,
-			new KeyGroupRange(0, 15),
-			true,
-			executionConfig,
-			TestLocalRecoveryConfig.disabled(),
-			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT,
-			new CloseableRegistry());
+		stateBackend = getStringHeapKeyedStateBackend(executionConfig);
 
 		try {
 			Assert.assertTrue(
@@ -106,28 +87,42 @@ public class StateSnapshotCompressionTest extends TestLogger {
 		snapshotRestoreRoundtrip(false);
 	}
 
-	private void snapshotRestoreRoundtrip(boolean useCompression) throws Exception {
+	private HeapKeyedStateBackend<String> getStringHeapKeyedStateBackend(ExecutionConfig executionConfig)
+		throws BackendBuildingException {
+		return getStringHeapKeyedStateBackend(executionConfig, Collections.emptyList());
+	}
 
-		ExecutionConfig executionConfig = new ExecutionConfig();
-		executionConfig.setUseSnapshotCompression(useCompression);
-
-		KeyedStateHandle stateHandle = null;
-
-		ValueStateDescriptor<String> stateDescriptor = new ValueStateDescriptor<>("test", String.class);
-		stateDescriptor.initializeSerializerUnlessSet(executionConfig);
-
-		AbstractKeyedStateBackend<String> stateBackend = new HeapKeyedStateBackend<>(
+	private HeapKeyedStateBackend<String> getStringHeapKeyedStateBackend(
+		ExecutionConfig executionConfig,
+		Collection<KeyedStateHandle> stateHandles)
+		throws BackendBuildingException {
+		return new HeapKeyedStateBackendBuilder<>(
 			mock(TaskKvStateRegistry.class),
 			StringSerializer.INSTANCE,
 			StateSnapshotCompressionTest.class.getClassLoader(),
 			16,
 			new KeyGroupRange(0, 15),
-			true,
 			executionConfig,
+			TtlTimeProvider.DEFAULT,
+			stateHandles,
+			AbstractStateBackend.getCompressionDecorator(executionConfig),
 			TestLocalRecoveryConfig.disabled(),
 			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT,
-			new CloseableRegistry());
+			true,
+			new CloseableRegistry()).build();
+	}
+
+	private void snapshotRestoreRoundtrip(boolean useCompression) throws Exception {
+
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.setUseSnapshotCompression(useCompression);
+
+		KeyedStateHandle stateHandle;
+
+		ValueStateDescriptor<String> stateDescriptor = new ValueStateDescriptor<>("test", String.class);
+		stateDescriptor.initializeSerializerUnlessSet(executionConfig);
+
+		AbstractKeyedStateBackend<String> stateBackend = getStringHeapKeyedStateBackend(executionConfig);
 
 		try {
 
@@ -160,22 +155,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 
 		executionConfig = new ExecutionConfig();
 
-		stateBackend = new HeapKeyedStateBackend<>(
-			mock(TaskKvStateRegistry.class),
-			StringSerializer.INSTANCE,
-			StateSnapshotCompressionTest.class.getClassLoader(),
-			16,
-			new KeyGroupRange(0, 15),
-			true,
-			executionConfig,
-			TestLocalRecoveryConfig.disabled(),
-			mock(HeapPriorityQueueSetFactory.class),
-			TtlTimeProvider.DEFAULT,
-			new CloseableRegistry());
+		stateBackend = getStringHeapKeyedStateBackend(executionConfig, StateObjectCollection.singleton(stateHandle));
 		try {
-
-			stateBackend.restore(StateObjectCollection.singleton(stateHandle));
-
 			InternalValueState<String, VoidNamespace, String> state = stateBackend.createInternalState(
 				new VoidNamespaceSerializer(),
 				stateDescriptor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state.heap;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
@@ -63,6 +64,7 @@ public abstract class HeapStateBackendTestBase {
 			new ExecutionConfig(),
 			TestLocalRecoveryConfig.disabled(),
 			new HeapPriorityQueueSetFactory(keyGroupRange, numKeyGroups, 128),
-			TtlTimeProvider.DEFAULT);
+			TtlTimeProvider.DEFAULT,
+			new CloseableRegistry());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
@@ -37,7 +36,6 @@ import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -135,17 +133,6 @@ public abstract class StateBackendTestContext {
 			snapshotRunnableFuture.run();
 		}
 		return snapshotRunnableFuture;
-	}
-
-	void restoreSnapshot(@Nullable KeyedStateHandle snapshot) throws Exception {
-		Collection<KeyedStateHandle> snapshots = new ArrayList<>();
-		snapshots.add(snapshot);
-		Collection<KeyedStateHandle> restoreState =
-			snapshot == null ? null : new StateObjectCollection<>(snapshots);
-		keyedStateBackend.restore(restoreState);
-		if (snapshot != null) {
-			snapshots.add(snapshot);
-		}
 	}
 
 	public void setCurrentKey(String key) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -129,7 +129,6 @@ public abstract class TtlStateTestBase {
 	protected <S extends State> StateDescriptor<S, Object> initTest(StateTtlConfig ttlConfig) throws Exception {
 		this.ttlConfig = ttlConfig;
 		sbetc.createAndRestoreKeyedStateBackend(null);
-		sbetc.restoreSnapshot(null);
 		sbetc.setCurrentKey("defaultKey");
 		StateDescriptor<S, Object> stateDesc = createState();
 		ctx().initTestValues();
@@ -155,7 +154,6 @@ public abstract class TtlStateTestBase {
 
 	private void restoreSnapshot(KeyedStateHandle snapshot, int numberOfKeyGroups) throws Exception {
 		sbetc.createAndRestoreKeyedStateBackend(numberOfKeyGroups, snapshot);
-		sbetc.restoreSnapshot(snapshot);
 		sbetc.setCurrentKey("defaultKey");
 		createState();
 	}
@@ -435,7 +433,6 @@ public abstract class TtlStateTestBase {
 		KeyedStateHandle snapshot = sbetc.takeSnapshot();
 		sbetc.createAndRestoreKeyedStateBackend(snapshot);
 
-		sbetc.restoreSnapshot(snapshot);
 		sbetc.setCurrentKey("defaultKey");
 		sbetc.createState(ctx().createStateDescriptor(), "");
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -30,7 +30,6 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
@@ -57,7 +56,6 @@ import javax.annotation.Nonnull;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,9 +85,9 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			Tuple2.of(FoldingStateDescriptor.class, (StateFactory) MockInternalFoldingState::createState)
 		).collect(Collectors.toMap(t -> t.f0, t -> t.f1));
 
-	private final Map<String, Map<K, Map<Object, Object>>> stateValues = new HashMap<>();
+	private final Map<String, Map<K, Map<Object, Object>>> stateValues;
 
-	private final Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters = new HashMap<>();
+	private final Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters;
 
 	MockKeyedStateBackend(
 		TaskKvStateRegistry kvStateRegistry,
@@ -99,10 +97,13 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		KeyGroupRange keyGroupRange,
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider,
-		MetricGroup operatorMetricGroup,
+		Map<String, Map<K, Map<Object, Object>>> stateValues,
+		Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters,
 		CloseableRegistry cancelStreamRegistry) {
 		super(kvStateRegistry, keySerializer, userCodeClassLoader,
 			numberOfKeyGroups, keyGroupRange, executionConfig, ttlTimeProvider, cancelStreamRegistry);
+		this.stateValues = stateValues;
+		this.stateSnapshotFilters = stateSnapshotFilters;
 	}
 
 	@Override
@@ -187,17 +188,10 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public void restore(Collection<KeyedStateHandle> state) {
-		stateValues.clear();
-		state = state == null ? Collections.emptyList() : state;
-		state.forEach(ksh -> stateValues.putAll(copy(((MockKeyedStateHandle<K>) ksh).snapshotStates)));
+		// all restore work done in builder and nothing to do here
 	}
 
-	private static <K> Map<String, Map<K, Map<Object, Object>>> copy(
-		Map<String, Map<K, Map<Object, Object>>> stateValues) {
-		return copy(stateValues, Collections.emptyMap());
-	}
-
-	private static <K> Map<String, Map<K, Map<Object, Object>>> copy(
+	static <K> Map<String, Map<K, Map<Object, Object>>> copy(
 		Map<String, Map<K, Map<Object, Object>>> stateValues, Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters) {
 		Map<String, Map<K, Map<Object, Object>>> snapshotStates = new HashMap<>();
 		for (String stateName : stateValues.keySet()) {
@@ -244,7 +238,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			0);
 	}
 
-	private static class MockKeyedStateHandle<K> implements KeyedStateHandle {
+	static class MockKeyedStateHandle<K> implements KeyedStateHandle {
 		private static final long serialVersionUID = 1L;
 
 		final Map<String, Map<K, Map<Object, Object>>> snapshotStates;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -99,9 +99,10 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		KeyGroupRange keyGroupRange,
 		ExecutionConfig executionConfig,
 		TtlTimeProvider ttlTimeProvider,
-		MetricGroup operatorMetricGroup) {
+		MetricGroup operatorMetricGroup,
+		CloseableRegistry cancelStreamRegistry) {
 		super(kvStateRegistry, keySerializer, userCodeClassLoader,
-			numberOfKeyGroups, keyGroupRange, executionConfig, ttlTimeProvider, new CloseableRegistry());
+			numberOfKeyGroups, keyGroupRange, executionConfig, ttlTimeProvider, cancelStreamRegistry);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackendBuilder;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builder class for {@link MockKeyedStateBackend}.
+ *
+ * @param <K> The data type that the key serializer serializes.
+ */
+public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBuilder<K> {
+	public MockKeyedStateBackendBuilder(
+		TaskKvStateRegistry kvStateRegistry,
+		TypeSerializer<K> keySerializer,
+		ClassLoader userCodeClassLoader,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		ExecutionConfig executionConfig,
+		TtlTimeProvider ttlTimeProvider,
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		StreamCompressionDecorator keyGroupCompressionDecorator,
+		CloseableRegistry cancelStreamRegistry) {
+		super(
+			kvStateRegistry,
+			keySerializer,
+			userCodeClassLoader,
+			numberOfKeyGroups,
+			keyGroupRange,
+			executionConfig,
+			ttlTimeProvider,
+			stateHandles,
+			keyGroupCompressionDecorator,
+			cancelStreamRegistry);
+	}
+
+	@Override
+	public MockKeyedStateBackend<K> build() {
+		Map<String, Map<K, Map<Object, Object>>> stateValues = new HashMap<>();
+		Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters = new HashMap<>();
+		MockRestoreOperation<K> restoreOperation = new MockRestoreOperation<>(restoreStateHandles, stateValues);
+		restoreOperation.restore();
+		return new MockKeyedStateBackend<>(
+			kvStateRegistry,
+			keySerializer,
+			userCodeClassLoader,
+			numberOfKeyGroups,
+			keyGroupRange,
+			executionConfig,
+			ttlTimeProvider,
+			stateValues,
+			stateSnapshotFilters,
+			cancelStreamRegistry);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockRestoreOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockRestoreOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.RestoreOperation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.copy;
+
+/**
+ * Implementation of mock restore operation.
+ *
+ * @param <K> The data type that the serializer serializes.
+ */
+public class MockRestoreOperation<K> implements RestoreOperation<Void> {
+	private final Collection<KeyedStateHandle> state;
+	private final Map<String, Map<K, Map<Object, Object>>> stateValues;
+
+	public MockRestoreOperation(
+		Collection<KeyedStateHandle> state,
+		Map<String, Map<K, Map<Object, Object>>> stateValues) {
+		this.state = state;
+		this.stateValues = stateValues;
+	}
+
+	@Override
+	public Void restore() {
+		state.forEach(ksh -> stateValues.putAll(
+			copy(((MockKeyedStateBackend.MockKeyedStateHandle<K>) ksh).snapshotStates,
+				Collections.emptyMap())));
+		return null;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.util.Collection;
 
 /** mack state backend. */
@@ -127,7 +128,7 @@ public class MockStateBackend extends AbstractStateBackend {
 		MetricGroup metricGroup,
 		@Nonnull Collection<KeyedStateHandle> stateHandles,
 		CloseableRegistry cancelStreamRegistry) {
-		return new MockKeyedStateBackend<>(
+		return new MockKeyedStateBackendBuilder<>(
 			new KvStateRegistry().createTaskRegistry(jobID, new JobVertexID()),
 			keySerializer,
 			env.getUserClassLoader(),
@@ -135,8 +136,9 @@ public class MockStateBackend extends AbstractStateBackend {
 			keyGroupRange,
 			env.getExecutionConfig(),
 			ttlTimeProvider,
-			metricGroup,
-			cancelStreamRegistry);
+			stateHandles,
+			AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
+			cancelStreamRegistry).build();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.ttl.mock;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -39,6 +40,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 
@@ -123,7 +125,8 @@ public class MockStateBackend extends AbstractStateBackend {
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		Collection<KeyedStateHandle> stateHandles) {
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) {
 		return new MockKeyedStateBackend<>(
 			new KvStateRegistry().createTaskRegistry(jobID, new JobVertexID()),
 			keySerializer,
@@ -132,7 +135,8 @@ public class MockStateBackend extends AbstractStateBackend {
 			keyGroupRange,
 			env.getExecutionConfig(),
 			ttlTimeProvider,
-			metricGroup);
+			metricGroup,
+			cancelStreamRegistry);
 	}
 
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -39,10 +39,8 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.OperatorStateBackend;
-import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
-import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.AbstractID;
@@ -519,14 +517,6 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			.setNumberOfTransferingThreads(getNumberOfTransferingThreads())
 			.setNativeMetricOptions(getMemoryWatcherOptions());
 		return builder.build();
-	}
-
-	public static StreamCompressionDecorator getCompressionDecorator(ExecutionConfig executionConfig) {
-		if (executionConfig != null && executionConfig.isUseSnapshotCompression()) {
-			return SnappyStreamCompressionDecorator.INSTANCE;
-		} else {
-			return UncompressedStreamCompressionDecorator.INSTANCE;
-		}
 	}
 
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -473,7 +474,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		TaskKvStateRegistry kvStateRegistry,
 		TtlTimeProvider ttlTimeProvider,
 		MetricGroup metricGroup,
-		@Nonnull Collection<KeyedStateHandle> stateHandles) throws IOException {
+		@Nonnull Collection<KeyedStateHandle> stateHandles,
+		CloseableRegistry cancelStreamRegistry) throws IOException {
 
 		// first, make sure that the RocksDB JNI library is loaded
 		// we do this explicitly here to have better error handling
@@ -510,7 +512,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 			ttlTimeProvider,
 			metricGroup,
 			stateHandles,
-			keyGroupCompressionDecorator
+			keyGroupCompressionDecorator,
+			cancelStreamRegistry
 		).setEnableIncrementalCheckpointing(isIncrementalCheckpointsEnabled())
 			.setEnableTtlCompactionFilter(isTtlCompactionFilterEnabled())
 			.setNumberOfTransferingThreads(getNumberOfTransferingThreads())

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -213,7 +214,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 			TtlTimeProvider.DEFAULT,
 			new UnregisteredMetricsGroup(),
 			Collections.emptyList(),
-			RocksDBStateBackend.getCompressionDecorator(env.getExecutionConfig()),
+			AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
 			spy(db),
 			defaultCFHandle,
 			new CloseableRegistry()).build();
@@ -290,7 +291,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 				TtlTimeProvider.DEFAULT,
 				new UnregisteredMetricsGroup(),
 				Collections.emptyList(),
-				RocksDBStateBackend.getCompressionDecorator(executionConfig),
+				AbstractStateBackend.getCompressionDecorator(executionConfig),
 				db,
 				defaultCFHandle,
 				new CloseableRegistry()).build();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -214,8 +215,8 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 			Collections.emptyList(),
 			RocksDBStateBackend.getCompressionDecorator(env.getExecutionConfig()),
 			spy(db),
-			defaultCFHandle
-		).build();
+			defaultCFHandle,
+			new CloseableRegistry()).build();
 
 		testState1 = keyedStateBackend.getPartitionedState(
 				VoidNamespace.INSTANCE,
@@ -291,8 +292,8 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 				Collections.emptyList(),
 				RocksDBStateBackend.getCompressionDecorator(executionConfig),
 				db,
-				defaultCFHandle
-			).build();
+				defaultCFHandle,
+				new CloseableRegistry()).build();
 			ValueStateDescriptor<String> stubState1 =
 				new ValueStateDescriptor<>("StubState-1", StringSerializer.INSTANCE);
 			test.createInternalState(StringSerializer.INSTANCE, stubState1);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -58,6 +58,8 @@ import org.apache.flink.util.CloseableIterable;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
@@ -146,7 +148,9 @@ public class StreamTaskStateInitializerImplTest {
 				int numberOfKeyGroups, KeyGroupRange keyGroupRange,
 				TaskKvStateRegistry kvStateRegistry,
 				TtlTimeProvider ttlTimeProvider,
-				MetricGroup metricGroup, Collection<KeyedStateHandle> stateHandles) throws Exception {
+				MetricGroup metricGroup,
+				@Nonnull Collection<KeyedStateHandle> stateHandles,
+				CloseableRegistry cancelStreamRegistry) throws Exception {
 				return mock(AbstractKeyedStateBackend.class);
 			}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobCacheService;
@@ -81,6 +82,8 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -270,7 +273,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 			TaskKvStateRegistry kvStateRegistry,
 			TtlTimeProvider ttlTimeProvider,
 			MetricGroup metricGroup,
-			Collection<KeyedStateHandle> stateHandles) {
+			@Nonnull Collection<KeyedStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry) {
 			return null;
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -32,6 +33,8 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -59,7 +62,9 @@ public class TestSpyWrapperStateBackend extends AbstractStateBackend {
 			KeyGroupRange keyGroupRange,
 			TaskKvStateRegistry kvStateRegistry,
 			TtlTimeProvider ttlTimeProvider,
-			MetricGroup metricGroup, Collection<KeyedStateHandle> stateHandles) throws IOException {
+			MetricGroup metricGroup,
+			@Nonnull Collection<KeyedStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry) throws IOException {
 			return spy(delegate.createKeyedStateBackend(
 				env,
 				jobID,
@@ -70,7 +75,8 @@ public class TestSpyWrapperStateBackend extends AbstractStateBackend {
 				kvStateRegistry,
 				ttlTimeProvider,
 				metricGroup,
-				null));
+				stateHandles,
+				cancelStreamRegistry));
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
@@ -43,6 +44,8 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Test;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -118,7 +121,8 @@ public class StateBackendITCase extends AbstractTestBase {
 			TaskKvStateRegistry kvStateRegistry,
 			TtlTimeProvider ttlTimeProvider,
 			MetricGroup metricGroup,
-			Collection<KeyedStateHandle> stateHandles) throws IOException {
+			@Nonnull Collection<KeyedStateHandle> stateHandles,
+			CloseableRegistry cancelStreamRegistry) throws IOException {
 			throw new SuccessException();
 		}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR makes `HeapKeyedStateBackend` and `MockKeyedStateBackend` construction follow the builder pattern.


## Brief change log

This PR introduces a builder for `HeapKeyedStateBackend` and `MockKeyedStateBackend` and moves all necessary initialization work including restore operation to their building process. It also removes invocation of `restore` method for all keyed backends.


## Verifying this change

This change is already covered by existing tests, such as all tests under `org.apache.flink.runtime.state` package, and verified locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
     * Added a static `getCompressionDecorator` method in `AbstractStateBackend`
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
