### PR TITLE
[FLINK-11420][core][bp1.8] Fixed duplicate method of TraversableSerializer

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestInstance.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestInstance.java
@@ -62,19 +62,27 @@ public class SerializerTestInstance<T> extends SerializerTestBase<T> {
 	}
 	
 	// --------------------------------------------------------------------------------------------
-	
+
 	public void testAll() {
-		testInstantiate();
-		testGetLength();
-		testCopy();
-		testCopyIntoNewElements();
-		testCopyIntoReusedElements();
-		testSerializeIndividually();
-		testSerializeIndividuallyReusingValues();
-		testSerializeAsSequenceNoReuse();
-		testSerializeAsSequenceReusingValues();
-		testSerializedCopyIndividually();
-		testSerializedCopyAsSequence();
-		testSerializabilityAndEquals();
+		try {
+			testConfigSnapshotInstantiation();
+			testCopy();
+			testCopyIntoNewElements();
+			testCopyIntoReusedElements();
+			testDuplicate();
+			testGetLength();
+			testInstantiate();
+			testNullability();
+			testSerializeIndividually();
+			testSerializeIndividuallyReusingValues();
+			testSerializeAsSequenceNoReuse();
+			testSerializeAsSequenceReusingValues();
+			testSerializedCopyIndividually();
+			testSerializedCopyAsSequence();
+			testSerializabilityAndEquals();
+			testSnapshotConfigurationAndReconfigure();
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
 	}
 }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableSerializer.scala
@@ -57,7 +57,7 @@ class TraversableSerializer[T <: TraversableOnce[E], E](
 
   override def duplicate = {
     val duplicateElementSerializer = elementSerializer.duplicate()
-    if (duplicateElementSerializer == elementSerializer) {
+    if (duplicateElementSerializer eq elementSerializer) {
       // is not stateful, so return ourselves
       this
     } else {


### PR DESCRIPTION
## What is the purpose of the change

The duplicate method of TypeSerializer used an equality check rather
than reference check of the element serializer to decide if we need a
deep copy. This commit uses proper reference comparison.

## Brief change log

*(for example:)*
  - enabled additional tests in SerializerTestInstance
  - fixed duplicate method of TraversableSerializer


## Verifying this change

* enabled additional test (including `duplicate` method test in `SerializerTestInstance`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicabl**e / docs / JavaDocs / not documented)
