### PR TITLE
[FLINK-5080] [Connectors / Cassandra] Cassandra connector ignores saveAsync result onSuccess

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraPojoOutputFormat.java
@@ -68,6 +68,12 @@ public class CassandraPojoOutputFormat<OUT> extends RichOutputFormat<OUT> {
 		this.outputClass = outputClass;
 	}
 
+	public CassandraPojoOutputFormat(ClusterBuilder builder, Class<OUT> outputClass, MapperOptions mapperOptions, FutureCallback<Void> customCallback) {
+		this(builder, outputClass, mapperOptions);
+		Preconditions.checkNotNull(customCallback, "Callback cannot be null");
+		this.callback = customCallback;
+	}
+
 	@Override
 	public void configure(Configuration parameters) {
 		this.cluster = builder.getCluster();
@@ -89,17 +95,19 @@ public class CassandraPojoOutputFormat<OUT> extends RichOutputFormat<OUT> {
 				mapper.setDefaultSaveOptions(optionsArray);
 			}
 		}
-		this.callback = new FutureCallback<Void>() {
-			@Override
-			public void onSuccess(Void ignored) {
-				onWriteSuccess();
-			}
+		if (this.callback == null) {
+			this.callback = new FutureCallback<Void>() {
+				@Override
+				public void onSuccess(Void ignored) {
+					onWriteSuccess();
+				}
 
-			@Override
-			public void onFailure(Throwable t) {
-				onWriteFailure(t);
-			}
-		};
+				@Override
+				public void onFailure(Throwable t) {
+					onWriteFailure(t);
+				}
+			};
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/CustomCassandraAnnotatedPojo2.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/CustomCassandraAnnotatedPojo2.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.batch.connectors.cassandra;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.Table;
+
+/**
+ * Example of Cassandra Annotated POJO class for use with {@link CassandraPojoInputFormat}.
+ */
+@Table(name = CustomCassandraAnnotatedPojo2.TABLE_NAME, keyspace = "flink")
+public class CustomCassandraAnnotatedPojo2 {
+
+	public static final String TABLE_NAME = "batches_custom_callback";
+
+	@Column(name = "id")
+	private String id;
+	@Column(name = "counter")
+	private Integer counter;
+	@Column(name = "batch_id")
+	private Integer batchId;
+
+	/**
+	 * Necessary for the driver's mapper instanciation.
+	 */
+	public CustomCassandraAnnotatedPojo2(){}
+
+	public CustomCassandraAnnotatedPojo2(String id, Integer counter, Integer batchId) {
+		this.id = id;
+		this.counter = counter;
+		this.batchId = batchId;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Integer getCounter() {
+		return counter;
+	}
+
+	public void setCounter(Integer counter) {
+		this.counter = counter;
+	}
+
+	public Integer getBatchId() {
+		return batchId;
+	}
+
+	public void setBatchId(Integer batchId) {
+		this.batchId = batchId;
+	}
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -37,6 +37,7 @@ import org.apache.flink.batch.connectors.cassandra.CassandraPojoOutputFormat;
 import org.apache.flink.batch.connectors.cassandra.CassandraRowOutputFormat;
 import org.apache.flink.batch.connectors.cassandra.CassandraTupleOutputFormat;
 import org.apache.flink.batch.connectors.cassandra.CustomCassandraAnnotatedPojo;
+import org.apache.flink.batch.connectors.cassandra.CustomCassandraAnnotatedPojo2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -53,6 +54,7 @@ import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.mapping.Mapper;
+import com.google.common.util.concurrent.FutureCallback;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -128,6 +130,7 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 
 	private static final ArrayList<Tuple3<String, Integer, Integer>> collection = new ArrayList<>(20);
 	private static final ArrayList<Row> rowCollection = new ArrayList<>(20);
+	private static final ArrayList<String> successWrites = new ArrayList<>();
 
 	private static final TypeInformation[] FIELD_TYPES = {
 		BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO};
@@ -524,6 +527,44 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 		customCassandraAnnotatedPojos.sort(Comparator.comparingInt(CustomCassandraAnnotatedPojo::getCounter));
 
 		assertThat(result, samePropertyValuesAs(customCassandraAnnotatedPojos));
+	}
+
+	@Test
+	public void testCassandraBatchPojoFormatWithCustomCallback() throws Exception {
+
+		session.execute(CREATE_TABLE_QUERY.replace(TABLE_NAME_VARIABLE, CustomCassandraAnnotatedPojo2.TABLE_NAME));
+
+		FutureCallback<Void> callback = new FutureCallback<Void>() {
+			@Override
+			public void onSuccess(Void ignored) {
+				onWriteSuccess();
+			}
+
+			@Override
+			public void onFailure(Throwable t) {
+
+			}
+		};
+
+		OutputFormat<CustomCassandraAnnotatedPojo2> sink = new CassandraPojoOutputFormat<>(builder, CustomCassandraAnnotatedPojo2.class, () -> new Mapper.Option[]{Mapper.Option.saveNullFields(true)}, callback);
+
+		List<CustomCassandraAnnotatedPojo2> customCassandraAnnotatedPojos = IntStream.range(0, 20)
+			.mapToObj(x -> new CustomCassandraAnnotatedPojo2(UUID.randomUUID().toString(), x, 0))
+			.collect(Collectors.toList());
+		try {
+			sink.configure(new Configuration());
+			sink.open(0, 1);
+			for (CustomCassandraAnnotatedPojo2 customCassandraAnnotatedPojo : customCassandraAnnotatedPojos) {
+				sink.writeRecord(customCassandraAnnotatedPojo);
+			}
+		} finally {
+			sink.close();
+		}
+		Assert.assertEquals(20, successWrites.size());
+	}
+
+	private void onWriteSuccess() {
+		successWrites.add("Successful writing");
 	}
 
 	@Test

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -38,7 +38,7 @@ under the License.
 
 		<!-- Cassandra connectors have to use guava directly -->
 		<suppress
-			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormatBase.java|CassandraSinkBase.java|CassandraSinkBaseTest.java|CassandraPojoSink.java|CassandraRowSink.java|CassandraTupleWriteAheadSink.java|CassandraRowWriteAheadSink.java|CassandraPojoOutputFormat.java"
+			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormatBase.java|CassandraSinkBase.java|CassandraSinkBaseTest.java|CassandraPojoSink.java|CassandraRowSink.java|CassandraTupleWriteAheadSink.java|CassandraRowWriteAheadSink.java|CassandraPojoOutputFormat.java|CassandraConnectorITCase.java"
 			checks="IllegalImport"/>
 		<!-- Kinesis producer has to use guava directly -->
 		<suppress


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Add possibility of passing a custom callback in CassandraPojoOutputFormat; in this way we could deal with a success or failure in more custom way


## Brief change log

  - *Added one more constructor in CassandraPojoOutputFormat providing custom callback*
  - *If custom callback is not provided in constructor than callback initiates like before*
  - *Unit test for this change is added*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test that validates that function from custom callback is invoked*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
