### PR TITLE
[FLINK-11865] Improve code generation speed in TraversableSerializer

### DIFF
--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
@@ -24,10 +24,12 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.typeutils.TraversableSerializer
 import org.junit.Assert._
-import org.junit.{Assert, Ignore, Test}
+import org.junit.{Assert, Test}
 
-import scala.collection.immutable.{BitSet, LinearSeq, SortedSet}
-import scala.collection.{SortedMap, mutable}
+import scala.collection.immutable.{BitSet, LinearSeq}
+import scala.collection.mutable
+import scala.ref.WeakReference
+import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 
 class TraversableSerializerTest {
 
@@ -97,6 +99,55 @@ class TraversableSerializerTest {
     runTests(testData)
   }
 
+  @Test
+  def sameClassLoaderAndCodeShouldProvideEqualKeys(): Unit = {
+    val classLoaderA = new URLClassLoader(Seq.empty[java.net.URL], null)
+
+    val keyA = TraversableSerializer.Key(classLoaderA, "code")
+    val keyB = TraversableSerializer.Key(classLoaderA, "code")
+
+    assertEquals(keyA, keyB)
+  }
+
+  @Test
+  def differentClassLoadersProvideNonEqualKeys(): Unit = {
+    val classLoaderA = new URLClassLoader(Seq.empty[java.net.URL], null)
+    val classLoaderB = new URLClassLoader(Seq.empty[java.net.URL], null)
+    
+    val keyA = TraversableSerializer.Key(classLoaderA, "code")
+    val keyB = TraversableSerializer.Key(classLoaderB, "code")
+    
+    assertNotEquals(keyA, keyB)
+  }
+
+  @Test
+  def expiredReferenceShouldProduceNonEqualKeys(): Unit = {
+    val classLoaderA = new URLClassLoader(Seq.empty[java.net.URL], null)
+
+    val keyA = TraversableSerializer.Key(classLoaderA, "code")
+    val keyB = keyA.copy(classLoaderRef = WeakReference(null)) 
+
+    assertNotEquals(keyA, keyB)
+  }
+
+  @Test
+  def bootStrapClassLoaderShouldProduceTheSameKeys(): Unit = {
+    val keyA = TraversableSerializer.Key(null, "a")
+    val keyB = TraversableSerializer.Key(null, "a")
+
+    assertEquals(keyA, keyB)
+  }
+
+  @Test
+  def differentCanBuildFromCodeShouldProduceDifferentKeys(): Unit = {
+    val classLoaderA = new URLClassLoader(Seq.empty[java.net.URL], null)
+
+    val keyA = TraversableSerializer.Key(classLoaderA, "a")
+    val keyB = TraversableSerializer.Key(classLoaderA, "b")
+
+    assertNotEquals(keyA, keyB)
+  }
+  
   private final def runTests[T : TypeInformation](instances: Array[T]) {
     try {
       val typeInfo = implicitly[TypeInformation[T]]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The `TraversableSerializer` is generating, at runtime, code that evaluates to an instance of a `CanBuildFrom`. This operation makes job submissions/translation prohibitively slow, and must be cached.
This PR adds a cache to the `TraversableSerializer`.

## Brief change log

  - da624a47ae Minor refactoring
  - 03f18df5ed Add and use the cache

## Verifying this change

This change is already covered by existing tests, such as `TraversableSerializerSnapshotMigrationTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)