### PR TITLE
[FLINK-11882][table-runtime-blink] Introduce BytesHashMap to batch hash agg

### DIFF
--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -84,5 +84,13 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/aggregate/BytesHashMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/aggregate/BytesHashMap.java
@@ -1,0 +1,707 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.aggregate;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.MemorySegmentSource;
+import org.apache.flink.runtime.io.disk.RandomAccessInputView;
+import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+import org.apache.flink.runtime.memory.AbstractPagedInputView;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.MutableObjectIterator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Bytes based hash map.
+ * It can be used for performing aggregations where the aggregated values are fixed-width, because
+ * the data is stored in continuous memory, AggBuffer of variable length cannot be applied to this
+ * HashMap.
+ * The KeyValue form in hash map is designed to reduce the cost of key fetching in lookup.
+ * The memory is divided into two areas:
+ * <p/>
+ * - Bucket area: this contains: pointer + hashcode.
+ * Bytes 0 to 8: a pointer to the record in the record area
+ * Bytes 8 to 16: a holds key's full 32-bit hashcode
+ * <p/>
+ * - Record area: this contains the actual data in linked list records.
+ * A BytesHashMap's record has four parts:
+ * Bytes 0 to 4: len(k)
+ * Bytes 4 to 4 + len(k): key data
+ * Bytes 4 + len(k) to 8 + len(k): len(v)
+ * Bytes 8 + len(k) to 8 + len(k) + len(v): value data
+ *
+ * <p>{@code BytesHashMap} are influenced by Apache Spark BytesToBytesMap.
+ */
+public class BytesHashMap {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BytesHashMap.class);
+
+	private static final int BUCKET_SIZE = 16;
+	private static final int RECORD_EXTRA_LENGTH = 8;
+	private static final int BUCKET_SIZE_BITS = 4;
+
+	private static final int ELEMENT_POINT_LENGTH = 8;
+
+	private static final long END_OF_LIST = Long.MAX_VALUE;
+	private static final int STEP_INCREMENT = 1;
+
+	private static final double LOAD_FACTOR = 0.75;
+	//a smaller bucket can make the best of l1/l2/l3 cache.
+	private static final long INIT_BUCKET_MEMORY_IN_BYTES = 1024 * 1024L;
+
+	private final int numBucketsPerSegment;
+	private final int numBucketsPerSegmentBits;
+	private final int numBucketsPerSegmentMask;
+	private final int lastBucketPosition;
+
+	private final int segmentSize;
+	/**
+	 * The segments where the actual data is stored.
+	 */
+	private final RecordArea recordArea;
+	/**
+	 * Set true when valueTypeInfos.length == 0. Usually in this case the BytesHashMap will be used as a HashSet.
+	 * The value from {@link BytesHashMap#append(LookupInfo info, BinaryRow value)}
+	 * will be ignored when hashSetMode set.
+	 * The reusedValue will always point to a 16 bytes long MemorySegment acted as
+	 * each BytesHashMap entry's value part when appended to make the BytesHashMap's spilling work compatible.
+	 */
+	private final boolean hashSetMode;
+	/**
+	 * Used to serialize hash map key and value into RecordArea's MemorySegments.
+	 */
+	private final BinaryRowSerializer valueSerializer;
+	private final BinaryRowSerializer keySerializer;
+	/**
+	 * Used as a reused object which lookup returned.
+	 */
+	private final LookupInfo reuseLookInfo;
+
+	private final MemoryManager memoryManager;
+
+	/**
+	 * Used as a reused object when retrieve the map's value by key and iteration.
+	 */
+	private BinaryRow reusedValue;
+	/**
+	 * Used as a reused object when lookup and iteration.
+	 */
+	private BinaryRow reusedKey;
+
+	private final List<MemorySegment> freeMemorySegments;
+	private List<MemorySegment> bucketSegments;
+
+	private long numElements = 0;
+	private int numBucketsMask;
+	//get the second hashcode based log2NumBuckets and numBucketsMask2
+	private int log2NumBuckets;
+	private int numBucketsMask2;
+
+	/**
+	 * The map will be expanded once the number of elements exceeds this threshold.
+	 */
+	private int growthThreshold;
+	private volatile RecordArea.DestructiveEntryIterator destructiveIterator = null;
+
+	private final int reservedNumBuffers;
+
+	//metric
+	private long numSpillFiles;
+	private long spillInBytes;
+
+	public BytesHashMap(
+			final Object owner,
+			MemoryManager memoryManager,
+			long memorySize,
+			InternalType[] keyTypes,
+			InternalType[] valueTypes) {
+		this(owner, memoryManager, memorySize, keyTypes, valueTypes, false);
+	}
+
+	public BytesHashMap(
+			final Object owner,
+			MemoryManager memoryManager,
+			long memorySize,
+			InternalType[] keyTypes,
+			InternalType[] valueTypes,
+			boolean inferBucketMemory) {
+		this.segmentSize = memoryManager.getPageSize();
+		this.reservedNumBuffers = (int) (memorySize / segmentSize);
+		this.memoryManager = memoryManager;
+		try {
+			this.freeMemorySegments = memoryManager.allocatePages(owner, reservedNumBuffers);
+		} catch (MemoryAllocationException e) {
+			throw new IllegalArgumentException("BytesHashMap can't allocate " + reservedNumBuffers + " pages", e);
+		}
+		this.numBucketsPerSegment = segmentSize / BUCKET_SIZE;
+		this.numBucketsPerSegmentBits = MathUtils.log2strict(this.numBucketsPerSegment);
+		this.numBucketsPerSegmentMask = (1 << this.numBucketsPerSegmentBits) - 1;
+		this.lastBucketPosition = (numBucketsPerSegment - 1) * BUCKET_SIZE;
+
+		checkArgument(keyTypes.length > 0);
+		this.keySerializer = new BinaryRowSerializer(keyTypes.length);
+		this.reusedKey = this.keySerializer.createInstance();
+
+		if (valueTypes.length == 0) {
+			this.valueSerializer = new BinaryRowSerializer(0);
+			this.hashSetMode = true;
+			this.reusedValue = new BinaryRow(0);
+			this.reusedValue.pointTo(MemorySegmentFactory.wrap(new byte[8]), 0, 8);
+			LOG.info("BytesHashMap with hashSetMode = true.");
+		} else {
+			this.valueSerializer = new BinaryRowSerializer(valueTypes.length);
+			this.hashSetMode = false;
+			this.reusedValue = this.valueSerializer.createInstance();
+		}
+
+		this.reuseLookInfo = new LookupInfo();
+
+		this.recordArea = new RecordArea();
+
+		int initBucketSegmentNum;
+		if (inferBucketMemory) {
+			initBucketSegmentNum = calcNumBucketSegments(keyTypes, valueTypes);
+		} else {
+			checkArgument(memorySize > INIT_BUCKET_MEMORY_IN_BYTES, "The minBucketMemorySize is not valid!");
+			initBucketSegmentNum = MathUtils.roundDownToPowerOf2((int) (INIT_BUCKET_MEMORY_IN_BYTES / segmentSize));
+		}
+
+		// allocate and initialize MemorySegments for bucket area
+		initBucketSegments(initBucketSegmentNum);
+
+		LOG.info("BytesHashMap with initial memory segments {}, {} in bytes, init allocating {} for bucket area.",
+				reservedNumBuffers, reservedNumBuffers * segmentSize, initBucketSegmentNum);
+	}
+
+	static int getVariableLength(InternalType[] types) {
+		int length = 0;
+		for (InternalType type : types) {
+			if (!BinaryRow.isInFixedLengthPart(type)) {
+				// find a better way of computing generic type field variable-length
+				// right now we use a small value assumption
+				length += 16;
+			}
+		}
+		return length;
+	}
+
+	private int calcNumBucketSegments(InternalType[] keyTypes, InternalType[] valueTypes) {
+		int calcRecordLength = reusedValue.getFixedLengthPartSize() + getVariableLength(valueTypes) +
+				reusedKey.getFixedLengthPartSize() + getVariableLength(keyTypes);
+		// We aim for a 200% utilization of the bucket table.
+		double averageBucketSize = BUCKET_SIZE / LOAD_FACTOR;
+		double fraction = averageBucketSize / (averageBucketSize + calcRecordLength + RECORD_EXTRA_LENGTH);
+		// We make the number of buckets a power of 2 so that taking modulo is efficient.
+		// To avoid rehash as far as possible, here use roundUpToPowerOfTwo firstly
+		int ret = Math.max(1, MathUtils.roundDownToPowerOf2((int) (reservedNumBuffers * fraction)));
+		// We can't handle more than Integer.MAX_VALUE buckets (eg. because hash functions return int)
+		if ((long) ret * numBucketsPerSegment > Integer.MAX_VALUE) {
+			ret = MathUtils.roundDownToPowerOf2(Integer.MAX_VALUE / numBucketsPerSegment);
+		}
+		return ret;
+	}
+
+	// ----------------------- Public interface -----------------------
+
+	/**
+	 * @return true when BytesHashMap's valueTypeInfos.length == 0.
+	 * Any appended value will be ignored and replaced with a reusedValue as a present tag.
+	 */
+	public boolean isHashSetMode() {
+		return hashSetMode;
+	}
+
+	/**
+	 * @param key by which looking up the value in the hash map.
+	 *            Only support the key in the BinaryRow form who has only one MemorySegment.
+	 * @return {@link LookupInfo}
+	 */
+	public LookupInfo lookup(BinaryRow key) {
+		// check the looking up key having only one memory segment
+		checkArgument(key.getSegments().length == 1);
+		final int hashCode1 = key.hashCode();
+		int newPos = hashCode1 & numBucketsMask;
+		// which segment contains the bucket
+		int bucketSegmentIndex = newPos >>> numBucketsPerSegmentBits;
+		// offset of the bucket in the segment
+		int bucketOffset = (newPos & numBucketsPerSegmentMask) << BUCKET_SIZE_BITS;
+
+		boolean found = false;
+		int step = STEP_INCREMENT;
+		long hashCode2 = 0;
+		long findElementPtr;
+		try {
+			do {
+				findElementPtr = bucketSegments.get(bucketSegmentIndex).getLong(bucketOffset);
+				if (findElementPtr == END_OF_LIST) {
+					// This is a new key.
+					break;
+				} else {
+					final int storedHashCode = bucketSegments.get(bucketSegmentIndex).getInt(
+							bucketOffset + ELEMENT_POINT_LENGTH);
+					if (hashCode1 == storedHashCode) {
+						recordArea.setReadPosition(findElementPtr);
+						if (recordArea.readKeyAndEquals(key)) {
+							// we found an element with a matching key, and not just a hash collision
+							found = true;
+							reusedValue = recordArea.readValue(reusedValue);
+							break;
+						}
+					}
+				}
+				if (step == 1) {
+					hashCode2 = calcSecondHashCode(hashCode1);
+				}
+				newPos = (int) ((hashCode1 + step * hashCode2) & numBucketsMask);
+				// which segment contains the bucket
+				bucketSegmentIndex = newPos >>> numBucketsPerSegmentBits;
+				// offset of the bucket in the segment
+				bucketOffset = (newPos & numBucketsPerSegmentMask) << BUCKET_SIZE_BITS;
+				step += STEP_INCREMENT;
+			} while (true);
+		} catch (IOException ex) {
+			throw new RuntimeException(
+					"Error reading record from the aggregate map: " + ex.getMessage(), ex);
+		}
+		reuseLookInfo.set(
+				found, hashCode1, key, reusedValue, bucketSegmentIndex, bucketOffset);
+		return reuseLookInfo;
+	}
+
+	// M(the num of buckets) is the nth power of 2,  so the second hash code must be odd, and always is
+	// H2(K) = 1 + 2 * ((H1(K)/M) mod (M-1))
+	private long calcSecondHashCode(final int firstHashCode) {
+		return ((((long) (firstHashCode >> log2NumBuckets)) & numBucketsMask2) << 1) + 1L;
+	}
+
+	/**
+	 * Append an value into the hash map's record area.
+	 *
+	 * @return An BinaryRow mapping to the memory segments in the map's record area belonging to
+	 * the newly appended value.
+	 * @throws EOFException if the map can't allocate much more memory.
+	 */
+	public BinaryRow append(LookupInfo info, BinaryRow value) throws IOException {
+		try {
+			if (numElements >= growthThreshold) {
+				growAndRehash();
+				//update info's bucketSegmentIndex and bucketOffset
+				lookup(info.key);
+			}
+			BinaryRow toAppend = hashSetMode ? reusedValue : value;
+			long pointerToAppended = recordArea.appendRecord(info.key, toAppend);
+			bucketSegments.get(info.bucketSegmentIndex).putLong(info.bucketOffset, pointerToAppended);
+			bucketSegments.get(info.bucketSegmentIndex).putInt(
+					info.bucketOffset + ELEMENT_POINT_LENGTH, info.keyHashCode);
+			numElements++;
+			recordArea.setReadPosition(pointerToAppended);
+			recordArea.skipKey();
+			return recordArea.readValue(reusedValue);
+		} catch (EOFException e) {
+			numSpillFiles++;
+			spillInBytes += recordArea.segments.size() * ((long) segmentSize);
+			throw e;
+		}
+
+	}
+
+	public long getNumSpillFiles() {
+		return numSpillFiles;
+	}
+
+	public long getUsedMemoryInBytes() {
+		return (bucketSegments.size() + recordArea.segments.size()) * ((long) segmentSize);
+	}
+
+	public long getSpillInBytes() {
+		return spillInBytes;
+	}
+
+	public long getNumElements() {
+		return numElements;
+	}
+
+	private void initBucketSegments(int numBucketSegments) {
+		if (numBucketSegments < 1) {
+			throw new RuntimeException("Too small memory allocated for BytesHashMap");
+		}
+		this.bucketSegments = new ArrayList<>(numBucketSegments);
+		for (int i = 0; i < numBucketSegments; i++) {
+			bucketSegments.add(i, freeMemorySegments.remove(freeMemorySegments.size() - 1));
+		}
+
+		resetBucketSegments(this.bucketSegments);
+		int numBuckets = numBucketSegments * numBucketsPerSegment;
+		this.log2NumBuckets = MathUtils.log2strict(numBuckets);
+		this.numBucketsMask = (1 << MathUtils.log2strict(numBuckets)) - 1;
+		this.numBucketsMask2 = (1 << MathUtils.log2strict(numBuckets >> 1)) - 1;
+		this.growthThreshold = (int) (numBuckets * LOAD_FACTOR);
+	}
+
+	private void resetBucketSegments(List<MemorySegment> resetBucketSegs) {
+		for (MemorySegment segment: resetBucketSegs) {
+			for (int j = 0; j <= lastBucketPosition; j += BUCKET_SIZE) {
+				segment.putLong(j, END_OF_LIST);
+			}
+		}
+	}
+
+	/**
+	 * @throws EOFException if the map can't allocate much more memory.
+	 */
+	private void growAndRehash() throws EOFException {
+		// allocate the new data structures
+		int required = 2 * bucketSegments.size();
+		if (required * numBucketsPerSegment > Integer.MAX_VALUE) {
+			LOG.warn("We can't handle more than Integer.MAX_VALUE buckets (eg. because hash functions return int)");
+			throw new EOFException();
+		}
+		List<MemorySegment> newBucketSegments = new ArrayList<>(required);
+
+		try {
+			int freeNumSegments = freeMemorySegments.size();
+			int numAllocatedSegments = required - freeNumSegments;
+			if (numAllocatedSegments > 0) {
+				throw new MemoryAllocationException();
+			}
+			int needNumFromFreeSegments = required - newBucketSegments.size();
+			for (int end = needNumFromFreeSegments; end > 0; end--) {
+				newBucketSegments.add(freeMemorySegments.remove(freeMemorySegments.size() - 1));
+			}
+
+			int numBuckets = newBucketSegments.size() * numBucketsPerSegment;
+			this.log2NumBuckets = MathUtils.log2strict(numBuckets);
+			this.numBucketsMask = (1 << MathUtils.log2strict(numBuckets)) - 1;
+			this.numBucketsMask2 = (1 << MathUtils.log2strict(numBuckets >> 1)) - 1;
+			this.growthThreshold = (int) (numBuckets * LOAD_FACTOR);
+		} catch (MemoryAllocationException e) {
+			LOG.warn("BytesHashMap can't allocate {} pages, and now used {} pages",
+					required, reservedNumBuffers, e);
+			throw new EOFException();
+		}
+		long reHashStartTime = System.currentTimeMillis();
+		resetBucketSegments(newBucketSegments);
+		// Re-mask (we don't recompute the hashcode because we stored all 32 bits of it)
+		for (MemorySegment memorySegment : bucketSegments) {
+			for (int j = 0; j < numBucketsPerSegment; j++) {
+				final long recordPointer = memorySegment.getLong(j * BUCKET_SIZE);
+				if (recordPointer != END_OF_LIST) {
+					final int hashCode1 = memorySegment.getInt(j * BUCKET_SIZE + ELEMENT_POINT_LENGTH);
+					int newPos = hashCode1 & numBucketsMask;
+					int bucketSegmentIndex = newPos >>> numBucketsPerSegmentBits;
+					int bucketOffset = (newPos & numBucketsPerSegmentMask) << BUCKET_SIZE_BITS;
+					int step = STEP_INCREMENT;
+					long hashCode2 = 0;
+					while (newBucketSegments.get(bucketSegmentIndex).getLong(bucketOffset) != END_OF_LIST) {
+						if (step == 1) {
+							hashCode2 = calcSecondHashCode(hashCode1);
+						}
+						newPos = (int) ((hashCode1 + step * hashCode2) & numBucketsMask);
+						bucketSegmentIndex = newPos >>> numBucketsPerSegmentBits;
+						bucketOffset = (newPos & numBucketsPerSegmentMask) << BUCKET_SIZE_BITS;
+						step += STEP_INCREMENT;
+					}
+					newBucketSegments.get(bucketSegmentIndex).putLong(bucketOffset, recordPointer);
+					newBucketSegments.get(bucketSegmentIndex).putInt(bucketOffset + ELEMENT_POINT_LENGTH, hashCode1);
+				}
+			}
+		}
+		LOG.info("The rehash take {} ms for {} segments", (System.currentTimeMillis() - reHashStartTime), required);
+		this.freeMemorySegments.addAll(this.bucketSegments);
+		this.bucketSegments = newBucketSegments;
+	}
+
+	/**
+	 * Returns a destructive iterator for iterating over the entries of this map. It frees each page
+	 * as it moves onto next one. Notice: it is illegal to call any method on the map after
+	 * `destructiveIterator()` has been called.
+	 * @return an entry iterator for iterating the value appended in the hash map.
+	 */
+	public MutableObjectIterator<Entry> getEntryIterator() {
+		if (destructiveIterator != null) {
+			throw new IllegalArgumentException("DestructiveIterator is not null, so this method can't be invoke!");
+		}
+		return recordArea.destructiveEntryIterator();
+	}
+
+	/**
+	 * @return the underlying memory segments of the hash map's record area
+	 */
+	public ArrayList<MemorySegment> getRecordAreaMemorySegments() {
+		return recordArea.segments;
+	}
+
+	public List<MemorySegment> getBucketAreaMemorySegments() {
+		return bucketSegments;
+	}
+
+	/**
+	 * release the map's record and bucket area's memory segments.
+	 */
+	public void free() {
+		free(false);
+	}
+
+	/**
+	 * @param reservedRecordMemory reserved fixed memory or not.
+	 */
+	public void free(boolean reservedRecordMemory) {
+		returnSegments(this.bucketSegments);
+		this.bucketSegments.clear();
+		recordArea.release();
+		if (!reservedRecordMemory) {
+			memoryManager.release(freeMemorySegments);
+		}
+		numElements = 0;
+		destructiveIterator = null;
+	}
+
+
+	/**
+	 * reset the map's record and bucket area's memory segments for reusing.
+	 */
+	public void reset() {
+		int numBuckets = bucketSegments.size() * numBucketsPerSegment;
+		this.log2NumBuckets = MathUtils.log2strict(numBuckets);
+		this.numBucketsMask = (1 << MathUtils.log2strict(numBuckets)) - 1;
+		this.numBucketsMask2 = (1 << MathUtils.log2strict(numBuckets >> 1)) - 1;
+		this.growthThreshold = (int) (numBuckets * LOAD_FACTOR);
+		//reset the record segments.
+		recordArea.reset();
+		resetBucketSegments(bucketSegments);
+		numElements = 0;
+		destructiveIterator = null;
+		LOG.info("reset BytesHashMap with record memory segments {}, {} in bytes, init allocating {} for bucket area.",
+				freeMemorySegments.size(), freeMemorySegments.size() * segmentSize, bucketSegments.size());
+	}
+
+	private void returnSegments(List<MemorySegment> segments) {
+		freeMemorySegments.addAll(segments);
+	}
+
+	// ----------------------- Record Area -----------------------
+
+	private final class RecordArea {
+		private final ArrayList<MemorySegment> segments = new ArrayList<>();
+
+		private final RandomAccessInputView inView;
+		private final SimpleCollectingOutputView outView;
+
+		RecordArea() {
+			this.outView = new SimpleCollectingOutputView(segments, new RecordAreaMemorySource(), segmentSize);
+			this.inView = new RandomAccessInputView(segments, segmentSize);
+		}
+
+		void release() {
+			returnSegments(segments);
+			segments.clear();
+		}
+
+		void reset() {
+			release();
+			// request a new memory segment from freeMemorySegments
+			// reset segmentNum and positionInSegment
+			outView.reset();
+			inView.setReadPosition(0);
+		}
+
+		// ----------------------- Memory Management -----------------------
+
+		private final class RecordAreaMemorySource implements MemorySegmentSource {
+			@Override
+			public MemorySegment nextSegment() {
+				int s = freeMemorySegments.size();
+				if (s > 0) {
+					return freeMemorySegments.remove(s - 1);
+				} else {
+					return null;
+				}
+			}
+		}
+
+		// ----------------------- Append -----------------------
+		private long appendRecord(BinaryRow key, BinaryRow value) throws IOException {
+			final long oldLastPosition = outView.getCurrentOffset();
+			// serialize the key into the BytesHashMap record area
+			int skip = keySerializer.serializeToPages(key, outView);
+
+			// serialize the value into the BytesHashMap record area
+			valueSerializer.serializeToPages(value, outView);
+			return oldLastPosition + skip;
+		}
+
+		// ----------------------- Read -----------------------
+		void setReadPosition(long position) {
+			inView.setReadPosition(position);
+		}
+
+		boolean readKeyAndEquals(BinaryRow lookup) throws IOException {
+			reusedKey = keySerializer.mapFromPages(reusedKey, inView);
+			return lookup.equals(reusedKey);
+		}
+
+		/**
+		 * @throws IOException when invalid memory address visited.
+		 */
+		void skipKey() throws IOException {
+			inView.skipBytes(inView.readInt());
+		}
+
+		BinaryRow readValue(BinaryRow reuse) throws IOException {
+			// depends on BinaryRowSerializer to check writing skip
+			// and to find the real start offset of the data
+			return valueSerializer.mapFromPages(reuse, inView);
+		}
+
+		// ----------------------- Iterator -----------------------
+
+		MutableObjectIterator<Entry> destructiveEntryIterator() {
+			return new RecordArea.DestructiveEntryIterator();
+		}
+
+		final class DestructiveEntryIterator extends AbstractPagedInputView implements MutableObjectIterator<Entry> {
+
+			private int count = 0;
+			private int currentSegmentIndex = 0;
+
+			public DestructiveEntryIterator() {
+				super(segments.get(0), segmentSize, 0);
+				destructiveIterator = this;
+			}
+
+			public boolean hasNext() {
+				return count < numElements;
+			}
+
+			@Override
+			public Entry next(Entry reuse) throws IOException {
+				if (hasNext()) {
+					count++;
+					//segment already is useless any more.
+					keySerializer.mapFromPages(reuse.getKey(), this);
+					valueSerializer.mapFromPages(reuse.getValue(), this);
+					return reuse;
+				} else {
+					return null;
+				}
+			}
+
+			@Override
+			public Entry next() throws IOException {
+				throw new UnsupportedOperationException("");
+			}
+
+			@Override
+			protected int getLimitForSegment(MemorySegment segment) {
+				return segmentSize;
+			}
+
+			@Override
+			protected MemorySegment nextSegment(MemorySegment current) throws EOFException, IOException {
+				return segments.get(++currentSegmentIndex);
+			}
+		}
+	}
+
+	/**
+	 * Handle returned by {@link BytesHashMap#lookup(BinaryRow)} function.
+	 */
+	public static final class LookupInfo {
+		private boolean found;
+		private BinaryRow key;
+		private BinaryRow value;
+
+		/**
+		 * The hashcode of the look up key passed to {@link BytesHashMap#lookup(BinaryRow)},
+		 * Caching this hashcode here allows us to avoid re-hashing the key when inserting a value
+		 * for that key.
+		 * The same purpose with bucketSegmentIndex, bucketOffset.
+		 */
+		private int keyHashCode;
+		private int bucketSegmentIndex;
+		private int bucketOffset;
+
+		LookupInfo() {
+			this.found = false;
+			this.keyHashCode = -1;
+			this.key = null;
+			this.value = null;
+			this.bucketSegmentIndex = -1;
+			this.bucketOffset = -1;
+		}
+
+		void set(
+				boolean found,
+				int keyHashCode,
+				BinaryRow key,
+				BinaryRow value,
+				int bucketSegmentIndex, int bucketOffset) {
+			this.found = found;
+			this.keyHashCode = keyHashCode;
+			this.key = key;
+			this.value = value;
+			this.bucketSegmentIndex = bucketSegmentIndex;
+			this.bucketOffset = bucketOffset;
+		}
+
+		public boolean isFound() {
+			return found;
+		}
+
+		public BinaryRow getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * BytesHashMap Entry contains key and value field.
+	 */
+	public static final class Entry {
+		private final BinaryRow key;
+		private final BinaryRow value;
+
+		public Entry(BinaryRow key, BinaryRow value) {
+			this.key = key;
+			this.value = value;
+		}
+
+		public BinaryRow getKey() {
+			return key;
+		}
+
+		public BinaryRow getValue() {
+			return value;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/aggregate/BytesHashMapSpillMemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/aggregate/BytesHashMapSpillMemorySegmentPool.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.aggregate;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+
+import java.util.List;
+
+/**
+ * MemorySegmentPool for {@link BytesHashMap} to fall back to sort agg.
+ * {@link #nextSegment} not remove segment from segments, just get from segments.
+ */
+public class BytesHashMapSpillMemorySegmentPool implements MemorySegmentPool {
+
+	private final List<MemorySegment> segments;
+	private final int pageSize;
+	private int allocated;
+
+	public BytesHashMapSpillMemorySegmentPool(List<MemorySegment> memorySegments) {
+		this.segments = memorySegments;
+		this.pageSize = memorySegments.get(0).size();
+		this.allocated = 0;
+	}
+
+	@Override
+	public MemorySegment nextSegment() {
+		allocated++;
+		if (allocated <= segments.size()) {
+			return segments.get(allocated - 1);
+		} else {
+			return MemorySegmentFactory.wrap(new byte[pageSize()]);
+		}
+	}
+
+	@Override
+	public void returnAll(List<MemorySegment> memory) {
+		throw new UnsupportedOperationException("not support!");
+	}
+
+	@Override
+	public int pageSize() {
+		return pageSize;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/aggregate/BytesHashMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/aggregate/BytesHashMapTest.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.aggregate;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.io.disk.RandomAccessInputView;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.BinaryString;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.InternalTypes;
+import org.apache.flink.table.type.RowType;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.MutableObjectIterator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ */
+public class BytesHashMapTest {
+
+	private static final long RANDOM_SEED = 76518743207143L;
+	private static final int PAGE_SIZE = 32 * 1024;
+	private static final int NUM_ENTRIES = 10000;
+	private static final int NUM_REWRITES = 10;
+
+	private final InternalType[] keyTypes;
+	private final InternalType[] valueTypes;
+	private final BinaryRow defaultValue;
+	private final BinaryRowSerializer keySerializer;
+	private final BinaryRowSerializer valueSerializer;
+
+	public BytesHashMapTest() {
+
+		this.keyTypes = new InternalType[] {
+				InternalTypes.INT,
+				InternalTypes.STRING,
+				InternalTypes.DOUBLE,
+				InternalTypes.LONG,
+				InternalTypes.BOOLEAN,
+				InternalTypes.FLOAT,
+				InternalTypes.SHORT
+		};
+		this.valueTypes = new InternalType[] {
+				InternalTypes.DOUBLE,
+				InternalTypes.LONG,
+				InternalTypes.BOOLEAN,
+				InternalTypes.FLOAT,
+				InternalTypes.SHORT
+		};
+
+		this.keySerializer = new BinaryRowSerializer(keyTypes.length);
+		this.valueSerializer = new BinaryRowSerializer(valueTypes.length);
+		this.defaultValue = valueSerializer.createInstance();
+		int valueSize = defaultValue.getFixedLengthPartSize();
+		this.defaultValue.pointTo(MemorySegmentFactory.wrap(new byte[valueSize]), 0, valueSize);
+	}
+
+	@Test
+	public void testHashSetMode() throws IOException {
+		final int numMemSegments = needNumMemSegments(
+				NUM_ENTRIES,
+				rowLength(new RowType(valueTypes)),
+				rowLength(new RowType(keyTypes)),
+				PAGE_SIZE);
+		int memorySize = numMemSegments * PAGE_SIZE;
+		MemoryManager memoryManager = new MemoryManager(numMemSegments * PAGE_SIZE, 32);
+
+		BytesHashMap table = new BytesHashMap(this, memoryManager,
+				memorySize, keyTypes, new InternalType[]{});
+		Assert.assertTrue(table.isHashSetMode());
+
+		final Random rnd = new Random(RANDOM_SEED);
+		BinaryRow[] keys = getRandomizedInput(NUM_ENTRIES, rnd, true);
+		verifyKeyInsert(keys, table);
+		verifyKeyPresent(keys, table);
+		table.free();
+	}
+
+	@Test
+	public void testBuildAndRetrieve() throws Exception {
+
+		final int numMemSegments = needNumMemSegments(
+				NUM_ENTRIES,
+				rowLength(new RowType(valueTypes)),
+				rowLength(new RowType(keyTypes)),
+				PAGE_SIZE);
+		int memorySize = numMemSegments * PAGE_SIZE;
+		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+
+		BytesHashMap table = new BytesHashMap(this, memoryManager,
+				memorySize, keyTypes, valueTypes);
+
+		final Random rnd = new Random(RANDOM_SEED);
+		BinaryRow[] rows = getRandomizedInput(NUM_ENTRIES, rnd, true);
+		List<BinaryRow> expected = new ArrayList<>(NUM_ENTRIES);
+		verifyInsert(rows, expected, table);
+		verifyRetrieve(table, rows, expected);
+		table.free();
+	}
+
+	@Test
+	public void testBuildAndUpdate() throws Exception {
+		final Random rnd = new Random(RANDOM_SEED);
+		final BinaryRow[] rows = getRandomizedInput(NUM_ENTRIES, rnd, true);
+		final int numMemSegments = needNumMemSegments(
+				NUM_ENTRIES,
+				rowLength(new RowType(valueTypes)),
+				rowLength(new RowType(keyTypes)),
+				PAGE_SIZE);
+		int memorySize = numMemSegments * PAGE_SIZE;
+
+		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+
+		BytesHashMap table = new BytesHashMap(this, memoryManager,
+				memorySize, keyTypes, valueTypes);
+
+		List<BinaryRow> expected = new ArrayList<>(NUM_ENTRIES);
+		verifyInsertAndUpdate(rnd, rows, expected, table);
+		verifyRetrieve(table, rows, expected);
+		table.free();
+	}
+
+	@Test
+	public void testRest() throws Exception {
+		final Random rnd = new Random(RANDOM_SEED);
+		final BinaryRow[] rows = getRandomizedInput(NUM_ENTRIES, rnd, true);
+
+		final int numMemSegments = needNumMemSegments(
+				NUM_ENTRIES,
+				rowLength(new RowType(valueTypes)),
+				rowLength(new RowType(keyTypes)),
+				PAGE_SIZE);
+
+		int memorySize = numMemSegments * PAGE_SIZE;
+
+		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+
+		BytesHashMap table = new BytesHashMap(this, memoryManager,
+				memorySize, keyTypes, valueTypes);
+
+		List<BinaryRow> expected = new ArrayList<>(NUM_ENTRIES);
+		verifyInsertAndUpdate(rnd, rows, expected, table);
+		verifyRetrieve(table, rows, expected);
+
+		table.reset();
+		Assert.assertEquals(0, table.getNumElements());
+		Assert.assertTrue(table.getRecordAreaMemorySegments().size() == 1);
+
+		expected.clear();
+		verifyInsertAndUpdate(rnd, rows, expected, table);
+		verifyRetrieve(table, rows, expected);
+		table.free();
+	}
+
+	@Test
+	public void testResetAndOutput() throws Exception {
+		final Random rnd = new Random(RANDOM_SEED);
+		final int reservedMemSegments = 32;
+
+		int minMemorySize = reservedMemSegments * PAGE_SIZE;
+
+		MemoryManager memoryManager = new MemoryManager(
+				minMemorySize, 32, MemoryManager.DEFAULT_PAGE_SIZE,
+				MemoryType.HEAP, true);
+		BytesHashMap table = new BytesHashMap(this, memoryManager,
+				minMemorySize, keyTypes, valueTypes, true);
+
+		BinaryRow[] rows = getRandomizedInput(NUM_ENTRIES, rnd, true);
+
+		List<BinaryRow> expected = new ArrayList<>(NUM_ENTRIES);
+		List<BinaryRow> actualValues = new ArrayList<>(NUM_ENTRIES);
+		List<BinaryRow> actualKeys = new ArrayList<>(NUM_ENTRIES);
+		for (int i = 0; i < NUM_ENTRIES; i++) {
+			BinaryRow groupKey = rows[i];
+			// look up and insert
+			BytesHashMap.LookupInfo info = table.lookup(groupKey);
+			Assert.assertFalse(info.isFound());
+			try {
+				BinaryRow entry =
+						table.append(info, defaultValue);
+				Assert.assertNotNull(entry);
+				// mock multiple updates
+				for (int j = 0; j < NUM_REWRITES; j++) {
+					updateOutputBuffer(entry, rnd);
+				}
+				expected.add(entry.copy());
+			} catch (Exception e) {
+				ArrayList<MemorySegment> segments = table.getRecordAreaMemorySegments();
+				RandomAccessInputView inView = new RandomAccessInputView(segments, segments.get(0).size());
+				BinaryRow reuseKey = this.keySerializer.createInstance();
+				BinaryRow reuseValue = this.valueSerializer.createInstance();
+				BytesHashMap.Entry reuse = new BytesHashMap.Entry(reuseKey, reuseValue);
+				for (int index = 0; index < table.getNumElements(); index++) {
+					reuseKey = keySerializer.mapFromPages(reuseKey, inView);
+					reuseValue = valueSerializer.mapFromPages(reuseValue, inView);
+					actualKeys.add(reuse.getKey().copy());
+					actualValues.add(reuse.getValue().copy());
+				}
+				table.reset();
+				// retry
+				info = table.lookup(groupKey);
+				BinaryRow entry = table.append(info, defaultValue);
+				Assert.assertNotNull(entry);
+				// mock multiple updates
+				for (int j = 0; j < NUM_REWRITES; j++) {
+					updateOutputBuffer(entry, rnd);
+				}
+				expected.add(entry.copy());
+			}
+		}
+		MutableObjectIterator<BytesHashMap.Entry> iter = table.getEntryIterator();
+		BinaryRow reuseKey = this.keySerializer.createInstance();
+		BinaryRow reuseValue = this.valueSerializer.createInstance();
+		BytesHashMap.Entry reuse = new BytesHashMap.Entry(reuseKey, reuseValue);
+
+		while ((reuse = iter.next(reuse)) != null) {
+			actualKeys.add(reuse.getKey().copy());
+			actualValues.add(reuse.getValue().copy());
+		}
+		Assert.assertEquals(NUM_ENTRIES, expected.size());
+		Assert.assertEquals(NUM_ENTRIES, actualKeys.size());
+		Assert.assertEquals(NUM_ENTRIES, actualValues.size());
+		Assert.assertEquals(expected, actualValues);
+		table.free();
+	}
+
+	@Test
+	public void testSingleKeyMultipleOps() throws Exception {
+		final int numMemSegments = needNumMemSegments(
+				NUM_ENTRIES,
+				rowLength(new RowType(valueTypes)),
+				rowLength(new RowType(keyTypes)),
+				PAGE_SIZE);
+
+		int memorySize = numMemSegments * PAGE_SIZE;
+		MemoryManager memoryManager = new MemoryManager(memorySize, 32);
+		BytesHashMap table = new BytesHashMap(this, memoryManager,
+				memorySize, keyTypes, valueTypes);
+		final Random rnd = new Random(RANDOM_SEED);
+		BinaryRow row = getNullableGroupkeyInput(rnd);
+		for (int i = 0; i < 3; i++) {
+			BytesHashMap.LookupInfo info = table.lookup(row);
+			Assert.assertFalse(info.isFound());
+		}
+
+		for (int i = 0; i < 3; i++) {
+			BytesHashMap.LookupInfo info = table.lookup(row);
+			BinaryRow entry = info.getValue();
+			if (i == 0) {
+				Assert.assertFalse(info.isFound());
+				entry = table.append(info, defaultValue);
+			} else {
+				Assert.assertTrue(info.isFound());
+			}
+			Assert.assertNotNull(entry);
+		}
+		table.free();
+	}
+
+	// ----------------------------------------------
+	/**
+	 * It will be codegened when in HashAggExec
+	 * using rnd to mock update/initExprs resultTerm.
+	 */
+	private void updateOutputBuffer(BinaryRow reuse, Random rnd) {
+		long longVal = rnd.nextLong();
+		double doubleVal = rnd.nextDouble();
+		boolean boolVal = longVal % 2 == 0;
+		reuse.setDouble(2, doubleVal);
+		reuse.setLong(3, longVal);
+		reuse.setBoolean(4, boolVal);
+	}
+
+	// ----------------------- Utilities  -----------------------
+
+	private void verifyRetrieve(
+			BytesHashMap table,
+			BinaryRow[] keys,
+			List<BinaryRow> expected) throws IOException {
+		Assert.assertEquals(NUM_ENTRIES, table.getNumElements());
+		for (int i = 0; i < NUM_ENTRIES; i++) {
+			BinaryRow groupKey = keys[i];
+			// look up and retrieve
+			BytesHashMap.LookupInfo info = table.lookup(groupKey);
+			Assert.assertTrue(info.isFound());
+			Assert.assertNotNull(info.getValue());
+			Assert.assertEquals(expected.get(i), info.getValue());
+		}
+	}
+
+	private void verifyInsert(
+			BinaryRow[] keys,
+			List<BinaryRow> inserted,
+			BytesHashMap table) throws IOException {
+		for (int i = 0; i < NUM_ENTRIES; i++) {
+			BinaryRow groupKey = keys[i];
+			// look up and insert
+			BytesHashMap.LookupInfo info = table.lookup(groupKey);
+			Assert.assertFalse(info.isFound());
+			BinaryRow entry  = table.append(info, defaultValue);
+			Assert.assertNotNull(entry);
+			Assert.assertEquals(entry, defaultValue);
+			inserted.add(entry.copy());
+		}
+		Assert.assertEquals(NUM_ENTRIES, table.getNumElements());
+	}
+
+	private void verifyInsertAndUpdate(
+			Random rnd,
+			BinaryRow[] keys,
+			List<BinaryRow> inserted,
+			BytesHashMap table) throws IOException {
+		for (int i = 0; i < NUM_ENTRIES; i++) {
+			BinaryRow groupKey = keys[i];
+			// look up and insert
+			BytesHashMap.LookupInfo info = table.lookup(groupKey);
+			Assert.assertFalse(info.isFound());
+			BinaryRow entry  = table.append(info, defaultValue);
+			Assert.assertNotNull(entry);
+			// mock multiple updates
+			for (int j = 0; j < NUM_REWRITES; j++) {
+				updateOutputBuffer(entry, rnd);
+			}
+			inserted.add(entry.copy());
+		}
+		Assert.assertEquals(NUM_ENTRIES, table.getNumElements());
+	}
+
+	private void verifyKeyPresent(BinaryRow[] keys, BytesHashMap table) throws IOException {
+		Assert.assertEquals(NUM_ENTRIES, table.getNumElements());
+		BinaryRow present = new BinaryRow(0);
+		present.pointTo(MemorySegmentFactory.wrap(new byte[8]), 0, 8);
+		for (int i = 0; i < NUM_ENTRIES; i++) {
+			BinaryRow groupKey = keys[i];
+			// look up and retrieve
+			BytesHashMap.LookupInfo info = table.lookup(groupKey);
+			Assert.assertTrue(info.isFound());
+			Assert.assertNotNull(info.getValue());
+			Assert.assertEquals(present, info.getValue());
+		}
+	}
+
+	private void verifyKeyInsert(BinaryRow[] keys, BytesHashMap table) throws IOException {
+		BinaryRow present = new BinaryRow(0);
+		present.pointTo(MemorySegmentFactory.wrap(new byte[8]), 0, 8);
+		for (int i = 0; i < NUM_ENTRIES; i++) {
+			BinaryRow groupKey = keys[i];
+			// look up and insert
+			BytesHashMap.LookupInfo info = table.lookup(groupKey);
+			Assert.assertFalse(info.isFound());
+			BinaryRow entry  = table.append(info, defaultValue);
+			Assert.assertNotNull(entry);
+			Assert.assertEquals(entry, present);
+		}
+		Assert.assertEquals(NUM_ENTRIES, table.getNumElements());
+	}
+
+	// ----------------------------------------------
+
+	private List<MemorySegment> getMemory(int numSegments, int segmentSize) {
+		ArrayList<MemorySegment> list = new ArrayList<>(numSegments);
+		for (int i = 0; i < numSegments; i++) {
+			list.add(MemorySegmentFactory.allocateUnpooledSegment(segmentSize));
+		}
+		return list;
+	}
+
+	private int needNumMemSegments(int numEntries, int valLen, int keyLen, int pageSize) {
+		return 2 * (valLen + keyLen + 1024 * 3 + 4 + 8 + 8) * numEntries / pageSize;
+	}
+
+	// ----------------------------------------------
+
+	private BinaryRow[] getRandomizedInput(int num, Random rnd, boolean nullable) {
+		BinaryRow[] lists = new BinaryRow[num];
+		for (int i = 0; i < num; i++) {
+			Integer intVal = rnd.nextInt(Integer.MAX_VALUE);
+			Long longVal = -rnd.nextLong();
+			Boolean boolVal = longVal % 2 == 0;
+			String strVal = nullable && boolVal ? null : getString(intVal, intVal % 1024) + i;
+			Double doubleVal = rnd.nextDouble();
+			Short shotVal = intVal.shortValue();
+			Float floatVal = nullable && boolVal ? null : rnd.nextFloat();
+			lists[i] = createRow(intVal, strVal, doubleVal, longVal, boolVal, floatVal, shotVal);
+		}
+		return lists;
+	}
+
+	private BinaryRow getNullableGroupkeyInput(Random rnd) {
+		Integer intVal = -rnd.nextInt(Integer.MAX_VALUE);
+		Long longVal = rnd.nextLong();
+		Boolean boolVal = intVal % 2 == 0;
+		Double doubleVal = rnd.nextDouble();
+		Short shotVal = intVal.shortValue();
+		Float floatVal = rnd.nextFloat();
+		return createRow(intVal, null, doubleVal, longVal, boolVal, floatVal, shotVal);
+	}
+
+	private BinaryRow createRow(
+			Integer f0, String f1,
+			Double f2, Long f3, Boolean f4, Float f5, Short f6) {
+
+		BinaryRow row = new BinaryRow(7);
+		BinaryRowWriter writer = new BinaryRowWriter(row);
+
+		// int, string, double, long, boolean
+		if (f0 == null) {
+			writer.setNullAt(0);
+		} else {
+			writer.writeInt(0, f0);
+		}
+		if (f1 == null) {
+			writer.setNullAt(1);
+		} else {
+			writer.writeString(1, BinaryString.fromString(f1));
+		}
+		if (f2 == null) {
+			writer.setNullAt(2);
+		} else {
+			writer.writeDouble(2, f2);
+		}
+		if (f3 == null) {
+			writer.setNullAt(3);
+		} else {
+			writer.writeLong(3, f3);
+		}
+		if (f4 == null) {
+			writer.setNullAt(4);
+		} else {
+			writer.writeBoolean(4, f4);
+		}
+		if (f5 == null) {
+			writer.setNullAt(5);
+		} else {
+			writer.writeFloat(5, f5);
+		}
+		if (f6 == null) {
+			writer.setNullAt(6);
+		} else {
+			writer.writeShort(6, f6);
+		}
+		writer.complete();
+		return row;
+	}
+
+	private String getString(int count, int length) {
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < length; i++) {
+			builder.append(count);
+		}
+		return builder.toString();
+	}
+
+	private int rowLength(RowType tpe) {
+		return BinaryRow.calculateFixPartSizeInBytes(tpe.getArity())
+				+ BytesHashMap.getVariableLength(tpe.getFieldTypes());
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/aggregate/HashAggTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/aggregate/HashAggTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.aggregate;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.util.Collector;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test hash agg.
+ */
+public class HashAggTest {
+
+	private static final int MEMORY_SIZE = 1024 * 1024 * 32;
+
+	private Map<Integer, Long> outputMap = new HashMap<>();
+	private MemoryManager memoryManager = new MemoryManager(MEMORY_SIZE, 1);
+	private IOManager ioManager;
+	private SumHashAggTestOperator operator;
+
+	@Before
+	public void before() throws Exception {
+		ioManager = new IOManagerAsync();
+		operator = new SumHashAggTestOperator(40 * 32 * 1024) {
+
+			@Override
+			Object getOwner() {
+				return HashAggTest.this;
+			}
+
+			@Override
+			MemoryManager getMemoryManager() {
+				return memoryManager;
+			}
+
+			@Override
+			Collector<StreamRecord<BaseRow>> getOutput() {
+				return new Collector<StreamRecord<BaseRow>>() {
+					@Override
+					public void collect(StreamRecord<BaseRow> record) {
+						BaseRow row = record.getValue();
+						outputMap.put(
+								row.isNullAt(0) ? null : row.getInt(0),
+								row.isNullAt(1) ? null : row.getLong(1));
+					}
+
+					@Override
+					public void close() {
+					}
+				};
+			}
+
+			@Override
+			Configuration getConf() {
+				return new Configuration();
+			}
+
+			@Override
+			public IOManager getIOManager() {
+				return ioManager;
+			}
+		};
+
+		operator.open();
+	}
+
+	@After
+	public void afterTest() {
+		this.ioManager.shutdown();
+		if (!this.ioManager.isProperlyShutDown()) {
+			Assert.fail("I/O Manager was not properly shut down.");
+		}
+
+		if (this.memoryManager != null) {
+			Assert.assertTrue("Memory leak: not all segments have been returned to the memory manager.",
+					this.memoryManager.verifyEmpty());
+			this.memoryManager.shutdown();
+			this.memoryManager = null;
+		}
+	}
+
+	private void addRow(BaseRow row) throws Exception {
+		operator.processElement(new StreamRecord<>(row));
+	}
+
+	@Test
+	public void testNormal() throws Exception {
+		addRow(GenericRow.of(1, 1L));
+		addRow(GenericRow.of(5, 2L));
+		addRow(GenericRow.of(2, 3L));
+		addRow(GenericRow.of(2, null));
+		addRow(GenericRow.of(1, 4L));
+		addRow(GenericRow.of(4, 5L));
+		addRow(GenericRow.of(1, 6L));
+		addRow(GenericRow.of(1, null));
+		addRow(GenericRow.of(2, 8L));
+		addRow(GenericRow.of(5, 9L));
+		addRow(GenericRow.of(10, null));
+		addRow(GenericRow.of(null, 5L));
+
+		operator.endInput();
+		operator.close();
+
+		Map<Integer, Long> expected = new HashMap<>();
+		expected.put(null, 5L);
+		expected.put(1, 11L);
+		expected.put(2, 11L);
+		expected.put(4, 5L);
+		expected.put(5, 11L);
+		expected.put(10, null);
+		Assert.assertEquals(expected, outputMap);
+	}
+
+	@Test
+	public void testSpill() throws Exception {
+		for (int i = 0; i < 30000; i++) {
+			addRow(GenericRow.of(i, (long) i));
+			addRow(GenericRow.of(i + 1, (long) i));
+		}
+		addRow(GenericRow.of(1, null));
+		addRow(GenericRow.of(null, 5L));
+		operator.endInput();
+		operator.close();
+		Assert.assertEquals(30002, outputMap.size());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/aggregate/SumHashAggTestOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/aggregate/SumHashAggTestOperator.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.aggregate;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.dataformat.util.BinaryRowUtil;
+import org.apache.flink.table.runtime.sort.BufferedKVExternalSorter;
+import org.apache.flink.table.runtime.sort.IntNormalizedKeyComputer;
+import org.apache.flink.table.runtime.sort.IntRecordComparator;
+import org.apache.flink.table.type.InternalType;
+import org.apache.flink.table.type.InternalTypes;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.MutableObjectIterator;
+
+import java.io.EOFException;
+
+/**
+ * Test for Hash aggregation of (select f0, sum(f1) from T).
+ */
+public class SumHashAggTestOperator extends AbstractStreamOperator<BaseRow>
+		implements OneInputStreamOperator<BaseRow, BaseRow> {
+
+	private final long memorySize;
+	private final InternalType[] keyTypes = new InternalType[] {InternalTypes.INT};
+	private final InternalType[] aggBufferTypes = new InternalType[] {InternalTypes.INT, InternalTypes.LONG};
+
+	private transient BinaryRow currentKey;
+	private transient BinaryRowWriter currentKeyWriter;
+
+	private transient BufferedKVExternalSorter sorter;
+	private transient BytesHashMap aggregateMap;
+
+	private transient BinaryRow emptyAggBuffer;
+
+	public SumHashAggTestOperator(long memorySize) throws Exception {
+		this.memorySize = memorySize;
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+		aggregateMap = new BytesHashMap(
+				getOwner(), getMemoryManager(), memorySize,
+				keyTypes, aggBufferTypes);
+
+		currentKey = new BinaryRow(1);
+		currentKeyWriter = new BinaryRowWriter(currentKey);
+		emptyAggBuffer = new BinaryRow(1);
+
+		// for null value
+		BinaryRowWriter emptyAggBufferWriter = new BinaryRowWriter(emptyAggBuffer);
+		emptyAggBufferWriter.reset();
+		emptyAggBufferWriter.setNullAt(0);
+		emptyAggBufferWriter.complete();
+	}
+
+	@Override
+	public void processElement(StreamRecord<BaseRow> element) throws Exception {
+		BaseRow in1 = element.getValue();
+
+		// project key from input
+		currentKeyWriter.reset();
+		if (in1.isNullAt(0)) {
+			currentKeyWriter.setNullAt(0);
+		} else {
+			currentKeyWriter.writeInt(0, in1.getInt(0));
+		}
+		currentKeyWriter.complete();
+
+		// look up output buffer using current group key
+		BytesHashMap.LookupInfo lookupInfo = aggregateMap.lookup(currentKey);
+		BinaryRow currentAggBuffer = lookupInfo.getValue();
+
+		if (!lookupInfo.isFound()) {
+
+			// append empty agg buffer into aggregate map for current group key
+			try {
+				currentAggBuffer = aggregateMap.append(lookupInfo, emptyAggBuffer);
+			} catch (EOFException exp) {
+				// hash map out of memory, spill to external sorter
+				if (sorter == null) {
+					sorter = new BufferedKVExternalSorter(
+							getIOManager(),
+							new BinaryRowSerializer(keyTypes.length),
+							new BinaryRowSerializer(aggBufferTypes.length),
+							new IntNormalizedKeyComputer(), new IntRecordComparator(),
+							getMemoryManager().getPageSize(),
+							getConf());
+				}
+				// sort and spill
+				sorter.sortAndSpill(
+						aggregateMap.getRecordAreaMemorySegments(),
+						aggregateMap.getNumElements(),
+						new BytesHashMapSpillMemorySegmentPool(aggregateMap.getBucketAreaMemorySegments()));
+
+				// retry append
+				// reset aggregate map retry append
+				aggregateMap.reset();
+				lookupInfo = aggregateMap.lookup(currentKey);
+				try {
+					currentAggBuffer = aggregateMap.append(lookupInfo, emptyAggBuffer);
+				} catch (EOFException e) {
+					throw new OutOfMemoryError("BytesHashMap Out of Memory.");
+				}
+			}
+		}
+
+		if (!in1.isNullAt(1)) {
+			long sumInput = in1.getLong(1);
+			if (currentAggBuffer.isNullAt(0)) {
+				currentAggBuffer.setLong(0, sumInput);
+			} else {
+				currentAggBuffer.setLong(0, sumInput + currentAggBuffer.getLong(0));
+			}
+		}
+	}
+
+	public void endInput() throws Exception {
+
+		StreamRecord<BaseRow> outElement = new StreamRecord<>(null);
+		JoinedRow hashAggOutput = new JoinedRow();
+		GenericRow aggValueOutput = new GenericRow(1);
+
+		if (sorter == null) {
+			// no spilling, output by iterating aggregate map.
+			MutableObjectIterator<BytesHashMap.Entry> iter = aggregateMap.getEntryIterator();
+
+			BinaryRow reuseAggMapKey = new BinaryRow(1);
+			BinaryRow reuseAggBuffer = new BinaryRow(1);
+			BytesHashMap.Entry reuseAggMapEntry = new BytesHashMap.Entry(reuseAggMapKey, reuseAggBuffer);
+
+			while (iter.next(reuseAggMapEntry) != null) {
+				// set result and output
+				aggValueOutput.setField(0, reuseAggBuffer.isNullAt(0) ? null : reuseAggBuffer.getLong(0));
+				hashAggOutput.replace(reuseAggMapKey, aggValueOutput);
+				getOutput().collect(outElement.replace(hashAggOutput));
+			}
+		} else {
+			// spill last part of input' aggregation output buffer
+			sorter.sortAndSpill(
+					aggregateMap.getRecordAreaMemorySegments(),
+					aggregateMap.getNumElements(),
+					new BytesHashMapSpillMemorySegmentPool(aggregateMap.getBucketAreaMemorySegments()));
+
+			// only release non-data memory in advance.
+			aggregateMap.free(true);
+
+			// fall back to sort based aggregation
+			BinaryRow lastKey = null;
+			JoinedRow fallbackInput = new JoinedRow();
+			boolean aggSumIsNull = false;
+			long aggSum = -1;
+
+			// free hash map memory, but not release back to memory manager
+			MutableObjectIterator<Tuple2<BinaryRow, BinaryRow>> iterator = sorter.getKVIterator();
+			Tuple2<BinaryRow, BinaryRow> kv;
+			while ((kv = iterator.next()) != null) {
+				BinaryRow key = kv.f0;
+				BinaryRow value = kv.f1;
+				// prepare input
+				fallbackInput.replace(key, value);
+				if (lastKey == null) {
+					// found first key group
+					lastKey = key.copy();
+					aggSumIsNull = true;
+					aggSum = -1L;
+				} else if (key.getSizeInBytes() != lastKey.getSizeInBytes() ||
+						!(BinaryRowUtil.byteArrayEquals(
+								key.getSegments()[0].getArray(),
+								lastKey.getSegments()[0].getArray(),
+								key.getSizeInBytes()))) {
+
+					// output current group aggregate result
+					aggValueOutput.setField(0, aggSumIsNull ? null : aggSum);
+					hashAggOutput.replace(lastKey, aggValueOutput);
+					getOutput().collect(outElement.replace(hashAggOutput));
+
+					// found new group
+					lastKey = key.copy();
+					aggSumIsNull = true;
+					aggSum = -1L;
+				}
+
+				if (!fallbackInput.isNullAt(1)) {
+					long sumInput = fallbackInput.getLong(1);
+					if (aggSumIsNull) {
+						aggSum = sumInput;
+					} else {
+						aggSum = aggSum + sumInput;
+					}
+					aggSumIsNull = false;
+				}
+			}
+
+			// output last key group aggregate result
+			aggValueOutput.setField(0, aggSumIsNull ? null : aggSum);
+			hashAggOutput.replace(lastKey, aggValueOutput);
+			getOutput().collect(outElement.replace(hashAggOutput));
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		aggregateMap.free();
+		if (sorter != null) {
+			sorter.close();
+		}
+	}
+
+	Object getOwner() {
+		return getContainingTask();
+	}
+
+	Collector<StreamRecord<BaseRow>> getOutput() {
+		return output;
+	}
+
+	MemoryManager getMemoryManager() {
+		return getContainingTask().getEnvironment().getMemoryManager();
+	}
+
+	Configuration getConf() {
+		return getContainingTask().getJobConfiguration();
+	}
+
+	public IOManager getIOManager() {
+		return getContainingTask().getEnvironment().getIOManager();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce bytes based hash table.
It can be used for performing aggregations where the aggregated values are fixed-width.
Because the data is stored in continuous memory, AggBuffer of variable length cannot be applied to this HashMap. The KeyValue form in hash map is designed to reduce the cost of key fetching in lookup.

Add a test to do a complete hash agg. When HashMap has enough memory, pure hash AGG is performed; when memory is insufficient, it degenerates into sort agg.

## Verifying this change

ut & coverage

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes, just add test dependency)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
