### PR TITLE
 [FLINK-11420][datastream] Fix duplicate and createInstance methods of CoGroupedStreams.UnionSerializer

### DIFF
--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerTest.scala
@@ -18,9 +18,10 @@
 
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeutils.SerializerTestBase
-import org.apache.flink.api.common.typeutils.base.{IntSerializer, StringSerializer}
-import org.apache.flink.api.scala.typeutils.ScalaCaseClassSerializerReflectionTest.SimpleCaseClass
+import org.apache.flink.api.scala.createTypeInformation
+import org.apache.flink.api.scala.typeutils.ScalaCaseClassSerializerTest.SimpleCaseClass
 
 /**
   * Test [[ScalaCaseClassSerializer]].
@@ -28,29 +29,22 @@ import org.apache.flink.api.scala.typeutils.ScalaCaseClassSerializerReflectionTe
 class ScalaCaseClassSerializerTest
     extends SerializerTestBase[SimpleCaseClass] {
 
-  override protected def createSerializer() =
-    new ScalaCaseClassSerializer[SimpleCaseClass](
-      classOf[SimpleCaseClass],
-      Array(StringSerializer.INSTANCE, IntSerializer.INSTANCE)
-    )
+  val serializer = createTypeInformation[SimpleCaseClass]
+    .createSerializer(new ExecutionConfig)
+
+  override protected def createSerializer() = serializer
 
   override protected def getLength = -1
 
   override protected def getTypeClass = classOf[SimpleCaseClass]
 
   override protected def getTestData = Array(
-    SimpleCaseClass("a", 1),
-    SimpleCaseClass("b", -1),
-    SimpleCaseClass("c", 5)
+    SimpleCaseClass("a", 1, Map("a" -> 15)),
+    SimpleCaseClass("b", -1, Map("c" -> "C")),
+    SimpleCaseClass("c", 5, Map("e" -> "f"))
   )
 }
 
 object ScalaCaseClassSerializerTest {
-
-  case class SimpleCaseClass(name: String, var age: Int) {
-
-    def this(name: String) = this(name, 0)
-
-  }
-
+  case class SimpleCaseClass(name: String, var age: Int, genericField: Map[String, Any])
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -523,12 +523,22 @@ public class CoGroupedStreams<T1, T2> {
 
 		@Override
 		public TypeSerializer<TaggedUnion<T1, T2>> duplicate() {
-			return this;
+			TypeSerializer<T1> duplicateOne = oneSerializer.duplicate();
+			TypeSerializer<T2> duplicateTwo = twoSerializer.duplicate();
+
+			// compare reference of nested serializers, if same instances returned, we can reuse
+			// this instance as well
+			if (duplicateOne != oneSerializer || duplicateTwo != twoSerializer) {
+				return new UnionSerializer<>(duplicateOne, duplicateTwo);
+			} else {
+				return this;
+			}
 		}
 
 		@Override
 		public TaggedUnion<T1, T2> createInstance() {
-			return null;
+			//we arbitrarily always create instance of one
+			return TaggedUnion.one(oneSerializer.createInstance());
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/UnionSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/UnionSerializerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.streaming.api.datastream.CoGroupedStreams.TaggedUnion;
+import org.apache.flink.streaming.api.datastream.CoGroupedStreams.UnionSerializer;
+import org.apache.flink.testutils.DeeplyEqualsChecker;
+
+/**
+ * Serializer tests for {@link UnionSerializer}.
+ */
+public class UnionSerializerTest extends SerializerTestBase<TaggedUnion<Object, Object>> {
+
+	public UnionSerializerTest() {
+		super(new DeeplyEqualsChecker()
+		.withCustomCheck(
+			(o1, o2) -> o1 instanceof TaggedUnion && o2 instanceof TaggedUnion,
+			(o1, o2, checker) -> {
+				TaggedUnion union1 = (TaggedUnion) o1;
+				TaggedUnion union2 = (TaggedUnion) o2;
+
+				if (union1.isOne() && union2.isOne()) {
+					return checker.deepEquals(union1.getOne(), union2.getOne());
+				} else if (union1.isTwo() && union2.isTwo()) {
+					return checker.deepEquals(union1.getTwo(), union2.getTwo());
+				} else {
+					return false;
+				}
+			}
+		));
+	}
+
+	@Override
+	protected TypeSerializer<TaggedUnion<Object, Object>> createSerializer() {
+		return new UnionSerializer<>(
+			new KryoSerializer<>(Object.class, new ExecutionConfig()),
+			new KryoSerializer<>(Object.class, new ExecutionConfig())
+		);
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Class<TaggedUnion<Object, Object>> getTypeClass() {
+		return (Class<TaggedUnion<Object, Object>>) (Class<?>) TaggedUnion.class;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected TaggedUnion<Object, Object>[] getTestData() {
+		return new TaggedUnion[]{
+			TaggedUnion.one(1),
+			TaggedUnion.two("A"),
+			TaggedUnion.one("C")
+		};
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

It fixes duplicate method of `org.apache.flink.streaming.api.datastream.CoGroupedStreams.UnionSerializer`


## Brief change log

*(for example:)*
 - a284a92 - minor improvement to `ScalaCaseClassSerializerTest.scala`
 - 997b3c7 - fixed `duplicate` and `createInstance` methods of `org.apache.flink.streaming.api.datastream.CoGroupedStreams.UnionSerializer`
   
## Verifying this change

* added test class: `org.apache.flink.streaming.api.datastream.UnionSerializerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
