### PR TITLE
[FLINK-11825][StateBackends] Resolve name clash of StateTTL TimeCharacteristic class

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.Preconditions;
 
@@ -43,6 +44,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * it can be wrapped with {@link org.apache.flink.api.java.typeutils.runtime.NullableSerializer}
  * at the cost of an extra byte in the serialized form.
  */
+@PublicEvolving
 public class StateTtlConfig implements Serializable {
 
 	private static final long serialVersionUID = -7592693245044289793L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -224,7 +224,8 @@ public class StateTtlConfig implements Serializable {
 		@Deprecated
 		@Nonnull
 		public Builder setTimeCharacteristic(@Nonnull TimeCharacteristic timeCharacteristic) {
-			// We only support ProcessingTime now, so transfer to  {@link TtlTimeCharacteristic.ProcessingTime} directly.
+			checkArgument(timeCharacteristic.equals(TimeCharacteristic.ProcessingTime),
+				"Only support TimeCharacteristic.ProcessingTime, this function has replaced by setTtlTimeCharacteristic.");
 			setTtlTimeCharacteristic(TtlTimeCharacteristic.ProcessingTime);
 			return this;
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -93,7 +93,7 @@ public class StateTtlConfig implements Serializable {
 
 	private final UpdateType updateType;
 	private final StateVisibility stateVisibility;
-	private TtlTimeCharacteristic ttlTimeCharacteristic;
+	private final TtlTimeCharacteristic ttlTimeCharacteristic;
 	private final Time ttl;
 	private final CleanupStrategies cleanupStrategies;
 
@@ -126,6 +126,7 @@ public class StateTtlConfig implements Serializable {
 		return ttl;
 	}
 
+	@Nonnull
 	public TtlTimeCharacteristic getTtlTimeCharacteristic() {
 		return ttlTimeCharacteristic;
 	}
@@ -221,9 +222,7 @@ public class StateTtlConfig implements Serializable {
 		@Deprecated
 		@Nonnull
 		public Builder setTimeCharacteristic(@Nonnull TimeCharacteristic timeCharacteristic) {
-			/**
-			 * We only support ProcessingTime now, so transfer to {@link TtlTimeCharacteristic.ProcessingTime} directly.
-			 */
+			// We only support ProcessingTime now, so transfer to  {@link TtlTimeCharacteristic.ProcessingTime} directly.
 			setTtlTimeCharacteristic(TtlTimeCharacteristic.ProcessingTime);
 			return this;
 		}
@@ -233,6 +232,7 @@ public class StateTtlConfig implements Serializable {
 		 *
 		 * @param ttlTimeCharacteristic The time characteristic configures time scale to use for ttl.
 		 */
+		@Nonnull
 		public Builder setTtlTimeCharacteristic(@Nonnull TtlTimeCharacteristic ttlTimeCharacteristic) {
 			this.ttlTimeCharacteristic = ttlTimeCharacteristic;
 			return this;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -73,10 +73,9 @@ public class StateTtlConfig implements Serializable {
 	}
 
 	/**
-	 * @deprecated use {@link TtlTimeCharacteristic} to avoid class name clash
-	 * with <code>org.apache.flink.streaming.api.TimeCharacteristic</code>.
-	 *
 	 * This option configures time scale to use for ttl.
+	 *
+	 * @deprecated will be removed in a future version in favor of {@link TtlTimeCharacteristic}
 	 */
 	@Deprecated
 	public enum TimeCharacteristic {
@@ -94,27 +93,9 @@ public class StateTtlConfig implements Serializable {
 
 	private final UpdateType updateType;
 	private final StateVisibility stateVisibility;
-	@Deprecated
-	private TimeCharacteristic timeCharacteristic;
 	private TtlTimeCharacteristic ttlTimeCharacteristic;
 	private final Time ttl;
 	private final CleanupStrategies cleanupStrategies;
-
-	@Deprecated
-	private StateTtlConfig(
-		UpdateType updateType,
-		StateVisibility stateVisibility,
-		TimeCharacteristic timeCharacteristic,
-		Time ttl,
-		CleanupStrategies cleanupStrategies) {
-
-		/**
-		 * We just support <code>TimeCharacteristic.ProcessingTime</code> only,
-		 * so transfer to <code>TtlTimeCharacteristic.ProcessingTime</code> directly.
-		 */
-		this(updateType, stateVisibility, ProcessingTime, ttl, cleanupStrategies);
-		this.timeCharacteristic = checkNotNull(timeCharacteristic);
-	}
 
 	private StateTtlConfig(
 		UpdateType updateType,
@@ -143,12 +124,6 @@ public class StateTtlConfig implements Serializable {
 	@Nonnull
 	public Time getTtl() {
 		return ttl;
-	}
-
-	@Deprecated
-	@Nonnull
-	public TimeCharacteristic getTimeCharacteristic() {
-		return timeCharacteristic;
 	}
 
 	public TtlTimeCharacteristic getTtlTimeCharacteristic() {
@@ -186,12 +161,6 @@ public class StateTtlConfig implements Serializable {
 
 		private UpdateType updateType = OnCreateAndWrite;
 		private StateVisibility stateVisibility = NeverReturnExpired;
-		/**
-		 * Set default value to null, in {@link #build()} use the default value to test
-		 * whether user has set timeCharacteristic ever.
-		 */
-		@Deprecated
-		private TimeCharacteristic timeCharacteristic = null;
 		private TtlTimeCharacteristic ttlTimeCharacteristic = ProcessingTime;
 		private Time ttl;
 		private CleanupStrategies cleanupStrategies = new CleanupStrategies();
@@ -246,11 +215,16 @@ public class StateTtlConfig implements Serializable {
 		 * Sets the time characteristic.
 		 *
 		 * @param timeCharacteristic The time characteristic configures time scale to use for ttl.
+		 *
+		 * @deprecated will be removed in a future version in favor of {@link #setTtlTimeCharacteristic}
 		 */
 		@Deprecated
 		@Nonnull
 		public Builder setTimeCharacteristic(@Nonnull TimeCharacteristic timeCharacteristic) {
-			this.timeCharacteristic = timeCharacteristic;
+			/**
+			 * We only support ProcessingTime now, so transfer to {@link TtlTimeCharacteristic.ProcessingTime} directly.
+			 */
+			setTtlTimeCharacteristic(TtlTimeCharacteristic.ProcessingTime);
 			return this;
 		}
 
@@ -362,21 +336,12 @@ public class StateTtlConfig implements Serializable {
 
 		@Nonnull
 		public StateTtlConfig build() {
-			if (timeCharacteristic != null) {
-				return new StateTtlConfig(
-					updateType,
-					stateVisibility,
-					timeCharacteristic,
-					ttl,
-					cleanupStrategies);
-			} else {
-				return new StateTtlConfig(
-					updateType,
-					stateVisibility,
-					ttlTimeCharacteristic,
-					ttl,
-					cleanupStrategies);
-			}
+			return new StateTtlConfig(
+				updateType,
+				stateVisibility,
+				ttlTimeCharacteristic,
+				ttl,
+				cleanupStrategies);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Resolve name class of StateTTL TimeCharacteristic class for at least following two reasons:
1. Users get confused because the mistakenly import org.apache.flink.api.common.state.TimeCharacteristic.
2. When using the StateTTL feature, users need to spell out the package name for org.apache.flink.api.common.state.TimeCharacteristic because the other class is most likely already imported.

## Brief change log

Changes include:
- Deprecated the StateTtlConfig#TimeCharacteristic class (for backward-compatibility).
- Introduce a new class named StateTtlConfig#TtlTimeCharacteristic.
- Annotate `StateTtlConfig` as `PublicEvolving`

We can not remove the class StateTtlConfig#TimeCharacteristic and use `org.apache.flink.streaming.api.TimeCharacteristic` directly,
because StateTtlConfig locates in module flink-core and `org.apache.flink.streaming.api.TimeCharacteristic` locates in flink-streaming-java,
so we choice to rename StateTtlConfig#TimeCharacteristic.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
