### PR TITLE
 [FLINK-11901][build] Update NOTICE files with year 2019

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------------
 
 Apache Flink
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -16,7 +16,7 @@ See bundled license files for details.
 - org.slf4j:slf4j-log4j12:1.7.15
 
 flink-metrics-datadog
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.squareup.okio:okio:1.12.0
 
 flink-dist
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -101,7 +101,7 @@ CS Systèmes d'Information (http://www.c-s.fr/)
 Copyright 2010-2012 CS Systèmes d'Information
 
 flink-runtime
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -146,7 +146,7 @@ WebSocket and HTTP server:
     * https://github.com/joewalnes/webbit
 
 flink-shaded-curator
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 - com.google.guava:guava:16.0.1
 - org.apache.curator:curator-client:2.12.0
@@ -166,7 +166,7 @@ Apache Commons IO
 Copyright 2002-2012 The Apache Software Foundation
 
 flink-shaded-jackson-2
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 # Jackson JSON processor
 
@@ -198,7 +198,7 @@ Apache Commons CLI
 Copyright 2001-2015 The Apache Software Foundation
 
 flink-mesos
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 - com.netflix.fenzo:fenzo-core:0.10.1
 - org.apache.mesos:mesos:1.0.1
@@ -212,7 +212,7 @@ mesos
 Copyright 2016 The Apache Software Foundation
 
 flink-yarn
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 Camel :: Core
 Copyright 2007-2017 The Apache Software Foundation
@@ -233,7 +233,7 @@ Objenesis
 Copyright 2006-2013 Joe Walnes, Henri Tremblay, Leonardo Mesquita
 
 flink-table
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -267,7 +267,7 @@ This product includes software developed by
 Joda.org (http://www.joda.org/).
 
 flink-runtime-web
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -305,7 +305,7 @@ See bundled license files for details.
 - font-awesome:4.5.0 (Font)
 
 flink-swift-fs-hadoop
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1854,7 +1854,7 @@ Apache Commons Compress
 Copyright 2002-2012 The Apache Software Foundation
 
 flink-hadoop-fs
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
@@ -2373,7 +2373,7 @@ Apache Commons Logging
 Copyright 2003-2013 The Apache Software Foundation
 
 flink-shaded-hadoop2-uber
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2424,7 +2424,7 @@ but some files are heavily based on public domain code written by Igor Pavlov.
 
 
 flink-shaded-hadoop2
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 - com.google.guava:guava:11.0.2
 - net.java.dev.jets3t:jets3t:0.9.0
@@ -2526,7 +2526,7 @@ Apache Commons Daemon
 Copyright 1999-2013 The Apache Software Foundation
 
 flink-s3-fs-presto
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2554,7 +2554,7 @@ See bundled license files for details.
 
 
 flink-s3-fs-base
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 - org.apache.hadoop:hadoop-aws:3.1.0
 - org.apache.httpcomponents:httpcore:4.4.6
@@ -2574,7 +2574,7 @@ Copyright 2014-2018 The Apache Software Foundation
 - joda-time:joda-time:2.5
 
 flink-fs-hadoop-shaded
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 - org.apache.hadoop:hadoop-annotations:3.1.0
 - org.apache.hadoop:hadoop-auth:3.1.0
@@ -5619,7 +5619,7 @@ force-shading
 Copyright 2018 The Apache Software Foundation
 
 flink-hadoop-fs
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 Apache HttpClient
 Copyright 1999-2017 The Apache Software Foundation
@@ -5649,7 +5649,7 @@ This product includes software developed by
 Joda.org (http://www.joda.org/).
 
 flink-metrics-prometheus
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5659,7 +5659,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.prometheus:simpleclient_pushgateway:0.3.0
 
 flink-s3-fs-base
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -5684,7 +5684,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - joda-time:joda-time:2.5
 
 flink-fs-hadoop-shaded
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 - org.apache.hadoop:hadoop-annotations:3.1.0
 - org.apache.hadoop:hadoop-auth:3.1.0
@@ -5714,7 +5714,7 @@ See bundled license files for details.
 - org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
 
 flink-sql-client
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
@@ -5724,7 +5724,7 @@ See bundled license files for details.
 
 
 flink-table
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5743,7 +5743,7 @@ See bundled license files for details
 - org.codehaus.janino:commons-compiler:3.0.7
 
 flink-table-common
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 Calcite Core
 Copyright 2012-2018 The Apache Software Foundation
@@ -5764,10 +5764,10 @@ force-shading
 Copyright 2018 The Apache Software Foundation
 
 flink-cep
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 flink-streaming-python
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -5778,7 +5778,7 @@ See bundled license files for details.
 - org.python:jython-standalone:2.7.1
 
 flink-metrics-graphite
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5796,7 +5796,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 flink-examples-streaming-state-machine
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5831,7 +5831,7 @@ Apache HttpCore
 Copyright 2005-2017 The Apache Software Foundation
 
 flink-connector-twitter
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/flink-connectors/flink-connector-cassandra/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-cassandra/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-cassandra
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-elasticsearch
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-elasticsearch2
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-elasticsearch5
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-kinesis
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-twitter/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-twitter/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-twitter
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-elasticsearch6
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka-0.10
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka-0.11/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka-0.9
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka-0.9/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.9/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka-0.9
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-dist
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-examples-streaming-state-machine
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-fs-hadoop-shaded
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/NOTICE
@@ -1,5 +1,5 @@
 flink-oss-fs-hadoop
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-s3-fs-base/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-base/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-s3-fs-base
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-s3-fs-presto
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-swift-fs-hadoop
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-avro-confluent-registry
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-libraries/flink-ml-uber/src/main/resources/META-INF/NOTICE
+++ b/flink-libraries/flink-ml-uber/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-ml-uber
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-libraries/flink-streaming-python/src/main/resources/META-INF/NOTICE
+++ b/flink-libraries/flink-streaming-python/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-streaming-python
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-mesos/src/main/resources/META-INF/NOTICE
+++ b/flink-mesos/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-mesos
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-datadog
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-graphite/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-graphite/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-graphite
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-influxdb
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-prometheus/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-prometheus/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-prometheus
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-runtime-web/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime-web/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-runtime-web
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-runtime
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-shaded-curator/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-curator/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-shaded-curator
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-shaded-hadoop/flink-shaded-hadoop2-uber/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2-uber/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-shaded-hadoop2-uber
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-shaded-hadoop/flink-shaded-hadoop2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-shaded-hadoop2
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-shaded-hadoop/flink-shaded-yarn-tests/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-hadoop/flink-shaded-yarn-tests/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-shaded-yarn-tests
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-client
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-planner-blink
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-planner
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-runtime-blink
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-test-utils-parent/flink-test-utils/src/main/resources/META-INF/NOTICE
+++ b/flink-test-utils-parent/flink-test-utils/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-test-utils
-Copyright 2014-2018 The Apache Software Foundation
+Copyright 2014-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tools/update_notice_year.sh
+++ b/tools/update_notice_year.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# This script updates the year in all NOTICE files
+
+set -Eeuo pipefail
+
+FLINK_DIR=${1:-}
+
+USAGE="update_notice_year <FLINK_DIR>"
+
+if [[ -z "${FLINK_DIR}" || "${FLINK_DIR}" = "-h" ]]; then
+	echo "${USAGE}"
+	exit 0
+fi
+
+NEW_YEAR=`date +'%Y'`
+
+for path in $(find "${FLINK_DIR}" -name "NOTICE*"); do
+	echo "Updating: ${path}"
+	sed "s/Copyright 2014-.* The Apache Software Foundation/Copyright 2014-${NEW_YEAR} The Apache Software Foundation/" "${path}" > "${path}_new"
+	mv "${path}_new" "${path}"
+done
+
+echo "The script is just a helper tool. Please verify the performed changes manually again!"


### PR DESCRIPTION
## What is the purpose of the change

Provides a script for updating the NOTICE file year and updates it to 2019.


## Brief change log

- Script added
- NOTICE files updated


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
