### PR TITLE
[FLINK-11786][travis] Merge cron branches into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,32 +60,31 @@ before_install:
    - chmod +x docker-compose
    - sudo mv docker-compose /usr/local/bin
 
-# When modifying the matrix you also have to modify travis_controller.sh#getCurrentStage
 jdk: "oraclejdk8"
 jobs:
   include:
     # main profile
     - stage: compile
-      script: ./tools/travis_controller.sh
+      script: ./tools/travis_controller.sh compile
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: compile
     - stage: test
-      script: ./tools/travis_controller.sh
+      script: ./tools/travis_controller.sh core
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: core
-    - script: ./tools/travis_controller.sh
+    - script: ./tools/travis_controller.sh libraries
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: libraries
-    - script: ./tools/travis_controller.sh
+    - script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: connectors
-    - script: ./tools/travis_controller.sh
+    - script: ./tools/travis_controller.sh tests
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: tests
-    - script: ./tools/travis_controller.sh
+    - script: ./tools/travis_controller.sh misc
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: misc
     - stage: cleanup
-      script: ./tools/travis_controller.sh
+      script: ./tools/travis_controller.sh cleanup
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,13 @@ before_install:
    - chmod +x docker-compose
    - sudo mv docker-compose /usr/local/bin
 
+notifications:
+  slack:
+    rooms:
+      - secure: ikPQn5JTpkyzxVyOPm/jIl3FPm6hY8xAdG4pSwxGWjBqF+NmmNTp9YZsJ6fD8xPql6T5n1hNDbZSC14jVUw/vvXGvibDXLN+06f25ZQl+4LJBXaiR7gTG6y3nO8G90Vw7XpvCme6n5Md9tvjygb17a4FEgRJFfwzWnnyPA1yvK0=
+    on_success: never
+    on_pull_requests: false
+
 stages:
   - name: compile
   - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ cache:
   # default timeout is too low
   timeout: 600
   directories:
+  - $HOME/.rvm/
   - $HOME/.m2
   - $HOME/flink_cache
   # keep in sync with tools/travis/setup_maven.sh
@@ -60,6 +61,13 @@ before_install:
    - chmod +x docker-compose
    - sudo mv docker-compose /usr/local/bin
 
+stages:
+  - name: compile
+  - name: test
+  - name: E2E
+    if: type = cron
+  - name: cleanup
+
 jdk: "oraclejdk8"
 jobs:
   include:
@@ -95,3 +103,169 @@ jobs:
       script: ./tools/travis_controller.sh cleanup
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: cleanup
+    # hadoop 2.4.1 profile
+    - if: type = cron
+      stage: compile
+      script: ./tools/travis_controller.sh compile
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: compile - hadoop 2.4.1
+    - if: type = cron
+      stage: test
+      script: ./tools/travis_controller.sh core
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: core - hadoop 2.4.1
+    - if: type = cron
+      script: ./tools/travis_controller.sh libraries
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: libraries - hadoop 2.4.1
+    - if: type = cron
+      script: ./tools/travis_controller.sh connectors
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: connectors - hadoop 2.4.1
+    - if: type = cron
+      script: ./tools/travis_controller.sh tests
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: tests - hadoop 2.4.1
+    - if: type = cron
+      script: ./tools/travis_controller.sh misc
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: misc - hadoop 2.4.1
+    - if: type = cron
+      stage: cleanup
+      script: ./tools/travis_controller.sh cleanup
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pinclude-kinesis"
+      name: cleanup - hadoop 2.4.1
+    # scala 2.12 profile
+    - if: type = cron
+      stage: compile
+      script: ./tools/travis_controller.sh compile
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: compile - scala 2.12
+    - if: type = cron
+      stage: test
+      script: ./tools/travis_controller.sh core
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: core - scala 2.12
+    - if: type = cron
+      script: ./tools/travis_controller.sh libraries
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: libraries - scala 2.12
+    - if: type = cron
+      script: ./tools/travis_controller.sh connectors
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: connectors - scala 2.12
+    - if: type = cron
+      script: ./tools/travis_controller.sh tests
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: tests - scala 2.12
+    - if: type = cron
+      script: ./tools/travis_controller.sh misc
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: misc - scala 2.12
+    - if: type = cron
+      stage: cleanup
+      script: ./tools/travis_controller.sh cleanup
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.112"
+      name: cleanup - scala 2.12
+    # JDK9 profile
+    - if: type = cron
+      jdk: "openjdk9"
+      stage: compile
+      script: ./tools/travis_controller.sh compile
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: compile - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      stage: test
+      script: ./tools/travis_controller.sh core
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: core - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      script: ./tools/travis_controller.sh libraries
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: libraries - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      script: ./tools/travis_controller.sh connectors
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: connectors - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      script: ./tools/travis_controller.sh tests
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: tests - jdk 9
+    - if: type = cron
+      jdk: "openjdk9"
+      script: ./tools/travis_controller.sh misc
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: misc
+    - if: type = cron
+      jdk: "openjdk9"
+      stage: cleanup
+      script: ./tools/travis_controller.sh cleanup
+      env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11 -Djdk9 -Djapicmp.skip=true"
+      name: cleanup - jdk 9
+    # Documentation 404 check
+    - if: type = cron
+      stage: compile
+      script: ./tools/travis/docs.sh
+      language: ruby
+      rvm: 2.4.0
+      name: Documentation links check
+    # E2E profile
+    - stage: E2E
+      env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -De2e-metrics"
+      script: ./tools/travis/nightly.sh split_misc.sh
+      name: misc - hadoop 2.8
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3"
+      script: ./tools/travis/nightly.sh split_ha.sh
+      name: ha - hadoop 2.8
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3"
+      script: ./tools/travis/nightly.sh split_sticky.sh
+      name: sticky - hadoop 2.8
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3"
+      script: ./tools/travis/nightly.sh split_checkpoints.sh
+      name: checkpoints - hadoop 2.8
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3"
+      script: ./tools/travis/nightly.sh split_container.sh
+      name: container - hadoop 2.8
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3"
+      script: ./tools/travis/nightly.sh split_heavy.sh
+      name: heavy - hadoop 2.8
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -De2e-metrics"
+      script: ./tools/travis/nightly.sh split_misc.sh
+      name: misc - scala 2.12
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12"
+      script: ./tools/travis/nightly.sh split_ha.sh
+      name: ha - scala 2.12
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12"
+      script: ./tools/travis/nightly.sh split_sticky.sh
+      name: sticky - scala 2.12
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12"
+      script: ./tools/travis/nightly.sh split_checkpoints.sh
+      name: checkpoints - scala 2.12
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12"
+      script: ./tools/travis/nightly.sh split_container.sh
+      name: container - scala 2.12
+    - env: PROFILE="-Pinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12"
+      script: ./tools/travis/nightly.sh split_heavy.sh
+      name: heavy - scala 2.12
+    - env: PROFILE="-De2e-metrics"
+      script: ./tools/travis/nightly.sh split_misc_hadoopfree.sh
+      name: misc
+    - env: PROFILE=""
+      script: ./tools/travis/nightly.sh split_ha.sh
+      name: ha
+    - env: PROFILE=""
+      script: ./tools/travis/nightly.sh split_sticky.sh
+      name: sticky
+    - env: PROFILE=""
+      script: ./tools/travis/nightly.sh split_checkpoints.sh
+      name: checkpoints
+    - env: PROFILE=""
+      script: ./tools/travis/nightly.sh split_container.sh
+      name: container
+    - env: PROFILE=""
+      script: ./tools/travis/nightly.sh split_heavy.sh
+      name: heavy

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,27 +64,34 @@ jdk: "oraclejdk8"
 jobs:
   include:
     # main profile
-    - stage: compile
+    - if: type in (pull_request, push)
+      stage: compile
       script: ./tools/travis_controller.sh compile
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: compile
-    - stage: test
+    - if: type in (pull_request, push)
+      stage: test
       script: ./tools/travis_controller.sh core
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: core
-    - script: ./tools/travis_controller.sh libraries
+    - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh libraries
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: libraries
-    - script: ./tools/travis_controller.sh connectors
+    - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh connectors
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: connectors
-    - script: ./tools/travis_controller.sh tests
+    - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh tests
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: tests
-    - script: ./tools/travis_controller.sh misc
+    - if: type in (pull_request, push)
+      script: ./tools/travis_controller.sh misc
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: misc
-    - stage: cleanup
+    - if: type in (pull_request, push)
+      stage: cleanup
       script: ./tools/travis_controller.sh cleanup
       env: PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis -Dinclude_hadoop_aws -Dscala-2.11"
       name: cleanup

--- a/tools/travis/docs.sh
+++ b/tools/travis/docs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+.docs/build_docs.sh -p &
+
+for i in `seq 1 30`;
+do
+	echo "Waiting for server..."
+	curl -Is http://localhost:4000 --fail
+	if [ $? -eq 0 ]; then
+		break
+	fi
+	sleep 10
+done
+
+./docs/check_links.sh

--- a/tools/travis/nightly.sh
+++ b/tools/travis/nightly.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+HERE="`dirname \"$0\"`"				# relative
+HERE="`( cd \"${HERE}\" && pwd -P)`" 	# absolutized and normalized
+if [ -z "${HERE}" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+
+ARTIFACTS_DIR="${HERE}/artifacts"
+FLINK_DIR="${HERE}/flink"
+
+mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
+
+LOG4J_PROPERTIES=${FLINK_DIR}/tools/log4j-travis.properties
+
+MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configuration=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+MVN_COMMON_OPTIONS="-nsu -B -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast"
+MVN_COMPILE_OPTIONS="-T1C -DskipTests"
+
+cp tools/travis/splits/* ${FLINK_DIR}/flink-end-to-end-tests
+
+cd "${FLINK_DIR}"
+
+COMMIT_HASH=$(git rev-parse HEAD)
+echo "Testing branch ${BRANCH} from remote ${REMOTE}. Commit hash: ${COMMIT_HASH}"
+
+e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')
+MVN_COMPILE="mvn ${MVN_COMMON_OPTIONS} ${MVN_COMPILE_OPTIONS} ${MVN_LOGGING_OPTIONS} ${PROFILE} clean install -pl ${e2e_modules},flink-dist -am"
+
+eval "${MVN_COMPILE}"
+EXIT_CODE=$?
+
+if [ $EXIT_CODE == 0 ]; then
+	printf "\n\n==============================================================================\n"
+	printf "Running Java end-to-end tests\n"
+	printf "==============================================================================\n"
+
+	MVN_TEST="mvn ${MVN_COMMON_OPTIONS} ${MVN_LOGGING_OPTIONS} ${PROFILE} verify -pl ${e2e_modules} -DdistDir=$(readlink -e build-target)"
+
+	eval "${MVN_TEST}"
+	EXIT_CODE=$?
+else
+	printf "\n\n==============================================================================\n"
+	printf "Compile failure detected, skipping Java end-to-end tests\n"
+	printf "==============================================================================\n"
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+	printf "\n\n==============================================================================\n"
+	printf "Running end-to-end tests\n"
+	printf "==============================================================================\n"
+
+	FLINK_DIR=build-target flink-end-to-end-tests/${SCRIPT}
+
+	EXIT_CODE=$?
+else
+	printf "\n\n==============================================================================\n"
+	printf "Compile failure detected, skipping end-to-end tests\n"
+	printf "==============================================================================\n"
+fi
+
+# Exit code for Travis build success/failure
+exit ${EXIT_CODE}

--- a/tools/travis/splits/split_checkpoints.sh
+++ b/tools/travis/splits/split_checkpoints.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd )`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Resuming Savepoint (file, async, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file true"
+run_test "Resuming Savepoint (file, sync, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file false"
+run_test "Resuming Savepoint (file, async, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file true"
+run_test "Resuming Savepoint (file, sync, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file false"
+run_test "Resuming Savepoint (file, async, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file true"
+run_test "Resuming Savepoint (file, sync, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file false"
+run_test "Resuming Savepoint (rocks, no parallelism change, heap timers) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 rocks false heap"
+run_test "Resuming Savepoint (rocks, scale up, heap timers) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 rocks false heap"
+run_test "Resuming Savepoint (rocks, scale down, heap timers) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 rocks false heap"
+run_test "Resuming Savepoint (rocks, no parallelism change, rocks timers) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 rocks false rocks"
+run_test "Resuming Savepoint (rocks, scale up, rocks timers) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 rocks false rocks"
+run_test "Resuming Savepoint (rocks, scale down, rocks timers) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 rocks false rocks"
+
+run_test "Resuming Externalized Checkpoint (file, async, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 file true true"
+run_test "Resuming Externalized Checkpoint (file, sync, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 file false true"
+run_test "Resuming Externalized Checkpoint (file, async, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 4 file true true"
+run_test "Resuming Externalized Checkpoint (file, sync, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 4 file false true"
+run_test "Resuming Externalized Checkpoint (file, async, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 4 2 file true true"
+run_test "Resuming Externalized Checkpoint (file, sync, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 4 2 file false true"
+run_test "Resuming Externalized Checkpoint (rocks, non-incremental, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 rocks true false"
+run_test "Resuming Externalized Checkpoint (rocks, incremental, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 rocks true true"
+run_test "Resuming Externalized Checkpoint (rocks, non-incremental, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 4 rocks true false"
+run_test "Resuming Externalized Checkpoint (rocks, incremental, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 4 rocks true true"
+run_test "Resuming Externalized Checkpoint (rocks, non-incremental, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 4 2 rocks true false"
+run_test "Resuming Externalized Checkpoint (rocks, incremental, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 4 2 rocks true true"
+
+run_test "Resuming Externalized Checkpoint after terminal failure (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 file true false true"
+run_test "Resuming Externalized Checkpoint after terminal failure (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 file false false true"
+run_test "Resuming Externalized Checkpoint after terminal failure (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 rocks true false true"
+run_test "Resuming Externalized Checkpoint after terminal failure (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 rocks true true true"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/splits/split_container.sh
+++ b/tools/travis/splits/split_container.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd -P)`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Running Kerberized YARN on Docker test " "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
+
+run_test "Run kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/splits/split_ha.sh
+++ b/tools/travis/splits/split_ha.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd -P)`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Running HA dataset end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_dataset.sh" "skip_check_exceptions"
+
+run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file true false" "skip_check_exceptions"
+run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file false false" "skip_check_exceptions"
+run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true false" "skip_check_exceptions"
+run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true true" "skip_check_exceptions"
+
+run_test "Running HA per-job cluster (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file true false" "skip_check_exceptions"
+run_test "Running HA per-job cluster (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file false false" "skip_check_exceptions"
+run_test "Running HA per-job cluster (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true false" "skip_check_exceptions"
+run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true true" "skip_check_exceptions"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/splits/split_heavy.sh
+++ b/tools/travis/splits/split_heavy.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd )`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Heavy deployment end-to-end test" "$END_TO_END_DIR/test-scripts/test_heavy_deployment.sh" "skip_check_exceptions"
+
+run_test "ConnectedComponents iterations with high parallelism end-to-end test" "$END_TO_END_DIR/test-scripts/test_high_parallelism_iterations.sh 25"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd -P)`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Flink CLI end-to-end test" "$END_TO_END_DIR/test-scripts/test_cli.sh"
+
+run_test "Queryable state (rocksdb) end-to-end test" "$END_TO_END_DIR/test-scripts/test_queryable_state.sh rocksdb"
+run_test "Queryable state (rocksdb) with TM restart end-to-end test" "$END_TO_END_DIR/test-scripts/test_queryable_state_restart_tm.sh" "skip_check_exceptions"
+
+run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
+run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh" "skip_check_exceptions"
+run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh" "skip_check_exceptions"
+run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh" "skip_check_exceptions"
+run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3" "skip_check_exceptions"
+run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
+
+run_test "Elasticsearch (v1.7.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
+run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"
+run_test "Elasticsearch (v5.1.2) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 5 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
+run_test "Elasticsearch (v6.3.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 6 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.1.tar.gz"
+
+run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
+run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
+
+run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
+
+run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh file"
+run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks"
+
+run_test "SQL Client end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_client.sh"
+run_test "SQL Client end-to-end test for Kafka 0.10" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka010.sh"
+run_test "SQL Client end-to-end test for Kafka 0.11" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka011.sh"
+run_test "SQL Client end-to-end test for modern Kafka" "$END_TO_END_DIR/test-scripts/test_sql_client_kafka.sh"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/splits/split_misc_hadoopfree.sh
+++ b/tools/travis/splits/split_misc_hadoopfree.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd -P)`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Flink CLI end-to-end test" "$END_TO_END_DIR/test-scripts/test_cli.sh"
+
+run_test "Queryable state (rocksdb) end-to-end test" "$END_TO_END_DIR/test-scripts/test_queryable_state.sh rocksdb"
+run_test "Queryable state (rocksdb) with TM restart end-to-end test" "$END_TO_END_DIR/test-scripts/test_queryable_state_restart_tm.sh" "skip_check_exceptions"
+
+run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
+run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh" "skip_check_exceptions"
+run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh" "skip_check_exceptions"
+run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3" "skip_check_exceptions"
+run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
+
+run_test "Elasticsearch (v1.7.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
+run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"
+run_test "Elasticsearch (v5.1.2) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 5 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
+run_test "Elasticsearch (v6.3.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 6 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.1.tar.gz"
+
+run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
+run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
+
+run_test "Avro Confluent Schema Registry nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_confluent_schema_registry.sh"
+
+run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh file"
+run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/splits/split_sticky.sh
+++ b/tools/travis/splits/split_sticky.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+END_TO_END_DIR="`dirname \"$0\"`" # relative
+END_TO_END_DIR="`( cd \"$END_TO_END_DIR\" && pwd -P)`" # absolutized and normalized
+if [ -z "$END_TO_END_DIR" ] ; then
+    # error; for some reason, the path is not accessible
+    # to the script (e.g. permissions re-evaled after suid)
+    exit 1  # fail
+fi
+
+export END_TO_END_DIR
+
+if [ -z "$FLINK_DIR" ] ; then
+    echo "You have to export the Flink distribution directory as FLINK_DIR"
+    exit 1
+fi
+
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
+
+FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized
+
+echo "flink-end-to-end-test directory: $END_TO_END_DIR"
+echo "Flink distribution directory: $FLINK_DIR"
+
+# Template for adding a test:
+
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false false" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false true" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false false" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true" "skip_check_exceptions"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true" "skip_check_exceptions"
+
+printf "\n[PASS] All tests passed\n"
+exit 0

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -38,6 +38,14 @@ flink-scala,\
 flink-streaming-java,\
 flink-streaming-scala"
 
+MODULES_CORE_JDK9_EXCLUSIONS="\
+!flink-state-backends/flink-statebackend-rocksdb,\
+!flink-clients,\
+!flink-java,\
+!flink-runtime,\
+!flink-scala,\
+!flink-scala-shell"
+
 MODULES_LIBRARIES="\
 flink-libraries/flink-cep,\
 flink-libraries/flink-cep-scala,\
@@ -89,8 +97,32 @@ flink-connectors/flink-connector-nifi,\
 flink-connectors/flink-connector-rabbitmq,\
 flink-connectors/flink-connector-twitter"
 
+MODULES_CONNECTORS_JDK9_EXCLUSIONS="\
+!flink-filesystems/flink-hadoop-fs,\
+!flink-filesystems/flink-mapr-fs,\
+!flink-filesystems/flink-s3-fs-hadoop,\
+!flink-filesystems/flink-s3-fs-presto,\
+!flink-formats/flink-avro,\
+!flink-connectors/flink-hbase,\
+!flink-connectors/flink-connector-cassandra,\
+!flink-connectors/flink-connector-elasticsearch,\
+!flink-connectors/flink-connector-kafka-0.9,\
+!flink-connectors/flink-connector-kafka-0.10,\
+!flink-connectors/flink-connector-kafka-0.11"
+
 MODULES_TESTS="\
 flink-tests"
+
+MODULES_TESTS_JDK9_EXCLUSIONS="\
+!flink-tests"
+
+MODULES_MISC_JDK9_EXCLUSIONS="\
+!flink-metrics/flink-metrics-jmx,\
+!flink-metrics/flink-metrics-dropwizard,\
+!flink-metrics/flink-metrics-prometheus,\
+!flink-metrics/flink-metrics-statsd,\
+!flink-metrics/flink-metrics-slf4j,\
+!flink-yarn-tests"
 
 if [[ ${PROFILE} == *"include-kinesis"* ]]; then
     MODULES_CONNECTORS="$MODULES_CONNECTORS,flink-connectors/flink-connector-kinesis"
@@ -99,6 +131,7 @@ fi
 # we can only build the Kafka 0.8 connector when building for Scala 2.11
 if [[ $PROFILE == *"scala-2.11"* ]]; then
     MODULES_CONNECTORS="$MODULES_CONNECTORS,flink-connectors/flink-connector-kafka-0.8"
+    MODULES_CONNECTORS_JDK9_EXCLUSIONS="${MODULES_CONNECTORS_JDK9_EXCLUSIONS},!flink-connectors/flink-connector-kafka-0.8"
 fi
 
 # we can only build the Scala Shell when building for Scala 2.11
@@ -132,25 +165,40 @@ function get_compile_modules_for_stage() {
 function get_test_modules_for_stage() {
     local stage=$1
 
+    local modules_core=$MODULES_CORE
+    local modules_libraries=$MODULES_LIBRARIES
+    local modules_connectors=$MODULES_CONNECTORS
+    local modules_tests=$MODULES_TESTS
+    local negated_core=\!${MODULES_CORE//,/,\!}
+    local negated_libraries=\!${MODULES_LIBRARIES//,/,\!}
+    local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
+    local negated_tests=\!${MODULES_TESTS//,/,\!}
+    local modules_misc="$negated_core,$negated_libraries,$negated_connectors,$negated_tests"
+
+    # various modules fail testing on JDK 9; exclude them
+    if [[ ${PROFILE} == *"jdk9"* ]]; then
+        modules_core="$modules_core,$MODULES_CORE_JDK9_EXCLUSIONS"
+        modules_connectors="$modules_connectors,$MODULES_CONNECTORS_JDK9_EXCLUSIONS"
+        # add flink-annotations so that at least one module is tested, otherwise maven fails
+        modules_tests="$modules_tests,$MODULES_TESTS_JDK9_EXCLUSIONS,flink-annotations"
+        modules_misc="$modules_misc,$MODULES_MISC_JDK9_EXCLUSIONS"
+    fi
+
     case ${stage} in
         (${STAGE_CORE})
-            echo "-pl $MODULES_CORE"
+            echo "-pl $modules_core"
         ;;
         (${STAGE_LIBRARIES})
-            echo "-pl $MODULES_LIBRARIES"
+            echo "-pl $modules_libraries"
         ;;
         (${STAGE_CONNECTORS})
-            echo "-pl $MODULES_CONNECTORS"
+            echo "-pl $modules_connectors"
         ;;
         (${STAGE_TESTS})
-            echo "-pl $MODULES_TESTS"
+            echo "-pl $modules_tests"
         ;;
         (${STAGE_MISC})
-            NEGATED_CORE=\!${MODULES_CORE//,/,\!}
-            NEGATED_LIBRARIES=\!${MODULES_LIBRARIES//,/,\!}
-            NEGATED_CONNECTORS=\!${MODULES_CONNECTORS//,/,\!}
-            NEGATED_TESTS=\!${MODULES_TESTS//,/,\!}
-            echo "-pl $NEGATED_CORE,$NEGATED_LIBRARIES,$NEGATED_CONNECTORS,$NEGATED_TESTS"
+            echo "-pl $modules_misc"
         ;;
     esac
 }

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -56,44 +56,7 @@ function deleteOldCaches() {
 # delete leftover caches from previous builds
 find "$CACHE_DIR" -mindepth 1 -maxdepth 1 | grep -v "$TRAVIS_BUILD_NUMBER" | deleteOldCaches
 
-function getCurrentStage() {
-	STAGE_NUMBER=$(echo "$TRAVIS_JOB_NUMBER" | cut -d'.' -f 2)
-	case $STAGE_NUMBER in
-		(1)
-			echo "$STAGE_COMPILE"
-			;;
-		(2)
-			echo "$STAGE_CORE"
-			;;
-		(3)
-			echo "$STAGE_LIBRARIES"
-			;;
-		(4)
-			echo "$STAGE_CONNECTORS"
-			;;
-		(5)
-			echo "$STAGE_TESTS"
-			;;
-		(6)
-			echo "$STAGE_MISC"
-			;;
-		(7)
-			echo "$STAGE_CLEANUP"
-			;;
-		(*)
-			echo "Invalid stage detected ($STAGE_NUMBER)"
-			return 1
-			;;
-	esac
-
-	return 0
-}
-
-STAGE=$(getCurrentStage)
-if [ $? != 0 ]; then
-	echo "Could not determine current stage."
-	exit 1
-fi
+STAGE=$1
 echo "Current stage: \"$STAGE\""
 
 EXIT_CODE=0
@@ -204,9 +167,12 @@ elif [ $STAGE != "$STAGE_CLEANUP" ]; then
 
 	TEST="$STAGE" "./tools/travis_mvn_watchdog.sh" 300
 	EXIT_CODE=$?
-else
+elif [ $STAGE == "$STAGE_CLEANUP" ]; then
 	echo "Cleaning up $CACHE_BUILD_DIR"
 	rm -rf "$CACHE_BUILD_DIR"
+else
+    echo "Invalid Stage specified: $STAGE"
+    exit 1
 fi
 
 # Exit code for Travis build success/failure

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -284,23 +284,29 @@ upload_artifacts_s3
 cd ../../
 
 # only run end-to-end tests in misc because we only have flink-dist here
-case $TEST in
-	(misc)
-		if [ $EXIT_CODE == 0 ]; then
-			printf "\n\n==============================================================================\n"
-			printf "Running end-to-end tests\n"
-			printf "==============================================================================\n"
-
-			FLINK_DIR=build-target flink-end-to-end-tests/run-pre-commit-tests.sh
-
-			EXIT_CODE=$?
-		else
-			printf "\n==============================================================================\n"
-			printf "Previous build failure detected, skipping end-to-end tests.\n"
-			printf "==============================================================================\n"
-		fi
-	;;
-esac
+if [[ ${PROFILE} == *"jdk9"* ]]; then
+    printf "\n\n==============================================================================\n"
+    printf "Skipping end-to-end tests since they fail on Java 9.\n"
+    printf "==============================================================================\n"
+else
+    case $TEST in
+        (misc)
+            if [ $EXIT_CODE == 0 ]; then
+                printf "\n\n==============================================================================\n"
+                printf "Running end-to-end tests\n"
+                printf "==============================================================================\n"
+    
+                FLINK_DIR=build-target flink-end-to-end-tests/run-pre-commit-tests.sh
+    
+                EXIT_CODE=$?
+            else
+                printf "\n==============================================================================\n"
+                printf "Previous build failure detected, skipping end-to-end tests.\n"
+                printf "==============================================================================\n"
+            fi
+        ;;
+    esac
+fi
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE


### PR DESCRIPTION
## What is the purpose of the change

This PR merges all **daily** cron branches into the master. This significantly improves their visibility, makes them easier to maintain as well as simplify the process of running e2e tests for contributors.

`cron-master-maven_compat` will continue to exist since we only want to run this weekly and we can't have 2 separate cron intervals for the same branch.

## Brief change log

* rework stage selection to be reliant on script parameters instead of implicitly relying on the order of jobs
* configure existing jobs to only be run for each pr/commit, excluding cron builds
* merge `cron-master-hadoop24`
* merge `cron-master-scala212`
* merge `cron-master-docs`
  * requires additional caching of `.rvm` so we don't re-download dependencies on every build
  * caching of other builds is not affected
* merge `cron-master-e2e`
* merge `cron-master-jdk9`
  * modify `stage.sh` to support excluding modules for which tests currently fail
  * modify `travis_mvn_watchdog.sh` to not run e2e tests (since they currently fail)

I made no attempts at de-duplicating code in various scripts (like compile calls). Ain't nobody got time for that.

## Verifying this change

Clone my branch and setup a cron build. Note that a full build can take a few hours.
I have started a build for this PR: https://travis-ci.org/zentol/flink/builds/502561735
