### PR TITLE
[FLINK-11866][python] documentation still shows old function

### DIFF
--- a/docs/dev/batch/python.md
+++ b/docs/dev/batch/python.md
@@ -435,7 +435,7 @@ class MyDeserializer(object):
         return MyObj(i)
 
 
-env.register_custom_type(MyObj, MySerializer(), MyDeserializer())
+env.register_type(MyObj, MySerializer(), MyDeserializer())
 {% endhighlight %}
 
 #### Tuples/Lists


### PR DESCRIPTION
## What is the purpose of the change

*Improving the documentation*


## Brief change log
  - *changed the outdated example function **register_custom_type** to **register_type***

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Jira
Jira Story can be found [here](https://issues.apache.org/jira/browse/FLINK-11866)
