### PR TITLE
[FLINK-11819][Documentation] Fix wrong description about attribute order by supported now

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -707,7 +707,7 @@ WHERE product EXISTS (
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
       <td>
-<b>Note:</b> The result of streaming queries must be primarily sorted on an ascending <a href="streaming/time_attributes.html">time attribute</a>. Additional sorting attributes are supported.
+<b>Note:</b> The result of streaming queries must be primarily sorted on an ascending <a href="streaming/time_attributes.html">time attribute</a>. Additional sorting attributes are not supported yet.
 
 {% highlight sql %}
 SELECT *


### PR DESCRIPTION

## What is the purpose of the change
This pull request  fix mistake about the description of attribute supported by `order by`.

Only time attribute is supported, additional attributes are not supported yet.

## Brief change log

  -  Fix mistake in docs about wrong description attribute `order by` supported



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
