### PR TITLE
[FLINK-9854][sql-client] Allow passing multi-line input to SQL Client CLI

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -64,7 +64,16 @@ Once the CLI has been started, you can use the `HELP` command to list all availa
 SELECT 'Hello World';
 {% endhighlight %}
 
-This query requires no table source and produces a single row result. The CLI will retrieve results from the cluster and visualize them. You can close the result view by pressing the `Q` key.
+This query requires no table source and produces a single row result.
+
+If a single statement is too long such as DDL, the CLI supports splitting it into multi-line mode using "|". E.g:
+
+{% highlight sql %}
+CREATE VIEW MyTable AS |
+SELECT 1+1 FROM y;
+{% endhighlight %}
+
+The CLI will retrieve results from the cluster and visualize them. You can close the result view by pressing the `Q` key.
 
 The CLI supports **two modes** for maintaining and visualizing results.
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support passing multi-line input to SQL Client CLI*

## Brief change log

  - *Allow passing multi-line input to SQL Client CLI in `CliClient.java`*
  - *Added test in `CliClientTest.java`*

## Verifying this change

This change is already covered by existing tests, such as *CliClient.java*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
