### PR TITLE
[FLINK-10935][ResourceManager] Implement KubeClient with Fabric8 Kubenetes clients

### DIFF
--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -1,0 +1,64 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.9-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	
+	<artifactId>flink-kubernetes_${scala.binary.version}</artifactId>
+	<name>flink-kubernetes</name>
+	<packaging>jar</packaging>
+	
+	<properties>
+		<kubernetes.version>1.0.1</kubernetes.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- set all Flink dependencies to provided, so they and their transitive  -->
+		<!-- dependencies do not get promoted to direct dependencies during shading -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -53,11 +53,37 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-client</artifactId>
+			<version>4.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-client</artifactId>
+			<version>4.0.0</version>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>0.1.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-server-mock</artifactId>
+			<version>4.0.0</version>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -59,12 +59,6 @@
 			<version>4.0.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>io.fabric8</groupId>
-			<artifactId>kubernetes-client</artifactId>
-			<version>4.0.0</version>
-		</dependency>
-
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -54,9 +54,30 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.7.5</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.7.5</version>
+		</dependency>
+
+		<dependency>
 			<groupId>io.fabric8</groupId>
 			<artifactId>kubernetes-client</artifactId>
 			<version>4.0.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -71,6 +71,20 @@
 			<artifactId>mockwebserver</artifactId>
 			<version>0.1.0</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.squareup.okhttp3</groupId>
+					<artifactId>okhttp</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Parameters that will be used in Flink on k8s cluster.
+ * */
+public class FlinkKubernetesOptions {
+
+	private Configuration configuration;
+
+	public Configuration getConfiguration() {
+		return configuration;
+	}
+
+	public FlinkKubernetesOptions(Configuration configuration) {
+		this.configuration = configuration;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/FlinkKubernetesOptions.java
@@ -18,20 +18,74 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
 
 /**
  * Parameters that will be used in Flink on k8s cluster.
  * */
 public class FlinkKubernetesOptions {
 
+	public static final ConfigOption<Boolean> DEBUG_MODE =
+		key("k8s.debugmode.enable")
+			.defaultValue(false)
+			.withDescription("Whether enable debug mode.");
+
+	public static final ConfigOption<String> EXTERNAL_IP =
+		key("jobmanager.k8s.externalip")
+			.defaultValue("")
+			.withDescription("The external ip for job manager external IP.");
+
 	private Configuration configuration;
+
+	private String clusterId;
+
+	private String namespace = "default";
+
+	private String imageName;
+
+	public FlinkKubernetesOptions(Configuration configuration, String clusterId) {
+		Preconditions.checkArgument(configuration != null);
+		this.configuration = configuration;
+		this.clusterId = clusterId;
+	}
+
+	public String getClusterId() {
+		return clusterId;
+	}
+
+	public void setClusterId(String clusterId) {
+		this.clusterId = clusterId;
+	}
+
+	public String getImageName(){
+		return this.imageName;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public String getExternalIP() {
+		return this.configuration.getString(FlinkKubernetesOptions.EXTERNAL_IP);
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public Integer getServicePort(ConfigOption<Integer> port) {
+		return this.configuration.getInteger(port);
+	}
+
+	public Boolean getIsDebugMode() {
+		return this.configuration.getBoolean(FlinkKubernetesOptions.DEBUG_MODE);
+	}
 
 	public Configuration getConfiguration() {
 		return configuration;
-	}
-
-	public FlinkKubernetesOptions(Configuration configuration) {
-		this.configuration = configuration;
 	}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cluster/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cluster/KubernetesClusterDescriptor.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.cluster;
+
+import org.apache.flink.client.deployment.ClusterDeploymentException;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterRetrieveException;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
+import org.apache.flink.kubernetes.kubeclient.KubeClient;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Kubernetes specific {@link ClusterDescriptor} implementation.
+ */
+public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesClusterDescriptor.class);
+
+	private static final String CLUSTER_ID_PREFIX = "flink-session-cluster-";
+
+	private static final String CLUSTER_DESCRIPTION = "Kubernetes cluster";
+
+	private FlinkKubernetesOptions options;
+
+	private KubeClient client;
+
+	public KubernetesClusterDescriptor(@Nonnull FlinkKubernetesOptions options, @Nonnull KubeClient client) {
+		this.options = options;
+		this.client = client;
+	}
+
+	private String generateClusterId() {
+		return CLUSTER_ID_PREFIX + UUID.randomUUID();
+	}
+
+	@Override
+	public String getClusterDescription() {
+		return CLUSTER_DESCRIPTION;
+	}
+
+	private ClusterClient<String> createClusterEndpoint(Endpoint clusterEndpoint, String clusterId) throws Exception {
+
+		Configuration configuration = new Configuration(this.options.getConfiguration());
+		configuration.setString(JobManagerOptions.ADDRESS, clusterEndpoint.getAddress());
+		configuration.setInteger(JobManagerOptions.PORT, clusterEndpoint.getPort());
+		return new RestClusterClient<>(configuration, clusterId);
+	}
+
+	@Override
+	public ClusterClient<String> retrieve(String clusterId) throws ClusterRetrieveException {
+		try {
+			Endpoint clusterEndpoint = this.client.getResetEndpoint(clusterId);
+			return this.createClusterEndpoint(clusterEndpoint, clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			throw new ClusterRetrieveException("Could not create the RestClusterClient.", e);
+		}
+	}
+
+	@Override
+	public ClusterClient<String> deploySessionCluster(ClusterSpecification clusterSpecification)
+		throws ClusterDeploymentException {
+
+		String clusterId = this.generateClusterId();
+
+		//TODO: add arguments
+		final List<String> args = Arrays.asList();
+
+		return this.deployClusterInternal(clusterId, args);
+	}
+
+	@Override
+	public ClusterClient<String> deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph, boolean detached) {
+		throw new NotImplementedException();
+	}
+
+	@Nonnull
+	private ClusterClient<String> deployClusterInternal(String clusterId, List<String> args) throws ClusterDeploymentException {
+		try {
+			Endpoint clusterEndpoint = this.client.createClusterService(clusterId).get();
+			this.client.createClusterPod();
+			return this.createClusterEndpoint(clusterEndpoint, clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			this.tryKillCluster(clusterId);
+			throw new ClusterDeploymentException("Could not create Kubernetes cluster " + clusterId, e);
+		}
+	}
+
+	/**
+	 * Try to kill cluster without throw exception.
+	 */
+	private void tryKillCluster(String clusterId) {
+		try {
+			this.killCluster(clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+		}
+	}
+
+	@Override
+	public void killCluster(String clusterId) throws FlinkException {
+		try {
+			this.client.stopAndCleanupCluster(clusterId);
+		} catch (Exception e) {
+			this.client.logException(e);
+			throw new FlinkException("Could not create Kubernetes cluster " + clusterId);
+		}
+	}
+
+	@Override
+	public void close() {
+		try {
+			this.client.close();
+		} catch (Exception e) {
+			this.client.logException(e);
+			LOG.error("failed to close client, exception {}", e.toString());
+		}
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesSessionClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesSessionClusterEntrypoint.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+
+/**
+ * Entrypoint for a Kubernetes session cluster.
+ */
+public class KubernetesSessionClusterEntrypoint extends SessionClusterEntrypoint {
+
+	public KubernetesSessionClusterEntrypoint(Configuration configuration) {
+		super(configuration);
+	}
+
+	@Override
+	protected DispatcherResourceManagerComponentFactory<?> createDispatcherResourceManagerComponentFactory(Configuration configuration) {
+		return null;
+	}
+
+	public static void main(String[] args) {
+		LOG.info("Started {}.", KubernetesSessionClusterEntrypoint.class.getSimpleName());
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Endpoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Endpoint.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+/**
+ * Represent an endpoint.
+ * */
+public class Endpoint {
+
+	private String address;
+
+	private int port;
+
+	public Endpoint(String address, int port) {
+		this.address = address;
+		this.port = port;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public int getPort() {
+		return port;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClient.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The client to talk with kubernetes.
+ * */
+public interface KubeClient extends AutoCloseable {
+
+	/**
+	 * Initialize client.
+	 * */
+	void initialize();
+
+	/**
+	 * Create kubernetes services and expose endpoints for access outside cluster.
+	 */
+	CompletableFuture<Endpoint> createClusterService(String clusterId) throws Exception;
+
+	/**
+	 * Create cluster pod.
+	 */
+	void createClusterPod();
+
+	/**
+	 * stop cluster and clean up all resources, include services, auxiliary services and all running pods.
+	 * */
+	void stopAndCleanupCluster(String clusterId);
+
+	/**
+	 * Log exceptions.
+	 * */
+	void logException(Exception e);
+
+	/**
+	 * retrieval rest endpoint of the giving flink clusterId.
+	 */
+	Endpoint getResetEndpoint(String flinkClusterId);
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/ActionWatcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/ActionWatcher.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
+import io.fabric8.kubernetes.client.Watcher;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * For watch a specific action.
+ * */
+public class ActionWatcher<T extends HasMetadata> implements Watcher<T> {
+	private final CountDownLatch latch = new CountDownLatch(1);
+	private final AtomicReference<T> reference = new AtomicReference();
+	private final T resource;
+	private Action expectedAction;
+
+	public ActionWatcher(Action expectedAction, T resource) {
+		this.resource = resource;
+		this.expectedAction = expectedAction;
+	}
+
+	public void eventReceived(Action action, T resource) {
+
+		if (action == this.expectedAction) {
+			this.reference.set(resource);
+			this.latch.countDown();
+		}
+	}
+
+	public void onClose(KubernetesClientException e) {
+	}
+
+	public T await(long amount, TimeUnit timeUnit) {
+		try {
+			if (this.latch.await(amount, timeUnit)) {
+				return (T) this.reference.get();
+			} else {
+				throw new KubernetesClientTimeoutException(this.resource, amount, timeUnit);
+			}
+		} catch (InterruptedException var5) {
+			throw new KubernetesClientTimeoutException(this.resource, amount, timeUnit);
+		}
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/Fabric8FlinkKubeClient.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8;
+
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
+import org.apache.flink.kubernetes.kubeclient.KubeClient;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.Decorator;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.ExternalIPDecorator;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.JobManagerPodDecorator;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.LoadBalancerDecorator;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.PodInitializerDecorator;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.ServiceInitializerDecorator;
+import org.apache.flink.kubernetes.kubeclient.fabric8.decorators.ServicePortDecorator;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The implementation of KubeClient.
+ * */
+public class Fabric8FlinkKubeClient implements KubeClient {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Fabric8FlinkKubeClient.class);
+
+	private FlinkKubernetesOptions flinkKubeOptions;
+
+	private List<Decorator<Pod, FlinkPod>> clusterPodDecorators;
+
+	private List<Decorator<Service, FlinkService>> serviceDecorators;
+
+	private KubernetesClient internalClient;
+
+	public Fabric8FlinkKubeClient(FlinkKubernetesOptions kubeOptions, KubernetesClient client) {
+		this.internalClient = client;
+		this.flinkKubeOptions = kubeOptions;
+		this.clusterPodDecorators = new ArrayList<>();
+		this.serviceDecorators = new ArrayList<>();
+	}
+
+	@Override
+	public void initialize() {
+		this.serviceDecorators.add(new ServiceInitializerDecorator());
+		this.serviceDecorators.add(new ServicePortDecorator());
+		this.serviceDecorators.add(new LoadBalancerDecorator());
+		this.serviceDecorators.add(new ExternalIPDecorator());
+
+		this.clusterPodDecorators.add(new PodInitializerDecorator());
+		this.clusterPodDecorators.add(new JobManagerPodDecorator());
+	}
+
+	@Override
+	public void createClusterPod() {
+		FlinkPod pod = new FlinkPod(this.flinkKubeOptions);
+
+		for (Decorator<Pod, FlinkPod> d : this.clusterPodDecorators) {
+			pod = d.decorate(pod);
+		}
+
+		this.internalClient.pods().create(pod.getInternalResource());
+	}
+
+	/**
+	 * Extract service address.
+	 * */
+	private String extractServiceAddress(Service service) {
+		if (service.getStatus() != null
+			&& service.getStatus().getLoadBalancer() != null
+			&& service.getStatus().getLoadBalancer().getIngress() != null
+			&& service.getStatus().getLoadBalancer().getIngress().size() > 0
+			) {
+			return service.getStatus().getLoadBalancer().getIngress().get(0).getIp();
+		} else if (service.getSpec().getExternalIPs() != null) {
+			return service.getSpec().getExternalIPs().get(0);
+		}
+
+		return null;
+	}
+
+	@Override
+	public CompletableFuture<Endpoint> createClusterService(String clusterId) {
+		this.flinkKubeOptions.setClusterId(clusterId);
+		FlinkService service = new FlinkService(this.flinkKubeOptions);
+
+		for (Decorator<Service, FlinkService> d : this.serviceDecorators) {
+			service = d.decorate(service);
+		}
+
+		this.internalClient.services().create(service.getInternalResource());
+
+		ActionWatcher<Service> watcher = new ActionWatcher<>(Watcher.Action.ADDED, service.getInternalResource());
+		this.internalClient.services().watch(watcher);
+
+		return CompletableFuture.supplyAsync(() -> {
+			Service createdService = watcher.await(1, TimeUnit.MINUTES);
+			String address = extractServiceAddress(createdService);
+			int uiPort = this.flinkKubeOptions.getServicePort(RestOptions.PORT);
+			return new Endpoint(address, uiPort);
+		});
+	}
+
+	@Override
+	public void stopAndCleanupCluster(String clusterId) {
+		this.internalClient.services().withName(clusterId).delete();
+	}
+
+	@Override
+	public void logException(Exception e) {
+
+	}
+
+	@Override
+	public Endpoint getResetEndpoint(String clusterId) {
+		Service service = this.internalClient.services().withName(clusterId).fromServer().get();
+
+		String address = service.getStatus().getLoadBalancer().getIngress().get(0).getIp();
+		int port = service.getSpec().getPorts().get(0).getPort();
+
+		return new Endpoint(address, port);
+	}
+
+	@Override
+	public void close() {
+
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/FlinkPod.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/FlinkPod.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+
+import io.fabric8.kubernetes.api.model.Pod;
+
+/**
+ * represent FlinkPod resource in kubernetes.
+ * */
+public class FlinkPod extends Resource<Pod> {
+
+	public FlinkPod(FlinkKubernetesOptions flinkOptions) {
+		super(flinkOptions);
+		this.internalResource = new Pod();
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/FlinkService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/FlinkService.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+
+import io.fabric8.kubernetes.api.model.Service;
+
+/**
+ * represent Service resource in kubernetes.
+ * */
+public class FlinkService extends Resource<Service> {
+
+	public FlinkService(FlinkKubernetesOptions flinkOptions) {
+		super(flinkOptions);
+		this.internalResource = new Service();
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/Resource.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/Resource.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+
+/**
+ * represent a kubernetes resource.
+ * */
+public abstract class Resource<T> {
+
+	protected T internalResource;
+
+	protected FlinkKubernetesOptions flinkOptions;
+
+	public Resource(FlinkKubernetesOptions flinkOptions) {
+		this.flinkOptions = flinkOptions;
+	}
+
+	public FlinkKubernetesOptions getFlinkOptions() {
+		return flinkOptions;
+	}
+
+	public T getInternalResource() {
+		return internalResource;
+	}
+
+	public void setInternalResource(T internalResource) {
+		this.internalResource = internalResource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/Decorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/Decorator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.Resource;
+
+/**
+ * Abstract decorator for add features to resource such as pod/service.
+ * */
+public abstract class Decorator<R, T extends Resource<R>> {
+
+	public static final String API_VERSION = "v1";
+
+	protected Boolean isEnabled(FlinkKubernetesOptions flinkKubernetesOptions) {
+		return true;
+	}
+
+	/**
+	 * do decorate the real resource.
+	 */
+	protected abstract R doDecorate(R resource, FlinkKubernetesOptions flinkKubernetesOptions);
+
+	/**
+	 * extract real resource from resource, decorate and put it back.
+	 */
+	public T decorate(T resource) {
+
+		//skip if it was disabled
+		if (!this.isEnabled(resource.getFlinkOptions())) {
+			return resource;
+		}
+
+		R realResource = resource.getInternalResource();
+		realResource = doDecorate(realResource, resource.getFlinkOptions());
+		resource.setInternalResource(realResource);
+
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/ExternalIPDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/ExternalIPDecorator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.FlinkService;
+import org.apache.flink.util.Preconditions;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+
+import java.util.Arrays;
+
+/**
+ * This decorator is for debug purpose.
+ * */
+public class ExternalIPDecorator extends Decorator<Service, FlinkService> {
+
+	protected Boolean isEnabled(FlinkKubernetesOptions flinkKubernetesOptions) {
+		return flinkKubernetesOptions.getIsDebugMode();
+	}
+
+	@Override
+	protected Service doDecorate(Service resource, FlinkKubernetesOptions flinkKubernetesOptions) {
+
+		String externalIP = flinkKubernetesOptions.getExternalIP();
+		Preconditions.checkState(externalIP != null);
+
+		ServiceSpec spec = resource.getSpec() != null ? resource.getSpec() : new ServiceSpec();
+		spec.setExternalIPs(Arrays.asList(externalIP));
+		resource.setSpec(spec);
+
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/JobManagerPodDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/JobManagerPodDecorator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.FlinkPod;
+import org.apache.flink.util.Preconditions;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Job manager specific pod configuration.
+ * */
+public class JobManagerPodDecorator extends Decorator<Pod, FlinkPod> {
+
+	@Override
+	protected Pod doDecorate(Pod resource, FlinkKubernetesOptions flinkKubernetesOptions) {
+
+		Preconditions.checkArgument(flinkKubernetesOptions != null && flinkKubernetesOptions.getClusterId() != null);
+
+		Map<String, String> labels = LabelBuilder
+			.withExist(resource.getMetadata().getLabels())
+			.withJobManagerRole()
+			.toLabels();
+
+		resource.getMetadata().setLabels(labels);
+
+		Container container = new ContainerBuilder()
+			.withName(flinkKubernetesOptions.getClusterId())
+			.withImage(flinkKubernetesOptions.getImageName())
+			.withImagePullPolicy("IfNotPresent")
+			.withPorts(Arrays.asList(
+				new ContainerPortBuilder().withContainerPort(flinkKubernetesOptions.getServicePort(RestOptions.PORT)).build(),
+				new ContainerPortBuilder().withContainerPort(flinkKubernetesOptions.getServicePort(JobManagerOptions.PORT)).build(),
+				new ContainerPortBuilder().withContainerPort(6124).build(),
+				new ContainerPortBuilder().withContainerPort(6125).build()))
+			.build();
+
+		resource.setSpec(new PodSpecBuilder().withContainers(Arrays.asList(container)).build());
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/LabelBuilder.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/LabelBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manager labels.
+ * */
+public class LabelBuilder {
+
+	private Map<String, String> labels;
+
+	private LabelBuilder(){
+		this(new HashMap<>());
+	}
+
+	private LabelBuilder(Map<String, String> labels){
+		this.labels = labels;
+	}
+
+	private LabelBuilder withLabel(String key, String value){
+		this.labels.put(key, value);
+		return this;
+	}
+
+	public static LabelBuilder withCommon(){
+		return new LabelBuilder()
+			.withLabel("app", "flink-native-k8s");
+	}
+
+	public static LabelBuilder withExist(Map<String, String> labels){
+		return new LabelBuilder(labels);
+	}
+
+	public LabelBuilder withClusterId(String id){
+		return this.withLabel("appId", id);
+	}
+
+	public LabelBuilder withJobManagerRole(){
+		return this.withLabel("role", "jobmanager");
+	}
+
+	public LabelBuilder withTaskManagerRole(){
+		return this.withLabel("role", "taskmanager");
+	}
+
+	public Map<String, String> toLabels(){
+		return labels;
+	}
+}
+

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/LoadBalancerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/LoadBalancerDecorator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.FlinkService;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+
+/**
+ * setup load balancer for service.
+ * */
+public class LoadBalancerDecorator extends Decorator<Service, FlinkService> {
+
+	protected Boolean isEnabled(FlinkKubernetesOptions flinkKubernetesOptions) {
+		return !flinkKubernetesOptions.getIsDebugMode();
+	}
+
+	@Override
+	protected Service doDecorate(Service resource, FlinkKubernetesOptions flinkKubernetesOptions) {
+
+		ServiceSpec spec = resource.getSpec() != null ? resource.getSpec() : new ServiceSpec();
+		spec.setType("LoadBalancer");
+		resource.setSpec(spec);
+
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/PodInitializerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/PodInitializerDecorator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.FlinkPod;
+import org.apache.flink.util.Preconditions;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+
+import java.util.Map;
+
+/**
+ * Initial setup for a flink pod.
+ * */
+public class PodInitializerDecorator extends Decorator<Pod, FlinkPod> {
+
+	@Override
+	protected Pod doDecorate(Pod resource, FlinkKubernetesOptions flinkKubernetesOptions) {
+
+		Preconditions.checkArgument(flinkKubernetesOptions != null && flinkKubernetesOptions.getClusterId() != null);
+
+		Map<String, String> labels = LabelBuilder
+			.withCommon()
+			.withClusterId(flinkKubernetesOptions.getClusterId())
+			.toLabels();
+
+		ObjectMeta meta = new ObjectMeta();
+		meta.setName(flinkKubernetesOptions.getClusterId());
+		meta.setLabels(labels);
+		meta.setNamespace(flinkKubernetesOptions.getNamespace());
+
+		resource.setApiVersion(Decorator.API_VERSION);
+		resource.setMetadata(meta);
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/ServiceInitializerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/ServiceInitializerDecorator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.FlinkService;
+import org.apache.flink.util.Preconditions;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
+
+import java.util.Map;
+
+/**
+ * Initial setup for flink service.
+ * */
+public class ServiceInitializerDecorator extends Decorator<Service, FlinkService> {
+
+	@Override
+	protected Service doDecorate(Service resource, FlinkKubernetesOptions flinkKubernetesOptions) {
+
+		Preconditions.checkArgument(flinkKubernetesOptions != null && flinkKubernetesOptions.getClusterId() != null);
+
+		Map<String, String> labels = LabelBuilder
+			.withCommon()
+			.withClusterId(flinkKubernetesOptions.getClusterId())
+			.toLabels();
+
+		ObjectMeta meta = new ObjectMeta();
+		meta.setName(flinkKubernetesOptions.getClusterId());
+		meta.setLabels(labels);
+		meta.setNamespace(flinkKubernetesOptions.getNamespace());
+
+		resource.setApiVersion(Decorator.API_VERSION);
+		resource.setMetadata(meta);
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/ServicePortDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/fabric8/decorators/ServicePortDecorator.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8.decorators;
+
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.QueryableStateOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.kubeclient.fabric8.FlinkService;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+
+import java.util.Arrays;
+
+/**
+ * setup services port.
+ * */
+public class ServicePortDecorator extends Decorator<Service, FlinkService> {
+
+	private ServicePort getServicePort(String name, int port) {
+		return new ServicePortBuilder()
+			.withName(name)
+			.withPort(port)
+			.build();
+	}
+
+	private String getPortName(String portName){
+		return portName.replace('.', '-');
+	}
+
+	@Override
+	protected Service doDecorate(Service resource, FlinkKubernetesOptions flinkKubernetesOptions) {
+
+		ServiceSpec spec = resource.getSpec() != null
+			? resource.getSpec() : new ServiceSpec();
+
+		spec.setPorts(Arrays.asList(
+			//UI, reset
+			getServicePort(getPortName(RestOptions.PORT.key()), flinkKubernetesOptions.getServicePort(RestOptions.PORT)),
+			//rpc
+			getServicePort(getPortName(JobManagerOptions.PORT.key()), flinkKubernetesOptions.getServicePort(JobManagerOptions.PORT)),
+			//blob
+			getServicePort(getPortName(BlobServerOptions.PORT.key()), 6124),
+			getServicePort(getPortName(QueryableStateOptions.SERVER_PORT_RANGE.key()), 6125)));
+
+		resource.setSpec(spec);
+
+		return resource;
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/MixedDispatcher.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/MixedDispatcher.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import io.fabric8.mockwebserver.dsl.HttpMethod;
+import io.fabric8.mockwebserver.internal.SimpleRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.util.Map;
+import java.util.Queue;
+
+/**
+ * A dispatcher that support both mock response and CRUD response.
+ * */
+public class MixedDispatcher extends KubernetesCrudDispatcher {
+	private final Map<ServerRequest, Queue<ServerResponse>> responses;
+
+	public MixedDispatcher(Map<ServerRequest, Queue<ServerResponse>> responses) {
+		this.responses = responses;
+	}
+
+	@Override
+	public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+		HttpMethod method = HttpMethod.valueOf(request.getMethod());
+		String path = request.getPath();
+		SimpleRequest key = new SimpleRequest(method, path);
+		SimpleRequest keyForAnyMethod = new SimpleRequest(path);
+		if (responses.containsKey(key)) {
+			Queue<ServerResponse> queue = responses.get(key);
+			return handleResponse(queue.peek(), queue, request);
+		} else if (responses.containsKey(keyForAnyMethod)) {
+			Queue<ServerResponse> queue = responses.get(keyForAnyMethod);
+			return handleResponse(queue.peek(), queue, request);
+		}
+
+		return super.dispatch(request);
+	}
+
+	private MockResponse handleResponse(ServerResponse response, Queue<ServerResponse> queue, RecordedRequest request) {
+		if (response == null) {
+			return new MockResponse().setResponseCode(404);
+		} else if (!response.isRepeatable()) {
+			queue.remove();
+		}
+		return response.toMockResponse(request);
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/MixedMockKubernetesServer.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/MixedMockKubernetesServer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import io.fabric8.mockwebserver.dsl.MockServerExpectation;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.rules.ExternalResource;
+
+import java.util.HashMap;
+import java.util.Queue;
+
+/**
+ * The mock server that host MixedDispatcher.
+ * */
+public class MixedMockKubernetesServer extends ExternalResource {
+
+	private KubernetesMockServer mock;
+	private NamespacedKubernetesClient client;
+	private boolean https;
+	// In this mode the mock web server will store, read, update and delete
+	// kubernetes resources using an in memory map and will appear as a real api
+	// server.
+	private boolean crudMode;
+
+	public MixedMockKubernetesServer(boolean https, boolean crudMode) {
+		this.https = https;
+		this.crudMode = crudMode;
+	}
+
+	public void before() {
+		HashMap<ServerRequest, Queue<ServerResponse>> response = new HashMap<>();
+		mock = crudMode
+			? new KubernetesMockServer(new Context(), new MockWebServer(), response, new MixedDispatcher(response), true)
+			: new KubernetesMockServer(https);
+		mock.init();
+		client = mock.createClient();
+	}
+
+	public void after() {
+		mock.destroy();
+		client.close();
+	}
+
+	public NamespacedKubernetesClient getClient() {
+		return client;
+	}
+
+	public MockServerExpectation expect() {
+		return mock.expect();
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/fabric8/Fabric8ClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/fabric8/Fabric8ClientTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.fabric8;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.FlinkKubernetesOptions;
+import org.apache.flink.kubernetes.MixedMockKubernetesServer;
+import org.apache.flink.kubernetes.kubeclient.Endpoint;
+
+import io.fabric8.kubernetes.api.model.LoadBalancerIngress;
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Tests for Fabric implementation of KubeClient.
+ * */
+public class Fabric8ClientTest {
+
+	@Rule
+	public MixedMockKubernetesServer server = new MixedMockKubernetesServer(true, true);
+
+	private Fabric8FlinkKubeClient getClient(FlinkKubernetesOptions options){
+		KubernetesClient client = server.getClient();
+		//only support namespace test
+		options.setNamespace("test");
+		Fabric8FlinkKubeClient flinkKubeClient = new Fabric8FlinkKubeClient(options, client);
+		flinkKubeClient.initialize();
+		return flinkKubeClient;
+	}
+
+	@Test
+	public void testCreateClusterPod() {
+		FlinkKubernetesOptions options = new FlinkKubernetesOptions(new Configuration(), "abc");
+		Fabric8FlinkKubeClient flinkKubeClient = this.getClient(options);
+		flinkKubeClient.createClusterPod();
+
+		KubernetesClient client = server.getClient();
+		PodList list = client.pods().list();
+		Assert.assertEquals(1, list.getItems().size());
+
+		Pod pod = list.getItems().get(0);
+
+		Assert.assertEquals(options.getClusterId(), pod.getMetadata().getName());
+		Assert.assertEquals(1, pod.getSpec().getContainers().size());
+		Assert.assertEquals(4, pod.getSpec().getContainers().get(0).getPorts().size());
+	}
+
+	@Test
+	public void testCreateService() throws  Exception {
+
+		ObjectMeta meta = new ObjectMeta();
+		meta.setResourceVersion("1");
+
+		Service serviceWithIngress = new ServiceBuilder()
+			.withMetadata(meta)
+			.withNewStatus()
+			.withLoadBalancer(new LoadBalancerStatus(Arrays.asList(new LoadBalancerIngress("null", "192.168.0.1"))))
+			.and()
+			.build();
+
+		server.expect()
+			.withPath("/api/v1/namespaces/test/services?watch=true")
+			.andUpgradeToWebSocket()
+			.open()
+			.waitFor(100)
+			.andEmit(new WatchEvent(serviceWithIngress, "ADDED"))
+			.done()
+			.once();
+
+		FlinkKubernetesOptions options = new FlinkKubernetesOptions(new Configuration(), "abc");
+		Fabric8FlinkKubeClient flinkKubeClient = this.getClient(options);
+
+		CompletableFuture<Endpoint> future = flinkKubeClient.createClusterService("abc");
+		KubernetesClient client = server.getClient();
+		ServiceList list = client.services().list();
+		Assert.assertEquals(1, list.getItems().size());
+
+		Service service = list.getItems().get(0);
+
+		Assert.assertEquals("abc", service.getMetadata().getName());
+		Assert.assertEquals(options.getNamespace(), service.getMetadata().getNamespace());
+
+		List<ServicePort> ports = service.getSpec().getPorts();
+		Assert.assertEquals(4, ports.size());
+		Assert.assertTrue(ports.stream()
+			.anyMatch(p -> p.getPort() == options.getConfiguration().getInteger(RestOptions.PORT)));
+
+		Endpoint endpoint = future.get();
+		Assert.assertEquals("192.168.0.1", endpoint.getAddress());
+		Assert.assertEquals(options.getConfiguration().getInteger(RestOptions.PORT), endpoint.getPort());
+	}
+}

--- a/flink-kubernetes/src/test/java/resources/log4j-test.properties
+++ b/flink-kubernetes/src/test/java/resources/log4j-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=OFF, testlogger
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@ under the License.
 		<module>flink-mesos</module>
 		<module>flink-metrics</module>
 		<module>flink-yarn</module>
+		<module>flink-kubernetes</module>
 		<module>flink-yarn-tests</module>
 		<module>flink-fs-tests</module>
 		<module>flink-docs</module>


### PR DESCRIPTION
##What is the purpose of the change
As part of native kubernetes integration. Introduce client wrapper to access Kubernetes service.

##Brief change log
* _Implement KubeClient interface and actual implementation.
* _Add mock kube server which is derived from Fabric's mock implementation.
* _A unit tests of KubeClient.

##Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with @Public(Evolving): ( no)
* The serializers: (no )
* The runtime per-record code paths (performance sensitive): ( no )
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
* The S3 file system connector: ( no )
##Documentation
* Does this pull request introduce a new feature? (yes)
* If yes, how is the feature documented? (the document will be introduced in later pull requests)