### PR TITLE
[FLINK-11781][yarn] Remove "DISABLED" as possible value for yarn.per-job-cluster.include-user-jar

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -45,7 +45,7 @@
         <tr>
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
             <td style="word-wrap: break-word;">"ORDER"</td>
-            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER"). Setting this parameter to "DISABLED" causes the jar to be included in the user class path instead.</td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER").</td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -245,6 +245,11 @@ public final class DelegatingConfiguration extends Configuration {
 	}
 
 	@Override
+	public <T extends Enum<T>> T getEnum(final Class<T> enumClass, final ConfigOption<String> configOption) {
+		return this.backingConfig.getEnum(enumClass, prefixOption(configOption, prefix));
+	}
+
+	@Override
 	public void addAllToProperties(Properties props) {
 		// only add keys with our prefix
 		synchronized (backingConfig.confData) {

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -23,10 +23,12 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -402,5 +404,57 @@ public class ConfigurationTest extends TestLogger {
 		assertTrue("Expected 'existedOption' is removed", cfg.removeConfig(deprecatedOption));
 		assertEquals("Wrong expectation about size", cfg.keySet().size(), 0);
 		assertFalse("Expected 'unexistedOption' is not removed", cfg.removeConfig(unexistedOption));
+	}
+
+	@Test
+	public void testShouldParseValidStringToEnum() {
+		final ConfigOption<String> configOption = createStringConfigOption();
+
+		final Configuration configuration = new Configuration();
+		configuration.setString(configOption.key(), TestEnum.VALUE1.toString());
+
+		final TestEnum parsedEnumValue = configuration.getEnum(TestEnum.class, configOption);
+		assertEquals(TestEnum.VALUE1, parsedEnumValue);
+	}
+
+	@Test
+	public void testShouldParseValidStringToEnumIgnoringCase() {
+		final ConfigOption<String> configOption = createStringConfigOption();
+
+		final Configuration configuration = new Configuration();
+		configuration.setString(configOption.key(), TestEnum.VALUE1.toString().toLowerCase());
+
+		final TestEnum parsedEnumValue = configuration.getEnum(TestEnum.class, configOption);
+		assertEquals(TestEnum.VALUE1, parsedEnumValue);
+	}
+
+	@Test
+	public void testThrowsExceptionIfTryingToParseInvalidStringForEnum() {
+		final ConfigOption<String> configOption = createStringConfigOption();
+
+		final Configuration configuration = new Configuration();
+		final String invalidValueForTestEnum = "InvalidValueForTestEnum";
+		configuration.setString(configOption.key(), invalidValueForTestEnum);
+
+		try {
+			configuration.getEnum(TestEnum.class, configOption);
+			fail("Expected exception not thrown");
+		} catch (IllegalArgumentException e) {
+			final String expectedMessage = "Value for config option " +
+				configOption.key() + " must be one of [VALUE1, VALUE2] (was " +
+				invalidValueForTestEnum + ")";
+			assertThat(e.getMessage(), containsString(expectedMessage));
+		}
+	}
+
+	enum TestEnum {
+		VALUE1,
+		VALUE2
+	}
+
+	private static ConfigOption<String> createStringConfigOption() {
+		return ConfigOptions
+			.key("test-string-key")
+			.noDefaultValue();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1825,7 +1825,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		// see what this means for us. currently, the first FAILED state means -> FAILED
 		if (newExecutionState == ExecutionState.FAILED) {
 			final Throwable ex = error != null ? error : new FlinkException("Unknown Error (missing cause)");
-			long timestamp = execution.getStateTimestamp(ExecutionState.FAILED);
 
 			// by filtering out late failure calls, we can save some work in
 			// avoiding redundant local failover

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -57,8 +57,7 @@ public class YarnConfigOptions {
 			.defaultValue("ORDER")
 			.withDescription("Defines whether user-jars are included in the system class path for per-job-clusters as" +
 				" well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the" +
-				" end (\"LAST\"), or be positioned based on their name (\"ORDER\"). Setting this parameter to" +
-				" \"DISABLED\" causes the jar to be included in the user class path instead.");
+				" end (\"LAST\"), or be positioned based on their name (\"ORDER\").");
 
 	/**
 	 * The vcores exposed by YARN.
@@ -156,7 +155,6 @@ public class YarnConfigOptions {
 
 	/** @see YarnConfigOptions#CLASSPATH_INCLUDE_USER_JAR */
 	public enum UserJarInclusion {
-		DISABLED,
 		FIRST,
 		LAST,
 		ORDER

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -53,7 +53,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -87,6 +89,27 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	@AfterClass
 	public static void tearDownClass() {
 		yarnClient.stop();
+	}
+
+	/**
+	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-11781">FLINK-11781</a>
+	 */
+	@Test
+	public void testThrowsExceptionIfUserTriesToDisableUserJarInclusionInSystemClassPath() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR, "DISABLED");
+
+		try {
+			new YarnClusterDescriptor(
+				configuration,
+				yarnConfiguration,
+				temporaryFolder.getRoot().getAbsolutePath(),
+				yarnClient,
+				true);
+			fail("Expected exception not thrown");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("cannot be set to DISABLED anymore"));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

*This removes `DISABLED` as a possible value for the config option `yarn.per-job-cluster.include-user-jar`. Since Flink 1.5, this feature is broken.*


## Brief change log

  - *See commits*
  
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
