### PR TITLE
[FLINK-11883] Harmonize the version of maven-shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1626,7 +1626,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.1.1</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
## What is the purpose of the change

Currently we're using two version of the maven-shade-plugin which might lead to confusion/collisions. Therefore I would to harmonize the two versions.

Ticket: https://jira.apache.org/jira/browse/FLINK-11883

https://github.com/apache/flink/blob/c4b42b8baed68ac118d9b071a1153088df00e483/pom.xml#L773-L775

## Brief change log

Set all the versions of the Maven shade plugin to 3.1.1

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial setting of versions.

This change is already covered by existing tests, such as the full test suite.

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
