### PR TITLE
[FLINK-11844][table-api] Simplify over window API classes and improve documentation

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/windows.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/windows.scala
@@ -18,9 +18,8 @@
 
 package org.apache.flink.table.api.java
 
-import org.apache.flink.table.api.scala.{CURRENT_RANGE, UNBOUNDED_RANGE}
-import org.apache.flink.table.api.{OverWindow, TumbleWithSize, OverWindowWithPreceding, SlideWithSize, SessionWithGap}
-import org.apache.flink.table.expressions.{Expression, ExpressionParser}
+import org.apache.flink.table.api._
+import org.apache.flink.table.expressions.ExpressionParser
 
 /**
   * Helper class for creating a tumbling window. Tumbling windows are consecutive, non-overlapping
@@ -86,80 +85,36 @@ object Session {
 }
 
 /**
-  * Helper object for creating a over window.
+  * Helper class for creating an over window. Similar to SQL, over window aggregates compute an
+  * aggregate for each input row over a range of its neighboring rows.
   */
 object Over {
 
   /**
-    * Specifies the time attribute on which rows are grouped.
+    * Specifies the time attribute on which rows are ordered.
     *
-    * For streaming tables call [[orderBy 'rowtime or orderBy 'proctime]] to specify time mode.
+    * For streaming tables, reference a rowtime or proctime time attribute here
+    * to specify the time mode.
     *
     * For batch tables, refer to a timestamp or long attribute.
+    *
+    * @param orderBy field reference
+    * @return an over window with defined order
     */
-  def orderBy(orderBy: String): OverWindowWithOrderBy = {
-    val orderByExpr = ExpressionParser.parseExpression(orderBy)
-    new OverWindowWithOrderBy(Array[Expression](), orderByExpr)
+  def orderBy(orderBy: String): OverWindowPartitionedOrdered = {
+    new OverWindowPartitionedOrdered(Seq(), ExpressionParser.parseExpression(orderBy))
   }
 
   /**
     * Partitions the elements on some partition keys.
     *
-    * @param partitionBy some partition keys.
-    * @return A partitionedOver instance that only contains the orderBy method.
-    */
-  def partitionBy(partitionBy: String): PartitionedOver = {
-    val partitionByExpr = ExpressionParser.parseExpressionList(partitionBy).toArray
-    new PartitionedOver(partitionByExpr)
-  }
-}
-
-class PartitionedOver(private val partitionByExpr: Array[Expression]) {
-
-  /**
-    * Specifies the time attribute on which rows are grouped.
+    * Each partition is individually sorted and aggregate functions are applied to each
+    * partition separately.
     *
-    * For streaming tables call [[orderBy 'rowtime or orderBy 'proctime]] to specify time mode.
-    *
-    * For batch tables, refer to a timestamp or long attribute.
+    * @param partitionBy list of field references
+    * @return an over window with defined partitioning
     */
-  def orderBy(orderBy: String): OverWindowWithOrderBy = {
-    val orderByExpr = ExpressionParser.parseExpression(orderBy)
-    new OverWindowWithOrderBy(partitionByExpr, orderByExpr)
-  }
-}
-
-
-class OverWindowWithOrderBy(
-  private val partitionByExpr: Array[Expression],
-  private val orderByExpr: Expression) {
-
-  /**
-    * Set the preceding offset (based on time or row-count intervals) for over window.
-    *
-    * @param preceding preceding offset relative to the current row.
-    * @return this over window
-    */
-  def preceding(preceding: String): OverWindowWithPreceding = {
-    val precedingExpr = ExpressionParser.parseExpression(preceding)
-    new OverWindowWithPreceding(partitionByExpr, orderByExpr, precedingExpr)
-  }
-
-  /**
-    * Assigns an alias for this window that the following `select()` clause can refer to.
-    *
-    * @param alias alias for this over window
-    * @return over window
-    */
-  def as(alias: String): OverWindow = as(ExpressionParser.parseExpression(alias))
-
-  /**
-    * Assigns an alias for this window that the following `select()` clause can refer to.
-    *
-    * @param alias alias for this over window
-    * @return over window
-    */
-  def as(alias: Expression): OverWindow = {
-    OverWindow(alias, partitionByExpr, orderByExpr, UNBOUNDED_RANGE, CURRENT_RANGE)
+  def partitionBy(partitionBy: String): OverWindowPartitioned = {
+    new OverWindowPartitioned(ExpressionParser.parseExpressionList(partitionBy))
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/windows.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/windows.scala
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.api.scala
 
-import org.apache.flink.table.api.{OverWindow, TumbleWithSize, OverWindowWithPreceding, SlideWithSize, SessionWithGap}
-import org.apache.flink.table.expressions.{Expression, ExpressionParser}
+import org.apache.flink.table.api._
+import org.apache.flink.table.expressions.Expression
 
 /**
   * Helper object for creating a tumbling window. Tumbling windows are consecutive, non-overlapping
@@ -85,73 +85,36 @@ object Session {
 }
 
 /**
-  * Helper object for creating a over window.
+  * Helper class for creating an over window. Similar to SQL, over window aggregates compute an
+  * aggregate for each input row over a range of its neighboring rows.
   */
 object Over {
 
   /**
-    * Specifies the time attribute on which rows are grouped.
+    * Specifies the time attribute on which rows are ordered.
     *
-    * For streaming tables call [[orderBy 'rowtime or orderBy 'proctime]] to specify time mode.
+    * For streaming tables, reference a rowtime or proctime time attribute here
+    * to specify the time mode.
     *
     * For batch tables, refer to a timestamp or long attribute.
+    *
+    * @param orderBy field reference
+    * @return an over window with defined order
     */
-  def orderBy(orderBy: Expression): OverWindowWithOrderBy = {
-    new OverWindowWithOrderBy(Seq[Expression](), orderBy)
+  def orderBy(orderBy: Expression): OverWindowPartitionedOrdered = {
+    new OverWindowPartitionedOrdered(Seq[Expression](), orderBy)
   }
 
   /**
     * Partitions the elements on some partition keys.
     *
-    * @param partitionBy some partition keys.
-    * @return A partitionedOver instance that only contains the orderBy method.
-    */
-  def partitionBy(partitionBy: Expression*): PartitionedOver = {
-    PartitionedOver(partitionBy.toArray)
-  }
-}
-
-case class PartitionedOver(partitionBy: Array[Expression]) {
-
-  /**
-    * Specifies the time attribute on which rows are grouped.
+    * Each partition is individually sorted and aggregate functions are applied to each
+    * partition separately.
     *
-    * For streaming tables call [[orderBy 'rowtime or orderBy 'proctime]] to specify time mode.
-    *
-    * For batch tables, refer to a timestamp or long attribute.
+    * @param partitionBy list of field references
+    * @return an over window with defined partitioning
     */
-  def orderBy(orderBy: Expression): OverWindowWithOrderBy = {
-    OverWindowWithOrderBy(partitionBy, orderBy)
-  }
-}
-
-case class OverWindowWithOrderBy(partitionBy: Seq[Expression], orderBy: Expression) {
-
-  /**
-    * Set the preceding offset (based on time or row-count intervals) for over window.
-    *
-    * @param preceding preceding offset relative to the current row.
-    * @return this over window
-    */
-  def preceding(preceding: Expression): OverWindowWithPreceding = {
-    new OverWindowWithPreceding(partitionBy, orderBy, preceding)
-  }
-
-  /**
-    * Assigns an alias for this window that the following `select()` clause can refer to.
-    *
-    * @param alias alias for this over window
-    * @return over window
-    */
-  def as(alias: String): OverWindow = as(ExpressionParser.parseExpression(alias))
-
-  /**
-    * Assigns an alias for this window that the following `select()` clause can refer to.
-    *
-    * @param alias alias for this over window
-    * @return over window
-    */
-  def as(alias: Expression): OverWindow = {
-    OverWindow(alias, partitionBy, orderBy, UNBOUNDED_RANGE, CURRENT_RANGE)
+  def partitionBy(partitionBy: Expression*): OverWindowPartitioned = {
+    new OverWindowPartitioned(partitionBy)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/windows.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/windows.scala
@@ -102,7 +102,7 @@ object Over {
     * @return an over window with defined order
     */
   def orderBy(orderBy: Expression): OverWindowPartitionedOrdered = {
-    new OverWindowPartitionedOrdered(Seq[Expression](), orderBy)
+    new OverWindowPartitionedOrdered(Seq(), orderBy)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/windows.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/windows.scala
@@ -22,7 +22,7 @@ import org.apache.flink.table.expressions._
 import org.apache.flink.table.plan.logical._
 
 /**
-  * A over-window specification.
+  * An over window specification.
   *
   * Similar to SQL, over window aggregates compute an aggregate for each input row over a range
   * of its neighboring rows.
@@ -62,11 +62,11 @@ class OverWindowPartitioned(partitionBy: Seq[Expression]) {
     *
     * For batch tables, refer to a timestamp or long attribute.
     *
-    * @param orderByExpr field reference
+    * @param orderBy field reference
     * @return an over window with defined order
     */
-  def orderBy(orderByExpr: String): OverWindowPartitionedOrdered = {
-    orderBy(ExpressionParser.parseExpression(orderByExpr))
+  def orderBy(orderBy: String): OverWindowPartitionedOrdered = {
+    this.orderBy(ExpressionParser.parseExpression(orderBy))
   }
 
   /**
@@ -93,11 +93,11 @@ class OverWindowPartitionedOrdered(partitionBy: Seq[Expression], orderBy: Expres
   /**
     * Set the preceding offset (based on time or row-count intervals) for over window.
     *
-    * @param precedingExpr preceding offset relative to the current row.
+    * @param preceding preceding offset relative to the current row.
     * @return an over window with defined preceding
     */
-  def preceding(precedingExpr: String): OverWindowPartitionedOrderedPreceding = {
-    preceding(ExpressionParser.parseExpression(precedingExpr))
+  def preceding(preceding: String): OverWindowPartitionedOrderedPreceding = {
+    this.preceding(ExpressionParser.parseExpression(preceding))
   }
 
   /**
@@ -160,11 +160,11 @@ class OverWindowPartitionedOrderedPreceding(
   /**
     * Set the following offset (based on time or row-count intervals) for over window.
     *
-    * @param followingExpr following offset that relative to the current row.
+    * @param following following offset that relative to the current row.
     * @return an over window with defined following
     */
-  def following(followingExpr: String): OverWindowPartitionedOrderedPreceding = {
-    following(ExpressionParser.parseExpression(followingExpr))
+  def following(following: String): OverWindowPartitionedOrderedPreceding = {
+    this.following(ExpressionParser.parseExpression(following))
   }
 
   /**
@@ -184,16 +184,16 @@ class OverWindowPartitionedOrderedPreceding(
 // ------------------------------------------------------------------------------------------------
 
 /**
-  * A group-window specification.
+  * A group window specification.
   *
-  * Group-windows group rows based on time or row-count intervals and is therefore essentially a
-  * special type of groupBy. Just like groupBy, group-windows allow to compute aggregates
+  * Group windows group rows based on time or row-count intervals and is therefore essentially a
+  * special type of groupBy. Just like groupBy, group windows allow to compute aggregates
   * on groups of elements.
   *
   * Infinite streaming tables can only be grouped into time or row intervals. Hence window grouping
   * is required to apply aggregations on streaming tables.
   *
-  * For finite batch tables, group-windows provide shortcuts for time-based groupBy.
+  * For finite batch tables, group windows provide shortcuts for time-based groupBy.
   */
 abstract class Window(val alias: Expression, val timeField: Expression) {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR removes duplicate code and thus simplifies the over window API classes. It improves the documentation as well.

## Brief change log

- Duplicate classes removed
- Docs about windows updated

## Verifying this change

This change is already covered by existing tests, such as OverWindowITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
