### PR TITLE
[FLINK-11790][table-planner-blink] Introduce FlinkRelNode interface and FlinkConventions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/FlinkConventions.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/FlinkConventions.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes
+
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalRel
+import org.apache.flink.table.plan.nodes.physical.batch.BatchPhysicalRel
+import org.apache.flink.table.plan.nodes.physical.stream.StreamPhysicalRel
+
+import org.apache.calcite.plan.{Convention, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Override the default convention implementation to support using AbstractConverter for conversion
+  */
+class FlinkConvention(name: String, relClass: Class[_ <: RelNode])
+  extends Convention.Impl(name, relClass) {
+
+  override def useAbstractConvertersForConversion(
+      fromTraits: RelTraitSet,
+      toTraits: RelTraitSet): Boolean = {
+    if (relClass == classOf[StreamPhysicalRel]) {
+      // stream
+      !fromTraits.satisfies(toTraits) &&
+        fromTraits.containsIfApplicable(FlinkConventions.STREAM_PHYSICAL) &&
+        toTraits.containsIfApplicable(FlinkConventions.STREAM_PHYSICAL)
+    } else {
+      // batch
+      !fromTraits.satisfies(toTraits) &&
+        fromTraits.containsIfApplicable(FlinkConventions.BATCH_PHYSICAL) &&
+        toTraits.containsIfApplicable(FlinkConventions.BATCH_PHYSICAL)
+    }
+  }
+}
+
+object FlinkConventions {
+  val LOGICAL = new Convention.Impl("LOGICAL", classOf[FlinkLogicalRel])
+  val STREAM_PHYSICAL = new FlinkConvention("STREAM_PHYSICAL", classOf[StreamPhysicalRel])
+  val BATCH_PHYSICAL = new FlinkConvention("BATCH_PHYSICAL", classOf[BatchPhysicalRel])
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/FlinkRelNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/FlinkRelNode.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes
+
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Base class for flink relational expression.
+  */
+trait FlinkRelNode extends RelNode {
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalRel.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.logical
+
+import org.apache.flink.table.plan.nodes.FlinkRelNode
+
+/**
+  * Base class for flink logical relational expression.
+  */
+trait FlinkLogicalRel extends FlinkRelNode {
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/FlinkPhysicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/FlinkPhysicalRel.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical
+
+import org.apache.flink.table.plan.nodes.FlinkRelNode
+
+import org.apache.calcite.plan.RelTraitSet
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Base class for flink physical relational expression.
+  */
+trait FlinkPhysicalRel extends FlinkRelNode {
+
+  /**
+    * Try to satisfy required traits by descendant of current node. If descendant can satisfy
+    * required traits, and current node will not destroy it, then returns the new node with
+    * converted inputs.
+    *
+    * @param requiredTraitSet required traits
+    * @return A converted node which satisfy required traits by inputs node of current node.
+    *         Returns null if required traits cannot be pushed down into inputs.
+    */
+  def satisfyTraitsByInput(requiredTraitSet: RelTraitSet): RelNode = null
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchPhysicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchPhysicalRel.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.batch
+
+import org.apache.flink.table.plan.nodes.physical.FlinkPhysicalRel
+
+/**
+  * Base class for batch physical relational expression.
+  */
+trait BatchPhysicalRel extends FlinkPhysicalRel {
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamPhysicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamPhysicalRel.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.nodes.physical.FlinkPhysicalRel
+
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Base class for stream physical relational expression.
+  */
+trait StreamPhysicalRel extends FlinkPhysicalRel {
+
+  /**
+    * Whether the [[StreamPhysicalRel]] produces update and delete changes.
+    */
+  def producesUpdates: Boolean = false
+
+  /**
+    * Whether the [[StreamPhysicalRel]] requires retraction messages or not.
+    */
+  def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  /**
+    * Whether the [[StreamPhysicalRel]] consumes retraction messages instead of forwarding them.
+    * The node might or might not produce new retraction messages.
+    */
+  def consumesRetractions: Boolean = false
+
+  /**
+    * Whether the [[StreamPhysicalRel]] produces retraction messages.
+    */
+  def producesRetractions: Boolean = false
+
+}


### PR DESCRIPTION

## What is the purpose of the change

Introduce basic Flink RelNode interface

## Brief change log

  - *Define Flink RelNode inheritance structure*
  - *Define FlinkConventions*

## Verifying this change

This change only contains interface definition, without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
