### PR TITLE
[BP-1.8][FLINK-11850][zk] Tolerate concurrent child deletions when deleting owned zNode

### DIFF
--- a/docs/_includes/generated/cluster_configuration.html
+++ b/docs/_includes/generated/cluster_configuration.html
@@ -27,5 +27,10 @@
             <td style="word-wrap: break-word;">30000</td>
             <td>The pause made after the registration attempt was refused in milliseconds.</td>
         </tr>
+        <tr>
+            <td><h5>cluster.services.shutdown-timeout</h5></td>
+            <td style="word-wrap: break-word;">30000</td>
+            <td>The shutdown timeout for cluster services like executors in milliseconds.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -45,4 +45,9 @@ public class ClusterOptions {
 		.key("cluster.registration.refused-registration-delay")
 		.defaultValue(30000L)
 		.withDescription("The pause made after the registration attempt was refused in milliseconds.");
+
+	public static final ConfigOption<Long> CLUSTER_SERVICES_SHUTDOWN_TIMEOUT = ConfigOptions
+		.key("cluster.services.shutdown-timeout")
+		.defaultValue(30000L)
+		.withDescription("The shutdown timeout for cluster services like executors in milliseconds.");
 }


### PR DESCRIPTION
Backport of #7928 to `release-1.8`.