### PR TITLE
[FLINK-11887][metrics] Fixed latency metrics drift apart

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -154,7 +154,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 					public void onProcessingTime(long timestamp) throws Exception {
 						try {
 							// ProcessingTimeService callbacks are executed under the checkpointing lock
-							output.emitLatencyMarker(new LatencyMarker(System.currentTimeMillis(), operatorId, subtaskIndex));
+							output.emitLatencyMarker(new LatencyMarker(processingTimeService.getCurrentProcessingTime(), operatorId, subtaskIndex));
 						} catch (Throwable t) {
 							// we catch the Throwables here so that we don't trigger the processing
 							// timer services async exception handler

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -154,7 +154,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 					public void onProcessingTime(long timestamp) throws Exception {
 						try {
 							// ProcessingTimeService callbacks are executed under the checkpointing lock
-							output.emitLatencyMarker(new LatencyMarker(timestamp, operatorId, subtaskIndex));
+							output.emitLatencyMarker(new LatencyMarker(System.currentTimeMillis(), operatorId, subtaskIndex));
 						} catch (Throwable t) {
 							// we catch the Throwables here so that we don't trigger the processing
 							// timer services async exception handler

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -169,6 +169,8 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			numberLatencyMarkers + 1, // + 1 is the final watermark element
 			output.size());
 
+		long timestamp = 0L;
+
 		int i = 0;
 		// verify that its only latency markers + a final watermark
 		for (; i < numberLatencyMarkers; i++) {
@@ -176,6 +178,9 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			Assert.assertTrue(se.isLatencyMarker());
 			Assert.assertEquals(operator.getOperatorID(), se.asLatencyMarker().getOperatorId());
 			Assert.assertEquals(0, se.asLatencyMarker().getSubtaskIndex());
+			Assert.assertTrue(se.asLatencyMarker().getMarkedTime() == timestamp);
+
+			timestamp += latencyMarkInterval;
 		}
 
 		Assert.assertTrue(output.get(i).isWatermark());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -169,8 +169,6 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			numberLatencyMarkers + 1, // + 1 is the final watermark element
 			output.size());
 
-		long timestamp = 0L;
-
 		int i = 0;
 		// verify that its only latency markers + a final watermark
 		for (; i < numberLatencyMarkers; i++) {
@@ -178,9 +176,6 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 			Assert.assertTrue(se.isLatencyMarker());
 			Assert.assertEquals(operator.getOperatorID(), se.asLatencyMarker().getOperatorId());
 			Assert.assertEquals(0, se.asLatencyMarker().getSubtaskIndex());
-			Assert.assertTrue(se.asLatencyMarker().getMarkedTime() == timestamp);
-
-			timestamp += latencyMarkInterval;
 		}
 
 		Assert.assertTrue(output.get(i).isWatermark());


### PR DESCRIPTION
## What is the purpose of the change

Use ```System.currentTimeMillis``` to replace ```System.nanoTime``` in ```LatencyMarker```,
in order to fix latency metrics drift apart.


## Verifying this change

LatencyMarker  only affect one latency metric.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
