### PR TITLE
[typo] Inaccurate info on Avro splitting support

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -222,7 +222,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 	protected long openTimeout = DEFAULT_OPENING_TIMEOUT;
 	
 	/**
-	 * Some file input formats are not splittable on a block level (avro, deflate)
+	 * Some file input formats are not splittable on a block level (deflate)
 	 * Therefore, the FileInputFormat can only read whole files.
 	 */
 	protected boolean unsplittable = false;


### PR DESCRIPTION

Fixes outdated comment in FileInputFormat. Flink has supported block-splitting Avro since https://github.com/apache/flink/pull/387.
