### PR TITLE
[FLINK-11336][zk] Delete ZNodes when ZooKeeperHaServices#closeAndCleanupAllData

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -45,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * An implementation of the {@link HighAvailabilityServices} using Apache ZooKeeper.
  * The services store data in ZooKeeper's nodes as illustrated by the following tree structure:
- * 
+ *
  * <pre>
  * /flink
  *      +/cluster_id_1/resource_manager_lock
@@ -56,7 +56,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *      |            |                     /latest-2
  *      |            |
  *      |            +/job-id-2/job_manager_lock
- *      |      
+ *      |
  *      +/cluster_id_2/resource_manager_lock
  *                   |
  *                   +/job-id-1/job_manager_lock
@@ -64,18 +64,18 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *                            |            /latest-1
  *                            |/persisted_job_graph
  * </pre>
- * 
+ *
  * <p>The root path "/flink" is configurable via the option {@link HighAvailabilityOptions#HA_ZOOKEEPER_ROOT}.
  * This makes sure Flink stores its data under specific subtrees in ZooKeeper, for example to
  * accommodate specific permission.
- * 
- * <p>The "cluster_id" part identifies the data stored for a specific Flink "cluster". 
+ *
+ * <p>The "cluster_id" part identifies the data stored for a specific Flink "cluster".
  * This "cluster" can be either a standalone or containerized Flink cluster, or it can be job
  * on a framework like YARN or Mesos (in a "per-job-cluster" mode).
- * 
+ *
  * <p>In case of a "per-job-cluster" on YARN or Mesos, the cluster-id is generated and configured
  * automatically by the client or dispatcher that submits the Job to YARN or Mesos.
- * 
+ *
  * <p>In the case of a standalone cluster, that cluster-id needs to be configured via
  * {@link HighAvailabilityOptions#HA_CLUSTER_ID}. All nodes with the same cluster id will join the same
  * cluster and participate in the execution of the same set of jobs.
@@ -93,21 +93,20 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	private static final String REST_SERVER_LEADER_PATH = "/rest_server_lock";
 
 	// ------------------------------------------------------------------------
-	
-	
-	/** The ZooKeeper client to use */
+
+	/** The ZooKeeper client to use. */
 	private final CuratorFramework client;
 
-	/** The executor to run ZooKeeper callbacks on */
+	/** The executor to run ZooKeeper callbacks on. */
 	private final Executor executor;
 
-	/** The runtime configuration */
+	/** The runtime configuration. */
 	private final Configuration configuration;
 
-	/** The zookeeper based running jobs registry */
+	/** The zookeeper based running jobs registry. */
 	private final RunningJobsRegistry runningJobsRegistry;
 
-	/** Store for arbitrary blobs */
+	/** Store for arbitrary blobs. */
 	private final BlobStoreService blobStoreService;
 
 	public ZooKeeperHaServices(
@@ -233,7 +232,7 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	}
 
 	/**
-	 * Closes components which don't distinguish between close and closeAndCleanupAllData
+	 * Closes components which don't distinguish between close and closeAndCleanupAllData.
 	 */
 	private void internalClose() {
 		client.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -169,8 +169,7 @@ public class ZooKeeperUtils {
 	 */
 	public static ZooKeeperLeaderRetrievalService createLeaderRetrievalService(
 		final CuratorFramework client,
-		final Configuration configuration) throws Exception
-	{
+		final Configuration configuration) throws Exception {
 		return createLeaderRetrievalService(client, configuration, "");
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobStoreService;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.TestingContender;
+import org.apache.flink.runtime.leaderelection.TestingListener;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link ZooKeeperHaServices}.
+ */
+public class ZooKeeperHaServicesTest extends TestLogger {
+
+	@ClassRule
+	public static final ZooKeeperResource ZOO_KEEPER_RESOURCE = new ZooKeeperResource();
+
+	private static CuratorFramework client;
+
+	@BeforeClass
+	public static void setupClass() {
+		client = startCuratorFramework();
+		client.start();
+	}
+
+	@Before
+	public void setup() throws Exception {
+		final List<String> children = client.getChildren().forPath("/");
+
+		for (String child : children) {
+			if (!child.equals("zookeeper")) {
+				client.delete().deletingChildrenIfNeeded().forPath('/' + child);
+			}
+		}
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (client != null) {
+			client.close();
+		}
+	}
+
+	/**
+	 * Tests that a simple {@link ZooKeeperHaServices#close()} does not delete ZooKeeper paths.
+	 */
+	@Test
+	public void testSimpleClose() throws Exception {
+		final String rootPath = "/foo/bar/flink";
+		final Configuration configuration = createConfiguration(rootPath);
+
+		final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
+
+		runCleanupTest(
+			configuration,
+			blobStoreService,
+			ZooKeeperHaServices::close);
+
+		assertThat(blobStoreService.isClosed(), is(true));
+		assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(false));
+
+		final List<String> children = client.getChildren().forPath(rootPath);
+		assertThat(children, is(not(empty())));
+	}
+
+	/**
+	 * Tests that the {@link ZooKeeperHaServices} cleans up all paths if
+	 * it is closed via {@link ZooKeeperHaServices#closeAndCleanupAllData()}.
+	 */
+	@Test
+	public void testSimpleCloseAndCleanupAllData() throws Exception {
+		final Configuration configuration = createConfiguration("/foo/bar/flink");
+
+		final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
+
+		final List<String> initialChildren = client.getChildren().forPath("/");
+
+		runCleanupTest(
+			configuration,
+			blobStoreService,
+			ZooKeeperHaServices::closeAndCleanupAllData);
+
+		assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(true));
+
+		final List<String> children = client.getChildren().forPath("/");
+		assertThat(children, is(equalTo(initialChildren)));
+	}
+
+	/**
+	 * Tests that we can only delete the parent znodes as long as they are empty.
+	 */
+	@Test
+	public void testCloseAndCleanupAllDataWithUncle() throws Exception {
+		final String prefix = "/foo/bar";
+		final String flinkPath = prefix + "/flink";
+		final Configuration configuration = createConfiguration(flinkPath);
+
+		final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
+
+		final String unclePath = prefix + "/foobar";
+		client.create().creatingParentContainersIfNeeded().forPath(unclePath);
+
+		runCleanupTest(
+			configuration,
+			blobStoreService,
+			ZooKeeperHaServices::closeAndCleanupAllData);
+
+		assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(true));
+
+		assertThat(client.checkExists().forPath(flinkPath), is(nullValue()));
+		assertThat(client.checkExists().forPath(unclePath), is(notNullValue()));
+	}
+
+	private static CuratorFramework startCuratorFramework() {
+		return CuratorFrameworkFactory.builder()
+				.connectString(ZOO_KEEPER_RESOURCE.getConnectString())
+				.retryPolicy(new RetryNTimes(50, 100))
+				.build();
+	}
+
+	@Nonnull
+	private Configuration createConfiguration(String rootPath) {
+		final Configuration configuration = new Configuration();
+		configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, ZOO_KEEPER_RESOURCE.getConnectString());
+		configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT, rootPath);
+		return configuration;
+	}
+
+	private void runCleanupTest(
+			Configuration configuration,
+			TestingBlobStoreService blobStoreService,
+			ThrowingConsumer<ZooKeeperHaServices, Exception> zooKeeperHaServicesConsumer) throws Exception {
+		try (ZooKeeperHaServices zooKeeperHaServices = new ZooKeeperHaServices(
+			ZooKeeperUtils.startCuratorFramework(configuration),
+			Executors.directExecutor(),
+			configuration,
+			blobStoreService)) {
+
+			// create some Zk services to trigger the generation of paths
+			final LeaderRetrievalService resourceManagerLeaderRetriever = zooKeeperHaServices.getResourceManagerLeaderRetriever();
+			final LeaderElectionService resourceManagerLeaderElectionService = zooKeeperHaServices.getResourceManagerLeaderElectionService();
+			final RunningJobsRegistry runningJobsRegistry = zooKeeperHaServices.getRunningJobsRegistry();
+
+			resourceManagerLeaderRetriever.start(new TestingListener());
+			resourceManagerLeaderElectionService.start(new TestingContender("foobar", resourceManagerLeaderElectionService));
+			final JobID jobId = new JobID();
+			runningJobsRegistry.setJobRunning(jobId);
+
+			resourceManagerLeaderRetriever.stop();
+			resourceManagerLeaderElectionService.stop();
+			runningJobsRegistry.clearJob(jobId);
+
+			zooKeeperHaServicesConsumer.accept(zooKeeperHaServices);
+		}
+	}
+
+	private static class TestingBlobStoreService implements BlobStoreService {
+
+		private boolean closedAndCleanedUpAllData = false;
+		private boolean closed = false;
+
+		@Override
+		public void closeAndCleanupAllData() {
+			closedAndCleanedUpAllData = true;
+		}
+
+		@Override
+		public void close() throws IOException {
+			closed = true;
+		}
+
+		@Override
+		public boolean put(File localFile, JobID jobId, BlobKey blobKey) {
+			return false;
+		}
+
+		@Override
+		public boolean delete(JobID jobId, BlobKey blobKey) {
+			return false;
+		}
+
+		@Override
+		public boolean deleteAll(JobID jobId) {
+			return false;
+		}
+
+		@Override
+		public boolean get(JobID jobId, BlobKey blobKey, File localFile) {
+			return false;
+		}
+
+		private boolean isClosed() {
+			return closed;
+		}
+
+		private boolean isClosedAndCleanedUpAllData() {
+			return closedAndCleanedUpAllData;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.test.TestingServer;
-
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.blob.VoidBlobStore;
@@ -35,11 +32,11 @@ import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -50,8 +47,13 @@ import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 
+import scala.concurrent.duration.FiniteDuration;
+
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests for the ZooKeeper based leader election and retrieval.
+ */
 public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 
 	private TestingServer testingServer;
@@ -79,7 +81,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 
 	@After
 	public void after() throws Exception {
-		if(testingServer != null) {
+		if (testingServer != null) {
 			testingServer.stop();
 
 			testingServer = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -197,7 +197,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 	 */
 	@Test
 	public void testTimeoutOfFindConnectingAddress() throws Exception {
-		FiniteDuration timeout = new FiniteDuration(10L, TimeUnit.SECONDS);
+		FiniteDuration timeout = new FiniteDuration(1L, TimeUnit.SECONDS);
 
 		LeaderRetrievalService leaderRetrievalService = highAvailabilityServices.getJobManagerLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID);
 		InetAddress result = LeaderRetrievalUtils.findConnectingAddress(leaderRetrievalService, timeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -81,16 +81,16 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger{
 
 	@After
 	public void after() throws Exception {
-		if (testingServer != null) {
-			testingServer.stop();
-
-			testingServer = null;
-		}
-
 		if (highAvailabilityServices != null) {
 			highAvailabilityServices.closeAndCleanupAllData();
 
 			highAvailabilityServices = null;
+		}
+
+		if (testingServer != null) {
+			testingServer.stop();
+
+			testingServer = null;
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

When calling ZooKeeperHaServices#closeAndCleanupAllData we should delete the
HA_CLUSTER_ID znode which is owned by the respective ZooKeeperHaServices.
Moreover, the method tries to go up the chain of parent znodes and tries to
delete all empty parent nodes. This should clean up otherwisely orphaned
parent znodes.

## Verifying this change

- Added `ZooKeeperHaServicesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
