### PR TITLE
[FLINK-11692] [Datadog Reporter] added proxy to datadog reporter

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -760,6 +760,8 @@ Parameters:
 
 - `apikey` - the Datadog API key
 - `tags` - (optional) the global tags that will be applied to metrics when sending to Datadog. Tags should be separated by comma only
+- `proxyHost` - (optional) The proxy host to use when sending to Datadog.
+- `proxyPort` - (optional) The proxy port to use when sending to Datadog.
 
 Example configuration:
 
@@ -768,6 +770,8 @@ Example configuration:
 metrics.reporter.dghttp.class: org.apache.flink.metrics.datadog.DatadogHttpReporter
 metrics.reporter.dghttp.apikey: xxx
 metrics.reporter.dghttp.tags: myflinkapp,prod
+metrics.reporter.dghttp.proxyHost: my.web.proxy.com
+metrics.reporter.dghttp.proxyPort: 8080
 
 {% endhighlight %}
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -761,7 +761,7 @@ Parameters:
 - `apikey` - the Datadog API key
 - `tags` - (optional) the global tags that will be applied to metrics when sending to Datadog. Tags should be separated by comma only
 - `proxyHost` - (optional) The proxy host to use when sending to Datadog.
-- `proxyPort` - (optional) The proxy port to use when sending to Datadog.
+- `proxyPort` - (optional) The proxy port to use when sending to Datadog, defaults to 8080.
 
 Example configuration:
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -32,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -51,21 +53,38 @@ public class DatadogHttpClient {
 	private final OkHttpClient client;
 	private final String apiKey;
 
-	public DatadogHttpClient(String dgApiKey) {
+	private final String proxyHost;
+	private final int proxyPort;
+
+	public DatadogHttpClient(String dgApiKey, String dgProxyHost, int dgProxyPort) {
 		if (dgApiKey == null || dgApiKey.isEmpty()) {
 			throw new IllegalArgumentException("Invalid API key:" + dgApiKey);
 		}
-
 		apiKey = dgApiKey;
+		proxyHost = dgProxyHost;
+		proxyPort = dgProxyPort;
+
+		Proxy proxy = getProxy();
+
 		client = new OkHttpClient.Builder()
 			.connectTimeout(TIMEOUT, TimeUnit.SECONDS)
 			.writeTimeout(TIMEOUT, TimeUnit.SECONDS)
 			.readTimeout(TIMEOUT, TimeUnit.SECONDS)
+			.proxy(proxy)
 			.build();
 
 		seriesUrl = String.format(SERIES_URL_FORMAT, apiKey);
 		validateUrl = String.format(VALIDATE_URL_FORMAT, apiKey);
 		validateApiKey();
+	}
+
+	Proxy getProxy() {
+		if (proxyHost == null) {
+			return Proxy.NO_PROXY;
+		}
+		else {
+			return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+		}
 	}
 
 	private void validateApiKey() {

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -81,8 +81,7 @@ public class DatadogHttpClient {
 	Proxy getProxy() {
 		if (proxyHost == null) {
 			return Proxy.NO_PROXY;
-		}
-		else {
+		} else {
 			return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
 		}
 	}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -56,6 +56,8 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	private List<String> configTags;
 
 	public static final String API_KEY = "apikey";
+	public static final String PROXY_HOST = "proxyHost";
+	public static final String PROXY_PORT = "proxyPort";
 	public static final String TAGS = "tags";
 
 	@Override
@@ -102,7 +104,11 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 
 	@Override
 	public void open(MetricConfig config) {
-		client = new DatadogHttpClient(config.getString(API_KEY, null));
+		String apiKey = config.getString(API_KEY, null);
+		String proxyHost = config.getString(PROXY_HOST, null);
+		Integer proxyPort = config.getInteger(PROXY_PORT, 8080);
+
+		client = new DatadogHttpClient(apiKey, proxyHost, proxyPort);
 		LOGGER.info("Configured DatadogHttpReporter");
 
 		configTags = getTagsFromConfig(config.getString(TAGS, ""));

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -28,19 +28,25 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.api.support.membermodification.MemberMatcher;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the DatadogHttpClient.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(DMetric.class)
+@PrepareForTest({DMetric.class, DatadogHttpClient.class})
+@PowerMockIgnore("javax.net.ssl.*")
 public class DatadogHttpClientTest {
 
 	private static List<String> tags = Arrays.asList("tag1", "tag2");
@@ -53,14 +59,37 @@ public class DatadogHttpClientTest {
 		PowerMockito.when(DMetric.getUnixEpochTimestamp()).thenReturn(MOCKED_SYSTEM_MILLIS);
 	}
 
+	@Before
+	public void suppressValidateApiKey(){
+		PowerMockito.suppress(MemberMatcher.method(DatadogHttpClient.class, "validateApiKey"));
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithEmptyKey() {
-		new DatadogHttpClient("");
+		new DatadogHttpClient("", null, 123);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithNullKey() {
-		new DatadogHttpClient(null);
+		new DatadogHttpClient(null, null, 123);
+	}
+
+	@Test
+	public void testGetProxyWithNullProxyHost() {
+		DatadogHttpClient client = new DatadogHttpClient("anApiKey", null, 123);
+		assert(client.getProxy() == Proxy.NO_PROXY);
+	}
+
+	@Test
+	public void testGetProxy() {
+		DatadogHttpClient client = new DatadogHttpClient("anApiKey", "localhost", 123);
+
+		assertTrue(client.getProxy().address() instanceof InetSocketAddress);
+
+		InetSocketAddress proxyAddress = (InetSocketAddress) client.getProxy().address();
+
+		assertEquals(123, proxyAddress.getPort());
+		assertEquals("localhost", proxyAddress.getHostString());
 	}
 
 	@Test

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -60,7 +60,7 @@ public class DatadogHttpClientTest {
 	}
 
 	@Before
-	public void suppressValidateApiKey(){
+	public void suppressValidateApiKey() {
 		PowerMockito.suppress(MemberMatcher.method(DatadogHttpClient.class, "validateApiKey"));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds a configurable proxy to the Datadog metric reporter.

## Brief change log

  - Proxy host and port configurable in flink config for Datadog reporter


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit test ensuring the correct proxy is used*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
