### PR TITLE
[FLINK-11850][zk] Tolerate concurrent child deletions when deleting owned zNode

### DIFF
--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -27,5 +27,10 @@
             <td style="word-wrap: break-word;">30000</td>
             <td>The pause made after the registration attempt was refused in milliseconds.</td>
         </tr>
+        <tr>
+            <td><h5>cluster.services.shutdown-timeout</h5></td>
+            <td style="word-wrap: break-word;">30000</td>
+            <td>The shutdown timeout for cluster services like executors in milliseconds.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -45,4 +45,9 @@ public class ClusterOptions {
 		.key("cluster.registration.refused-registration-delay")
 		.defaultValue(30000L)
 		.withDescription("The pause made after the registration attempt was refused in milliseconds.");
+
+	public static final ConfigOption<Long> CLUSTER_SERVICES_SHUTDOWN_TIMEOUT = ConfigOptions
+		.key("cluster.services.shutdown-timeout")
+		.defaultValue(30000L)
+		.withDescription("The shutdown timeout for cluster services like executors in milliseconds.");
 }


### PR DESCRIPTION
## What is the purpose of the change

When calling ZooKeeperHaServices#closeAndCleanupAllData it can happen that a child of the owned
zNode of the ZooKeeperHaServices is being concurrently deleted (e.g. a LeaderElectionService has
been shut down). In order to tolerate concurrent deletions, we use now ZKPaths#deleteChildren.

## Verifying this change

- Covered by existing `ZooKeeperHaServicesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
