### PR TITLE
[FLINK-11696][checkpoint] Avoid to send mkdir requests to DFS from task side

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -251,6 +251,7 @@ public class CheckpointCoordinator {
 
 		try {
 			this.checkpointStorage = checkpointStateBackend.createCheckpointStorage(job);
+			checkpointStorage.initializeBaseLocations();
 		} catch (IOException e) {
 			throw new FlinkRuntimeException("Failed to create checkpoint storage at checkpoint coordinator side.", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
@@ -59,6 +59,17 @@ public interface CheckpointStorageCoordinatorView {
 	CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) throws IOException;
 
 	/**
+	 * Initializes the necessary prerequisites for storage locations of checkpoints/savepoints.
+	 *
+	 * <p>For file-based checkpoint storage, this method would initialize essential base checkpoint directories
+	 * on checkpoint coordinator side and should be executed before calling {@link #initializeLocationForCheckpoint(long)}
+	 * and {@link #initializeLocationForSavepoint(long, String)}.
+	 *
+	 * @throws IOException Thrown, if these base storage locations cannot be initialized due to an I/O exception.
+	 */
+	void initializeBaseLocations() throws IOException;
+
+	/**
 	 * Initializes a storage location for new checkpoint with the given ID.
 	 *
 	 * <p>The returned storage location can be used to write the checkpoint data and metadata

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorage.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.memory;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -83,8 +84,6 @@ public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage 
 		else {
 			this.fileSystem = checkpointsBaseDirectory.getFileSystem();
 			this.checkpointsDirectory = getCheckpointDirectoryForJob(checkpointsBaseDirectory, jobId);
-
-			fileSystem.mkdirs(checkpointsDirectory);
 		}
 	}
 
@@ -99,6 +98,11 @@ public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage 
 		return maxStateSize;
 	}
 
+	@VisibleForTesting
+	Path getCheckpointsDirectory() {
+		return checkpointsDirectory;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Checkpoint Storage
 	// ------------------------------------------------------------------------
@@ -106,6 +110,12 @@ public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage 
 	@Override
 	public boolean supportsHighlyAvailableStorage() {
 		return checkpointsDirectory != null;
+	}
+
+	@Override
+	public void initializeBaseLocations() {
+		// since 'checkpointDir' which under 'checkpointsDirectory' would be created when calling
+		// #initializeLocationForCheckpoint, we could also avoid to call mkdirs for the 'checkpointsDirectory' here.
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1153,8 +1153,10 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 	private CheckpointStreamFactory createStreamFactory() throws Exception {
 		if (checkpointStorageLocation == null) {
-			checkpointStorageLocation = getStateBackend()
-				.createCheckpointStorage(new JobID())
+			CheckpointStorage checkpointStorage = getStateBackend()
+				.createCheckpointStorage(new JobID());
+			checkpointStorage.initializeBaseLocations();
+			checkpointStorageLocation = checkpointStorage
 				.initializeLocationForCheckpoint(1L);
 		}
 		return checkpointStorageLocation;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageTestBase.java
@@ -159,7 +159,9 @@ public abstract class AbstractFileCheckpointStorageTestBase {
 		final long checkpointId = 177;
 
 		final CheckpointStorage storage1 = createCheckpointStorage(checkpointDir);
+		storage1.initializeBaseLocations();
 		final CheckpointStorage storage2 = createCheckpointStorage(checkpointDir);
+		storage2.initializeBaseLocations();
 
 		final CheckpointStorageLocation loc1 = storage1.initializeLocationForCheckpoint(checkpointId);
 		final CheckpointStorageLocation loc2 = storage2.initializeLocationForCheckpoint(checkpointId);
@@ -209,6 +211,7 @@ public abstract class AbstractFileCheckpointStorageTestBase {
 		final long checkpointId = 177;
 
 		final CheckpointStorage storage = createCheckpointStorage(randomTempPath());
+		storage.initializeBaseLocations();
 		final CheckpointStorageLocation loc = storage.initializeLocationForCheckpoint(checkpointId);
 
 		// write to the metadata file for the checkpoint

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
@@ -192,15 +191,24 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 	}
 
 	/**
-	 * This test checks that no mkdirs is called by the checkpoint storage location when resolved.
+	 * This test checks that the expected mkdirs action for checkpoint storage,
+	 * only be called when initializeBaseLocations and not called when resolveCheckpointStorageLocation.
 	 */
 	@Test
-	public void testStorageLocationDoesNotMkdirs() throws Exception {
+	public void testStorageLocationMkdirs() throws Exception {
 		FsCheckpointStorage storage = new FsCheckpointStorage(
 				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 
-		File baseDir =  new File(storage.getCheckpointsDirectory().getPath());
+		File baseDir = new File(storage.getCheckpointsDirectory().getPath());
+		assertFalse(baseDir.exists());
+
+		// mkdirs would only be called when initializeBaseLocations
+		storage.initializeBaseLocations();
 		assertTrue(baseDir.exists());
+
+		// mkdir would not be called when resolveCheckpointStorageLocation
+		storage = new FsCheckpointStorage(
+				randomTempPath(), null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
 
 		FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
 				storage.resolveCheckpointStorageLocation(177, CheckpointStorageLocationReference.getDefault());
@@ -256,7 +264,7 @@ public class FsCheckpointStorageTest extends AbstractFileCheckpointStorageTestBa
 		}
 
 		@Override
-		public FileSystem getFileSystem() throws IOException {
+		public FileSystem getFileSystem() {
 			return fileSystem;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -57,10 +57,11 @@ public class FsStateBackendEntropyTest {
 		final Path checkpointDir = new Path(Path.fromLocalFile(tmp.newFolder()), ENTROPY_MARKER + "/checkpoints");
 		final String checkpointDirStr = checkpointDir.toString();
 
-		FsCheckpointStorage storage = new FsCheckpointStorage(
+		final FsCheckpointStorage storage = new FsCheckpointStorage(
 				fs, checkpointDir, null, new JobID(), 1024, 4096);
+		storage.initializeBaseLocations();
 
-		FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
+		final FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
 				storage.initializeLocationForCheckpoint(96562);
 
 		assertThat(location.getCheckpointDirectory().toString(), startsWith(checkpointDirStr));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory.MemoryCh
 
 import org.junit.Test;
 
+import java.io.File;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
@@ -184,5 +185,22 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		try (ObjectInputStream in = new ObjectInputStream(stateHandle.openInputStream())) {
 			assertEquals(state, in.readObject());
 		}
+	}
+
+	/**
+	 * This test checks that the expected mkdirs action for checkpoint storage,
+	 * only called when initializeLocationForCheckpoint.
+	 */
+	@Test
+	public void testStorageLocationMkdirs() throws Exception {
+		MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+			new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
+
+		File baseDir = new File(storage.getCheckpointsDirectory().getPath());
+		assertFalse(baseDir.exists());
+
+		// mkdirs only be called when initializeLocationForCheckpoint
+		storage.initializeLocationForCheckpoint(177L);
+		assertTrue(baseDir.exists());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -90,6 +90,11 @@ public class BackendForTestStream extends MemoryStateBackend {
 		}
 
 		@Override
+		public void initializeBaseLocations() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {
 			throw new UnsupportedOperationException();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -74,6 +74,11 @@ public class MockStateBackend extends AbstractStateBackend {
 			}
 
 			@Override
+			public void initializeBaseLocations() {
+
+			}
+
+			@Override
 			public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {
 				return new CheckpointStorageLocation() {
 


### PR DESCRIPTION
## What is the purpose of the change
Previously, not only checkpoint coordinator but also tasks would always send those `mkdir` requests out when initialization. This would actually put a lot of pressure to master of distributed file system.
This pull request avoids to call file system's `mkdir` when creating `CheckpointStorage`, but call it only once when checkpoint coordinator `initializeLocationForCheckpoint`. 

## Brief change log

  - Move the `mkdir` operations lazily to first `initializeLocationForCheckpoint` instead of each time when creating the `CheckpointStorage`.

 - [5bdbbd9a](https://github.com/apache/flink/commit/5bdbbd9ab5970209af289c323ee5b61c1ba40d41) Rebase code and introduce new method `initializeBaseLocations` for `CheckpointStorageCoordinatorView` to initialize those directories.


## Verifying this change

This change added tests and can be verified as follows:

  - refactor `testStorageLocationMkdirs` to verify checkpoint directories would be created once `initializeLocationForCheckpoint` instead of each time creating the `CheckpointStorage`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
