### PR TITLE
[FLINK-11752] [dist] Move flink-python to opt (backport)

### DIFF
--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -227,17 +227,7 @@ under the License.
 				<include>flink-gelly-examples_${scala.binary.version}-${project.version}.jar</include>
 			</includes>
 		</fileSet>
-
-		<!-- copy python jar -->
-		<fileSet>
-			<directory>../flink-libraries/flink-python/target</directory>
-			<outputDirectory>lib</outputDirectory>
-			<fileMode>0644</fileMode>
-			<includes>
-				<include>flink-python_${scala.binary.version}-${project.version}.jar</include>
-			</includes>
-		</fileSet>
-
+		
 		<!-- copy python example to examples of dist -->
 		<fileSet>
 			<directory>../flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/example</directory>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -162,6 +162,14 @@
 			<fileMode>0644</fileMode>
 		</file>
 
+		<!-- Batch Python API -->
+		<file>
+			<source>../flink-libraries/flink-python/target/flink-python_${scala.binary.version}-${project.version}.jar</source>
+			<outputDirectory>opt</outputDirectory>
+			<destName>flink-python_${scala.binary.version}-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
 		<!-- Streaming Python API -->
 		<file>
 			<source>../flink-libraries/flink-streaming-python/target/flink-streaming-python_${scala.binary.version}-${project.version}.jar</source>

--- a/flink-dist/src/main/flink-bin/bin/pyflink.bat
+++ b/flink-dist/src/main/flink-bin/bin/pyflink.bat
@@ -22,4 +22,4 @@ setlocal EnableDelayedExpansion
 SET bin=%~dp0
 SET FLINK_ROOT_DIR=%bin%..
 
-"%FLINK_ROOT_DIR%\bin\flink" run -v "%FLINK_ROOT_DIR%"\lib\flink-python*.jar %*
+"%FLINK_ROOT_DIR%\bin\flink" run -v "%FLINK_ROOT_DIR%"\opt\flink-python*.jar %*

--- a/flink-dist/src/main/flink-bin/bin/pyflink.sh
+++ b/flink-dist/src/main/flink-bin/bin/pyflink.sh
@@ -22,4 +22,4 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/lib/flink-python*.jar "$@"
+"$FLINK_BIN_DIR"/flink run -v "$FLINK_ROOT_DIR"/opt/flink-python*.jar "$@"


### PR DESCRIPTION
Backport of #7843 to `release-1.8`. Cherry picked d637d8613d without any conflicts.

I talked to @aljoscha (1.8 release manager) before opening this PR and he agrees that this should go into 1.8.