### PR TITLE
[FLINK-11892] [docs] Refine README of end-to-end tests to make it more clear

### DIFF
--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -31,8 +31,7 @@ You can also run tests individually via
 $ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh your_test.sh arg1 arg2
 ```
 
-**NOTICE**: Although ```run-nightly-tests.sh``` is a shell script, ```#!/usr/bin/env bash``` is specified as its header to assure [flexibility on different systems](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash).
- Please _DON'T_ run it with explicit command like ```sh run-nightly-tests.sh``` or you may get weird issues like syntax error or port conflict. More details please refer to [FLINK-11892](https://issues.apache.org/jira/browse/FLINK-11892).
+**NOTICE**: Please _DON'T_ run the scripts with explicit command like ```sh run-nightly-tests.sh``` since ```#!/usr/bin/env bash``` is specified as the header of the scripts to assure flexibility on different systems.
 
 ### Kubernetes test
 

--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -23,13 +23,16 @@ and all nightly tests via
 $ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-nightly-tests.sh
 ```
 
-where <flink dir> is a Flink distribution directory.
+where \<flink dir\> is a Flink distribution directory.
 
 You can also run tests individually via
 
 ```
 $ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh your_test.sh arg1 arg2
 ```
+
+**NOTICE**: Although ```run-nightly-tests.sh``` is a shell script, ```#!/usr/bin/env bash``` is specified as its header to assure [flexibility on different systems](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash).
+ Please _DON'T_ run it with explicit command like ```sh run-nightly-tests.sh``` or you may get weird issues like syntax error or port conflict. More details please refer to [FLINK-11892](https://issues.apache.org/jira/browse/FLINK-11892).
 
 ### Kubernetes test
 


### PR DESCRIPTION
## What is the purpose of the change

* This PR is a document refinement for end-to-end tests.


## Brief change log

  - Correct the markdown syntax error so as to show the `flink dir` meaning clearly.
  - Add note to prevent user run the nightly script with explicit bash command.


## Verifying this change

This change is a document refinement without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
