### PR TITLE
[FLINK-11913] Shading cassandra driver dependencies in cassandra conector

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -89,6 +89,10 @@ under the License.
 									https://issues.apache.org/jira/browse/FLINK-8295
 								-->
 								<relocation>
+									<pattern>com.datastax.driver</pattern>
+									<shadedPattern>org.apache.flink.cassandra.shaded.com.datastax.driver</shadedPattern>
+								</relocation>
+								<relocation>
 									<pattern>io.netty</pattern>
 									<shadedPattern>com.datastax.shaded.netty</shadedPattern>
 								</relocation>


### PR DESCRIPTION
## What is the purpose of the change

The Cassandra connector have some dependencies that need to be available and should not conflict with other user or system code. It should thus shade all its dependencies and become self-contained.

A simple example would be when an application read data from Cassandra using the javax driver.


## Brief change log

  - Shaded dependencies of `cassandra-driver-core`
  - Shaded dependencies of `cassandra-driver-mapping`

## Verifying this change

In the shaded jar files verify that cassrandra-driver `.classes` are found in the `org.apache.flink.cassandra.shaded.com.datastax.driver` package 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable