### PR TITLE
[FLINK-11817] Uses aggregate function in DataStream API Tutorial

### DIFF
--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -198,7 +198,7 @@ DataStream<Tuple2<String, Long>> result = keyedEdits
 
         @Override
         public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
-          	return new Tuple2<>(a.f0 + b.f0, a.f1 + b.f1);
+          	return new Tuple2<>(a.f0, a.f1 + b.f1);
         }
     });
 {% endhighlight %}
@@ -275,7 +275,7 @@ public class WikipediaAnalysis {
 
       	@Override
       	public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
-      	  return new Tuple2<>(a.f0 + b.f0, a.f1 + b.f1);
+      	  return new Tuple2<>(a.f0, a.f1 + b.f1);
       	}
       });
 

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -178,18 +178,33 @@ that we want to aggregate the sum of edited bytes for every five seconds:
 {% highlight java %}
 DataStream<Tuple2<String, Long>> result = keyedEdits
     .timeWindow(Time.seconds(5))
-    .fold(new Tuple2<>("", 0L), new FoldFunction<WikipediaEditEvent, Tuple2<String, Long>>() {
+    .aggregate(new AggregateFunction<WikipediaEditEvent, Tuple2<String, Long>, Tuple2<String, Long>>() {
         @Override
-        public Tuple2<String, Long> fold(Tuple2<String, Long> acc, WikipediaEditEvent event) {
-            acc.f0 = event.getUser();
-            acc.f1 += event.getByteDiff();
-            return acc;
+        public Tuple2<String, Long> createAccumulator() {
+          	return new Tuple2<>("", 0L);
+        }
+
+        @Override
+        public Tuple2<String, Long> add(WikipediaEditEvent value, Tuple2<String, Long> accumulator) {
+          	accumulator.f0 = value.getUser();
+          	accumulator.f1 += value.getByteDiff();
+            return accumulator;
+        }
+
+        @Override
+        public Tuple2<String, Long> getResult(Tuple2<String, Long> accumulator) {
+          	return accumulator;
+        }
+
+        @Override
+        public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
+          	return a;
         }
     });
 {% endhighlight %}
 
 The first call, `.timeWindow()`, specifies that we want to have tumbling (non-overlapping) windows
-of five seconds. The second call specifies a *Fold transformation* on each window slice for
+of five seconds. The second call specifies a *Aggregate transformation* on each window slice for
 each unique key. In our case we start from an initial value of `("", 0L)` and add to it the byte
 difference of every edit in that time window for a user. The resulting Stream now contains
 a `Tuple2<String, Long>` for every user which gets emitted every five seconds.
@@ -212,7 +227,7 @@ The complete code so far is this:
 {% highlight java %}
 package wikiedits;
 
-import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -240,13 +255,28 @@ public class WikipediaAnalysis {
 
     DataStream<Tuple2<String, Long>> result = keyedEdits
       .timeWindow(Time.seconds(5))
-      .fold(new Tuple2<>("", 0L), new FoldFunction<WikipediaEditEvent, Tuple2<String, Long>>() {
+      .aggregate(new AggregateFunction<WikipediaEditEvent, Tuple2<String, Long>, Tuple2<String, Long>>() {
         @Override
-        public Tuple2<String, Long> fold(Tuple2<String, Long> acc, WikipediaEditEvent event) {
-          acc.f0 = event.getUser();
-          acc.f1 += event.getByteDiff();
-          return acc;
-        }
+      	public Tuple2<String, Long> createAccumulator() {
+      	  return new Tuple2<>("", 0L);
+      	}
+
+      	@Override
+      	public Tuple2<String, Long> add(WikipediaEditEvent value, Tuple2<String, Long> accumulator) {
+      	  accumulator.f0 = value.getUser();
+      	  accumulator.f1 += value.getByteDiff();
+          return accumulator;
+      	}
+
+      	@Override
+      	public Tuple2<String, Long> getResult(Tuple2<String, Long> accumulator) {
+      	  return accumulator;
+      	}
+
+      	@Override
+      	public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
+      	  return a;
+      	}
       });
 
     result.print();
@@ -368,14 +398,14 @@ The output of that command should look similar to this, if everything went accor
 03/08/2016 15:09:27 Job execution switched to status RUNNING.
 03/08/2016 15:09:27 Source: Custom Source(1/1) switched to SCHEDULED
 03/08/2016 15:09:27 Source: Custom Source(1/1) switched to DEPLOYING
-03/08/2016 15:09:27 TriggerWindow(TumblingProcessingTimeWindows(5000), FoldingStateDescriptor{name=window-contents, defaultValue=(,0), serializer=null}, ProcessingTimeTrigger(), WindowedStream.fold(WindowedStream.java:207)) -> Map -> Sink: Unnamed(1/1) switched to SCHEDULED
-03/08/2016 15:09:27 TriggerWindow(TumblingProcessingTimeWindows(5000), FoldingStateDescriptor{name=window-contents, defaultValue=(,0), serializer=null}, ProcessingTimeTrigger(), WindowedStream.fold(WindowedStream.java:207)) -> Map -> Sink: Unnamed(1/1) switched to DEPLOYING
-03/08/2016 15:09:27 TriggerWindow(TumblingProcessingTimeWindows(5000), FoldingStateDescriptor{name=window-contents, defaultValue=(,0), serializer=null}, ProcessingTimeTrigger(), WindowedStream.fold(WindowedStream.java:207)) -> Map -> Sink: Unnamed(1/1) switched to RUNNING
+03/08/2016 15:09:27 Window(TumblingProcessingTimeWindows(5000), ProcessingTimeTrigger, AggregateFunction$3, PassThroughWindowFunction) -> Sink: Print to Std. Out (1/1) switched from CREATED to SCHEDULED
+03/08/2016 15:09:27 Window(TumblingProcessingTimeWindows(5000), ProcessingTimeTrigger, AggregateFunction$3, PassThroughWindowFunction) -> Sink: Print to Std. Out (1/1) switched from SCHEDULED to DEPLOYING
+03/08/2016 15:09:27 Window(TumblingProcessingTimeWindows(5000), ProcessingTimeTrigger, AggregateFunction$3, PassThroughWindowFunction) -> Sink: Print to Std. Out (1/1) switched from DEPLOYING to RUNNING
 03/08/2016 15:09:27 Source: Custom Source(1/1) switched to RUNNING
 {% endhighlight %}
 
 You can see how the individual operators start running. There are only two, because
-the operations after the window get folded into one operation for performance reasons. In Flink
+the operations after the window get aggregated into one operation for performance reasons. In Flink
 we call this *chaining*.
 
 You can observe the output of the program by inspecting the Kafka topic using the Kafka

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -181,7 +181,7 @@ DataStream<Tuple2<String, Long>> result = keyedEdits
     .aggregate(new AggregateFunction<WikipediaEditEvent, Tuple2<String, Long>, Tuple2<String, Long>>() {
         @Override
         public Tuple2<String, Long> createAccumulator() {
-          	return new Tuple2<>("", 0L);
+            return new Tuple2<>("", 0L);
         }
 
         @Override
@@ -193,12 +193,12 @@ DataStream<Tuple2<String, Long>> result = keyedEdits
 
         @Override
         public Tuple2<String, Long> getResult(Tuple2<String, Long> accumulator) {
-          	return accumulator;
+            return accumulator;
         }
 
         @Override
         public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
-          	return new Tuple2<>(a.f0, a.f1 + b.f1);
+            return new Tuple2<>(a.f0, a.f1 + b.f1);
         }
     });
 {% endhighlight %}

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -186,8 +186,8 @@ DataStream<Tuple2<String, Long>> result = keyedEdits
 
         @Override
         public Tuple2<String, Long> add(WikipediaEditEvent value, Tuple2<String, Long> accumulator) {
-          	accumulator.f0 = value.getUser();
-          	accumulator.f1 += value.getByteDiff();
+            accumulator.f0 = value.getUser();
+            accumulator.f1 += value.getByteDiff();
             return accumulator;
         }
 

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -198,7 +198,7 @@ DataStream<Tuple2<String, Long>> result = keyedEdits
 
         @Override
         public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
-          	return a;
+          	return new Tuple2<>(a.f0 + b.f0, a.f1 + b.f1);
         }
     });
 {% endhighlight %}
@@ -275,7 +275,7 @@ public class WikipediaAnalysis {
 
       	@Override
       	public Tuple2<String, Long> merge(Tuple2<String, Long> a, Tuple2<String, Long> b) {
-      	  return a;
+      	  return new Tuple2<>(a.f0 + b.f0, a.f1 + b.f1);
       	}
       });
 
@@ -405,7 +405,7 @@ The output of that command should look similar to this, if everything went accor
 {% endhighlight %}
 
 You can see how the individual operators start running. There are only two, because
-the operations after the window get aggregated into one operation for performance reasons. In Flink
+the operations after the window get folded into one operation for performance reasons. In Flink
 we call this *chaining*.
 
 You can observe the output of the program by inspecting the Kafka topic using the Kafka


### PR DESCRIPTION


## What is the purpose of the change

Fold function is deprecated, thus change it to Aggregate function in DataStream API Tutorial.

## Brief change log

use Aggregate api in DataStream API Tutorial.

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
