### PR TITLE
[FLINK-11665] Wait for job termination before recovery in Dispatcher

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -93,7 +93,7 @@ class TestingDispatcher extends Dispatcher {
 			() -> jobReachedGloballyTerminalState(archivedExecutionGraph));
 	}
 
-	CompletableFuture<Void> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {
+	CompletableFuture<JobID> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {
 		return callAsyncWithoutFencing(
 			() -> getJobTerminationFuture(jobId),
 			timeout).thenCompose(Function.identity());


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses a concurrency problem when dispatcher loses leadership and immediately gains it again. When dispatcher recovers the job it has to wait for the termination of previous job run. Otherwise, it can happen job recovery for the next run adds execution graph in HA store and the concurrent termination of the previous run can subsequently remove it which leads to a further inconsistent state of the storage.

## Brief change log

  - Change future ordering in Dispatcher methods which involve job recovery.
  - Add unit tests to check the problem

## Verifying this change

run unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
