### PR TITLE
[FLINK-11826] Fix flaky Kafka ratelimiter test

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Properties;
 
 /**
  * IT cases for Kafka 0.9 .
@@ -202,7 +203,12 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 			}
 		});
 
-		stream.addSink(new FlinkKafkaProducer09<>(testTopic, new SimpleStringSchema(), standardProps)).setParallelism(1);
+		Properties producerProperties = new Properties();
+		producerProperties.putAll(standardProps);
+		producerProperties.putAll(secureProps);
+		producerProperties.put("retries", 3);
+
+		stream.addSink(new FlinkKafkaProducer09<>(testTopic, new SimpleStringSchema(), producerProperties));
 		env.execute("Produce 100 bytes of data to test topic");
 
 		// ---------- Consumer from Kafka in a ratelimited way -----------

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -168,7 +168,6 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 	 * a desired rate of 3 bytes / second. Based on the execution time, the test asserts that this rate was not surpassed.
 	 * If no rate limiter is set on the consumer, the test should fail.
 	 */
-	@Ignore
 	@Test(timeout = 60000)
 	public void testRateLimitedConsumer() throws Exception {
 		final String testTopic = "testRateLimitedConsumer";

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -34,7 +34,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -217,7 +217,7 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 		env.getConfig().disableSysoutLogging();
 
 		// ---------- RateLimiter config -------------
-		long globalRate = 3; // bytes/second
+		long globalRate = 10; // bytes/second
 		FlinkKafkaConsumer09<String> consumer09 = new FlinkKafkaConsumer09<>(testTopic,
 			new StringDeserializer(globalRate), standardProps);
 		FlinkConnectorRateLimiter rateLimiter = new GuavaFlinkConnectorRateLimiter();


### PR DESCRIPTION
## What is the purpose of the change

A test PR to re-run and remove flakiness from`testRateLimitedConsumer()` in `Kafka09ITCase` 
## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
