### PR TITLE
[FLINK-11910] [Yarn] add customizable yarn application type

### DIFF
--- a/docs/ops/deployment/yarn_setup.md
+++ b/docs/ops/deployment/yarn_setup.md
@@ -101,6 +101,7 @@ Usage:
      -d,--detached                   Start detached
      -jm,--jobManagerMemory <arg>    Memory for JobManager Container with optional unit (default: MB)
      -nm,--name                      Set a custom name for the application on YARN
+     -at,--applicationType           Set a custom application type on YARN
      -q,--query                      Display available YARN resources (memory, cores)
      -qu,--queue <arg>               Specify YARN queue.
      -s,--slots <arg>                Number of slots per TaskManager

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -111,7 +111,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		args.add("1024m");
 
 		args.add("-D");
-		args.add("flink-version=1.6");
+		args.add("application-type=Apache Flink 1.6");
 
 		if (SecureTestEnvironment.getTestKeytab() != null) {
 			args.add("-D" + SecurityOptions.KERBEROS_LOGIN_KEYTAB.key() + "=" + SecureTestEnvironment.getTestKeytab());
@@ -170,6 +170,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			ApplicationReport app = apps.get(0);
 
 			Assert.assertEquals("MyCustomName", app.getName());
+			Assert.assertEquals("Apache Flink 1.6", app.getApplicationType());
 			ApplicationId id = app.getApplicationId();
 			yc.killApplication(id);
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -110,6 +110,9 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		args.add("-tm");
 		args.add("1024m");
 
+		args.add("-D");
+		args.add("flink-version=1.6");
+
 		if (SecureTestEnvironment.getTestKeytab() != null) {
 			args.add("-D" + SecurityOptions.KERBEROS_LOGIN_KEYTAB.key() + "=" + SecureTestEnvironment.getTestKeytab());
 		}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -110,17 +110,18 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		args.add("-tm");
 		args.add("1024m");
 
-		args.add("-D");
-		args.add("application-type=Apache Flink 1.6");
-
 		if (SecureTestEnvironment.getTestKeytab() != null) {
 			args.add("-D" + SecurityOptions.KERBEROS_LOGIN_KEYTAB.key() + "=" + SecureTestEnvironment.getTestKeytab());
 		}
 		if (SecureTestEnvironment.getHadoopServicePrincipal() != null) {
 			args.add("-D" + SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key() + "=" + SecureTestEnvironment.getHadoopServicePrincipal());
 		}
+
 		args.add("--name");
 		args.add("MyCustomName");
+
+		args.add("--applicationType");
+		args.add("Apache Flink 1.x");
 
 		args.add("--detached");
 
@@ -170,7 +171,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 			ApplicationReport app = apps.get(0);
 
 			Assert.assertEquals("MyCustomName", app.getName());
-			Assert.assertEquals("Apache Flink 1.6", app.getApplicationType());
+			Assert.assertEquals("Apache Flink 1.x", app.getApplicationType());
 			ApplicationId id = app.getApplicationId();
 			yc.killApplication(id);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -140,7 +140,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	private String zookeeperNamespace;
 
 	private String nodeLabel;
-	/* This field can be override by dynamic property application-type */
+
 	private String applicationType;
 
 	/** Optional Jar file to include in the system class loader of all application nodes
@@ -471,8 +471,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		for (Map.Entry<String, String> dynProperty : dynProperties.entrySet()) {
 			flinkConfiguration.setString(dynProperty.getKey(), dynProperty.getValue());
 		}
-
-		this.applicationType = dynProperties.getOrDefault("application-type", "");
 
 		// ------------------ Check if the YARN ClusterClient has the requested resources --------------
 
@@ -990,7 +988,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		final String customApplicationName = customName != null ? customName : applicationName;
 
 		appContext.setApplicationName(customApplicationName);
-		appContext.setApplicationType(applicationType.isEmpty() ? "Apache Flink" : applicationType);
+		appContext.setApplicationType(applicationType != null ? applicationType : "Apache Flink");
 		appContext.setAMContainerSpec(amContainer);
 		appContext.setResource(capability);
 
@@ -1287,6 +1285,13 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			throw new IllegalArgumentException("The passed name is null");
 		}
 		customName = name;
+	}
+
+	public void setApplicationType(String type) {
+		if (type == null) {
+			throw new IllegalArgumentException("The passed application type is null");
+		}
+		applicationType = type;
 	}
 
 	private void activateHighAvailabilitySupport(ApplicationSubmissionContext appContext) throws

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -140,8 +140,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	private String zookeeperNamespace;
 
 	private String nodeLabel;
-
-	private String flinkVersion;
+	/* This field can be override by dynamic property application-type */
+	private String applicationType;
 
 	/** Optional Jar file to include in the system class loader of all application nodes
 	 * (for per-job submission). */
@@ -472,7 +472,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			flinkConfiguration.setString(dynProperty.getKey(), dynProperty.getValue());
 		}
 
-		this.flinkVersion = dynProperties.getOrDefault("flink-version", "");
+		this.applicationType = dynProperties.getOrDefault("application-type", "");
 
 		// ------------------ Check if the YARN ClusterClient has the requested resources --------------
 
@@ -990,7 +990,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		final String customApplicationName = customName != null ? customName : applicationName;
 
 		appContext.setApplicationName(customApplicationName);
-		appContext.setApplicationType(flinkVersion.isEmpty() ? "Apache Flink" : "Apache Flink " + flinkVersion);
+		appContext.setApplicationType(applicationType.isEmpty() ? "Apache Flink" : applicationType);
 		appContext.setAMContainerSpec(amContainer);
 		appContext.setResource(capability);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -1281,17 +1281,11 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	}
 
 	public void setName(String name) {
-		if (name == null) {
-			throw new IllegalArgumentException("The passed name is null");
-		}
-		customName = name;
+		this.customName = Preconditions.checkNotNull(name, "The customized name must not be null");
 	}
 
 	public void setApplicationType(String type) {
-		if (type == null) {
-			throw new IllegalArgumentException("The passed application type is null");
-		}
-		applicationType = type;
+		this.applicationType = Preconditions.checkNotNull(type, "The customized application type must not be null");
 	}
 
 	private void activateHighAvailabilitySupport(ApplicationSubmissionContext appContext) throws

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -141,6 +141,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	private String nodeLabel;
 
+	private String flinkVersion;
+
 	/** Optional Jar file to include in the system class loader of all application nodes
 	 * (for per-job submission). */
 	private final Set<File> userJarFiles = new HashSet<>();
@@ -469,6 +471,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		for (Map.Entry<String, String> dynProperty : dynProperties.entrySet()) {
 			flinkConfiguration.setString(dynProperty.getKey(), dynProperty.getValue());
 		}
+
+		this.flinkVersion = dynProperties.getOrDefault("flink-version", "");
 
 		// ------------------ Check if the YARN ClusterClient has the requested resources --------------
 
@@ -986,7 +990,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		final String customApplicationName = customName != null ? customName : applicationName;
 
 		appContext.setApplicationName(customApplicationName);
-		appContext.setApplicationType("Apache Flink");
+		appContext.setApplicationType(flinkVersion.isEmpty() ? "Apache Flink" : "Apache Flink " + flinkVersion);
 		appContext.setAMContainerSpec(amContainer);
 		appContext.setResource(capability);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -143,6 +143,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	@Deprecated
 	private final Option streaming;
 	private final Option name;
+	private final Option applicationType;
 
 	private final Options allOptions;
 
@@ -201,6 +202,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			.build();
 		streaming = new Option(shortPrefix + "st", longPrefix + "streaming", false, "Start Flink in streaming mode");
 		name = new Option(shortPrefix + "nm", longPrefix + "name", true, "Set a custom name for the application on YARN");
+		applicationType = new Option(shortPrefix + "at", longPrefix + "applicationType", true, "Set a custom application type for the application on YARN");
 		zookeeperNamespace = new Option(shortPrefix + "z", longPrefix + "zookeeperNamespace", true, "Namespace to create the Zookeeper sub-paths for high availability mode");
 		nodeLabel = new Option(shortPrefix + "nl", longPrefix + "nodeLabel", true, "Specify YARN node label for the YARN application");
 		help = new Option(shortPrefix + "h", longPrefix + "help", false, "Help for the Yarn session CLI.");
@@ -221,6 +223,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		allOptions.addOption(streaming);
 		allOptions.addOption(name);
 		allOptions.addOption(applicationId);
+		allOptions.addOption(applicationType);
 		allOptions.addOption(zookeeperNamespace);
 		allOptions.addOption(nodeLabel);
 		allOptions.addOption(help);
@@ -356,6 +359,10 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 		if (cmd.hasOption(name.getOpt())) {
 			yarnClusterDescriptor.setName(cmd.getOptionValue(name.getOpt()));
+		}
+
+		if (cmd.hasOption(applicationType.getOpt())) {
+			yarnClusterDescriptor.setApplicationType(cmd.getOptionValue(applicationType.getOpt()));
 		}
 
 		if (cmd.hasOption(zookeeperNamespace.getOpt())) {


### PR DESCRIPTION
## What is the purpose of the change

Let user customize yarn application type tag by using dynamic properties.

## Brief change log
   - use flink-version as a default key for user to specify the flink version
   - If flink-version is set, the value will be added after original "Apache Flink ".

## Verifying this change

This change is verified in YARNSessionCapacitySchedulerITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? no)
  - If yes, how is the feature documented? (not applicable)
