### PR TITLE
[FLINK-10941] Keep slots which contain unconsumed result partitions (on top of #7186)

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -107,6 +107,28 @@ public class ResourceManagerOptions {
 			.build());
 
 	/**
+	 * Release task executor only when each produced result partition is either consumed or failed.
+	 *
+	 * <p>Currently, produced result partition is released when it fails or consumer sends close request
+	 * to confirm successful end of consumption and to close the communication channel.
+	 *
+	 * @deprecated The default value should be reasonable enough in all cases, this option is to fallback to older behaviour
+	 * which will be removed or refactored in future.
+	 */
+	@Deprecated
+	public static final ConfigOption<Boolean> TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED = ConfigOptions
+		.key("resourcemanager.taskmanager-release.wait.result.consumed")
+		.defaultValue(true)
+		.withDescription(Description.builder()
+			.text("Release task executor only when each produced result partition is either consumed or failed. " +
+				"'True' is default. 'False' means that idle task executor release is not blocked " +
+				"by receiver confirming consumption of result partition " +
+				"and can happen right away after 'resourcemanager.taskmanager-timeout' has elapsed. " +
+				"Setting this option to 'false' can speed up task executor release but can lead to unexpected failures " +
+				"if end of consumption is slower than 'resourcemanager.taskmanager-timeout'.")
+			.build());
+
+	/**
 	 * Prefix for passing custom environment variables to Flink's master process.
 	 * For example for passing LD_LIBRARY_PATH as an env variable to the AppMaster, set:
 	 * containerized.master.env.LD_LIBRARY_PATH: "/usr/lib/native"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.NetworkSequenceViewReader;
-import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
-import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import org.apache.flink.runtime.io.network.partition.ProducerFailedException;
@@ -134,9 +132,15 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 		ctx.pipeline().fireUserEventTriggered(receiverId);
 	}
 
-	public void close() {
+	public void close() throws IOException {
 		if (ctx != null) {
 			ctx.channel().close();
+		}
+
+		for (NetworkSequenceViewReader reader : allReaders.values()) {
+			reader.notifySubpartitionConsumed();
+			reader.releaseAllResources();
+			markAsReleased(reader.getReceiverId());
 		}
 	}
 
@@ -247,13 +251,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 						reader.getReceiverId(),
 						next.buffersInBacklog());
 
-					if (isEndOfPartitionEvent(next.buffer())) {
-						reader.notifySubpartitionConsumed();
-						reader.releaseAllResources();
-
-						markAsReleased(reader.getReceiverId());
-					}
-
 					// Write and flush and wait until this is done before
 					// trying to continue with the next buffer.
 					channel.writeAndFlush(msg).addListener(writeListener);
@@ -282,10 +279,6 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 			reader.setRegisteredAsAvailable(false);
 		}
 		return reader;
-	}
-
-	private boolean isEndOfPartitionEvent(Buffer buffer) throws IOException {
-		return EventSerializer.isEvent(buffer, EndOfPartitionEvent.class);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -142,6 +142,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 			reader.releaseAllResources();
 			markAsReleased(reader.getReceiverId());
 		}
+		allReaders.clear();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -378,6 +378,16 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		}
 	}
 
+	/**
+	 * Whether this partition is released.
+	 *
+	 * <p>A partition is released when each subpartition is either consumed and communication is closed by consumer
+	 * or failed. A partition is also released if task is cancelled.
+	 */
+	public boolean isReleased() {
+		return isReleased.get();
+	}
+
 	@Override
 	public String toString() {
 		return "ResultPartition " + partitionId.toString() + " [" + partitionType + ", "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -147,4 +147,15 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 			LOG.debug("Released {}.", partition);
 		}
 	}
+
+	public boolean areAllPartitionsReleased() {
+		synchronized (registeredPartitions) {
+			for (ResultPartition partition : registeredPartitions.values()) {
+				if (!partition.isReleased()) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -58,7 +58,8 @@ public class ResourceManagerRuntimeServices {
 			scheduledExecutor,
 			slotManagerConfiguration.getTaskManagerRequestTimeout(),
 			slotManagerConfiguration.getSlotRequestTimeout(),
-			slotManagerConfiguration.getTaskManagerTimeout());
+			slotManagerConfiguration.getTaskManagerTimeout(),
+			slotManagerConfiguration.isWaitResultConsumedBeforeRelease());
 
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
 			highAvailabilityServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -120,15 +120,21 @@ public class SlotManager implements AutoCloseable {
 	/** True iff the component has been started. */
 	private boolean started;
 
+	/** Release task executor only when each produced result partition is either consumed or failed. */
+	private final boolean waitResultConsumedBeforeRelease;
+
 	public SlotManager(
 			ScheduledExecutor scheduledExecutor,
 			Time taskManagerRequestTimeout,
 			Time slotRequestTimeout,
-			Time taskManagerTimeout) {
+			Time taskManagerTimeout,
+			boolean waitResultConsumedBeforeRelease) {
+
 		this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
+		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
 
 		slots = new HashMap<>(16);
 		freeSlots = new LinkedHashMap<>(16);
@@ -999,28 +1005,44 @@ public class SlotManager implements AutoCloseable {
 	// Internal timeout methods
 	// ---------------------------------------------------------------------------------------------
 
-	private void checkTaskManagerTimeouts() {
+	@VisibleForTesting
+	void checkTaskManagerTimeouts() {
 		if (!taskManagerRegistrations.isEmpty()) {
 			long currentTime = System.currentTimeMillis();
 
-			ArrayList<InstanceID> timedOutTaskManagerIds = new ArrayList<>(taskManagerRegistrations.size());
+			ArrayList<TaskManagerRegistration> timedOutTaskManagers = new ArrayList<>(taskManagerRegistrations.size());
 
 			// first retrieve the timed out TaskManagers
 			for (TaskManagerRegistration taskManagerRegistration : taskManagerRegistrations.values()) {
 				if (currentTime - taskManagerRegistration.getIdleSince() >= taskManagerTimeout.toMilliseconds()) {
 					// we collect the instance ids first in order to avoid concurrent modifications by the
 					// ResourceActions.releaseResource call
-					timedOutTaskManagerIds.add(taskManagerRegistration.getInstanceId());
+					timedOutTaskManagers.add(taskManagerRegistration);
 				}
 			}
 
 			// second we trigger the release resource callback which can decide upon the resource release
-			final FlinkException cause = new FlinkException("TaskExecutor exceeded the idle timeout.");
-			for (InstanceID timedOutTaskManagerId : timedOutTaskManagerIds) {
-				LOG.debug("Release TaskExecutor {} because it exceeded the idle timeout.", timedOutTaskManagerId);
-				resourceActions.releaseResource(timedOutTaskManagerId, cause);
+			for (TaskManagerRegistration taskManagerRegistration : timedOutTaskManagers) {
+				InstanceID timedOutTaskManagerId = taskManagerRegistration.getInstanceId();
+				if (waitResultConsumedBeforeRelease) {
+					// checking whether TaskManagers can be safely removed
+					taskManagerRegistration.getTaskManagerConnection().getTaskExecutorGateway().canBeReleased()
+						.thenAcceptAsync(canBeReleased -> {
+							if (canBeReleased) {
+								releaseTaskExecutor(timedOutTaskManagerId);
+							}},
+							mainThreadExecutor);
+				} else {
+					releaseTaskExecutor(timedOutTaskManagerId);
+				}
 			}
 		}
+	}
+
+	private void releaseTaskExecutor(InstanceID timedOutTaskManagerId) {
+		final FlinkException cause = new FlinkException("TaskExecutor exceeded the idle timeout.");
+		LOG.debug("Release TaskExecutor {} because it exceeded the idle timeout.", timedOutTaskManagerId);
+		resourceActions.releaseResource(timedOutTaskManagerId, cause);
 	}
 
 	private void checkSlotRequestTimeouts() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -41,14 +41,18 @@ public class SlotManagerConfiguration {
 	private final Time taskManagerRequestTimeout;
 	private final Time slotRequestTimeout;
 	private final Time taskManagerTimeout;
+	private final boolean waitResultConsumedBeforeRelease;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
 			Time slotRequestTimeout,
-			Time taskManagerTimeout) {
+			Time taskManagerTimeout,
+			boolean waitResultConsumedBeforeRelease) {
+
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
+		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -61,6 +65,10 @@ public class SlotManagerConfiguration {
 
 	public Time getTaskManagerTimeout() {
 		return taskManagerTimeout;
+	}
+
+	public boolean isWaitResultConsumedBeforeRelease() {
+		return waitResultConsumedBeforeRelease;
 	}
 
 	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
@@ -78,7 +86,10 @@ public class SlotManagerConfiguration {
 		final Time taskManagerTimeout = Time.milliseconds(
 				configuration.getLong(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
 
-		return new SlotManagerConfiguration(rpcTimeout, slotRequestTimeout, taskManagerTimeout);
+		boolean waitResultConsumedBeforeRelease =
+			configuration.getBoolean(ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
+
+		return new SlotManagerConfiguration(rpcTimeout, slotRequestTimeout, taskManagerTimeout, waitResultConsumedBeforeRelease);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -270,6 +270,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.stackTraceSampleService = new StackTraceSampleService(rpcService.getScheduledExecutor());
 	}
 
+	@Override
+	public CompletableFuture<Boolean> canBeReleased() {
+		return CompletableFuture.completedFuture(
+			taskExecutorServices.getNetworkEnvironment().getResultPartitionManager().areAllPartitionsReleased());
+	}
+
 	// ------------------------------------------------------------------------
 	//  Life cycle
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -203,4 +203,11 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @return Future gateway of Metric Query Service on the TaskManager.
 	 */
 	CompletableFuture<SerializableOptional<String>> requestMetricQueryServiceAddress(@RpcTimeout Time timeout);
+
+	/**
+	 * Checks whether the task executor can be released. It cannot be released if there're unconsumed result partitions.
+	 *
+	 * @return Future flag indicating whether the task executor can be released.
+	 */
+	CompletableFuture<Boolean> canBeReleased();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -294,7 +294,7 @@ public class TaskSlot {
 	 */
 	public SlotOffer generateSlotOffer() {
 		Preconditions.checkState(TaskSlotState.ACTIVE == state || TaskSlotState.ALLOCATED == state,
-				"The task slot is not in state active or allocated.");
+			"The task slot is not in state active or allocated.");
 		Preconditions.checkState(allocationId != null, "The task slot are not allocated");
 
 		return new SlotOffer(allocationId, index, resourceProfile);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -616,7 +616,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 		private final Iterator<TaskSlot> iterator;
 
 		private AllocationIDIterator(JobID jobId, TaskSlotState state) {
-				iterator = new TaskSlotIterator(jobId, state);
+			iterator = new TaskSlotIterator(jobId, state);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -56,6 +56,13 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor, Co
 		}
 	}
 
+	/** Triggers all {@code queuedRunnables}. */
+	public void triggerAll() {
+		while (numQueuedRunnables() > 0) {
+			trigger();
+		}
+	}
+
 	/**
 	 * Triggers the next queued runnable and executes it synchronously.
 	 * This method throws an exception if no Runnable is currently queued.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledBufferConsumer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -160,6 +161,7 @@ public class ResultPartitionTest {
 			partition.release();
 			// partition.add() silently drops the bufferConsumer but recycles it
 			partition.addBufferConsumer(bufferConsumer, 0);
+			assertTrue(partition.isReleased());
 		} finally {
 			if (!bufferConsumer.isRecycled()) {
 				bufferConsumer.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -68,7 +68,8 @@ public class ResourceManagerHATest extends TestLogger {
 			new SlotManagerConfiguration(
 				TestingUtils.infiniteTime(),
 				TestingUtils.infiniteTime(),
-				TestingUtils.infiniteTime()));
+				TestingUtils.infiniteTime(),
+				true));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -38,10 +38,10 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -137,11 +137,9 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 			rpcService.getScheduledExecutor(),
 			Time.minutes(5L));
 
-		final SlotManager slotManager = new SlotManager(
-			rpcService.getScheduledExecutor(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime());
+		final SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(rpcService.getScheduledExecutor())
+			.build();
 
 		ResourceManager<?> resourceManager = new StandaloneResourceManager(
 			rpcService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -44,7 +45,6 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -136,11 +136,9 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 		HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
 		highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
 
-		SlotManager slotManager = new SlotManager(
-			rpcService.getScheduledExecutor(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime());
+		SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(rpcService.getScheduledExecutor())
+			.build();
 
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -235,11 +236,9 @@ public class ResourceManagerTest extends TestLogger {
 	}
 
 	private TestingResourceManager createAndStartResourceManager(HeartbeatServices heartbeatServices) throws Exception {
-		final SlotManager slotManager = new SlotManager(
-			rpcService.getScheduledExecutor(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime());
+		final SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(rpcService.getScheduledExecutor())
+			.build();
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
 			highAvailabilityServices,
 			rpcService.getScheduledExecutor(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+/** Builder for {@link SlotManager}. */
+public class SlotManagerBuilder {
+	private ScheduledExecutor scheduledExecutor;
+	private Time taskManagerRequestTimeout;
+	private Time slotRequestTimeout;
+	private Time taskManagerTimeout;
+	private boolean waitResultConsumedBeforeRelease;
+
+	private SlotManagerBuilder() {
+		this.scheduledExecutor = TestingUtils.defaultScheduledExecutor();
+		this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
+		this.slotRequestTimeout = TestingUtils.infiniteTime();
+		this.taskManagerTimeout = TestingUtils.infiniteTime();
+		this.waitResultConsumedBeforeRelease = true;
+	}
+
+	public static SlotManagerBuilder newBuilder() {
+		return new SlotManagerBuilder();
+	}
+
+	public SlotManagerBuilder setScheduledExecutor(ScheduledExecutor scheduledExecutor) {
+		this.scheduledExecutor = scheduledExecutor;
+		return this;
+	}
+
+	public SlotManagerBuilder setTaskManagerRequestTimeout(Time taskManagerRequestTimeout) {
+		this.taskManagerRequestTimeout = taskManagerRequestTimeout;
+		return this;
+	}
+
+	public SlotManagerBuilder setSlotRequestTimeout(Time slotRequestTimeout) {
+		this.slotRequestTimeout = slotRequestTimeout;
+		return this;
+	}
+
+	public SlotManagerBuilder setTaskManagerTimeout(Time taskManagerTimeout) {
+		this.taskManagerTimeout = taskManagerTimeout;
+		return this;
+	}
+
+	public SlotManagerBuilder setWaitResultConsumedBeforeRelease(boolean waitResultConsumedBeforeRelease) {
+		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+		return this;
+	}
+
+	public SlotManager build() {
+		return new SlotManager(
+			scheduledExecutor,
+			taskManagerRequestTimeout,
+			slotRequestTimeout,
+			taskManagerTimeout,
+			waitResultConsumedBeforeRelease);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -82,11 +81,9 @@ public class SlotProtocolTest extends TestLogger {
 
 		final ResourceManagerId rmLeaderID = ResourceManagerId.generate();
 
-		try (SlotManager slotManager = new SlotManager(
-			scheduledExecutor,
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(scheduledExecutor)
+			.build()) {
 
 			final CompletableFuture<ResourceProfile> resourceProfileFuture = new CompletableFuture<>();
 			ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
@@ -150,11 +147,9 @@ public class SlotProtocolTest extends TestLogger {
 			})
 			.createTestingTaskExecutorGateway();
 
-		try (SlotManager slotManager = new SlotManager(
-			scheduledExecutor,
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime(),
-			TestingUtils.infiniteTime())) {
+		try (SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(scheduledExecutor)
+			.build()) {
 
 			ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -42,6 +42,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Simple {@link TaskExecutorGateway} implementation for testing purposes.
@@ -68,6 +69,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction;
 
+	private final Supplier<Boolean> canBeReleasedSupplier;
+
 	TestingTaskExecutorGateway(
 			String address,
 			String hostname,
@@ -78,7 +81,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 			BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction,
 			Consumer<ResourceID> heartbeatResourceManagerConsumer,
 			Consumer<Exception> disconnectResourceManagerConsumer,
-			Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction) {
+			Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction,
+			Supplier<Boolean> canBeReleasedSupplier) {
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
 		this.heartbeatJobManagerConsumer = Preconditions.checkNotNull(heartbeatJobManagerConsumer);
@@ -89,6 +93,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 		this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
 		this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
 		this.cancelTaskFunction = cancelTaskFunction;
+		this.canBeReleasedSupplier = canBeReleasedSupplier;
 	}
 
 	@Override
@@ -175,6 +180,11 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	@Override
 	public CompletableFuture<SerializableOptional<String>> requestMetricQueryServiceAddress(Time timeout) {
 		return CompletableFuture.completedFuture(SerializableOptional.empty());
+	}
+
+	@Override
+	public CompletableFuture<Boolean> canBeReleased() {
+		return CompletableFuture.completedFuture(canBeReleasedSupplier.get());
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -34,6 +34,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Builder for a {@link TestingTaskExecutorGateway}.
@@ -59,6 +60,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private Consumer<ResourceID> heartbeatResourceManagerConsumer = NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
 	private Consumer<Exception> disconnectResourceManagerConsumer = NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
 	private Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction = NOOP_CANCEL_TASK_FUNCTION;
+	private Supplier<Boolean> canBeReleasedSupplier = () -> true;
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
 		this.address = address;
@@ -110,6 +112,11 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
+	public TestingTaskExecutorGatewayBuilder setCanBeReleasedSupplier(Supplier<Boolean> canBeReleasedSupplier) {
+		this.canBeReleasedSupplier = canBeReleasedSupplier;
+		return this;
+	}
+
 	public TestingTaskExecutorGateway createTestingTaskExecutorGateway() {
 		return new TestingTaskExecutorGateway(
 			address,
@@ -121,6 +128,7 @@ public class TestingTaskExecutorGatewayBuilder {
 			freeSlotFunction,
 			heartbeatResourceManagerConsumer,
 			disconnectResourceManagerConsumer,
-			cancelTaskFunction);
+			cancelTaskFunction,
+			canBeReleasedSupplier);
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -305,9 +306,12 @@ public class YarnResourceManagerTest extends TestLogger {
 				highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
 				heartbeatServices = new TestingHeartbeatServices();
 				metricRegistry = NoOpMetricRegistry.INSTANCE;
-				slotManager = new SlotManager(
-						new ScheduledExecutorServiceAdapter(new DirectScheduledExecutorService()),
-						Time.seconds(10), Time.seconds(10), Time.minutes(1));
+				slotManager = SlotManagerBuilder.newBuilder()
+					.setScheduledExecutor(new ScheduledExecutorServiceAdapter(new DirectScheduledExecutorService()))
+					.setTaskManagerRequestTimeout(Time.seconds(10))
+					.setSlotRequestTimeout(Time.seconds(10))
+					.setTaskManagerTimeout(Time.minutes(1))
+					.build();
 				jobLeaderIdService = new JobLeaderIdService(
 						highAvailabilityServices,
 						rpcService.getScheduledExecutor(),


### PR DESCRIPTION
## What is the purpose of the change

More changes based on #7186.

## Brief change log

The task executor gateway can use `NetworkEviroment.PartitionManager` to check still registered and unreleased partitions because it is the central point to manage partitions. It would also simplify how it is queried now going through `TaskSlot` and lingering `Tasks`. Eventually, `NetworkEviroment` becomes `ShuffleService` which could decide whether producer can be released or not this way or another.

We still make producer task executor depend on another consumer task executor, though, we do not see any problems with it now, I think it is still more safe to introduce an option as a feature flag. By default, task executor will wait for consumers, as this PR suggests, but users can always fallback to the previous behaviour using the option.

## Verifying this change

unit tests, e2e tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
