### PR TITLE
[FLINK-11896] [table-planner-blink] Introduce stream physical nodes

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/PartialFinalType.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/PartialFinalType.java
@@ -20,13 +20,22 @@ package org.apache.flink.table.plan;
 
 /**
  * Enumerations for partial final aggregate types.
+ *
  * @see org.apache.flink.table.plan.rules.physical.stream.SplitAggregateRule
  */
 public enum PartialFinalType {
-	/** partial aggregate type. */
+	/**
+	 * partial aggregate type represents partial-aggregation,
+	 * which produces a partial distinct aggregated result based on group key and bucket number.
+	 */
 	PARTIAL,
-	/** final aggregate type. */
+	/**
+	 * final aggregate type represents final-aggregation,
+	 * which produces final result based on the partially distinct aggregated result.
+	 */
 	FINAL,
-	/** the aggregate which has not been split. */
+	/**
+	 * the aggregate which has not been split.
+	 */
 	NONE
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/PartialFinalType.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/PartialFinalType.java
@@ -16,28 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
-
-import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
-
-import java.util
+package org.apache.flink.table.plan;
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
-  */
-final class LogicalWatermarkAssigner(
-    cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
-
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
-  }
+ * Enumerations for partial final aggregate types.
+ * @see org.apache.flink.table.plan.rules.physical.stream.SplitAggregateRule
+ */
+public enum PartialFinalType {
+	/** partial aggregate type. */
+	PARTIAL,
+	/** final aggregate type. */
+	FINAL,
+	/** the aggregate which has not been split. */
+	NONE
 }
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableConfig.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableConfig.scala
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.table.api
 
+import org.apache.flink.configuration.{Configuration, GlobalConfiguration}
+
 import _root_.java.util.TimeZone
 import _root_.java.math.MathContext
 
@@ -46,6 +48,11 @@ class TableConfig {
     * maximum method length of 64 KB. This setting allows for finer granularity if necessary.
     */
   private var maxGeneratedCodeLength: Int = 64000 // just an estimate
+
+  /**
+    * Defines user-defined configuration
+    */
+  private var conf = GlobalConfiguration.loadConfiguration()
 
   /**
    * Sets the timezone for date/time/timestamp conversions.
@@ -103,6 +110,19 @@ class TableConfig {
       throw new IllegalArgumentException("Length must be greater than 0.")
     }
     this.maxGeneratedCodeLength = maxGeneratedCodeLength
+  }
+
+  /**
+    * Returns user-defined configuration
+    */
+  def getConf: Configuration = conf
+
+  /**
+    * Sets user-defined configuration
+    */
+  def setConf(conf: Configuration): Unit = {
+    this.conf = GlobalConfiguration.loadConfiguration()
+    this.conf.addAll(conf)
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -282,6 +282,11 @@ object FlinkTypeFactory {
     case _ => false
   }
 
+  def isRowtimeIndicatorType(relDataType: RelDataType): Boolean = relDataType match {
+    case ti: TimeIndicatorRelDataType if ti.isEventTime => true
+    case _ => false
+  }
+
   def toInternalType(relDataType: RelDataType): InternalType = relDataType.getSqlTypeName match {
     case BOOLEAN => InternalTypes.BOOLEAN
     case TINYINT => InternalTypes.BYTE

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/LogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/LogicalWatermarkAssigner.scala
@@ -33,11 +33,11 @@ final class LogicalWatermarkAssigner(
     traits: RelTraitSet,
     input: RelNode,
     rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+    watermarkDelay: Option[Long])
+  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkDelay) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkDelay)
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/Rank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/Rank.scala
@@ -110,7 +110,7 @@ abstract class Rank(
     super.explainTerms(pw)
       .item("rankFunction", rankFunction)
       .item("partitionBy", partitionKey.map(i => s"$$$i").mkString(","))
-      .item("orderBy", Rank.sortFieldsToString(sortCollation))
+      .item("orderBy", RelExplainUtil.collationToString(sortCollation))
       .item("rankRange", rankRange.toString())
       .item("select", select)
   }
@@ -166,26 +166,5 @@ case class VariableRankRange(rankEndIndex: Int) extends RankRange {
 
   override def toString: String = {
     s"rankEnd=$$$rankEndIndex"
-  }
-}
-
-object Rank {
-  def sortFieldsToString(collationSort: RelCollation): String = {
-    val fieldCollations = collationSort.getFieldCollations
-      .map(c => (c.getFieldIndex, FlinkRelOptUtil.directionToOrder(c.getDirection)))
-
-    fieldCollations.map {
-      case (index, order) => s"$$$index ${order.getShortName}"
-    }.mkString(", ")
-  }
-
-  def sortFieldsToString(collationSort: RelCollation, inputType: RelDataType): String = {
-    val fieldCollations = collationSort.getFieldCollations
-      .map(c => (c.getFieldIndex, FlinkRelOptUtil.directionToOrder(c.getDirection)))
-    val inputFieldNames = inputType.getFieldNames
-
-    fieldCollations.map {
-      case (index, order) => s"${inputFieldNames.get(index)} ${order.getShortName}"
-    }.mkString(", ")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/Rank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/Rank.scala
@@ -109,9 +109,9 @@ abstract class Rank(
     }.mkString(", ")
     super.explainTerms(pw)
       .item("rankFunction", rankFunction)
+      .item("rankRange", rankRange.toString())
       .item("partitionBy", partitionKey.map(i => s"$$$i").mkString(","))
       .item("orderBy", RelExplainUtil.collationToString(sortCollation))
-      .item("rankRange", rankRange.toString())
       .item("select", select)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/WatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/WatermarkAssigner.scala
@@ -32,21 +32,21 @@ import scala.collection.JavaConversions._
 abstract class WatermarkAssigner(
     cluster: RelOptCluster,
     traits: RelTraitSet,
-    inputNode: RelNode,
-    val rowtimeField: String,
-    val watermarkOffset: Long)
-  extends SingleRel(cluster, traits, inputNode) {
+    inputRel: RelNode,
+    val rowtimeFieldIndex: Option[Int],
+    val watermarkOffset: Option[Long])
+  extends SingleRel(cluster, traits, inputRel) {
 
   override def deriveRowType(): RelDataType = {
-    val inputRowType = inputNode.getRowType
+    val inputRowType = inputRel.getRowType
     val typeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
 
     val newFieldList = inputRowType.getFieldList.map { f =>
-      if (f.getName.equals(rowtimeField)) {
-        val rowtimeIndicatorType = typeFactory.createRowtimeIndicatorType()
-        new RelDataTypeFieldImpl(rowtimeField, f.getIndex, rowtimeIndicatorType)
-      } else {
-        f
+      rowtimeFieldIndex match {
+        case Some(index) if f.getIndex == index =>
+          val rowtimeIndicatorType = typeFactory.createRowtimeIndicatorType()
+          new RelDataTypeFieldImpl(f.getName, f.getIndex, rowtimeIndicatorType)
+        case _ => f
       }
     }
 
@@ -57,8 +57,9 @@ abstract class WatermarkAssigner(
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     super.explainTerms(pw)
-      .item("fields", getRowType.getFieldNames)
-      .item("rowtimeField", rowtimeField)
-      .item("watermarkOffset", watermarkOffset)
+      .item("fields", getRowType.getFieldNames.mkString(", "))
+      .itemIf("rowtimeField", getRowType.getFieldNames.get(rowtimeFieldIndex.getOrElse(0)),
+        rowtimeFieldIndex.isDefined)
+      .itemIf("watermarkOffset", watermarkOffset.getOrElse(0L), watermarkOffset.isDefined)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/WatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/calcite/WatermarkAssigner.scala
@@ -34,7 +34,7 @@ abstract class WatermarkAssigner(
     traits: RelTraitSet,
     inputRel: RelNode,
     val rowtimeFieldIndex: Option[Int],
-    val watermarkOffset: Option[Long])
+    val watermarkDelay: Option[Long])
   extends SingleRel(cluster, traits, inputRel) {
 
   override def deriveRowType(): RelDataType = {
@@ -60,6 +60,6 @@ abstract class WatermarkAssigner(
       .item("fields", getRowType.getFieldNames.mkString(", "))
       .itemIf("rowtimeField", getRowType.getFieldNames.get(rowtimeFieldIndex.getOrElse(0)),
         rowtimeFieldIndex.isDefined)
-      .itemIf("watermarkOffset", watermarkOffset.getOrElse(0L), watermarkOffset.isDefined)
+      .itemIf("watermarkDelay", watermarkDelay.getOrElse(0L), watermarkDelay.isDefined)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonJoin.scala
@@ -70,9 +70,9 @@ trait CommonJoin extends Join with FlinkPhysicalRel {
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     pw.input("left", getLeft).input("right", getRight)
+      .item("joinType", RelExplainUtil.joinTypeToString(flinkJoinType))
       .item("where",
         RelExplainUtil.expressionToString(getCondition, inputRowType, getExpressionString))
-      .item("join", getRowType.getFieldNames.mkString(", "))
-      .item("joinType", RelExplainUtil.joinTypeToString(flinkJoinType))
+      .item("select", getRowType.getFieldNames.mkString(", "))
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonJoin.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.plan.nodes.common
 
 import org.apache.flink.table.plan.FlinkJoinRelType

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonPhysicalExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonPhysicalExchange.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.plan.nodes.common
 import org.apache.flink.table.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.plan.cost.FlinkCost._
 import org.apache.flink.table.plan.cost.FlinkCostFactory
-import org.apache.flink.table.plan.nodes.FlinkRelNode
+import org.apache.flink.table.plan.nodes.physical.FlinkPhysicalRel
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
 import org.apache.calcite.rel.core.Exchange
@@ -33,13 +33,13 @@ import scala.collection.JavaConverters._
 /**
   * Base class for flink [[Exchange]].
   */
-abstract class CommonExchange(
+abstract class CommonPhysicalExchange(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     relNode: RelNode,
     relDistribution: RelDistribution)
   extends Exchange(cluster, traitSet, relNode, relDistribution)
-  with FlinkRelNode {
+  with FlinkPhysicalRel {
 
   override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
     val inputRows = mq.getRowCount(input)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonPhysicalJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/common/CommonPhysicalJoin.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConversions._
 /**
   * Base physical class for flink [[Join]].
   */
-trait CommonJoin extends Join with FlinkPhysicalRel {
+trait CommonPhysicalJoin extends Join with FlinkPhysicalRel {
 
   lazy val (joinInfo, filterNulls) = {
     val filterNulls = new util.ArrayList[java.lang.Boolean]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalRank.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.plan.nodes.logical
 
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.calcite.{LogicalRank, Rank, RankRange}
+import org.apache.flink.table.plan.util.RelExplainUtil
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.`type`.RelDataType
@@ -60,7 +61,7 @@ class FlinkLogicalRank(
     pw.item("input", getInput)
       .item("rankFunction", rankFunction)
       .item("partitionBy", partitionKey.map(inputFieldNames.get(_)).mkString(","))
-      .item("orderBy", Rank.sortFieldsToString(sortCollation, input.getRowType))
+      .item("orderBy", RelExplainUtil.collationToString(sortCollation, input.getRowType))
       .item("rankRange", rankRange.toString(inputFieldNames))
       .item("select", getRowType.getFieldNames.mkString(", "))
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
@@ -35,16 +35,16 @@ class FlinkLogicalWatermarkAssigner(
     cluster: RelOptCluster,
     traits: RelTraitSet,
     input: RelNode,
-    rowtimeField: String,
-    watermarkOffset: Long)
-  extends WatermarkAssigner(cluster, traits, input, rowtimeField, watermarkOffset)
+    rowtimeFieldIndex: Option[Int],
+    watermarkOffset: Option[Long])
+  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset)
   with FlinkLogicalRel {
 
   override def copy(
       traitSet: RelTraitSet,
       inputs: util.List[RelNode]): RelNode = {
     new FlinkLogicalWatermarkAssigner(
-      cluster, traitSet, inputs.get(0), rowtimeField, watermarkOffset)
+      cluster, traitSet, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
   }
 
 }
@@ -60,7 +60,7 @@ class FlinkLogicalWatermarkAssignerConverter extends ConverterRule(
     val newInput = RelOptRule.convert(watermark.getInput, FlinkConventions.LOGICAL)
     FlinkLogicalWatermarkAssigner.create(
       newInput,
-      watermark.rowtimeField,
+      watermark.rowtimeFieldIndex,
       watermark.watermarkOffset)
   }
 }
@@ -70,12 +70,10 @@ object FlinkLogicalWatermarkAssigner {
 
   def create(
       input: RelNode,
-      rowtimeField: String,
-      watermarkOffset: Long): FlinkLogicalWatermarkAssigner = {
+      rowtimeFieldIndex: Option[Int],
+      watermarkOffset: Option[Long]): FlinkLogicalWatermarkAssigner = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSet().replace(FlinkConventions.LOGICAL).simplify()
-    new FlinkLogicalWatermarkAssigner(cluster, traitSet, input, rowtimeField, watermarkOffset)
+    new FlinkLogicalWatermarkAssigner(cluster, traitSet, input, rowtimeFieldIndex, watermarkOffset)
   }
 }
-
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
@@ -61,7 +61,7 @@ class FlinkLogicalWatermarkAssignerConverter extends ConverterRule(
     FlinkLogicalWatermarkAssigner.create(
       newInput,
       watermark.rowtimeFieldIndex,
-      watermark.watermarkOffset)
+      watermark.watermarkDelay)
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalWatermarkAssigner.scala
@@ -36,15 +36,15 @@ class FlinkLogicalWatermarkAssigner(
     traits: RelTraitSet,
     input: RelNode,
     rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset)
+    watermarkDelay: Option[Long])
+  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkDelay)
   with FlinkLogicalRel {
 
   override def copy(
       traitSet: RelTraitSet,
       inputs: util.List[RelNode]): RelNode = {
     new FlinkLogicalWatermarkAssigner(
-      cluster, traitSet, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+      cluster, traitSet, inputs.get(0), rowtimeFieldIndex, watermarkDelay)
   }
 
 }
@@ -71,9 +71,9 @@ object FlinkLogicalWatermarkAssigner {
   def create(
       input: RelNode,
       rowtimeFieldIndex: Option[Int],
-      watermarkOffset: Option[Long]): FlinkLogicalWatermarkAssigner = {
+      watermarkDelay: Option[Long]): FlinkLogicalWatermarkAssigner = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSet().replace(FlinkConventions.LOGICAL).simplify()
-    new FlinkLogicalWatermarkAssigner(cluster, traitSet, input, rowtimeFieldIndex, watermarkOffset)
+    new FlinkLogicalWatermarkAssigner(cluster, traitSet, input, rowtimeFieldIndex, watermarkDelay)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecExchange.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.plan.nodes.physical.batch
 
-import org.apache.flink.table.plan.nodes.common.CommonExchange
+import org.apache.flink.table.plan.nodes.common.CommonPhysicalExchange
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelDistribution, RelNode}
@@ -76,7 +76,7 @@ class BatchExecExchange(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     relDistribution: RelDistribution)
-  extends CommonExchange(cluster, traitSet, inputRel, relDistribution)
+  extends CommonPhysicalExchange(cluster, traitSet, inputRel, relDistribution)
   with BatchPhysicalRel {
 
   override def copy(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecGroupAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecGroupAggregateBase.scala
@@ -31,13 +31,13 @@ import org.apache.calcite.tools.RelBuilder
   * Batch physical RelNode for aggregate.
   *
   * <P>There are two differences between this node and [[Aggregate]]:
-  * 1. This node supports two-stage aggregation to reduce shuffle data:
-  * local-aggregation (or named partial-aggregation in other engines) and
-  * global-aggregation (or named final-aggregation).
-  * local-aggregation produces a partial result for each group before shuffle,
-  * and then global-aggregation produces final result based on shuffled partial result.
-  * Two-stage aggregation is enabled only if all aggregate functions are splittable.
-  * (e.g. SUM, AVG, MAX) see [[org.apache.calcite.sql.SqlSplittableAggFunction]] for more info.
+  * 1. This node supports two-stage aggregation to reduce data-shuffling:
+  * local-aggregation and global-aggregation.
+  * local-aggregation produces a partial result for each group before shuffle in stage 1,
+  * and then the partially aggregated results are shuffled to global-aggregation
+  * which produces the final result in stage 2.
+  * Two-stage aggregation is enabled only if all aggregate functions are mergeable.
+  * (e.g. SUM, AVG, MAX)
   * 2. This node supports auxiliary group keys which will not be computed as key and
   * does not also affect the correctness of the final result. [[Aggregate]] does not distinguish
   * group keys and auxiliary group keys, and combines them as a complete `groupSet`.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecGroupAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecGroupAggregateBase.scala
@@ -36,7 +36,8 @@ import org.apache.calcite.tools.RelBuilder
   * global-aggregation (or named final-aggregation).
   * local-aggregation produces a partial result for each group before shuffle,
   * and then global-aggregation produces final result based on shuffled partial result.
-  * Two-stage aggregation is enabled only if all aggregate calls are mergeable. (e.g. SUM, AVG, MAX)
+  * Two-stage aggregation is enabled only if all aggregate functions are splittable.
+  * (e.g. SUM, AVG, MAX) see [[org.apache.calcite.sql.SqlSplittableAggFunction]] for more info.
   * 2. This node supports auxiliary group keys which will not be computed as key and
   * does not also affect the correctness of the final result. [[Aggregate]] does not distinguish
   * group keys and auxiliary group keys, and combines them as a complete `groupSet`.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecJoinBase.scala
@@ -17,13 +17,13 @@
  */
 package org.apache.flink.table.plan.nodes.physical.batch
 
-import org.apache.flink.table.plan.nodes.common.CommonJoin
+import org.apache.flink.table.plan.nodes.common.CommonPhysicalJoin
 
 import org.apache.calcite.rel.core.Join
 
 /**
   * Batch physical RelNode for [[Join]]
   */
-trait BatchExecJoinBase extends CommonJoin with BatchPhysicalRel {
+trait BatchExecJoinBase extends CommonPhysicalJoin with BatchPhysicalRel {
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecJoinBase.scala
@@ -17,56 +17,13 @@
  */
 package org.apache.flink.table.plan.nodes.physical.batch
 
-import org.apache.flink.table.plan.FlinkJoinRelType
-import org.apache.flink.table.plan.util.RelExplainUtil
+import org.apache.flink.table.plan.nodes.common.CommonJoin
 
-import org.apache.calcite.rel.RelWriter
-import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField}
-import org.apache.calcite.rel.core.{Join, JoinInfo, SemiJoin}
-import org.apache.calcite.sql.validate.SqlValidatorUtil
-import org.apache.calcite.util.mapping.IntPair
-
-import java.util.Collections
-
-import scala.collection.JavaConversions._
+import org.apache.calcite.rel.core.Join
 
 /**
   * Batch physical RelNode for [[Join]]
   */
-trait BatchExecJoinBase extends Join with BatchPhysicalRel {
-
-  lazy val joinInfo: JoinInfo = JoinInfo.of(getLeft, getRight, getCondition)
-
-  lazy val keyPairs: List[IntPair] = joinInfo.pairs.toList
-
-  // TODO supports FlinkJoinRelType.ANTI
-  lazy val flinkJoinType: FlinkJoinRelType = this match {
-    case sj: SemiJoin => FlinkJoinRelType.SEMI
-    case j: Join => FlinkJoinRelType.toFlinkJoinRelType(getJoinType)
-    case _ => throw new IllegalArgumentException(s"Illegal join node: ${this.getRelTypeName}")
-  }
-
-  lazy val inputRowType: RelDataType = this match {
-    case sj: SemiJoin =>
-      // Combines inputs' RowType, the result is different from SemiJoin's RowType.
-      SqlValidatorUtil.deriveJoinRowType(
-        sj.getLeft.getRowType,
-        sj.getRight.getRowType,
-        getJoinType,
-        sj.getCluster.getTypeFactory,
-        null,
-        Collections.emptyList[RelDataTypeField]
-      )
-    case j: Join => getRowType
-    case _ => throw new IllegalArgumentException(s"Illegal join node: ${this.getRelTypeName}")
-  }
-
-  override def explainTerms(pw: RelWriter): RelWriter = {
-    pw.input("left", getLeft).input("right", getRight)
-      .item("where",
-        RelExplainUtil.expressionToString(getCondition, inputRowType, getExpressionString))
-      .item("join", getRowType.getFieldNames.mkString(", "))
-      .item("joinType", RelExplainUtil.joinTypeToString(flinkJoinType))
-  }
+trait BatchExecJoinBase extends CommonJoin with BatchPhysicalRel {
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecOverAggregate.scala
@@ -104,10 +104,10 @@ class BatchExecOverAggregate(
     val constants: Seq[RexLiteral] = logicWindow.constants
 
     val writer = super.explainTerms(pw)
-      .itemIf("partitionBy", RelExplainUtil.fieldToString(partitionKeys, outputRowType),
+      .itemIf("partitionBy", RelExplainUtil.fieldToString(partitionKeys, inputRowType),
         partitionKeys.nonEmpty)
       .itemIf("orderBy",
-        RelExplainUtil.orderingToString(groups.head.orderKeys.getFieldCollations, outputRowType),
+        RelExplainUtil.collationToString(groups.head.orderKeys, inputRowType),
         orderKeyIndices.nonEmpty)
 
     var offset = inputRowType.getFieldCount

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecRank.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.plan.nodes.physical.batch
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.plan.cost.{FlinkCost, FlinkCostFactory}
 import org.apache.flink.table.plan.nodes.calcite.{ConstantRankRange, Rank, RankRange}
+import org.apache.flink.table.plan.util.RelExplainUtil
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel._
@@ -85,12 +86,12 @@ class BatchExecRank(
   }
 
   override def explainTerms(pw: RelWriter): RelWriter = {
-    val inputFieldNames = inputRel.getRowType.getFieldNames
+    val inputRowType = inputRel.getRowType
     pw.item("input", getInput)
       .item("rankFunction", rankFunction)
-      .item("partitionBy", partitionKey.map(inputFieldNames.get(_)).mkString(","))
-      .item("orderBy", Rank.sortFieldsToString(sortCollation, inputRel.getRowType))
-      .item("rankRange", rankRange.toString(inputFieldNames))
+      .item("partitionBy", RelExplainUtil.fieldToString(partitionKey.toArray, inputRowType))
+      .item("orderBy", RelExplainUtil.collationToString(sortCollation, inputRowType))
+      .item("rankRange", rankRange.toString(inputRowType.getFieldNames))
       .item("global", isGlobal)
       .item("select", getRowType.getFieldNames.mkString(", "))
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/batch/BatchExecRank.scala
@@ -89,9 +89,9 @@ class BatchExecRank(
     val inputRowType = inputRel.getRowType
     pw.item("input", getInput)
       .item("rankFunction", rankFunction)
+      .item("rankRange", rankRange.toString(inputRowType.getFieldNames))
       .item("partitionBy", RelExplainUtil.fieldToString(partitionKey.toArray, inputRowType))
       .item("orderBy", RelExplainUtil.collationToString(sortCollation, inputRowType))
-      .item("rankRange", rankRange.toString(inputRowType.getFieldNames))
       .item("global", isGlobal)
       .item("select", getRowType.getFieldNames.mkString(", "))
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecCalc.scala
@@ -16,28 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
+package org.apache.flink.table.plan.nodes.physical.stream
 
-import org.apache.calcite.plan._
+import org.apache.flink.table.plan.nodes.common.CommonCalc
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
-
-import java.util
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Calc
+import org.apache.calcite.rex.RexProgram
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Stream physical RelNode for [[Calc]].
   */
-final class LogicalWatermarkAssigner(
+class StreamExecCalc(
     cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    calcProgram: RexProgram,
+    outputRowType: RelDataType)
+  extends CommonCalc(cluster, traitSet, inputRel, calcProgram)
+  with StreamPhysicalRel {
 
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, child: RelNode, program: RexProgram): Calc = {
+    new StreamExecCalc(cluster, traitSet, child, program, outputRowType)
   }
 }
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecCalc.scala
@@ -38,9 +38,20 @@ class StreamExecCalc(
   extends CommonCalc(cluster, traitSet, inputRel, calcProgram)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def deriveRowType(): RelDataType = outputRowType
 
   override def copy(traitSet: RelTraitSet, child: RelNode, program: RexProgram): Calc = {
     new StreamExecCalc(cluster, traitSet, child, program, outputRowType)
   }
+
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecDataStreamScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecDataStreamScan.scala
@@ -47,7 +47,13 @@ class StreamExecDataStreamScan(
 
   override def producesUpdates: Boolean = dataStreamTable.producesUpdates
 
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
   override def producesRetractions: Boolean = producesUpdates && isAccRetract
+
+  override def requireWatermark: Boolean = false
 
   override def deriveRowType(): RelDataType = relDataType
 
@@ -65,4 +71,5 @@ class StreamExecDataStreamScan(
     super.explainTerms(pw)
       .item("fields", getRowType.getFieldNames.asScala.mkString(", "))
   }
+
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExchange.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.plan.nodes.physical.stream
 
-import org.apache.flink.table.plan.nodes.common.CommonExchange
+import org.apache.flink.table.plan.nodes.common.CommonPhysicalExchange
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelDistribution, RelNode}
@@ -31,7 +31,7 @@ class StreamExecExchange(
     traitSet: RelTraitSet,
     relNode: RelNode,
     relDistribution: RelDistribution)
-  extends CommonExchange(cluster, traitSet, relNode, relDistribution)
+  extends CommonPhysicalExchange(cluster, traitSet, relNode, relDistribution)
   with StreamPhysicalRel {
 
   override def producesUpdates: Boolean = false

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExchange.scala
@@ -34,6 +34,16 @@ class StreamExecExchange(
   extends CommonExchange(cluster, traitSet, relNode, relDistribution)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(
       traitSet: RelTraitSet,
       newInput: RelNode,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExchange.scala
@@ -16,28 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
+package org.apache.flink.table.plan.nodes.physical.stream
 
-import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
+import org.apache.flink.table.plan.nodes.common.CommonExchange
 
-import java.util
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelDistribution, RelNode}
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Stream physical RelNode for [[org.apache.calcite.rel.core.Exchange]].
   */
-final class LogicalWatermarkAssigner(
+class StreamExecExchange(
     cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+    traitSet: RelTraitSet,
+    relNode: RelNode,
+    relDistribution: RelDistribution)
+  extends CommonExchange(cluster, traitSet, relNode, relDistribution)
+  with StreamPhysicalRel {
 
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+  override def copy(
+      traitSet: RelTraitSet,
+      newInput: RelNode,
+      newDistribution: RelDistribution): StreamExecExchange = {
+    new StreamExecExchange(cluster, traitSet, newInput, newDistribution)
   }
 }
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExpand.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExpand.scala
@@ -39,6 +39,16 @@ class StreamExecExpand(
   extends Expand(cluster, traitSet, inputRel, outputRowType, projects, expandIdIndex)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new StreamExecExpand(cluster, traitSet, inputs.get(0), outputRowType, projects, expandIdIndex)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExpand.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecExpand.scala
@@ -15,29 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.flink.table.plan.nodes.physical.stream
 
-package org.apache.flink.table.plan.nodes.calcite
+import org.apache.flink.table.plan.nodes.calcite.Expand
 
-import org.apache.calcite.plan._
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rex.RexNode
 
 import java.util
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Stream physical RelNode for [[Expand]].
   */
-final class LogicalWatermarkAssigner(
+class StreamExecExpand(
     cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    projects: util.List[util.List[RexNode]],
+    expandIdIndex: Int)
+  extends Expand(cluster, traitSet, inputRel, outputRowType, projects, expandIdIndex)
+  with StreamPhysicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+    new StreamExecExpand(cluster, traitSet, inputs.get(0), outputRowType, projects, expandIdIndex)
   }
-}
 
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecFirstLastRow.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecFirstLastRow.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Stream physical RelNode which deduplicate on keys and keeps only first row or last row.
+  * <p>NOTES: only supports sort on proctime now.
+  */
+class StreamExecFirstLastRow(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    uniqueKeys: Array[Int],
+    isRowtime: Boolean,
+    isLastRowMode: Boolean)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel {
+
+  def getUniqueKeys: Array[Int] = uniqueKeys
+
+  override def producesUpdates: Boolean = isLastRowMode
+
+  override def consumesRetractions: Boolean = true
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = true
+
+  override def deriveRowType(): RelDataType = getInput.getRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecFirstLastRow(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      uniqueKeys,
+      isRowtime,
+      isLastRowMode)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val fieldNames = getRowType.getFieldNames
+    val orderString = if (isRowtime) "ROWTIME" else "PROCTIME"
+    super.explainTerms(pw)
+      .item("key", uniqueKeys.map(fieldNames.get).mkString(", "))
+      .item("select", fieldNames.mkString(", "))
+      .item("order", orderString)
+      .item("mode", if (isLastRowMode) "LastRow" else "FirstRow")
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecFirstLastRow.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecFirstLastRow.scala
@@ -44,9 +44,13 @@ class StreamExecFirstLastRow(
 
   override def producesUpdates: Boolean = isLastRowMode
 
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = true
+
   override def consumesRetractions: Boolean = true
 
-  override def needsUpdatesAsRetraction(input: RelNode): Boolean = true
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
 
   override def deriveRowType(): RelDataType = getInput.getRowType
 
@@ -64,10 +68,9 @@ class StreamExecFirstLastRow(
     val fieldNames = getRowType.getFieldNames
     val orderString = if (isRowtime) "ROWTIME" else "PROCTIME"
     super.explainTerms(pw)
-      .item("key", uniqueKeys.map(fieldNames.get).mkString(", "))
-      .item("select", fieldNames.mkString(", "))
-      .item("order", orderString)
       .item("mode", if (isLastRowMode) "LastRow" else "FirstRow")
+      .item("key", uniqueKeys.map(fieldNames.get).mkString(", "))
+      .item("order", orderString)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.PartialFinalType
+import org.apache.flink.table.plan.util.{AggregateInfoList, RelExplainUtil}
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
+/**
+  * Stream physical RelNode for unbounded global group aggregate.
+  *
+  * @see [[StreamExecGroupAggregateBase]] for more info.
+  */
+class StreamExecGlobalGroupAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    inputRowType: RelDataType,
+    outputRowType: RelDataType,
+    val localAggInfoList: AggregateInfoList,
+    val globalAggInfoList: AggregateInfoList,
+    val grouping: Array[Int],
+    val partialFinalType: PartialFinalType)
+  extends StreamExecGroupAggregateBase(cluster, traitSet, inputRel) {
+
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
+  override def producesUpdates = true
+
+  override def consumesRetractions = true
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new StreamExecGlobalGroupAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      inputRowType,
+      outputRowType,
+      localAggInfoList,
+      globalAggInfoList,
+      grouping,
+      partialFinalType)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .itemIf("groupBy",
+        RelExplainUtil.fieldToString(grouping, inputRel.getRowType), grouping.nonEmpty)
+      .itemIf("partialFinalType", partialFinalType, partialFinalType != PartialFinalType.NONE)
+      .item("select", RelExplainUtil.streamGroupAggregationToString(
+        inputRel.getRowType,
+        getRowType,
+        globalAggInfoList,
+        grouping,
+        isGlobal = true))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
@@ -41,11 +41,15 @@ class StreamExecGlobalGroupAggregate(
     val partialFinalType: PartialFinalType)
   extends StreamExecGroupAggregateBase(cluster, traitSet, inputRel) {
 
-  override def needsUpdatesAsRetraction(input: RelNode) = true
-
   override def producesUpdates = true
 
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
   override def consumesRetractions = true
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
 
   override def deriveRowType(): RelDataType = outputRowType
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
@@ -44,11 +44,15 @@ class StreamExecGroupAggregate(
     var partialFinalType: PartialFinalType = PartialFinalType.NONE)
   extends StreamExecGroupAggregateBase(cluster, traitSet, inputRel) {
 
-  override def needsUpdatesAsRetraction(input: RelNode) = true
-
   override def producesUpdates = true
 
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
   override def consumesRetractions = true
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
 
   override def deriveRowType(): RelDataType = outputRowType
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.PartialFinalType
+import org.apache.flink.table.plan.util.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
+import java.util
+
+/**
+  * Stream physical RelNode for unbounded group aggregate.
+  *
+  * This node does support un-splittable aggregate function (e.g. STDDEV_POP).
+  *
+  * @see [[StreamExecGroupAggregateBase]] for more info.
+  */
+class StreamExecGroupAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    val aggCalls: Seq[AggregateCall],
+    val grouping: Array[Int],
+    var partialFinalType: PartialFinalType = PartialFinalType.NONE)
+  extends StreamExecGroupAggregateBase(cluster, traitSet, inputRel) {
+
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
+  override def producesUpdates = true
+
+  override def consumesRetractions = true
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecGroupAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      outputRowType,
+      aggCalls,
+      grouping)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val inputRowType = getInput.getRowType
+    super.explainTerms(pw)
+      .itemIf("groupBy",
+        RelExplainUtil.fieldToString(grouping, inputRowType), grouping.nonEmpty)
+      .itemIf("partialFinalType", partialFinalType, partialFinalType != PartialFinalType.NONE)
+      // TODO print aggInfoList
+      .item("select", RelExplainUtil.streamGroupAggregationToString(
+        inputRowType,
+        getRowType,
+        aggCalls,
+        grouping))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecGroupAggregateBase.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.calcite.rel.core.Aggregate
+
+/**
+  * Base stream physical RelNode for unbounded group aggregate.
+  *
+  * <P>There are two differences between stream group aggregate and [[Aggregate]]:
+  * 1. stream group aggregate supports two-stage aggregation to reduce shuffle data:
+  * local-aggregation and global-aggregation.
+  * local-aggregation produces a partial result for each group before shuffle,
+  * and then global-aggregation produces final result based on shuffled partial result.
+  * Two-stage aggregation is enabled only if all aggregate functions are splittable.
+  * (e.g. SUM, AVG, MAX) see [[org.apache.calcite.sql.SqlSplittableAggFunction]] for more info.
+  * 2. stream group aggregate supports partial-final aggregation to resolve data-skew for
+  * distinct agg. partial-aggregation produces a partial distinct agg result for each bucket group,
+  * and then final-aggregation produces final result based on partial result.
+  * Both partial-aggregation and final-aggregation need to shuffle data.
+  * partial-final aggregation is enabled only if all distinct aggregate calls are mergeable.
+  *
+  * <p>NOTES: partial-aggregation has local-global mode, so does final-aggregation.
+  */
+abstract class StreamExecGroupAggregateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel {
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.util.{AggregateInfoList, RelExplainUtil}
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
+import java.util
+
+/**
+  * Stream physical RelNode for unbounded incremental group aggregate.
+  *
+  * <p>Considering the following sub-plan:
+  * {{{
+  *   StreamExecGlobalGroupAggregate (final-global-aggregate)
+  *   +- StreamExecExchange
+  *      +- StreamExecLocalGroupAggregate (final-local-aggregate)
+  *         +- StreamExecGlobalGroupAggregate (partial-global-aggregate)
+  *            +- StreamExecExchange
+  *               +- StreamExecLocalGroupAggregate (partial-local-aggregate)
+  * }}}
+  *
+  * partial-global-aggregate and final-local-aggregate can be combined as
+  * this node to share [[org.apache.flink.api.common.state.State]].
+  * now the sub-plan is
+  * {{{
+  *   StreamExecGlobalGroupAggregate (final-global-aggregate)
+  *   +- StreamExecExchange
+  *      +- StreamExecIncrementalGroupAggregate
+  *         +- StreamExecExchange
+  *            +- StreamExecLocalGroupAggregate (partial-local-aggregate)
+  * }}}
+  *
+  * @see [[StreamExecGroupAggregateBase]] for more info.
+  */
+class StreamExecIncrementalGroupAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    inputRowType: RelDataType,
+    outputRowType: RelDataType,
+    val partialAggInfoList: AggregateInfoList,
+    finalAggInfoList: AggregateInfoList,
+    val finalAggCalls: Seq[AggregateCall],
+    val finalAggGrouping: Array[Int],
+    val partialAggGrouping: Array[Int])
+  extends StreamExecGroupAggregateBase(cluster, traitSet, inputRel) {
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
+  override def producesUpdates = false
+
+  override def consumesRetractions = true
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecIncrementalGroupAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      inputRowType,
+      outputRowType,
+      partialAggInfoList,
+      finalAggInfoList,
+      finalAggCalls,
+      finalAggGrouping,
+      partialAggGrouping)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val inputRowType = getInput.getRowType
+    super.explainTerms(pw)
+      .item("finalAggGrouping", RelExplainUtil.fieldToString(finalAggGrouping, inputRowType))
+      .item("partialAggGrouping",
+        RelExplainUtil.fieldToString(partialAggGrouping, inputRel.getRowType))
+      .item("select", RelExplainUtil.streamGroupAggregationToString(
+        inputRel.getRowType,
+        getRowType,
+        finalAggInfoList,
+        partialAggGrouping,
+        shuffleKey = Some(finalAggGrouping)))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
@@ -67,11 +67,15 @@ class StreamExecIncrementalGroupAggregate(
 
   override def deriveRowType(): RelDataType = outputRowType
 
-  override def needsUpdatesAsRetraction(input: RelNode) = true
-
   override def producesUpdates = false
 
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
   override def consumesRetractions = true
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new StreamExecIncrementalGroupAggregate(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecJoinBase.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.plan.nodes.physical.stream
 
 import org.apache.flink.table.plan.FlinkJoinRelType
-import org.apache.flink.table.plan.nodes.common.CommonJoin
+import org.apache.flink.table.plan.nodes.common.CommonPhysicalJoin
 
 import org.apache.calcite.plan._
 import org.apache.calcite.plan.hep.HepRelVertex
@@ -33,7 +33,7 @@ import scala.collection.JavaConversions._
 /**
   * Stream physical RelNode for [[Join]].
   */
-trait StreamExecJoinBase extends CommonJoin with StreamPhysicalRel {
+trait StreamExecJoinBase extends CommonPhysicalJoin with StreamPhysicalRel {
 
   override def producesUpdates: Boolean = {
     flinkJoinType != FlinkJoinRelType.INNER && flinkJoinType != FlinkJoinRelType.SEMI

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecJoinBase.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.FlinkJoinRelType
+import org.apache.flink.table.plan.nodes.common.CommonJoin
+
+import org.apache.calcite.plan._
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.{CorrelationId, Join, JoinRelType}
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.rex.RexNode
+
+import scala.collection.JavaConversions._
+
+/**
+  * Stream physical RelNode for [[Join]].
+  */
+trait StreamExecJoinBase extends CommonJoin with StreamPhysicalRel {
+
+  override def producesUpdates: Boolean = {
+    flinkJoinType != FlinkJoinRelType.INNER && flinkJoinType != FlinkJoinRelType.SEMI
+  }
+
+  override def producesRetractions: Boolean = {
+    flinkJoinType match {
+      case FlinkJoinRelType.FULL | FlinkJoinRelType.RIGHT | FlinkJoinRelType.LEFT => true
+      case FlinkJoinRelType.ANTI => true
+      case _ => false
+    }
+  }
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = {
+    def getCurrentRel(rel: RelNode): RelNode = {
+      rel match {
+        case _: HepRelVertex => rel.asInstanceOf[HepRelVertex].getCurrentRel
+        case _ => rel
+      }
+    }
+
+    val realInput = getCurrentRel(input)
+    val inputUniqueKeys = getCluster.getMetadataQuery.getUniqueKeys(realInput)
+    if (inputUniqueKeys != null) {
+      val joinKeys = if (input == getCurrentRel(getLeft)) {
+        keyPairs.map(_.source).toArray
+      } else {
+        keyPairs.map(_.target).toArray
+      }
+      val pkContainJoinKey = inputUniqueKeys.exists {
+        uniqueKey => joinKeys.forall(uniqueKey.toArray.contains(_))
+      }
+      if (pkContainJoinKey) false else true
+    } else {
+      true
+    }
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
+    val elementRate = 100.0d * 2 // two input stream
+    planner.getCostFactory.makeCost(elementRate, elementRate, 0)
+  }
+
+}
+
+class StreamExecJoin(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    leftRel: RelNode,
+    rightRel: RelNode,
+    condition: RexNode,
+    joinType: JoinRelType)
+  extends Join(cluster, traitSet, leftRel, rightRel, condition, Set.empty[CorrelationId], joinType)
+  with StreamExecJoinBase {
+
+  override def copy(
+      traitSet: RelTraitSet,
+      conditionExpr: RexNode,
+      left: RelNode,
+      right: RelNode,
+      joinType: JoinRelType,
+      semiJoinDone: Boolean): Join = {
+    new StreamExecJoin(cluster, traitSet, left, right, conditionExpr, joinType)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecJoinBase.scala
@@ -39,14 +39,6 @@ trait StreamExecJoinBase extends CommonJoin with StreamPhysicalRel {
     flinkJoinType != FlinkJoinRelType.INNER && flinkJoinType != FlinkJoinRelType.SEMI
   }
 
-  override def producesRetractions: Boolean = {
-    flinkJoinType match {
-      case FlinkJoinRelType.FULL | FlinkJoinRelType.RIGHT | FlinkJoinRelType.LEFT => true
-      case FlinkJoinRelType.ANTI => true
-      case _ => false
-    }
-  }
-
   override def needsUpdatesAsRetraction(input: RelNode): Boolean = {
     def getCurrentRel(rel: RelNode): RelNode = {
       rel match {
@@ -71,6 +63,18 @@ trait StreamExecJoinBase extends CommonJoin with StreamPhysicalRel {
       true
     }
   }
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = {
+    flinkJoinType match {
+      case FlinkJoinRelType.FULL | FlinkJoinRelType.RIGHT | FlinkJoinRelType.LEFT => true
+      case FlinkJoinRelType.ANTI => true
+      case _ => false
+    }
+  }
+
+  override def requireWatermark: Boolean = false
 
   override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
     val elementRate = 100.0d * 2 // two input stream

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.PartialFinalType
+import org.apache.flink.table.plan.util.{AggregateInfoList, RelExplainUtil}
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
+import java.util
+
+/**
+  * Stream physical RelNode for unbounded global group aggregate.
+  *
+  * @see [[StreamExecGroupAggregateBase]] for more info.
+  */
+class StreamExecLocalGroupAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    val aggInfoList: AggregateInfoList,
+    val grouping: Array[Int],
+    val aggCalls: Seq[AggregateCall],
+    val partialFinalType: PartialFinalType)
+  extends StreamExecGroupAggregateBase(cluster, traitSet, inputRel) {
+
+  override def producesUpdates = false
+
+  override def consumesRetractions = true
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecLocalGroupAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      outputRowType,
+      aggInfoList,
+      grouping,
+      aggCalls,
+      partialFinalType)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val inputRowType = getInput.getRowType
+    super.explainTerms(pw)
+      .itemIf("groupBy", RelExplainUtil.fieldToString(grouping, inputRowType),
+        grouping.nonEmpty)
+      .itemIf("partialFinalType", partialFinalType, partialFinalType != PartialFinalType.NONE)
+      .item("select", RelExplainUtil.streamGroupAggregationToString(
+        inputRowType,
+        getRowType,
+        aggInfoList,
+        grouping,
+        isLocal = true))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
@@ -45,7 +45,13 @@ class StreamExecLocalGroupAggregate(
 
   override def producesUpdates = false
 
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
   override def consumesRetractions = true
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
 
   override def deriveRowType(): RelDataType = outputRowType
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecOverAggregate.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.CalcitePair
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.util.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Window.Group
+import org.apache.calcite.rel.core.{AggregateCall, Window}
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rex.RexLiteral
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+/**
+  * Stream physical RelNode for time-based over [[Window]].
+  */
+class StreamExecOverAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    inputRowType: RelDataType,
+    logicWindow: Window)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel {
+
+  override def needsUpdatesAsRetraction(input: RelNode) = true
+
+  override def requireWatermark: Boolean = {
+    if (logicWindow.groups.size() != 1
+      || logicWindow.groups.get(0).orderKeys.getFieldCollations.size() != 1) {
+      return false
+    }
+    val orderKey = logicWindow.groups.get(0).orderKeys.getFieldCollations.get(0)
+    val timeType = outputRowType.getFieldList.get(orderKey.getFieldIndex).getType
+    FlinkTypeFactory.isRowtimeIndicatorType(timeType)
+  }
+
+  override def consumesRetractions = true
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecOverAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      outputRowType,
+      inputRowType,
+      logicWindow
+    )
+  }
+
+  override def estimateRowCount(mq: RelMetadataQuery): Double = {
+    // over window: one input at least one output (do not introduce retract amplification)
+    mq.getRowCount(getInput)
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    // by default, assume cost is proportional to number of rows
+    val rowCnt: Double = mq.getRowCount(this)
+    val count = (getRowType.getFieldCount - 1) * 1.0 / inputRel.getRowType.getFieldCount
+    planner.getCostFactory.makeCost(rowCnt, rowCnt * count, 0)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val overWindow: Group = logicWindow.groups.get(0)
+    val constants: Seq[RexLiteral] = logicWindow.constants.asScala
+    val partitionKeys: Array[Int] = overWindow.keys.toArray
+    val namedAggregates: Seq[CalcitePair[AggregateCall, String]] = generateNamedAggregates
+
+    super.explainTerms(pw)
+      .itemIf("partitionBy", RelExplainUtil.fieldToString(partitionKeys, inputRowType),
+        partitionKeys.nonEmpty)
+      .item("orderBy", RelExplainUtil.collationToString(overWindow.orderKeys, inputRowType))
+      .item("window", RelExplainUtil.windowRangeToString(logicWindow, overWindow))
+      .item("select", RelExplainUtil.overAggregationToString(
+        inputRowType,
+        outputRowType,
+        constants,
+        namedAggregates))
+  }
+
+  private def generateNamedAggregates: Seq[CalcitePair[AggregateCall, String]] = {
+    val overWindow: Group = logicWindow.groups.get(0)
+
+    val aggregateCalls = overWindow.getAggregateCalls(logicWindow)
+    for (i <- 0 until aggregateCalls.size())
+      yield new CalcitePair[AggregateCall, String](aggregateCalls.get(i), "w0$o" + i)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecOverAggregate.scala
@@ -46,7 +46,13 @@ class StreamExecOverAggregate(
   extends SingleRel(cluster, traitSet, inputRel)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
   override def needsUpdatesAsRetraction(input: RelNode) = true
+
+  override def consumesRetractions = true
+
+  override def producesRetractions: Boolean = false
 
   override def requireWatermark: Boolean = {
     if (logicWindow.groups.size() != 1
@@ -57,8 +63,6 @@ class StreamExecOverAggregate(
     val timeType = outputRowType.getFieldList.get(orderKey.getFieldIndex).getType
     FlinkTypeFactory.isRowtimeIndicatorType(timeType)
   }
-
-  override def consumesRetractions = true
 
   override def deriveRowType(): RelDataType = outputRowType
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecRank.scala
@@ -68,11 +68,15 @@ class StreamExecRank(
 
   override def producesUpdates = true
 
-  override def consumesRetractions = true
-
   override def needsUpdatesAsRetraction(input: RelNode): Boolean = {
     getStrategy(forceRecompute = true) == RetractRank
   }
+
+  override def consumesRetractions = true
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
 
   override def deriveRowType(): RelDataType = {
     if (outputRankFunColumn) {
@@ -97,11 +101,11 @@ class StreamExecRank(
   override def explainTerms(pw: RelWriter): RelWriter = {
     val inputRowType = inputRel.getRowType
     pw.input("input", getInput)
+      .item("strategy", getStrategy())
       .item("rankFunction", rankFunction.getKind)
+      .item("rankRange", rankRange.toString(inputRowType.getFieldNames))
       .item("partitionBy", RelExplainUtil.fieldToString(partitionKey.toArray, inputRowType))
       .item("orderBy", RelExplainUtil.collationToString(sortCollation, inputRowType))
-      .item("rankRange", rankRange.toString(inputRowType.getFieldNames))
-      .item("strategy", getStrategy())
       .item("select", getRowType.getFieldNames.mkString(", "))
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecRank.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.`trait`.TraitUtil
+import org.apache.flink.table.plan.nodes.calcite.{Rank, RankRange}
+import org.apache.flink.table.plan.util.{RelExplainUtil, UpdatingPlanChecker}
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.sql.SqlRankFunction
+import org.apache.calcite.util.ImmutableBitSet
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Stream physical RelNode for [[Rank]].
+  *
+  * @see [[StreamExecTemporalSort]] which must be time-ascending-order sort without `limit`.
+  * @see [[StreamExecSort]] which can be used for testing now, its sort key can be any type.
+  */
+class StreamExecRank(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    rankFunction: SqlRankFunction,
+    partitionKey: ImmutableBitSet,
+    sortCollation: RelCollation,
+    rankRange: RankRange,
+    val outputRankFunColumn: Boolean)
+  extends Rank(
+    cluster,
+    traitSet,
+    inputRel,
+    rankFunction,
+    partitionKey,
+    sortCollation,
+    rankRange)
+  with StreamPhysicalRel {
+
+  /** please uses [[getStrategy]] instead of this field */
+  private var strategy: RankStrategy = _
+
+  def getStrategy(forceRecompute: Boolean = false): RankStrategy = {
+    if (strategy == null || forceRecompute) {
+      strategy = analyzeRankStrategy
+    }
+    strategy
+  }
+
+  override def producesUpdates = true
+
+  override def consumesRetractions = true
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = {
+    getStrategy(forceRecompute = true) == RetractRank
+  }
+
+  override def deriveRowType(): RelDataType = {
+    if (outputRankFunColumn) {
+      super.deriveRowType()
+    } else {
+      inputRel.getRowType
+    }
+  }
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecRank(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      rankFunction,
+      partitionKey,
+      sortCollation,
+      rankRange,
+      outputRankFunColumn)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val inputRowType = inputRel.getRowType
+    pw.input("input", getInput)
+      .item("rankFunction", rankFunction.getKind)
+      .item("partitionBy", RelExplainUtil.fieldToString(partitionKey.toArray, inputRowType))
+      .item("orderBy", RelExplainUtil.collationToString(sortCollation, inputRowType))
+      .item("rankRange", rankRange.toString(inputRowType.getFieldNames))
+      .item("strategy", getStrategy())
+      .item("select", getRowType.getFieldNames.mkString(", "))
+  }
+
+  private def analyzeRankStrategy: RankStrategy = {
+    val rankInput = getInput
+    val mq = cluster.getMetadataQuery
+    val isUpdateStream = !UpdatingPlanChecker.isAppendOnly(rankInput)
+
+    if (isUpdateStream) {
+      val inputIsAccRetract = TraitUtil.isAccRetract(rankInput)
+      val uniqueKeys = mq.getUniqueKeys(rankInput)
+      if (inputIsAccRetract || uniqueKeys == null || uniqueKeys.isEmpty
+        // unique key should contains partition key
+        || !uniqueKeys.exists(k => k.contains(partitionKey))) {
+        // input is AccRetract or extract the unique keys failed,
+        // and we fall back to using retract rank
+        RetractRank
+      } else {
+        // TODO get `isMonotonic` value by RelModifiedMonotonicity handler
+        val isMonotonic = false
+
+        if (isMonotonic) {
+          //FIXME choose a set of primary key
+          UpdateFastRank(uniqueKeys.iterator().next().toArray)
+        } else {
+          val fieldCollations = sortCollation.getFieldCollations
+          if (fieldCollations.length == 1) {
+            // single sort key in update stream scenario (no monotonic)
+            // we can utilize unary rank function to speed up processing
+            UnaryUpdateRank(uniqueKeys.iterator().next().toArray)
+          } else {
+            // no other choices, have to use retract rank
+            RetractRank
+          }
+        }
+      }
+    } else {
+      AppendFastRank
+    }
+  }
+}
+
+/**
+  * Base class of Strategy to choose different process function.
+  */
+sealed trait RankStrategy
+
+case object AppendFastRank extends RankStrategy
+
+case object RetractRank extends RankStrategy
+
+case class UpdateFastRank(primaryKeys: Array[Int]) extends RankStrategy {
+  override def toString: String = "UpdateFastRank" + primaryKeys.mkString("[", ",", "]")
+}
+
+case class UnaryUpdateRank(primaryKeys: Array[Int]) extends RankStrategy {
+  override def toString: String = "UnaryUpdateRank" + primaryKeys.mkString("[", ",", "]")
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSink.scala
@@ -38,11 +38,20 @@ class StreamExecSink[T](
   extends Sink(cluster, traitSet, inputRel, sink, sinkName)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean =
+    sink.isInstanceOf[BaseRetractStreamTableSink[_]]
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new StreamExecSink(cluster, traitSet, inputs.get(0), sink, sinkName)
   }
 
-  override def needsUpdatesAsRetraction(input: RelNode): Boolean =
-    sink.isInstanceOf[BaseRetractStreamTableSink[_]]
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSink.scala
@@ -16,28 +16,33 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
+package org.apache.flink.table.plan.nodes.physical.stream
 
-import org.apache.calcite.plan._
+import org.apache.flink.table.plan.nodes.calcite.Sink
+import org.apache.flink.table.sinks._
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 
 import java.util
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Stream physical RelNode to to write data into an external sink defined by a [[TableSink]].
   */
-final class LogicalWatermarkAssigner(
+class StreamExecSink[T](
     cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    sink: TableSink[T],
+    sinkName: String)
+  extends Sink(cluster, traitSet, inputRel, sink, sinkName)
+  with StreamPhysicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+    new StreamExecSink(cluster, traitSet, inputs.get(0), sink, sinkName)
   }
-}
 
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean =
+    sink.isInstanceOf[BaseRetractStreamTableSink[_]]
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSort.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.annotation.Experimental
+import org.apache.flink.table.plan.util.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.core.Sort
+import org.apache.calcite.rex.RexNode
+
+/**
+  * Stream physical RelNode for [[Sort]].
+  *
+  * <p><b>NOTES:</b> This class is used for testing now.
+  *
+  * @see [[StreamExecRank]] which must be with `limit` order by.
+  * @see [[StreamExecTemporalSort]] which must be time-ascending-order sort without `limit`.
+  *
+  * <p>e.g.
+  * <p>''SELECT * FROM TABLE ORDER BY ROWTIME, a'' will be converted to [[StreamExecTemporalSort]]
+  * <p>''SELECT * FROM TABLE ORDER BY a LIMIT 2'' will be converted to [[StreamExecRank]]
+  * <p>''SELECT * FROM TABLE ORDER BY a, ROWTIME'' will be converted to [[StreamExecSort]]
+  */
+@Experimental
+class StreamExecSort(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    sortCollation: RelCollation)
+  extends Sort(cluster, traitSet, inputRel, sortCollation)
+  with StreamPhysicalRel {
+
+  override def copy(
+      traitSet: RelTraitSet,
+      input: RelNode,
+      newCollation: RelCollation,
+      offset: RexNode,
+      fetch: RexNode): Sort = {
+    new StreamExecSort(cluster, traitSet, input, newCollation)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    pw.input("input", getInput())
+      .item("orderBy", RelExplainUtil.collationToString(sortCollation, getRowType))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecSort.scala
@@ -48,6 +48,16 @@ class StreamExecSort(
   extends Sort(cluster, traitSet, inputRel, sortCollation)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(
       traitSet: RelTraitSet,
       input: RelNode,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.nodes.physical.PhysicalTableSourceScan
+import org.apache.flink.table.plan.schema.FlinkRelOptTable
+import org.apache.flink.table.sources.StreamTableSource
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+
+/**
+  * Stream physical RelNode to read data from an external source defined by a [[StreamTableSource]].
+  */
+class StreamExecTableSourceScan(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    relOptTable: FlinkRelOptTable)
+  extends PhysicalTableSourceScan(cluster, traitSet, relOptTable)
+  with StreamPhysicalRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new StreamExecTableSourceScan(cluster, traitSet, relOptTable)
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
+    val rowCnt = mq.getRowCount(this)
+    val rowSize = mq.getAverageRowSize(this)
+    planner.getCostFactory.makeCost(rowCnt, rowCnt, rowCnt * rowSize)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -36,6 +36,16 @@ class StreamExecTableSourceScan(
   extends PhysicalTableSourceScan(cluster, traitSet, relOptTable)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new StreamExecTableSourceScan(cluster, traitSet, relOptTable)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTemporalSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTemporalSort.scala
@@ -39,6 +39,16 @@ class StreamExecTemporalSort(
   extends Sort(cluster, traitSet, inputRel, sortCollation)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(
       traitSet: RelTraitSet,
       input: RelNode,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTemporalSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecTemporalSort.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.util.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.core.Sort
+import org.apache.calcite.rex.RexNode
+
+/**
+  * Stream physical RelNode for time-ascending-order [[Sort]] without `limit`.
+  *
+  * @see [[StreamExecRank]] which must be with `limit` order by.
+  * @see [[StreamExecSort]] which can be used for testing now, its sort key can be any type.
+  */
+class StreamExecTemporalSort(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    sortCollation: RelCollation)
+  extends Sort(cluster, traitSet, inputRel, sortCollation)
+  with StreamPhysicalRel {
+
+  override def copy(
+      traitSet: RelTraitSet,
+      input: RelNode,
+      newCollation: RelCollation,
+      offset: RexNode,
+      fetch: RexNode): Sort = {
+    new StreamExecTemporalSort(cluster, traitSet, input, newCollation)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    pw.input("input", getInput())
+      .item("orderBy", RelExplainUtil.collationToString(sortCollation, getRowType))
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecUnion.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecUnion.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{SetOp, Union}
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Stream physical RelNode for [[Union]].
+  */
+class StreamExecUnion(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRels: util.List[RelNode],
+    all: Boolean,
+    outputRowType: RelDataType)
+  extends Union(cluster, traitSet, inputRels, all)
+  with StreamPhysicalRel {
+
+  require(all, "Only support union all")
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode], all: Boolean): SetOp = {
+    new StreamExecUnion(cluster, traitSet, inputs, all, outputRowType)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw).item("union", outputRowType.getFieldNames.mkString(", "))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecUnion.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecUnion.scala
@@ -41,6 +41,16 @@ class StreamExecUnion(
 
   require(all, "Only support union all")
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def deriveRowType(): RelDataType = outputRowType
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode], all: Boolean): SetOp = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecValues.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecValues.scala
@@ -16,28 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
+package org.apache.flink.table.plan.nodes.physical.stream
 
+import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
-
-import java.util
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Values
+import org.apache.calcite.rex.RexLiteral
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Stream physical RelNode for [[Values]].
   */
-final class LogicalWatermarkAssigner(
+class StreamExecValues(
     cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+    traitSet: RelTraitSet,
+    tuples: ImmutableList[ImmutableList[RexLiteral]],
+    outputRowType: RelDataType)
+  extends Values(cluster, outputRowType, tuples, traitSet)
+  with StreamPhysicalRel {
 
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new StreamExecValues(cluster, traitSet, getTuples, outputRowType)
   }
 }
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecValues.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecValues.scala
@@ -36,6 +36,16 @@ class StreamExecValues(
   extends Values(cluster, outputRowType, tuples, traitSet)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def deriveRowType(): RelDataType = outputRowType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
@@ -41,6 +41,16 @@ class StreamExecWatermarkAssigner(
   extends WatermarkAssigner(cluster, traits, inputRel, rowtimeFieldIndex, watermarkOffset)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new StreamExecWatermarkAssigner(
       cluster,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.api.{TableConfigOptions, TableException}
+import org.apache.flink.table.plan.`trait`.{MiniBatchIntervalTraitDef, MiniBatchMode}
+import org.apache.flink.table.plan.nodes.calcite.WatermarkAssigner
+import org.apache.flink.table.plan.optimize.program.FlinkOptimizeContext
+import org.apache.flink.util.Preconditions
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
+import java.util
+
+/**
+  * Stream physical RelNode for [[WatermarkAssigner]].
+  */
+class StreamExecWatermarkAssigner(
+    cluster: RelOptCluster,
+    traits: RelTraitSet,
+    inputRel: RelNode,
+    rowtimeFieldIndex: Option[Int],
+    watermarkOffset: Option[Long])
+  extends WatermarkAssigner(cluster, traits, inputRel, rowtimeFieldIndex, watermarkOffset)
+  with StreamPhysicalRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecWatermarkAssigner(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      rowtimeFieldIndex,
+      watermarkOffset)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val miniBatchInterval = traits.getTrait(MiniBatchIntervalTraitDef.INSTANCE).getMiniBatchInterval
+
+    val value = miniBatchInterval.mode match {
+      case MiniBatchMode.None =>
+        // 1. operator requiring watermark, but minibatch is not enabled
+        // 2. redundant watermark definition in DDL
+        // 3. existing window, and window minibatch is disabled.
+        "None"
+      case MiniBatchMode.ProcTime =>
+        val config = cluster.getPlanner.getContext.asInstanceOf[FlinkOptimizeContext].getTableConfig
+        val miniBatchLatency = config.getConf.getLong(
+          TableConfigOptions.SQL_EXEC_MINIBATCH_ALLOW_LATENCY)
+        Preconditions.checkArgument(miniBatchLatency > 0,
+          "MiniBatch latency must be greater that 0.", null)
+        s"Proctime, ${miniBatchLatency}ms"
+      case MiniBatchMode.RowTime =>
+        s"Rowtime, ${miniBatchInterval.interval}ms"
+      case o => throw new TableException(s"Unsupported mode: $o")
+    }
+    super.explainTerms(pw).item("miniBatchInterval", value)
+  }
+
+}
+
+object StreamExecWatermarkAssigner {
+
+  def createRowTimeWatermarkAssigner(
+      cluster: RelOptCluster,
+      traits: RelTraitSet,
+      inputRel: RelNode,
+      rowtimeFieldIndex: Int,
+      watermarkOffset: Long): StreamExecWatermarkAssigner = {
+    new StreamExecWatermarkAssigner(
+      cluster,
+      traits,
+      inputRel,
+      Some(rowtimeFieldIndex),
+      Some(watermarkOffset))
+  }
+
+  def createIngestionTimeWatermarkAssigner(
+      cluster: RelOptCluster,
+      traits: RelTraitSet,
+      inputRel: RelNode): StreamExecWatermarkAssigner = {
+    new StreamExecWatermarkAssigner(cluster, traits, inputRel, None, None)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
@@ -37,8 +37,8 @@ class StreamExecWatermarkAssigner(
     traits: RelTraitSet,
     inputRel: RelNode,
     rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, inputRel, rowtimeFieldIndex, watermarkOffset)
+    watermarkDelay: Option[Long])
+  extends WatermarkAssigner(cluster, traits, inputRel, rowtimeFieldIndex, watermarkDelay)
   with StreamPhysicalRel {
 
   override def producesUpdates: Boolean = false
@@ -57,7 +57,7 @@ class StreamExecWatermarkAssigner(
       traitSet,
       inputs.get(0),
       rowtimeFieldIndex,
-      watermarkOffset)
+      watermarkDelay)
   }
 
   override def explainTerms(pw: RelWriter): RelWriter = {
@@ -92,13 +92,13 @@ object StreamExecWatermarkAssigner {
       traits: RelTraitSet,
       inputRel: RelNode,
       rowtimeFieldIndex: Int,
-      watermarkOffset: Long): StreamExecWatermarkAssigner = {
+      watermarkDelay: Long): StreamExecWatermarkAssigner = {
     new StreamExecWatermarkAssigner(
       cluster,
       traits,
       inputRel,
       Some(rowtimeFieldIndex),
-      Some(watermarkOffset))
+      Some(watermarkDelay))
   }
 
   def createIngestionTimeWatermarkAssigner(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWindowJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWindowJoin.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.physical.stream
+
+import org.apache.flink.table.plan.FlinkJoinRelType
+import org.apache.flink.table.plan.util.RelExplainUtil
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rel.{BiRel, RelNode, RelWriter}
+import org.apache.calcite.rex.RexNode
+
+import scala.collection.JavaConversions._
+
+/**
+  * Stream physical RelNode for a time windowed stream join.
+  */
+class StreamExecWindowJoin(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    leftRel: RelNode,
+    rightRel: RelNode,
+    val joinCondition: RexNode,
+    val joinType: JoinRelType,
+    leftInputRowType: RelDataType,
+    rightInputRowType: RelDataType,
+    outputRowType: RelDataType,
+    val isRowTime: Boolean,
+    leftLowerBound: Long,
+    leftUpperBound: Long,
+    leftTimeIndex: Int,
+    rightTimeIndex: Int,
+    remainCondition: Option[RexNode])
+  extends BiRel(cluster, traitSet, leftRel, rightRel)
+  with StreamPhysicalRel {
+
+  override def requireWatermark: Boolean = isRowTime
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new StreamExecWindowJoin(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      inputs.get(1),
+      joinCondition,
+      joinType,
+      leftInputRowType,
+      rightInputRowType,
+      outputRowType,
+      isRowTime,
+      leftLowerBound,
+      leftUpperBound,
+      leftTimeIndex,
+      rightTimeIndex,
+      remainCondition)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val windowBounds = s"isRowTime=$isRowTime, leftLowerBound=$leftLowerBound, " +
+      s"leftUpperBound=$leftUpperBound, leftTimeIndex=$leftTimeIndex, " +
+      s"rightTimeIndex=$rightTimeIndex"
+    super.explainTerms(pw)
+      .item("where",
+        RelExplainUtil.expressionToString(joinCondition, outputRowType, getExpressionString))
+      .item("join", getRowType.getFieldNames.mkString(", "))
+      .item("joinType",
+        RelExplainUtil.joinTypeToString(FlinkJoinRelType.toFlinkJoinRelType(joinType)))
+      .item("windowBounds", windowBounds)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWindowJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamExecWindowJoin.scala
@@ -51,6 +51,14 @@ class StreamExecWindowJoin(
   extends BiRel(cluster, traitSet, leftRel, rightRel)
   with StreamPhysicalRel {
 
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
   override def requireWatermark: Boolean = isRowTime
 
   override def deriveRowType(): RelDataType = outputRowType

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamPhysicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamPhysicalRel.scala
@@ -30,26 +30,26 @@ trait StreamPhysicalRel extends FlinkPhysicalRel {
   /**
     * Whether the [[StreamPhysicalRel]] produces update and delete changes.
     */
-  def producesUpdates: Boolean = false
+  def producesUpdates: Boolean
 
   /**
     * Whether the [[StreamPhysicalRel]] requires retraction messages or not.
     */
-  def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+  def needsUpdatesAsRetraction(input: RelNode): Boolean
 
   /**
     * Whether the [[StreamPhysicalRel]] consumes retraction messages instead of forwarding them.
     * The node might or might not produce new retraction messages.
     */
-  def consumesRetractions: Boolean = false
+  def consumesRetractions: Boolean
 
   /**
     * Whether the [[StreamPhysicalRel]] produces retraction messages.
     */
-  def producesRetractions: Boolean = false
+  def producesRetractions: Boolean
 
   /**
     * Whether the [[StreamPhysicalRel]] requires rowtime watermark in processing logic.
     */
-  def requireWatermark: Boolean = false
+  def requireWatermark: Boolean
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamPhysicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/physical/stream/StreamPhysicalRel.scala
@@ -48,4 +48,8 @@ trait StreamPhysicalRel extends FlinkPhysicalRel {
     */
   def producesRetractions: Boolean = false
 
+  /**
+    * Whether the [[StreamPhysicalRel]] requires rowtime watermark in processing logic.
+    */
+  def requireWatermark: Boolean = false
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkOptimizeContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkOptimizeContext.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.plan.optimize.program
 
+import org.apache.flink.table.api.TableConfig
+
 import org.apache.calcite.plan.Context
 import org.apache.calcite.plan.volcano.VolcanoPlanner
 
@@ -25,6 +27,11 @@ import org.apache.calcite.plan.volcano.VolcanoPlanner
   * A FlinkOptimizeContext allows to obtain table environment information when optimizing.
   */
 trait FlinkOptimizeContext extends Context {
+
+  /**
+    * Gets [[TableConfig]] instance defined in [[org.apache.flink.table.api.TableEnvironment]].
+    */
+  def getTableConfig: TableConfig
 
   /**
     * Gets [[VolcanoPlanner]] instance defined in [[org.apache.flink.table.api.TableEnvironment]].

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/MiniBatchIntervalTrait.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/MiniBatchIntervalTrait.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.`trait`
+
+import org.apache.flink.table.plan.`trait`.MiniBatchMode.MiniBatchMode
+
+import org.apache.calcite.plan.{RelOptPlanner, RelTrait, RelTraitDef}
+
+/**
+  * The MiniBatchIntervalTrait is used to describe how the elements are divided into batches
+  * when flowing out from a [[org.apache.calcite.rel.RelNode]],
+  * e,g,. MiniBatchIntervalTrait(1000L, ProcTime)
+  * means elements are divided into 1000ms proctime mini batches.
+  */
+class MiniBatchIntervalTrait(miniBatchInterval: MiniBatchInterval) extends RelTrait {
+
+  def getMiniBatchInterval: MiniBatchInterval = miniBatchInterval
+
+  override def getTraitDef: RelTraitDef[_ <: RelTrait] = MiniBatchIntervalTraitDef.INSTANCE
+
+  override def satisfies(`trait`: RelTrait): Boolean = this.equals(`trait`)
+
+  override def register(planner: RelOptPlanner): Unit = {}
+
+  override def hashCode(): Int = {
+    miniBatchInterval
+      .interval
+      .hashCode()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case eTrait: MiniBatchIntervalTrait =>
+        this.getMiniBatchInterval == eTrait.getMiniBatchInterval
+      case _ => false
+    }
+  }
+
+  override def toString: String = miniBatchInterval.mode + ": " + miniBatchInterval.interval
+}
+
+/**
+  * @param interval interval of minibatch
+  * @param mode type of minibatch: rowtime/proctime
+  */
+case class MiniBatchInterval(interval: Long, mode: MiniBatchMode)
+
+object MiniBatchInterval {
+  val NONE = MiniBatchInterval(0L, MiniBatchMode.None)
+}
+
+object MiniBatchIntervalTrait {
+  val NONE = new MiniBatchIntervalTrait(MiniBatchInterval.NONE)
+}
+
+/**
+  * The type of minibatch interval: rowtime or proctime.
+  */
+object MiniBatchMode extends Enumeration {
+  type MiniBatchMode = Value
+  /**
+    * An operator in [[ProcTime]] mode requires watermarks emitted in proctime interval,
+    * i.e., unbounded group agg with minibatch enabled.
+    */
+  val ProcTime = Value
+
+  /**
+    * An operator in [[RowTime]] mode requires watermarks extracted from elements,
+    * and emitted in rowtime interval, e.g., window, window join...
+    */
+  val RowTime = Value
+
+  /**
+    * Default value, meaning no minibatch interval is required.
+    */
+  val None = Value
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/MiniBatchIntervalTraitDef.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/MiniBatchIntervalTraitDef.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.`trait`
+
+import org.apache.calcite.plan.{RelOptPlanner, RelTraitDef}
+import org.apache.calcite.rel.RelNode
+
+class MiniBatchIntervalTraitDef extends RelTraitDef[MiniBatchIntervalTrait] {
+
+  override def getTraitClass: Class[MiniBatchIntervalTrait] = classOf[MiniBatchIntervalTrait]
+
+  override def getSimpleName: String = this.getClass.getSimpleName
+
+  override def convert(
+      planner: RelOptPlanner,
+      rel: RelNode,
+      toTrait: MiniBatchIntervalTrait,
+      allowInfiniteCostConverters: Boolean): RelNode = {
+    rel.copy(rel.getTraitSet.plus(toTrait), rel.getInputs)
+  }
+
+  override def canConvert(
+      planner: RelOptPlanner,
+      fromTrait: MiniBatchIntervalTrait,
+      toTrait: MiniBatchIntervalTrait): Boolean = true
+
+  override def getDefault: MiniBatchIntervalTrait = MiniBatchIntervalTrait.NONE
+}
+
+object MiniBatchIntervalTraitDef {
+  val INSTANCE = new MiniBatchIntervalTraitDef
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/TraitUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/TraitUtil.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.`trait`
+
+import org.apache.calcite.plan.RelTrait
+import org.apache.calcite.rel.{RelCollation, RelCollations, RelFieldCollation, RelNode}
+import org.apache.calcite.util.mapping.Mappings
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+/**
+  * Utility for [[RelTrait]]
+  */
+object TraitUtil {
+
+  /**
+    * Apply collation based on the given mapping restrict. Returns RelCollations.EMPTY if there
+    * exists collation fields which has no target values in the given mapping.
+    *
+    * @param collation collation which to apply mapping
+    * @param mapping mapping columns to a target.
+    * @return A new collation after apply collation based on the given mapping restrict.
+    *         Returns RelCollations.EMPTY if there exists collation fields which has no target
+    *         values in the given mapping.
+    */
+  def apply(collation: RelCollation, mapping: Mappings.TargetMapping): RelCollation = {
+    val fieldCollations = collation.getFieldCollations
+    if (fieldCollations.isEmpty) collation
+    else {
+      val newFieldCollations = mutable.ArrayBuffer[RelFieldCollation]()
+      fieldCollations.foreach { fieldCollation =>
+        try {
+          val i = mapping.getTargetOpt(fieldCollation.getFieldIndex)
+          if (i >= 0) newFieldCollations.add(fieldCollation.copy(i)) else return RelCollations.EMPTY
+        } catch {
+          case _: IndexOutOfBoundsException => return RelCollations.EMPTY
+        }
+      }
+      RelCollations.of(newFieldCollations: _*)
+    }
+  }
+
+  /**
+    * Checks if a [[RelNode]] is in [[AccMode.AccRetract]] mode.
+    */
+  def isAccRetract(rel: RelNode): Boolean = {
+    val accModeTrait = rel.getTraitSet.getTrait(AccModeTraitDef.INSTANCE)
+    null != accModeTrait && accModeTrait.getAccMode == AccMode.AccRetract
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/retractionTraitDefs.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/retractionTraitDefs.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.`trait`
+
+import org.apache.calcite.plan.{RelOptPlanner, RelTraitDef}
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Definition of the [[UpdateAsRetractionTrait]].
+  */
+class UpdateAsRetractionTraitDef extends RelTraitDef[UpdateAsRetractionTrait] {
+  override def convert(
+      planner: RelOptPlanner,
+      rel: RelNode,
+      toTrait: UpdateAsRetractionTrait,
+      allowInfiniteCostConverters: Boolean): RelNode = {
+
+    rel.copy(rel.getTraitSet.plus(toTrait), rel.getInputs)
+  }
+
+  override def canConvert(
+      planner: RelOptPlanner,
+      fromTrait: UpdateAsRetractionTrait,
+      toTrait: UpdateAsRetractionTrait): Boolean = true
+
+  override def getTraitClass: Class[UpdateAsRetractionTrait] = classOf[UpdateAsRetractionTrait]
+
+  override def getSimpleName: String = this.getClass.getSimpleName
+
+  override def getDefault: UpdateAsRetractionTrait = UpdateAsRetractionTrait.DEFAULT
+}
+
+object UpdateAsRetractionTraitDef {
+  val INSTANCE = new UpdateAsRetractionTraitDef
+}
+
+/**
+  * Definition of the [[AccModeTrait]].
+  */
+class AccModeTraitDef extends RelTraitDef[AccModeTrait] {
+
+  override def convert(
+      planner: RelOptPlanner,
+      rel: RelNode,
+      toTrait: AccModeTrait,
+      allowInfiniteCostConverters: Boolean): RelNode = {
+
+    rel.copy(rel.getTraitSet.plus(toTrait), rel.getInputs)
+  }
+
+  override def canConvert(
+      planner: RelOptPlanner,
+      fromTrait: AccModeTrait,
+      toTrait: AccModeTrait): Boolean = true
+
+  override def getTraitClass: Class[AccModeTrait] = classOf[AccModeTrait]
+
+  override def getSimpleName: String = this.getClass.getSimpleName
+
+  override def getDefault: AccModeTrait = AccModeTrait.DEFAULT
+}
+
+object AccModeTraitDef {
+  val INSTANCE = new AccModeTraitDef
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/retractionTraits.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/trait/retractionTraits.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.`trait`
+
+import org.apache.flink.table.plan.`trait`.AccMode.AccMode
+
+import org.apache.calcite.plan.{RelOptPlanner, RelTrait, RelTraitDef}
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Tracks if a [[RelNode]] needs to send update and delete changes as
+  * retraction messages.
+  */
+class UpdateAsRetractionTrait extends RelTrait {
+
+  /**
+    * Defines whether the [[RelNode]] needs to send update and delete
+    * changes as retraction messages.
+    */
+  private var updateAsRetraction: Boolean = false
+
+  def this(updateAsRetraction: Boolean) {
+    this()
+    this.updateAsRetraction = updateAsRetraction
+  }
+
+  def sendsUpdatesAsRetractions: Boolean = updateAsRetraction
+
+  override def register(planner: RelOptPlanner): Unit = {}
+
+  override def getTraitDef: RelTraitDef[_ <: RelTrait] = UpdateAsRetractionTraitDef.INSTANCE
+
+  override def satisfies(`trait`: RelTrait): Boolean = this.equals(`trait`)
+
+  override def toString: String = updateAsRetraction.toString
+
+}
+
+object UpdateAsRetractionTrait {
+  val DEFAULT = new UpdateAsRetractionTrait(false)
+}
+
+/**
+  * Tracks the AccMode of a [[RelNode]].
+  */
+class AccModeTrait extends RelTrait {
+
+  /** Defines the accumulating mode for a operator. */
+  private var accMode = AccMode.Acc
+
+  def this(accMode: AccMode) {
+    this()
+    this.accMode = accMode
+  }
+
+  def getAccMode: AccMode = accMode
+
+  override def register(planner: RelOptPlanner): Unit = {}
+
+  override def getTraitDef: RelTraitDef[_ <: RelTrait] = AccModeTraitDef.INSTANCE
+
+  override def satisfies(`trait`: RelTrait): Boolean = this.equals(`trait`)
+
+  override def toString: String = accMode.toString
+}
+
+object AccModeTrait {
+  val DEFAULT = new AccModeTrait(AccMode.Acc)
+}
+
+/**
+  * The [[AccMode]] determines how insert, update, and delete changes of tables are encoded
+  * by the messeages that an operator emits.
+  */
+object AccMode extends Enumeration {
+  type AccMode = Value
+
+  /**
+    * An operator in [[Acc]] mode emits change messages as
+    * [[org.apache.flink.table.dataformat.BaseRow]] which encode a data row with header info,
+    * logically equivalent to (boolean, row).
+    *
+    * An operator in [[Acc]] mode may only produce update and delete messages, if the table has
+    * a unique key and all key attributes are contained in the Row.
+    *
+    * Changes are encoded as follows:
+    * - insert: (true, NewRow)
+    * - update: (true, NewRow) // the Row includes the full unique key to identify the row to update
+    * - delete: (false, OldRow) // the Row includes the full unique key to idenify the row to delete
+    *
+    */
+  val Acc = Value
+
+  /**
+    * * An operator in [[AccRetract]] mode emits change messages as
+    * [[org.apache.flink.table.dataformat.BaseRow]] which encode a data row with header info,
+    * logically equivalent to (boolean, row).
+    *
+    * Changes are encoded as follows:
+    * - insert: (true, NewRow)
+    * - update: (false, OldRow), (true, NewRow) // updates are encoded in two messages!
+    * - delete: (false, OldRow)
+    *
+    */
+  val AccRetract = Value
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/UpdatingPlanChecker.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/UpdatingPlanChecker.scala
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.table.plan.nodes.physical.stream._
+
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.rel.{RelNode, RelVisitor}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
+import org.apache.calcite.sql.SqlKind
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+object UpdatingPlanChecker {
+
+  /** Validates that the plan produces only append changes. */
+  def isAppendOnly(plan: RelNode): Boolean = {
+    val appendOnlyValidator = new AppendOnlyValidator
+    appendOnlyValidator.go(plan)
+
+    appendOnlyValidator.isAppendOnly
+  }
+
+  /** Extracts the unique keys of the table produced by the plan. */
+  def getUniqueKeyFields(plan: RelNode): Option[Array[String]] = {
+    getUniqueKeyGroups(plan).map(_.map(_._1).toArray)
+  }
+
+  /** Extracts the unique keys and groups of the table produced by the plan. */
+  def getUniqueKeyGroups(plan: RelNode): Option[Seq[(String, String)]] = {
+    val keyExtractor = new UniqueKeyExtractor
+    keyExtractor.visit(plan)
+  }
+
+  private class AppendOnlyValidator extends RelVisitor {
+
+    var isAppendOnly = true
+
+    override def visit(node: RelNode, ordinal: Int, parent: RelNode): Unit = {
+      node match {
+        case s: StreamPhysicalRel if s.producesUpdates =>
+          isAppendOnly = false
+        case hep: HepRelVertex =>
+          visit(hep.getCurrentRel, ordinal, parent)   //remove wrapper node
+        case rs: RelSubset =>
+          visit(rs.getOriginal, ordinal, parent)      //remove wrapper node
+        case _ =>
+          super.visit(node, ordinal, parent)
+      }
+    }
+  }
+
+  /** Identifies unique key fields in the output of a RelNode. */
+  private class UniqueKeyExtractor {
+
+    // visit() function will return a tuple, the first element is the name of a key field, the
+    // second is a group name that is shared by all equivalent key fields. The group names are
+    // used to identify same keys, for example: select('pk as pk1, 'pk as pk2), both pk1 and pk2
+    // belong to the same group, i.e., pk1. Here we use the lexicographic smallest attribute as
+    // the common group id. A node can have keys if it generates the keys by itself or it
+    // forwards keys from its input(s).
+    def visit(node: RelNode): Option[Seq[(String, String)]] = {
+      node match {
+        case c: StreamExecCalc =>
+          val inputKeys = visit(node.getInput(0))
+          // check if input has keys
+          if (inputKeys.isDefined) {
+            // track keys forward
+            val inNames = c.getInput.getRowType.getFieldNames
+            val inOutNames = c.getProgram.getNamedProjects.map(p => {
+              c.getProgram.expandLocalRef(p.left) match {
+                // output field is forwarded input field
+                case i: RexInputRef => (i.getIndex, p.right)
+                // output field is renamed input field
+                case a: RexCall if a.getKind.equals(SqlKind.AS) =>
+                  a.getOperands.get(0) match {
+                    case ref: RexInputRef =>
+                      (ref.getIndex, p.right)
+                    case _ =>
+                      (-1, p.right)
+                  }
+                // output field is not forwarded from input
+                case _: RexNode => (-1, p.right)
+              }
+            })
+              // filter all non-forwarded fields
+              .filter(_._1 >= 0)
+              // resolve names of input fields
+              .map(io => (inNames.get(io._1), io._2))
+
+            // filter by input keys
+            val inputKeysAndOutput = inOutNames
+              .filter(io => inputKeys.get.map(e => e._1).contains(io._1))
+
+            val inputKeysMap = inputKeys.get.toMap
+            val inOutGroups = inputKeysAndOutput.sorted.reverse
+              .map(e => (inputKeysMap(e._1), e._2))
+              .toMap
+
+            // get output keys
+            val outputKeys = inputKeysAndOutput
+              .map(io => (io._2, inOutGroups(inputKeysMap(io._1))))
+
+            // check if all keys have been preserved
+            if (outputKeys.map(_._2).distinct.length == inputKeys.get.map(_._2).distinct.length) {
+              // all key have been preserved (but possibly renamed)
+              Some(outputKeys)
+            } else {
+              // some (or all) keys have been removed. Keys are no longer unique and removed
+              None
+            }
+          } else {
+            None
+          }
+
+        case _: StreamExecOverAggregate =>
+          // keys are always forwarded by Over aggregate
+          visit(node.getInput(0))
+        case a: StreamExecGroupAggregate =>
+          // get grouping keys
+          val groupKeys = a.getRowType.getFieldNames.take(a.grouping.length)
+          Some(groupKeys.map(e => (e, e)))
+
+        // TODO supports StreamExecGroupWindowAggregate
+
+        case j: StreamExecJoin =>
+          // get key(s) for join
+          val lInKeys = visit(j.getLeft)
+          val rInKeys = visit(j.getRight)
+          if (lInKeys.isEmpty || rInKeys.isEmpty) {
+            None
+          } else {
+            // Output of join must have keys if left and right both contain key(s).
+            // Key groups from both side will be merged by join equi-predicates
+            val lInNames: Seq[String] = j.getLeft.getRowType.getFieldNames
+            val rInNames: Seq[String] = j.getRight.getRowType.getFieldNames
+            val joinNames = j.getRowType.getFieldNames
+
+            // if right field names equal to left field names, calcite will rename right
+            // field names. For example, T1(pk, a) join T2(pk, b), calcite will rename T2(pk, b)
+            // to T2(pk0, b).
+            val rInNamesToJoinNamesMap = rInNames
+              .zip(joinNames.subList(lInNames.size, joinNames.length))
+              .toMap
+
+            val lJoinKeys: Seq[String] = j.joinInfo.leftKeys
+              .map(lInNames.get(_))
+            val rJoinKeys: Seq[String] = j.joinInfo.rightKeys
+              .map(rInNames.get(_))
+              .map(rInNamesToJoinNamesMap(_))
+
+            val inKeys: Seq[(String, String)] = lInKeys.get ++ rInKeys.get
+              .map(e => (rInNamesToJoinNamesMap(e._1), rInNamesToJoinNamesMap(e._2)))
+
+            getOutputKeysForNonWindowJoin(
+              joinNames,
+              inKeys,
+              lJoinKeys.zip(rJoinKeys)
+            )
+          }
+        case _: StreamPhysicalRel =>
+          // anything else does not forward keys, so we can stop
+          None
+      }
+    }
+
+    /**
+      * Get output keys for non-window join according to it's inputs.
+      *
+      * @param inNames  Field names of join
+      * @param inKeys   Input keys of join
+      * @param joinKeys JoinKeys of join
+      * @return Return output keys of join
+      */
+    def getOutputKeysForNonWindowJoin(
+        inNames: Seq[String],
+        inKeys: Seq[(String, String)],
+        joinKeys: Seq[(String, String)])
+    : Option[Seq[(String, String)]] = {
+
+      val nameToGroups = mutable.HashMap.empty[String, String]
+
+      // merge two groups
+      def merge(nameA: String, nameB: String): Unit = {
+        val ga: String = findGroup(nameA)
+        val gb: String = findGroup(nameB)
+        if (!ga.equals(gb)) {
+          if (ga.compare(gb) < 0) {
+            nameToGroups += (gb -> ga)
+          } else {
+            nameToGroups += (ga -> gb)
+          }
+        }
+      }
+
+      def findGroup(x: String): String = {
+        // find the group of x
+        var r: String = x
+        while (!nameToGroups(r).equals(r)) {
+          r = nameToGroups(r)
+        }
+
+        // point all name to the group name directly
+        var a: String = x
+        var b: String = null
+        while (!nameToGroups(a).equals(r)) {
+          b = nameToGroups(a)
+          nameToGroups += (a -> r)
+          a = b
+        }
+        r
+      }
+
+      // init groups
+      inNames.foreach(e => nameToGroups += (e -> e))
+      inKeys.foreach(e => nameToGroups += (e._1 -> e._2))
+      // merge groups
+      joinKeys.foreach(e => merge(e._1, e._2))
+      // make sure all name point to the group name directly
+      inNames.foreach(findGroup)
+
+      val outputGroups = inKeys.map(e => nameToGroups(e._1)).distinct
+      Some(
+        inNames
+          .filter(e => outputGroups.contains(nameToGroups(e)))
+          .map(e => (e, nameToGroups(e)))
+      )
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sinks/BaseRetractStreamTableSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sinks/BaseRetractStreamTableSink.scala
@@ -16,28 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
+package org.apache.flink.table.sinks
 
-import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
-
-import java.util
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
+import org.apache.flink.table.api.Table
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Defines an external [[TableSink]] to emit a streaming [[Table]] with insert, update, and delete
+  * changes.
+  *
+  * @tparam T Type of records that this [[TableSink]] expects and supports.
   */
-final class LogicalWatermarkAssigner(
-    cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+trait BaseRetractStreamTableSink[T] extends StreamTableSink[T] {
 
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
-  }
+  /** Emits the DataStream. */
+  def emitDataStream(dataStream: DataStream[T]): DataStreamSink[_]
 }
-

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sinks/StreamTableSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/sinks/StreamTableSink.scala
@@ -16,28 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.plan.nodes.calcite
+package org.apache.flink.table.sinks
 
-import org.apache.calcite.plan._
-import org.apache.calcite.rel.RelNode
-
-import java.util
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 
 /**
-  * Sub-class of [[WatermarkAssigner]] that is a relational operator
-  * which generates [[org.apache.flink.streaming.api.watermark.Watermark]].
-  * This class corresponds to Calcite logical rel.
+  * Defines an external stream table and provides write access to its data.
+  *
+  * @tparam T Type of the [[DataStream]] created by this [[TableSink]].
   */
-final class LogicalWatermarkAssigner(
-    cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode,
-    rowtimeFieldIndex: Option[Int],
-    watermarkOffset: Option[Long])
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkOffset) {
+trait StreamTableSink[T] extends TableSink[T] {
 
-  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traits, inputs.get(0), rowtimeFieldIndex, watermarkOffset)
-  }
+  /** Emits the DataStream. */
+  def emitDataStream(dataStream: DataStream[T]): DataStreamSink[_]
+
 }
-

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/api/TableConfigOptions.java
@@ -65,4 +65,13 @@ public class TableConfigOptions {
 					.withDescription("The buffer is to compress. The larger the buffer," +
 							" the better the compression ratio, but the more memory consumption.");
 
+	// ------------------------------------------------------------------------
+	//  MiniBatch Options
+	// ------------------------------------------------------------------------
+
+	public static final ConfigOption<Long> SQL_EXEC_MINIBATCH_ALLOW_LATENCY =
+			key("sql.exec.mini-batch.allow-latency.ms")
+					.defaultValue(Long.MIN_VALUE)
+					.withDescription("MiniBatch allow latency(ms). Value > 0 means MiniBatch enabled.");
+
 }


### PR DESCRIPTION
## What is the purpose of the change

*Introduce stream physical RelNode*

## Brief change log

  - *adds all stream physical nodes, excludes StreamExecCorrelate, StreamExecTemporalTableJoin, StreamExecGroupWindowAggregate, StreamExecMatch, StreamExecTemporalTableFunctionJoin*

## Verifying this change

This change is an initialization work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
