### PR TITLE
[FLINK-11801] [table-api] Port SqlParserException to flink-table-api-java

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlParserException.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SqlParserException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Exception for all errors occurring during sql parsing.
+ *
+ * <p>This exception indicates that the SQL parse failed.
+ */
+@PublicEvolving
+public class SqlParserException extends RuntimeException {
+
+	public SqlParserException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SqlParserException(String message) {
+		super(message);
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -29,18 +29,6 @@ import _root_.scala.collection.JavaConverters._
 case class ExpressionParserException(msg: String) extends RuntimeException(msg)
 
 /**
-  * Exception for all errors occurring during sql parsing.
-  */
-case class SqlParserException(
-    msg: String,
-    cause: Throwable)
-  extends RuntimeException(msg, cause) {
-
-  def this(msg: String) = this(msg, null)
-
-}
-
-/**
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -91,7 +91,7 @@ class FlinkPlannerImpl(
       sqlNode
     } catch {
       case e: CSqlParseException =>
-        throw SqlParserException(s"SQL parse failed. ${e.getMessage}", e)
+        throw new SqlParserException(s"SQL parse failed. ${e.getMessage}", e)
     }
   }
 
@@ -154,7 +154,7 @@ class FlinkPlannerImpl(
       }
       catch {
         case e: CSqlParseException =>
-          throw SqlParserException(s"SQL parse failed. ${e.getMessage}", e)
+          throw new SqlParserException(s"SQL parse failed. ${e.getMessage}", e)
       }
       val catalogReader: CalciteCatalogReader = createCatalogReader(false)
         .withSchemaPath(schemaPath)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Port `SqlParserException` to flink-table-api-java

`SqlParserException` is used in `FlinkPlannerImpl` for sql parsing. We will have another `FlinkPlannerImpl` in flink-table-planner-blink. 

Because `SqlParserException` is an API level exception, we should move it to `flink-table-api-java` to avoid coping it to `flink-table-planner-blink`.

As @twalthr mentioned in #7886, we would move it to `api-java` for now, and move to common when it is really required across many different modules.

## Brief change log

 - Port `SqlParserException` to flink-table-api-java

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
