### PR TITLE
[FLINK-11829][checkpoint] Avoid FsCheckpointStateOutputStream to store state in files when size below fileStateThreshold

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -187,7 +187,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
 		@Override
 		public void write(byte[] b, int off, int len) throws IOException {
-			if (len < writeBuffer.length / 2) {
+			if (len < writeBuffer.length) {
 				// copy it into our write buffer first
 				final int remaining = writeBuffer.length - pos;
 				if (len > remaining) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
@@ -86,7 +86,7 @@ public class FsCheckpointStateOutputStreamTest {
 
 	@Test
 	public void testStateBelowMemThreshold() throws Exception {
-		runTest(222, 999, 512, false);
+		runTest(999, 1024, 1000, false);
 	}
 
 	@Test
@@ -216,7 +216,8 @@ public class FsCheckpointStateOutputStreamTest {
 				stream.write(bytes[pos++]);
 			}
 			else {
-				int num = rnd.nextInt(Math.min(10, bytes.length - pos));
+				int num = rnd.nextBoolean() ?
+					(bytes.length - pos) : rnd.nextInt(bytes.length - pos);
 				stream.write(bytes, pos, num);
 				pos += num;
 			}


### PR DESCRIPTION

## What is the purpose of the change

Avoid `FsCheckpointStateOutputStream` to store state in files when size below file state threshold.


## Brief change log
  - fix the implementation bug of `FsCheckpointStateOutputStream#write(byte[] , int , int)`


## Verifying this change
This change added tests and can be verified as follows:

  - Modify previous `FsCheckpointStateOutputStreamTest#testStateBelowMemThreshold` to verify this PR fix the bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
