### PR TITLE
[FLINK-11855] Fix race condition in EmbeddedLeaderService#GrantLeadershipCall

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -102,6 +102,13 @@ public class EmbeddedLeaderService {
 		}
 	}
 
+	@VisibleForTesting
+	public boolean isShutdown() {
+		synchronized (lock) {
+			return shutdown;
+		}
+	}
+
 	private void fatalError(Throwable error) {
 		LOG.error("Embedded leader election service encountered a fatal error. Shutting down service.", error);
 
@@ -171,7 +178,11 @@ public class EmbeddedLeaderService {
 				service.contender = contender;
 				service.running = true;
 
-				updateLeader();
+				updateLeader().whenComplete((aVoid, throwable) -> {
+					if (throwable != null) {
+						fatalError(throwable);
+					}
+				});
 			}
 			catch (Throwable t) {
 				fatalError(t);
@@ -210,7 +221,11 @@ public class EmbeddedLeaderService {
 					currentLeaderSessionId = null;
 				}
 
-				updateLeader();
+				updateLeader().whenComplete((aVoid, throwable) -> {
+					if (throwable != null) {
+						fatalError(throwable);
+					}
+				});
 			}
 			catch (Throwable t) {
 				fatalError(t);
@@ -280,11 +295,12 @@ public class EmbeddedLeaderService {
 
 				currentLeaderSessionId = leaderSessionId;
 				currentLeaderProposed = leaderService;
+				currentLeaderProposed.isLeader = true;
 
 				LOG.info("Proposing leadership to contender {} @ {}",
 						leaderService.contender, leaderService.contender.getAddress());
 
-				return execute(new GrantLeadershipCall(leaderService, leaderSessionId, LOG));
+				return execute(new GrantLeadershipCall(leaderService.contender, leaderSessionId, LOG));
 			}
 		} else {
 			return CompletableFuture.completedFuture(null);
@@ -373,7 +389,8 @@ public class EmbeddedLeaderService {
 				}
 
 				LOG.info("Revoking leadership of {}.", leaderService.contender);
-				CompletableFuture<Void> revokeLeadershipCallFuture = execute(new RevokeLeadershipCall(leaderService));
+				leaderService.isLeader = false;
+				CompletableFuture<Void> revokeLeadershipCallFuture = execute(new RevokeLeadershipCall(leaderService.contender));
 
 				CompletableFuture<Void> notifyAllListenersFuture = notifyAllListeners(null, null);
 
@@ -506,33 +523,28 @@ public class EmbeddedLeaderService {
 
 	private static class GrantLeadershipCall implements Runnable {
 
-		private final EmbeddedLeaderElectionService leaderElectionService;
+		private final LeaderContender contender;
 		private final UUID leaderSessionId;
 		private final Logger logger;
 
 		GrantLeadershipCall(
-				EmbeddedLeaderElectionService leaderElectionService,
+				LeaderContender contender,
 				UUID leaderSessionId,
 				Logger logger) {
 
-			this.leaderElectionService = checkNotNull(leaderElectionService);
+			this.contender = checkNotNull(contender);
 			this.leaderSessionId = checkNotNull(leaderSessionId);
 			this.logger = checkNotNull(logger);
 		}
 
 		@Override
 		public void run() {
-			leaderElectionService.isLeader = true;
-
-			final LeaderContender contender = leaderElectionService.contender;
-
 			try {
 				contender.grantLeadership(leaderSessionId);
 			}
 			catch (Throwable t) {
 				logger.warn("Error granting leadership to contender", t);
 				contender.handleError(t instanceof Exception ? (Exception) t : new Exception(t));
-				leaderElectionService.isLeader = false;
 			}
 		}
 	}
@@ -540,17 +552,15 @@ public class EmbeddedLeaderService {
 	private static class RevokeLeadershipCall implements Runnable {
 
 		@Nonnull
-		private final EmbeddedLeaderElectionService leaderElectionService;
+		private final LeaderContender contender;
 
-		RevokeLeadershipCall(@Nonnull EmbeddedLeaderElectionService leaderElectionService) {
-			this.leaderElectionService = leaderElectionService;
+		RevokeLeadershipCall(@Nonnull LeaderContender contender) {
+			this.contender = contender;
 		}
 
 		@Override
 		public void run() {
-			leaderElectionService.isLeader = false;
-
-			leaderElectionService.contender.revokeLeadership();
+			contender.revokeLeadership();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.embedded;
+
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for the {@link EmbeddedLeaderService}.
+ */
+public class EmbeddedLeaderServiceTest extends TestLogger {
+
+	/**
+	 * Tests that the {@link EmbeddedLeaderService} can handle a concurrent grant
+	 * leadership call and a shutdown.
+	 */
+	@Test
+	public void testConcurrentGrantLeadershipAndShutdown() throws Exception {
+		final EmbeddedLeaderService embeddedLeaderService = new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+
+		try {
+			final LeaderElectionService leaderElectionService = embeddedLeaderService.createLeaderElectionService();
+
+			final TestingLeaderContender contender = new TestingLeaderContender();
+
+			leaderElectionService.start(contender);
+			leaderElectionService.stop();
+
+			try {
+				// check that no exception occurred
+				contender.getLeaderSessionFuture().get(10L, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException ignored) {
+				// we haven't participated in the leader election
+			}
+
+			// the election service should still be running
+			Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+		} finally {
+			embeddedLeaderService.shutdown();
+		}
+	}
+
+	/**
+	 * Tests that the {@link EmbeddedLeaderService} can handle a concurrent revoke
+	 * leadership call and a shutdown.
+	 */
+	@Test
+	public void testConcurrentRevokeLeadershipAndShutdown() throws Exception {
+		final EmbeddedLeaderService embeddedLeaderService = new EmbeddedLeaderService(TestingUtils.defaultExecutor());
+
+		try {
+			final LeaderElectionService leaderElectionService = embeddedLeaderService.createLeaderElectionService();
+
+			final TestingLeaderContender contender = new TestingLeaderContender();
+
+			leaderElectionService.start(contender);
+
+			// wait for the leadership
+			contender.getLeaderSessionFuture().get();
+
+			final CompletableFuture<Void> revokeLeadershipFuture = embeddedLeaderService.revokeLeadership();
+			leaderElectionService.stop();
+
+			try {
+				// check that no exception occurred
+				revokeLeadershipFuture.get(10L, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException ignored) {
+				// the leader election service has been stopped before revoking could be executed
+			}
+
+			// the election service should still be running
+			Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+		} finally {
+			embeddedLeaderService.shutdown();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.embedded;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.leaderelection.LeaderContender;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link LeaderContender} implementation for testing purposes.
+ */
+final class TestingLeaderContender implements LeaderContender {
+
+	private final Object lock = new Object();
+
+	private CompletableFuture<UUID> leaderSessionFuture;
+
+	TestingLeaderContender() {
+		leaderSessionFuture = new CompletableFuture<>();
+	}
+
+	@Override
+	public void grantLeadership(UUID leaderSessionID) {
+		synchronized (lock) {
+			if (!leaderSessionFuture.isCompletedExceptionally()) {
+				if (!leaderSessionFuture.complete(leaderSessionID)) {
+					leaderSessionFuture = CompletableFuture.completedFuture(leaderSessionID);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void revokeLeadership() {
+		synchronized (lock) {
+			if (leaderSessionFuture.isDone() && !leaderSessionFuture.isCompletedExceptionally()) {
+				leaderSessionFuture = new CompletableFuture<>();
+			}
+		}
+	}
+
+	@Override
+	public String getAddress() {
+		return "foobar";
+	}
+
+	@Override
+	public void handleError(Exception exception) {
+		synchronized (lock) {
+			if (!(leaderSessionFuture.isCompletedExceptionally() || leaderSessionFuture.completeExceptionally(exception))) {
+				leaderSessionFuture = FutureUtils.completedExceptionally(exception);
+			}
+		}
+	}
+
+	public void tryRethrowException() {
+		synchronized (lock) {
+			if (leaderSessionFuture.isCompletedExceptionally()) {
+				leaderSessionFuture.getNow(null);
+			}
+		}
+	}
+
+	CompletableFuture<UUID> getLeaderSessionFuture() {
+		synchronized (lock) {
+			return leaderSessionFuture;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix the race condition between executing EmbeddedLeaderService#GrantLeadershipCall
and a concurrent shutdown of the leader service by making GrantLeadershipCall not
accessing mutable state outside of a lock.

## Verifying this change

- Added `EmbeddedLeaderServiceTest#testConcurrentGrantLeadershipAndShutdown`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
