### PR TITLE
[FLINK-11082][network] Fix the calculation of backlog in PipelinedSubpartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -367,7 +367,11 @@ class PipelinedSubpartition extends ResultSubpartition {
 	@SuppressWarnings("FieldAccessNotGuarded")
 	@VisibleForTesting
 	public int getBuffersInBacklog() {
-		return buffersInBacklog;
+		if (flushRequested || isFinished) {
+			return buffersInBacklog;
+		} else {
+			return Math.max(buffersInBacklog - 1, 0);
+		}
 	}
 
 	private boolean shouldNotifyDataAvailable() {


### PR DESCRIPTION
## What is the purpose of the change

*The backlog of subpartition should indicate how many buffers are consumable, then the consumer could feedback the corresponding credits for transporting these buffers. But in current `PipelinedSubpartition` implementation, the backlog is increased by 1 when a `BufferConsumer` is added into `PipelinedSubpartition`, and decreased by 1 when a `BufferConsumer` is removed from `PipelinedSubpartition`.  So the backlog only reflects how many buffers are retained in `PipelinedSubpartition`, which is not always equivalent to the number of consumable buffers.*

*The backlog inconsistency might result in floating buffers misdistribution on consumer side, because the consumer would request floating buffers based on backlog value, then one floating buffer might not be used in `RemoteInputChannel` long time after requesting.*

*Considering the solution, the last buffer in `PipelinedSubpartition` could only be consumable in the case of flush triggered or partition finished. So we could calculate the backlog precisely based on partition flushed/finished conditions.*

## Brief change log

  - *Adjust the implementation in `PipelinedSubpartition#getBuffersInBacklog` to decrease 1 if not flushed or finished.*
  - *Adjust the previous old unit tests and add new unit tests*

## Verifying this change

*Add three new unit tests `testBacklogConsistentWithNumberOfConsumableBuffers` in `PipelinedSubpartitionWithReadViewTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)