### PR TITLE
[FLINK-11803][table-planner-blink] Improve FlinkTypeFactory for Blink

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import org.apache.calcite.rel.`type`.RelDataTypeSystemImpl
+import org.apache.calcite.sql.`type`.SqlTypeName
+
+/**
+  * Custom type system for Flink.
+  */
+class FlinkTypeSystem extends RelDataTypeSystemImpl {
+
+  // we cannot use Int.MaxValue because of an overflow in Calcite's type inference logic
+  // half should be enough for all use cases
+  override def getMaxNumericScale: Int = Int.MaxValue / 2
+
+  // we cannot use Int.MaxValue because of an overflow in Calcite's type inference logic
+  // half should be enough for all use cases
+  override def getMaxNumericPrecision: Int = Int.MaxValue / 2
+
+  override def getDefaultPrecision(typeName: SqlTypeName): Int = typeName match {
+
+    // Calcite will limit the length of the VARCHAR field to 65536
+    case SqlTypeName.VARCHAR =>
+      Int.MaxValue
+
+    // we currently support only timestamps with milliseconds precision
+    case SqlTypeName.TIMESTAMP =>
+      3
+
+    case _ =>
+      super.getDefaultPrecision(typeName)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/ArrayRelDataType.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/ArrayRelDataType.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.schema
+
+import org.apache.flink.table.`type`.ArrayType
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.sql.`type`.ArraySqlType
+
+/**
+  * Flink distinguishes between primitive arrays (int[], double[], ...) and
+  * object arrays (Integer[], MyPojo[], ...). This custom type supports both cases.
+  */
+class ArrayRelDataType(
+    val arrayType: ArrayType,
+    elementType: RelDataType,
+    isNullable: Boolean)
+  extends ArraySqlType(
+    elementType,
+    isNullable) {
+
+  override def toString = s"ARRAY($arrayType)"
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[ArrayRelDataType]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ArrayRelDataType =>
+      super.equals(that) &&
+        (that canEqual this) &&
+          arrayType == that.arrayType &&
+        isNullable == that.isNullable
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    arrayType.hashCode()
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/MapRelDataType.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/MapRelDataType.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.schema
+
+import org.apache.flink.table.`type`.MapType
+
+import com.google.common.base.Objects
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.sql.`type`.MapSqlType
+
+class MapRelDataType(
+   val mapType: MapType,
+   val keyType: RelDataType,
+   val valueType: RelDataType,
+   isNullable: Boolean) extends MapSqlType(keyType, valueType, isNullable) {
+
+  override def toString: String = s"MAP($mapType)"
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[MapRelDataType]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MapRelDataType =>
+      super.equals(that) &&
+        (that canEqual this) &&
+        keyType == that.keyType &&
+        valueType == that.valueType &&
+        isNullable == that.isNullable
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    Objects.hashCode(keyType, valueType)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/RowRelDataType.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/RowRelDataType.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.schema
+
+import java.util
+import org.apache.calcite.rel.`type`.{RelDataTypeField, RelDataTypeFieldImpl, RelRecordType, StructKind}
+import org.apache.flink.table.`type`.RowType
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.schema.RowRelDataType.createFieldList
+
+import scala.collection.JavaConverters._
+
+/**
+  * Row type for encapsulating Flink's [[RowType]].
+  *
+  * @param rowType rowType to encapsulate
+  * @param nullable flag if type can be nullable
+  * @param typeFactory Flink's type factory
+  */
+class RowRelDataType(
+    val rowType: RowType,
+    val nullable: Boolean,
+    typeFactory: FlinkTypeFactory)
+  extends RelRecordType(
+    StructKind.PEEK_FIELDS_NO_EXPAND,
+    createFieldList(rowType, typeFactory)) {
+
+  override def toString = s"ROW($rowType)"
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[RowRelDataType]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: RowRelDataType =>
+      super.equals(that) &&
+        (that canEqual this) &&
+          rowType == that.rowType &&
+        nullable == that.nullable
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    rowType.hashCode()
+  }
+
+  override def isNullable: Boolean = nullable
+
+}
+
+object RowRelDataType {
+
+  /**
+    * Converts the fields of a row type to list of [[RelDataTypeField]].
+    */
+  private def createFieldList(
+      rowType: RowType,
+      typeFactory: FlinkTypeFactory)
+    : util.List[RelDataTypeField] = {
+
+    rowType
+      .getFieldNames
+      .zipWithIndex
+      .map { case (name, index) =>
+        new RelDataTypeFieldImpl(
+          name,
+          index,
+          // TODO the row type should provide the information if subtypes are nullable
+          typeFactory.createTypeFromInternalType(rowType.getTypeAt(index), isNullable = true)
+        ).asInstanceOf[RelDataTypeField]
+      }
+      .toList
+      .asJava
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.schema
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.`type`.{InternalType, RowType}
+import org.apache.flink.table.calcite.FlinkTypeFactory
+
+import scala.collection.JavaConversions._
+
+/**
+  * Schema that describes both a logical and physical row.
+  */
+class RowSchema(private val logicalRowType: RelDataType) {
+
+  private lazy val internalFieldTypes: Seq[InternalType] =
+    logicalRowType.getFieldList map { f => FlinkTypeFactory.toInternalType(f.getType) }
+
+  private lazy val internalRowType: RowType = new RowType(
+    internalFieldTypes.toArray, fieldNames.toArray)
+
+  /**
+    * Returns the arity of the schema.
+    */
+  def arity: Int = logicalRowType.getFieldCount
+
+  /**
+    * Returns the [[RelDataType]] of the schema
+    */
+  def relDataType: RelDataType = logicalRowType
+
+  /**
+    * Returns the [[RowType]] of the schema
+    */
+  def internalType: RowType = internalRowType
+
+  /**
+    * Returns the [[RowType]] of fields of the schema
+    */
+  def fieldInternalTypes: Seq[InternalType] = internalFieldTypes
+
+  /**
+    * Returns the fields names
+    */
+  def fieldNames: Seq[String] = logicalRowType.getFieldNames
+
+  /**
+    * Returns a projected [[TypeInformation]] of the schema.
+    */
+  def projectedInternalType(fields: Array[Int]): RowType = {
+    val projectedTypes = fields.map(fieldInternalTypes(_))
+    val projectedNames = fields.map(fieldNames(_))
+    new RowType(projectedTypes, projectedNames)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/calcite/FlinkTypeFactoryTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/calcite/FlinkTypeFactoryTest.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import org.apache.flink.table.`type`.{InternalType, InternalTypes}
+
+import org.junit.{Assert, Test}
+
+class FlinkTypeFactoryTest {
+
+  @Test
+  def testInternalToRelType(): Unit = {
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem)
+
+    def test(t: InternalType): Unit = {
+      Assert.assertEquals(
+        t,
+        FlinkTypeFactory.toInternalType(
+          typeFactory.createTypeFromInternalType(t, isNullable = true))
+      )
+
+      Assert.assertEquals(
+        t,
+        FlinkTypeFactory.toInternalType(
+          typeFactory.createTypeFromInternalType(t, isNullable = false))
+      )
+
+      // twice for cache.
+      Assert.assertEquals(
+        t,
+        FlinkTypeFactory.toInternalType(
+          typeFactory.createTypeFromInternalType(t, isNullable = true))
+      )
+
+      Assert.assertEquals(
+        t,
+        FlinkTypeFactory.toInternalType(
+          typeFactory.createTypeFromInternalType(t, isNullable = false))
+      )
+    }
+
+    test(InternalTypes.BOOLEAN)
+    test(InternalTypes.BYTE)
+    test(InternalTypes.STRING)
+    test(InternalTypes.DOUBLE)
+    test(InternalTypes.FLOAT)
+    test(InternalTypes.INT)
+    test(InternalTypes.LONG)
+    test(InternalTypes.SHORT)
+    test(InternalTypes.BINARY)
+    test(InternalTypes.DATE)
+    test(InternalTypes.TIME)
+    test(InternalTypes.TIMESTAMP)
+
+    test(InternalTypes.createArrayType(InternalTypes.DOUBLE))
+    test(InternalTypes.createMapType(InternalTypes.DOUBLE, InternalTypes.STRING))
+    test(InternalTypes.createRowType(InternalTypes.DOUBLE, InternalTypes.STRING))
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Improve FlinkTypeFactory for createTypeFromInternalType and toInternalType

## Verifying this change

ut

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no))

## Documentation

  - Does this pull request introduce a new feature? (no)