### PR TITLE
[FLINK-12204] [jdbc] make JDBCOutputFormat ClassCastException more helpful

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -126,75 +126,82 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 					if (row.getField(index) == null) {
 						upload.setNull(index + 1, typesArray[index]);
 					} else {
-						// casting values as suggested by http://docs.oracle.com/javase/1.5.0/docs/guide/jdbc/getstart/mapping.html
-						switch (typesArray[index]) {
-							case java.sql.Types.NULL:
-								upload.setNull(index + 1, typesArray[index]);
-								break;
-							case java.sql.Types.BOOLEAN:
-							case java.sql.Types.BIT:
-								upload.setBoolean(index + 1, (boolean) row.getField(index));
-								break;
-							case java.sql.Types.CHAR:
-							case java.sql.Types.NCHAR:
-							case java.sql.Types.VARCHAR:
-							case java.sql.Types.LONGVARCHAR:
-							case java.sql.Types.LONGNVARCHAR:
-								upload.setString(index + 1, (String) row.getField(index));
-								break;
-							case java.sql.Types.TINYINT:
-								upload.setByte(index + 1, (byte) row.getField(index));
-								break;
-							case java.sql.Types.SMALLINT:
-								upload.setShort(index + 1, (short) row.getField(index));
-								break;
-							case java.sql.Types.INTEGER:
-								upload.setInt(index + 1, (int) row.getField(index));
-								break;
-							case java.sql.Types.BIGINT:
-								upload.setLong(index + 1, (long) row.getField(index));
-								break;
-							case java.sql.Types.REAL:
-								upload.setFloat(index + 1, (float) row.getField(index));
-								break;
-							case java.sql.Types.FLOAT:
-							case java.sql.Types.DOUBLE:
-								upload.setDouble(index + 1, (double) row.getField(index));
-								break;
-							case java.sql.Types.DECIMAL:
-							case java.sql.Types.NUMERIC:
-								upload.setBigDecimal(index + 1, (java.math.BigDecimal) row.getField(index));
-								break;
-							case java.sql.Types.DATE:
-								upload.setDate(index + 1, (java.sql.Date) row.getField(index));
-								break;
-							case java.sql.Types.TIME:
-								upload.setTime(index + 1, (java.sql.Time) row.getField(index));
-								break;
-							case java.sql.Types.TIMESTAMP:
-								upload.setTimestamp(index + 1, (java.sql.Timestamp) row.getField(index));
-								break;
-							case java.sql.Types.BINARY:
-							case java.sql.Types.VARBINARY:
-							case java.sql.Types.LONGVARBINARY:
-								upload.setBytes(index + 1, (byte[]) row.getField(index));
-								break;
-							default:
-								upload.setObject(index + 1, row.getField(index));
-								LOG.warn("Unmanaged sql type ({}) for column {}. Best effort approach to set its value: {}.",
-									typesArray[index], index + 1, row.getField(index));
-								// case java.sql.Types.SQLXML
-								// case java.sql.Types.ARRAY:
-								// case java.sql.Types.JAVA_OBJECT:
-								// case java.sql.Types.BLOB:
-								// case java.sql.Types.CLOB:
-								// case java.sql.Types.NCLOB:
-								// case java.sql.Types.DATALINK:
-								// case java.sql.Types.DISTINCT:
-								// case java.sql.Types.OTHER:
-								// case java.sql.Types.REF:
-								// case java.sql.Types.ROWID:
-								// case java.sql.Types.STRUC
+						try {
+							// casting values as suggested by http://docs.oracle.com/javase/1.5.0/docs/guide/jdbc/getstart/mapping.html
+							switch (typesArray[index]) {
+								case java.sql.Types.NULL:
+									upload.setNull(index + 1, typesArray[index]);
+									break;
+								case java.sql.Types.BOOLEAN:
+								case java.sql.Types.BIT:
+									upload.setBoolean(index + 1, (boolean) row.getField(index));
+									break;
+								case java.sql.Types.CHAR:
+								case java.sql.Types.NCHAR:
+								case java.sql.Types.VARCHAR:
+								case java.sql.Types.LONGVARCHAR:
+								case java.sql.Types.LONGNVARCHAR:
+									upload.setString(index + 1, (String) row.getField(index));
+									break;
+								case java.sql.Types.TINYINT:
+									upload.setByte(index + 1, (byte) row.getField(index));
+									break;
+								case java.sql.Types.SMALLINT:
+									upload.setShort(index + 1, (short) row.getField(index));
+									break;
+								case java.sql.Types.INTEGER:
+									upload.setInt(index + 1, (int) row.getField(index));
+									break;
+								case java.sql.Types.BIGINT:
+									upload.setLong(index + 1, (long) row.getField(index));
+									break;
+								case java.sql.Types.REAL:
+									upload.setFloat(index + 1, (float) row.getField(index));
+									break;
+								case java.sql.Types.FLOAT:
+								case java.sql.Types.DOUBLE:
+									upload.setDouble(index + 1, (double) row.getField(index));
+									break;
+								case java.sql.Types.DECIMAL:
+								case java.sql.Types.NUMERIC:
+									upload.setBigDecimal(index + 1, (java.math.BigDecimal) row.getField(index));
+									break;
+								case java.sql.Types.DATE:
+									upload.setDate(index + 1, (java.sql.Date) row.getField(index));
+									break;
+								case java.sql.Types.TIME:
+									upload.setTime(index + 1, (java.sql.Time) row.getField(index));
+									break;
+								case java.sql.Types.TIMESTAMP:
+									upload.setTimestamp(index + 1, (java.sql.Timestamp) row.getField(index));
+									break;
+								case java.sql.Types.BINARY:
+								case java.sql.Types.VARBINARY:
+								case java.sql.Types.LONGVARBINARY:
+									upload.setBytes(index + 1, (byte[]) row.getField(index));
+									break;
+								default:
+									upload.setObject(index + 1, row.getField(index));
+									LOG.warn("Unmanaged sql type ({}) for column {}. Best effort approach to set its value: {}.",
+										typesArray[index], index + 1, row.getField(index));
+									// case java.sql.Types.SQLXML
+									// case java.sql.Types.ARRAY:
+									// case java.sql.Types.JAVA_OBJECT:
+									// case java.sql.Types.BLOB:
+									// case java.sql.Types.CLOB:
+									// case java.sql.Types.NCLOB:
+									// case java.sql.Types.DATALINK:
+									// case java.sql.Types.DISTINCT:
+									// case java.sql.Types.OTHER:
+									// case java.sql.Types.REF:
+									// case java.sql.Types.ROWID:
+									// case java.sql.Types.STRUC
+							}
+						} catch (ClassCastException e) {
+							throw new RuntimeException(
+								"Field index: " + index +
+									" field value: " + row.getField(index) +
+									" " + e.getMessage(), e);
 						}
 					}
 				}


### PR DESCRIPTION
## What is the purpose of the change
This PR makes JDBCOutputFormat's ClassCastException more readable. Current exception make me confused which column is wrong. The new error message will help people find the error location.

## Brief change log


## Verifying this change

This change added tests and can be verified as follows:
	- Already check by org.apache.flink.api.java.io.jdbc.JDBCOutputFormatTest#testExceptionOnInvalidType

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented