### PR TITLE
[FLINK-10517][rest] Add stability test

### DIFF
--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -55,6 +55,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-metrics-prometheus_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -18,29 +18,15 @@
 
 package org.apache.flink.docs.rest;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.RestOptions;
-import org.apache.flink.runtime.dispatcher.DispatcherGateway;
-import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
-import org.apache.flink.runtime.leaderelection.LeaderContender;
-import org.apache.flink.runtime.leaderelection.LeaderElectionService;
-import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
-import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
-import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
-import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
-import org.apache.flink.runtime.rest.handler.legacy.metrics.VoidMetricFetcher;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.util.DocumentingDispatcherRestEndpoint;
+import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
-import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.util.ConfigurationException;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.SerializableString;
@@ -49,12 +35,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.io.Serialized
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -62,13 +45,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.docs.util.Utils.escapeCharacters;
@@ -311,102 +290,6 @@ public class RestAPIDocGenerator {
 		@Override
 		public SerializableString getEscapeSequence(int i) {
 			return escapeSequences.getOrDefault(i, null);
-		}
-	}
-
-	/**
-	 * Utility class to extract the {@link MessageHeaders} that the {@link DispatcherRestEndpoint} supports.
-	 */
-	private static class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint implements DocumentingRestEndpoint {
-
-		private static final Configuration config;
-		private static final RestServerEndpointConfiguration restConfig;
-		private static final RestHandlerConfiguration handlerConfig;
-		private static final GatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever;
-		private static final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
-
-		static {
-			config = new Configuration();
-			config.setString(RestOptions.ADDRESS, "localhost");
-			// necessary for loading the web-submission extension
-			config.setString(JobManagerOptions.ADDRESS, "localhost");
-			try {
-				restConfig = RestServerEndpointConfiguration.fromConfiguration(config);
-			} catch (ConfigurationException e) {
-				throw new RuntimeException("Implementation error. RestServerEndpointConfiguration#fromConfiguration failed for default configuration.");
-			}
-			handlerConfig = RestHandlerConfiguration.fromConfiguration(config);
-
-			dispatcherGatewayRetriever = () -> null;
-			resourceManagerGatewayRetriever = () -> null;
-		}
-
-		private DocumentingDispatcherRestEndpoint() throws IOException {
-			super(
-				restConfig,
-				dispatcherGatewayRetriever,
-				config,
-				handlerConfig,
-				resourceManagerGatewayRetriever,
-				NoOpTransientBlobService.INSTANCE,
-				Executors.newFixedThreadPool(1),
-				VoidMetricFetcher.INSTANCE,
-				NoOpElectionService.INSTANCE,
-				NoOpFatalErrorHandler.INSTANCE);
-		}
-
-		@Override
-		public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(final CompletableFuture<String> localAddressFuture) {
-			return super.initializeHandlers(localAddressFuture);
-		}
-
-		private enum NoOpElectionService implements LeaderElectionService {
-			INSTANCE;
-			@Override
-			public void start(final LeaderContender contender) throws Exception {
-
-			}
-
-			@Override
-			public void stop() throws Exception {
-
-			}
-
-			@Override
-			public void confirmLeaderSessionID(final UUID leaderSessionID) {
-
-			}
-
-			@Override
-			public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
-				return false;
-			}
-		}
-
-		private enum NoOpFatalErrorHandler implements FatalErrorHandler {
-			INSTANCE;
-
-			@Override
-			public void onFatalError(final Throwable exception) {
-
-			}
-		}
-	}
-
-	/**
-	 * Interface to expose the supported {@link MessageHeaders} of a {@link RestServerEndpoint}.
-	 */
-	private interface DocumentingRestEndpoint {
-		List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(final CompletableFuture<String> localAddressFuture);
-
-		default List<MessageHeaders> getSpecs() {
-			Comparator<String> comparator = new RestServerEndpoint.RestHandlerUrlComparator.CaseInsensitiveOrderComparator();
-			return initializeHandlers(CompletableFuture.completedFuture(null)).stream()
-				.map(tuple -> tuple.f0)
-				.filter(spec -> spec instanceof MessageHeaders)
-				.map(spec -> (MessageHeaders) spec)
-				.sorted((spec1, spec2) -> comparator.compare(spec1.getTargetRestEndpointURL(), spec2.getTargetRestEndpointURL()))
-				.collect(Collectors.toList());
 		}
 	}
 }

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -298,6 +298,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-jackson-module-jsonSchema</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-testkit_${scala.binary.version}</artifactId>
 		</dependency>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/versioning/RestAPIVersion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/versioning/RestAPIVersion.java
@@ -34,16 +34,19 @@ import java.util.Comparator;
  * - modifications to request/response bodies (excluding additions)
  */
 public enum RestAPIVersion {
-	V0(0, false), // strictly for testing purposes
-	V1(1, true);
+	V0(0, false, false), // strictly for testing purposes
+	V1(1, true, true);
 
 	private final int versionNumber;
 
 	private final boolean isDefaultVersion;
 
-	RestAPIVersion(int versionNumber, boolean isDefaultVersion) {
+	private final boolean isStable;
+
+	RestAPIVersion(int versionNumber, boolean isDefaultVersion, boolean isStable) {
 		this.versionNumber = versionNumber;
 		this.isDefaultVersion = isDefaultVersion;
+		this.isStable = isStable;
 	}
 
 	/**
@@ -62,6 +65,15 @@ public enum RestAPIVersion {
 	 */
 	public boolean isDefaultVersion() {
 		return isDefaultVersion;
+	}
+
+	/**
+	 * Returns whether this version is considered stable.
+	 *
+	 * @return whether this version is stable
+	 */
+	public boolean isStableVersion() {
+		return isStable;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/Compatibility.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/Compatibility.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.compatibility;
+
+/**
+ * Compatibility-qualifier for the REST API.
+ */
+enum Compatibility {
+	/**
+	 * The API is not backward compatible, meaning that the API was modified in a breaking way.
+	 */
+	INCOMPATIBLE,
+	/**
+	 * The API is backward compatible, meaning that the API was modified but not in a breaking way.
+	 */
+	COMPATIBLE,
+	/**
+	 * The API is identical to a previous version. Exists primarily to determine whether the snapshot file must be updated.
+	 */
+	IDENTICAL;
+
+	/**
+	 * Merges 2 compatibilities by prioritizing the most restrictive one.
+	 */
+	Compatibility merge(final Compatibility other) {
+		if (this == INCOMPATIBLE || other == INCOMPATIBLE) {
+			return INCOMPATIBLE;
+		}
+		if (this == COMPATIBLE || other == COMPATIBLE) {
+			return COMPATIBLE;
+		}
+		return IDENTICAL;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/CompatibilityCheckResult.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/CompatibilityCheckResult.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.compatibility;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The (potentially aggregated) result of a compatibility check that may also contain a list of {@link AssertionError}
+ * for each found incompatibility.
+ */
+final class CompatibilityCheckResult {
+
+	private final Compatibility backwardCompatibility;
+	private final int backwardCompatibilityGrade;
+	private final Collection<AssertionError> backwardCompatibilityErrors;
+
+	private CompatibilityCheckResult(final Compatibility backwardCompatibility) {
+		this(backwardCompatibility, 1, Collections.emptyList());
+		if (backwardCompatibility == Compatibility.INCOMPATIBLE) {
+			throw new RuntimeException("This constructor must not be used for incompatible results.");
+		}
+	}
+
+	private CompatibilityCheckResult(final Compatibility backwardCompatibility, final int backwardCompatibilityGrade, final Collection<AssertionError> backwardCompatibilityErrors) {
+		this.backwardCompatibility = backwardCompatibility;
+		this.backwardCompatibilityGrade = backwardCompatibilityGrade;
+		this.backwardCompatibilityErrors = Collections.unmodifiableCollection(backwardCompatibilityErrors);
+	}
+
+	public Compatibility getBackwardCompatibility() {
+		return backwardCompatibility;
+	}
+
+	public int getBackwardCompatibilityGrade() {
+		return backwardCompatibilityGrade;
+	}
+
+	public Collection<AssertionError> getBackwardCompatibilityErrors() {
+		return backwardCompatibilityErrors;
+	}
+
+	CompatibilityCheckResult merge(final CompatibilityCheckResult other) {
+		final Compatibility mergedCompatibility = this.backwardCompatibility.merge(other.backwardCompatibility);
+
+		final int mergedGrade = this.backwardCompatibilityGrade + other.backwardCompatibilityGrade;
+
+		final List<AssertionError> mergedErrors = new ArrayList<>(this.backwardCompatibilityErrors.size() + other.backwardCompatibilityErrors.size());
+		mergedErrors.addAll(this.backwardCompatibilityErrors);
+		mergedErrors.addAll(other.backwardCompatibilityErrors);
+
+		return new CompatibilityCheckResult(mergedCompatibility, mergedGrade, mergedErrors);
+	}
+
+	public static CompatibilityCheckResult identical() {
+		return new CompatibilityCheckResult(Compatibility.IDENTICAL);
+	}
+
+	public static CompatibilityCheckResult compatible() {
+		return new CompatibilityCheckResult(Compatibility.COMPATIBLE);
+	}
+
+	public static CompatibilityCheckResult incompatible(final AssertionError backwardCompatibilityError) {
+		return new CompatibilityCheckResult(Compatibility.INCOMPATIBLE, 0, Collections.singletonList(backwardCompatibilityError));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/CompatibilityRoutine.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/CompatibilityRoutine.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.compatibility;
+
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Assert;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Routine for checking the compatibility of a {@link MessageHeaders} pair.
+ *
+ * <p>The 'extractor' {@link Function} generates a 'container', a jackson-compatible object containing the data that
+ * the routine bases it's compatibility-evaluation on.
+ * The 'assertion' {@link BiConsumer} accepts a pair of containers and asserts the compatibility. Incompatibilities are
+ * signaled by throwing an {@link AssertionError}. This implies that the method body will typically contain jUnit
+ * assertions.
+ */
+final class CompatibilityRoutine<C> {
+
+	private final String key;
+	private final Class<C> containerClass;
+	private final Function<MessageHeaders<?, ?, ?>, C> extractor;
+	private final BiConsumer<C, C> assertion;
+
+	CompatibilityRoutine(
+			final String key,
+			final Class<C> containerClass,
+			final Function<MessageHeaders<?, ?, ?>, C> extractor,
+			final BiConsumer<C, C> assertion) {
+		this.key = key;
+		this.containerClass = containerClass;
+		this.extractor = extractor;
+		this.assertion = assertion;
+	}
+
+	String getKey() {
+		return key;
+	}
+
+	Class<C> getContainerClass() {
+		return containerClass;
+	}
+
+	C getContainer(final MessageHeaders<?, ?, ?> header) {
+		final C container = extractor.apply(header);
+		Assert.assertNotNull("Implementation error: Extractor returned null.", container);
+		return container;
+	}
+
+	CompatibilityCheckResult checkCompatibility(final Optional<C> old, final Optional<C> cur) {
+		Preconditions.checkArgument(
+			old.isPresent() || cur.isPresent(),
+			"Implementation error: Compatibility check container for routine {} for both old and new version is null.", key);
+
+		if (!old.isPresent()) {
+			// allow addition of new compatibility routines
+			return CompatibilityCheckResult.compatible();
+		}
+		if (!cur.isPresent()) {
+			// forbid removal of compatibility routines
+			return CompatibilityCheckResult.incompatible(
+				new AssertionError(String.format(
+					"Compatibility check container for routine %s not found in current version.", key)));
+		}
+
+		try {
+			assertion.accept(old.get(), cur.get());
+		} catch (final AssertionError e) {
+			final AssertionError backwardIncompatibilityCause = new AssertionError(key + ": " + e.getMessage());
+			return CompatibilityCheckResult.incompatible(backwardIncompatibilityCause);
+		}
+
+		try {
+			assertion.accept(cur.get(), old.get());
+			return CompatibilityCheckResult.identical();
+		} catch (final AssertionError e) {
+			return CompatibilityCheckResult.compatible();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/CompatibilityRoutines.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/CompatibilityRoutines.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.compatibility;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
+
+import org.junit.Assert;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Contains the compatibility checks that are applied by the {@link RestAPIStabilityTest}. New checks must be added to
+ * the {@link CompatibilityRoutines#ROUTINES} collection.
+ */
+enum CompatibilityRoutines {
+	;
+
+	private static final CompatibilityRoutine<String> URL_ROUTINE = new CompatibilityRoutine<>(
+		"url",
+		String.class,
+		RestHandlerSpecification::getTargetRestEndpointURL,
+		Assert::assertEquals);
+
+	private static final CompatibilityRoutine<String> METHOD_ROUTINE = new CompatibilityRoutine<>(
+		"method",
+		String.class,
+		header -> header.getHttpMethod().getNettyHttpMethod().name(),
+		Assert::assertEquals);
+
+	private static final CompatibilityRoutine<String> STATUS_CODE_ROUTINE = new CompatibilityRoutine<>(
+		"status-code",
+		String.class,
+		header -> header.getResponseStatusCode().toString(),
+		Assert::assertEquals);
+
+	private static final CompatibilityRoutine<Boolean> FILE_UPLOAD_ROUTINE = new CompatibilityRoutine<>(
+		"file-upload",
+		Boolean.class,
+		UntypedResponseMessageHeaders::acceptsFileUploads,
+		Assert::assertEquals);
+
+	private static final CompatibilityRoutine<PathParameterContainer> PATH_PARAMETER_ROUTINE = new CompatibilityRoutine<>(
+		"path-parameters",
+		PathParameterContainer.class,
+		header -> {
+			List<PathParameterContainer.PathParameter> pathParameters = header.getUnresolvedMessageParameters().getPathParameters().stream()
+				.map(param -> new PathParameterContainer.PathParameter(param.getKey()))
+				.collect(Collectors.toList());
+			return new PathParameterContainer(pathParameters);
+		},
+		CompatibilityRoutines::assertCompatible);
+
+	private static final CompatibilityRoutine<QueryParameterContainer> QUERY_PARAMETER_ROUTINE = new CompatibilityRoutine<>(
+		"query-parameters",
+		QueryParameterContainer.class,
+		header -> {
+			List<QueryParameterContainer.QueryParameter> pathParameters = header.getUnresolvedMessageParameters().getQueryParameters().stream()
+				.map(param -> new QueryParameterContainer.QueryParameter(param.getKey(), param.isMandatory()))
+				.collect(Collectors.toList());
+			return new QueryParameterContainer(pathParameters);
+		},
+		CompatibilityRoutines::assertCompatible);
+
+	private static final CompatibilityRoutine<JsonNode> REQUEST_ROUTINE = new CompatibilityRoutine<>(
+		"request",
+		JsonNode.class,
+		header -> extractSchema(header.getRequestClass()),
+		CompatibilityRoutines::assertCompatible
+	);
+
+	private static final CompatibilityRoutine<JsonNode> RESPONSE_ROUTINE = new CompatibilityRoutine<>(
+		"response",
+		JsonNode.class,
+		header -> extractSchema(header.getResponseClass()),
+		CompatibilityRoutines::assertCompatible
+	);
+
+	static final Collection<CompatibilityRoutine<?>> ROUTINES = Collections.unmodifiableList(Arrays.asList(
+		URL_ROUTINE,
+		METHOD_ROUTINE,
+		STATUS_CODE_ROUTINE,
+		FILE_UPLOAD_ROUTINE,
+		PATH_PARAMETER_ROUTINE,
+		QUERY_PARAMETER_ROUTINE,
+		REQUEST_ROUTINE,
+		RESPONSE_ROUTINE
+	));
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+	private static final JsonSchemaGenerator SCHEMA_GENERATOR = new JsonSchemaGenerator(OBJECT_MAPPER);
+
+	private static void assertCompatible(final PathParameterContainer old, final PathParameterContainer cur) {
+		for (final PathParameterContainer.PathParameter oldParam : old.pathParameters) {
+			if (cur.pathParameters.stream().noneMatch(param -> param.key.equals(oldParam.key))) {
+				Assert.fail(String.format(
+					"Existing Path parameter %s was removed.",
+					oldParam.key));
+			}
+		}
+		// contrary to other routines path parameters must be completely identical between versions, so we have to
+		// check both directions
+		for (final PathParameterContainer.PathParameter curParam : cur.pathParameters) {
+			if (old.pathParameters.stream().noneMatch(param -> param.key.equals(curParam.key))) {
+				Assert.fail(String.format(
+					"New path parameter %s was added.",
+					curParam.key));
+			}
+		}
+	}
+
+	private static void assertCompatible(final QueryParameterContainer old, final QueryParameterContainer cur) {
+		for (final QueryParameterContainer.QueryParameter oldParam : old.queryParameters) {
+			final Optional<QueryParameterContainer.QueryParameter> matchingParameter = cur.queryParameters.stream()
+				.filter(param -> param.key.equals(oldParam.key))
+				.findAny();
+
+			if (matchingParameter.isPresent()) {
+				final QueryParameterContainer.QueryParameter newParam = matchingParameter.get();
+				if (!oldParam.mandatory && newParam.mandatory) {
+					Assert.fail(String.format(
+						"Previously optional query parameter %s is now mandatory.",
+						oldParam.key));
+				}
+			} else {
+				Assert.fail(String.format(
+					"Query parameter %s was removed.",
+					oldParam.key));
+			}
+		}
+	}
+
+	private static JsonNode extractSchema(final Class<?> messageClass) {
+		try {
+			final JsonSchema schema = SCHEMA_GENERATOR.generateSchema(messageClass);
+
+			return OBJECT_MAPPER.valueToTree(schema);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Failed to generate message schema for class " + messageClass.getCanonicalName() + '.', e);
+		}
+	}
+
+	private static void assertCompatible(final JsonNode old, final JsonNode cur) {
+		final Deque<Tuple2<JsonNode, JsonNode>> stack = new ArrayDeque<>(8);
+		stack.add(Tuple2.of(old, cur));
+
+		while (!stack.isEmpty()) {
+			final Tuple2<JsonNode, JsonNode> propertyPair = stack.pop();
+
+			final JsonNode oldProperty = propertyPair.f0;
+			final JsonNode curProperty = propertyPair.f1;
+
+			Assert.assertNotNull("Field " + oldProperty + " was removed.", curProperty);
+
+			final String oldType = oldProperty.get("type").asText();
+			final String curType = curProperty.get("type").asText();
+
+			// 'any' as a type only occurs for properties where we have custom serialization code
+			// removing this custom code (and thus improving the schema) should be possible
+			// hence we only check equality for other types
+			if (!oldType.equals("any")) {
+				Assert.assertEquals(
+					String.format("Type of field was changed from '%s' to '%s'.", oldType, curType),
+					oldType, curType);
+			}
+
+			if (oldType.equals("array")) {
+				final JsonNode oldArrayItems = oldProperty.get("items");
+				final JsonNode curArrayItems = curProperty.get("items");
+
+				stack.addLast(Tuple2.of(
+					oldArrayItems,
+					curArrayItems));
+			} else if (oldType.equals("object")) {
+				final JsonNode oldProperties = oldProperty.get("properties");
+				final JsonNode curProperties = curProperty.get("properties");
+
+				if (oldProperties != null) {
+					for (Iterator<Map.Entry<String, JsonNode>> it = oldProperties.fields(); it.hasNext(); ) {
+						final Map.Entry<String, JsonNode> oldPropertyWithKey = it.next();
+						stack.addLast(Tuple2.of(
+							oldPropertyWithKey.getValue(),
+							curProperties.get(oldPropertyWithKey.getKey())));
+					}
+				}
+			} // else assume basic types
+		}
+	}
+
+	static final class PathParameterContainer {
+		public Collection<PathParameterContainer.PathParameter> pathParameters;
+
+		private PathParameterContainer() {
+			// required by jackson
+		}
+
+		PathParameterContainer(Collection<PathParameterContainer.PathParameter> pathParameters) {
+			this.pathParameters = pathParameters;
+		}
+
+		static final class PathParameter {
+			public String key;
+
+			private PathParameter() {
+				// required by jackson
+			}
+
+			PathParameter(String key) {
+				this.key = key;
+			}
+		}
+	}
+
+	static final class QueryParameterContainer {
+		public Collection<QueryParameterContainer.QueryParameter> queryParameters;
+
+		private QueryParameterContainer() {
+			// required by jackson
+		}
+
+		QueryParameterContainer(Collection<QueryParameterContainer.QueryParameter> queryParameters) {
+			this.queryParameters = queryParameters;
+		}
+
+		static final class QueryParameter {
+			public String key;
+			public boolean mandatory;
+
+			private QueryParameter() {
+			}
+
+			QueryParameter(String key, boolean mandatory) {
+				this.key = key;
+				this.mandatory = mandatory;
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/RestAPIStabilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/compatibility/RestAPIStabilityTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.compatibility;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.rest.util.DocumentingDispatcherRestEndpoint;
+import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Stability test and snapshot generator for the REST API.
+ */
+@RunWith(Parameterized.class)
+public final class RestAPIStabilityTest extends TestLogger {
+
+	private static final String REGENERATE_SNAPSHOT_PROPERTY = "generate-rest-snapshot";
+
+	private static final String SNAPSHOT_RESOURCE_PATTERN = "rest_api_%s.snapshot";
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	@Parameterized.Parameters(name = "version = {0}")
+	public static Iterable<RestAPIVersion> getStableVersions() {
+		return Arrays.stream(RestAPIVersion.values())
+			.filter(RestAPIVersion::isStableVersion)
+			.collect(Collectors.toList());
+	}
+
+	private final RestAPIVersion apiVersion;
+
+	public RestAPIStabilityTest(final RestAPIVersion apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+
+	@Test
+	public void testDispatcherRestAPIStability() throws IOException {
+		final String versionedSnapshotFileName = String.format(SNAPSHOT_RESOURCE_PATTERN, apiVersion.getURLVersionPrefix());
+
+		final RestAPISnapshot currentSnapshot = createSnapshot(new DocumentingDispatcherRestEndpoint());
+
+		if (System.getProperty(REGENERATE_SNAPSHOT_PROPERTY) != null) {
+			writeSnapshot(versionedSnapshotFileName, currentSnapshot);
+		}
+
+		final URL resource = RestAPIStabilityTest.class.getClassLoader().getResource(versionedSnapshotFileName);
+		if (resource == null) {
+			Assert.fail("Snapshot file does not exist. If you added a new version, re-run this test with" +
+				" -D" + REGENERATE_SNAPSHOT_PROPERTY + " being set.");
+		}
+		final RestAPISnapshot previousSnapshot = OBJECT_MAPPER.readValue(resource, RestAPISnapshot.class);
+
+		assertCompatible(previousSnapshot, currentSnapshot);
+	}
+
+	private static void writeSnapshot(final String versionedSnapshotFileName, final RestAPISnapshot snapshot) throws IOException {
+		OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
+			.writeValue(
+				new File("src/test/resources/" + versionedSnapshotFileName),
+				snapshot);
+		System.out.println("REST API snapshot " + versionedSnapshotFileName + " was updated, please remember to commit the snapshot.");
+	}
+
+	private RestAPISnapshot createSnapshot(final DocumentingRestEndpoint restEndpoint) {
+		final List<JsonNode> calls = restEndpoint.getSpecs().stream()
+			// we only compare compatibility within the given version
+			.filter(spec -> spec.getSupportedAPIVersions().contains(apiVersion))
+			.map(spec -> {
+				final ObjectNode json = OBJECT_MAPPER.createObjectNode();
+
+				for (final CompatibilityRoutine<?> routine : CompatibilityRoutines.ROUTINES) {
+					final Object extract = routine.getContainer(spec);
+					json.set(routine.getKey(), OBJECT_MAPPER.valueToTree(extract));
+				}
+
+				return json;
+			})
+			.collect(Collectors.toList());
+
+		return new RestAPISnapshot(calls);
+	}
+
+	private static void assertCompatible(final RestAPISnapshot old, final RestAPISnapshot cur) {
+		for (final JsonNode oldCall : old.calls) {
+			final List<Tuple2<JsonNode, CompatibilityCheckResult>> compatibilityCheckResults = cur.calls.stream()
+				.map(curCall -> Tuple2.of(curCall, checkCompatibility(oldCall, curCall)))
+				.collect(Collectors.toList());
+
+			if (compatibilityCheckResults.stream().allMatch(result -> result.f1.getBackwardCompatibility() == Compatibility.INCOMPATIBLE)) {
+				fail(oldCall, compatibilityCheckResults);
+			}
+
+			if (compatibilityCheckResults.stream().noneMatch(result -> result.f1.getBackwardCompatibility() == Compatibility.IDENTICAL)) {
+				Assert.fail("The API was modified in a compatible way, but the snapshot was not updated. " +
+					"To update the snapshot, re-run this test with -D" + REGENERATE_SNAPSHOT_PROPERTY + " being set.");
+			}
+		}
+	}
+
+	private static void fail(final JsonNode oldCall, final List<Tuple2<JsonNode, CompatibilityCheckResult>> compatibilityCheckResults) {
+		final StringBuilder sb = new StringBuilder();
+		sb.append("No compatible call could be found for " + oldCall + '.');
+		compatibilityCheckResults.stream()
+			.sorted(Collections.reverseOrder(Comparator.comparingInt(tuple -> tuple.f1.getBackwardCompatibilityGrade())))
+			.forEachOrdered(result -> {
+				sb.append(System.lineSeparator());
+				sb.append("\tRejected by candidate: " + result.f0 + '.');
+
+				sb.append(System.lineSeparator());
+				sb.append("\tCompatibility grade: " + result.f1.getBackwardCompatibilityGrade() + '/' + CompatibilityRoutines.ROUTINES.size());
+
+				sb.append(System.lineSeparator());
+				sb.append("\tIncompatibilities: ");
+
+				for (AssertionError error : result.f1.getBackwardCompatibilityErrors()) {
+					sb.append(System.lineSeparator());
+					sb.append("\t\t" + error.getMessage());
+				}
+			});
+		Assert.fail(sb.toString());
+	}
+
+	private static CompatibilityCheckResult checkCompatibility(final JsonNode oldCall, final JsonNode newCall) {
+		return CompatibilityRoutines.ROUTINES.stream()
+			.map(routine -> checkCompatibility(routine, oldCall, newCall))
+			.reduce(CompatibilityCheckResult::merge)
+			.get();
+	}
+
+	private static <X> CompatibilityCheckResult checkCompatibility(final CompatibilityRoutine<X> routine, final JsonNode oldCall, final JsonNode curCall) {
+		final Optional<X> old = readJson(routine, oldCall);
+		final Optional<X> cur = readJson(routine, curCall);
+
+		return routine.checkCompatibility(old, cur);
+	}
+
+	private static <X> Optional<X> readJson(final CompatibilityRoutine<X> routine, final JsonNode call) {
+		final Optional<JsonNode> jsonContainer = Optional.ofNullable(call.get(routine.getKey()));
+		return jsonContainer.map(container -> jsonToObject(container, routine.getContainerClass()));
+	}
+
+	private static <X> X jsonToObject(final JsonNode jsonContainer, final Class<X> containerClass) {
+		try {
+			return OBJECT_MAPPER.treeToValue(jsonContainer, containerClass);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	static final class RestAPISnapshot {
+		public List<JsonNode> calls;
+
+		private RestAPISnapshot() {
+			// required by jackson
+		}
+
+		RestAPISnapshot(List<JsonNode> calls) {
+			this.calls = calls;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.util;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.blob.TransientBlobService;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
+import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
+import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.VoidMetricFetcher;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ConfigurationException;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+/**
+ * Utility class to extract the {@link MessageHeaders} that the {@link DispatcherRestEndpoint} supports.
+ */
+public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint implements DocumentingRestEndpoint {
+
+	private static final Configuration config;
+	private static final RestServerEndpointConfiguration restConfig;
+	private static final RestHandlerConfiguration handlerConfig;
+	private static final GatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever;
+	private static final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
+
+	static {
+		config = new Configuration();
+		config.setString(RestOptions.ADDRESS, "localhost");
+		// necessary for loading the web-submission extension
+		config.setString(JobManagerOptions.ADDRESS, "localhost");
+		try {
+			restConfig = RestServerEndpointConfiguration.fromConfiguration(config);
+		} catch (ConfigurationException e) {
+			throw new RuntimeException("Implementation error. RestServerEndpointConfiguration#fromConfiguration failed for default configuration.");
+		}
+		handlerConfig = RestHandlerConfiguration.fromConfiguration(config);
+
+		dispatcherGatewayRetriever = () -> null;
+		resourceManagerGatewayRetriever = () -> null;
+	}
+
+	public DocumentingDispatcherRestEndpoint() throws IOException {
+		super(
+			restConfig,
+			dispatcherGatewayRetriever,
+			config,
+			handlerConfig,
+			resourceManagerGatewayRetriever,
+			NoOpTransientBlobService.INSTANCE,
+			Executors.newFixedThreadPool(1),
+			VoidMetricFetcher.INSTANCE,
+			NoOpElectionService.INSTANCE,
+			NoOpFatalErrorHandler.INSTANCE);
+	}
+
+	@Override
+	public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(final CompletableFuture<String> localAddressFuture) {
+		return super.initializeHandlers(localAddressFuture);
+	}
+
+	private enum NoOpElectionService implements LeaderElectionService {
+		INSTANCE;
+		@Override
+		public void start(final LeaderContender contender) throws Exception {
+
+		}
+
+		@Override
+		public void stop() throws Exception {
+
+		}
+
+		@Override
+		public void confirmLeaderSessionID(final UUID leaderSessionID) {
+
+		}
+
+		@Override
+		public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+			return false;
+		}
+	}
+
+	private enum NoOpFatalErrorHandler implements FatalErrorHandler {
+		INSTANCE;
+
+		@Override
+		public void onFatalError(final Throwable exception) {
+
+		}
+	}
+
+	/**
+	 * No-op implementation of {@link TransientBlobService}.
+	 */
+	private enum NoOpTransientBlobService implements TransientBlobService {
+		INSTANCE;
+
+		@Override
+		public File getFile(TransientBlobKey key) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public File getFile(JobID jobId, TransientBlobKey key) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TransientBlobKey putTransient(byte[] value) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TransientBlobKey putTransient(JobID jobId, byte[] value) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TransientBlobKey putTransient(InputStream inputStream) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TransientBlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean deleteFromCache(TransientBlobKey key) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean deleteFromCache(JobID jobId, TransientBlobKey key) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void close() throws IOException {}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -70,7 +70,7 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint im
 		try {
 			restConfig = RestServerEndpointConfiguration.fromConfiguration(config);
 		} catch (ConfigurationException e) {
-			throw new RuntimeException("Implementation error. RestServerEndpointConfiguration#fromConfiguration failed for default configuration.");
+			throw new RuntimeException("Implementation error. RestServerEndpointConfiguration#fromConfiguration failed for default configuration.", e);
 		}
 		handlerConfig = RestHandlerConfiguration.fromConfiguration(config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingRestEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.util;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.rest.RestServerEndpoint;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Interface to expose the supported {@link MessageHeaders} of a {@link RestServerEndpoint}.
+ */
+public interface DocumentingRestEndpoint {
+	List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(final CompletableFuture<String> localAddressFuture);
+
+	default List<MessageHeaders<?, ?, ?>> getSpecs() {
+		final Comparator<String> comparator = new RestServerEndpoint.RestHandlerUrlComparator.CaseInsensitiveOrderComparator();
+
+		return initializeHandlers(CompletableFuture.completedFuture(null)).stream()
+			.map(tuple -> tuple.f0)
+			.filter(spec -> spec instanceof MessageHeaders)
+			.map(spec -> (MessageHeaders<?, ?, ?>) spec)
+			.sorted((spec1, spec2) -> comparator.compare(spec1.getTargetRestEndpointURL(), spec2.getTargetRestEndpointURL()))
+			.collect(Collectors.toList());
+	}
+}

--- a/flink-runtime/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime/src/test/resources/rest_api_v1.snapshot
@@ -1,0 +1,2330 @@
+{
+  "calls" : [ {
+    "url" : "/cluster",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/config",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:DashboardConfiguration",
+      "properties" : {
+        "refresh-interval" : {
+          "type" : "integer"
+        },
+        "timezone-name" : {
+          "type" : "string"
+        },
+        "timezone-offset" : {
+          "type" : "integer"
+        },
+        "flink-version" : {
+          "type" : "string"
+        },
+        "flink-revision" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobmanager/config",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ClusterConfigurationInfoEntry",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobmanager/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:messages:webmonitor:JobIdsWithStatusOverview",
+      "properties" : {
+        "jobs" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:messages:webmonitor:JobIdsWithStatusOverview:JobIdWithStatus",
+            "properties" : {
+              "id" : {
+                "type" : "any"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "CREATED", "RUNNING", "FAILING", "FAILED", "CANCELLING", "CANCELED", "FINISHED", "RESTARTING", "SUSPENDED", "RECONCILING" ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs",
+    "method" : "POST",
+    "status-code" : "202 Accepted",
+    "file-upload" : true,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitRequestBody",
+      "properties" : {
+        "jobGraphFileName" : {
+          "type" : "string"
+        },
+        "jobJarFileNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "jobArtifactFileNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitRequestBody:DistributedCacheFile",
+            "properties" : {
+              "entryName" : {
+                "type" : "string"
+              },
+              "fileName" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitResponseBody",
+      "properties" : {
+        "jobUrl" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      }, {
+        "key" : "agg",
+        "mandatory" : false
+      }, {
+        "key" : "jobs",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/overview",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:messages:webmonitor:MultipleJobsDetails",
+      "properties" : {
+        "jobs" : {
+          "type" : "array",
+          "items" : {
+            "type" : "any"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobDetailsInfo",
+      "properties" : {
+        "jid" : {
+          "type" : "any"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "isStoppable" : {
+          "type" : "boolean"
+        },
+        "state" : {
+          "type" : "string",
+          "enum" : [ "CREATED", "RUNNING", "FAILING", "FAILED", "CANCELLING", "CANCELED", "FINISHED", "RESTARTING", "SUSPENDED", "RECONCILING" ]
+        },
+        "start-time" : {
+          "type" : "integer"
+        },
+        "end-time" : {
+          "type" : "integer"
+        },
+        "duration" : {
+          "type" : "integer"
+        },
+        "now" : {
+          "type" : "integer"
+        },
+        "timestamps" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer"
+          }
+        },
+        "vertices" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobDetailsInfo:JobVertexDetailsInfo",
+            "properties" : {
+              "id" : {
+                "type" : "any"
+              },
+              "name" : {
+                "type" : "string"
+              },
+              "parallelism" : {
+                "type" : "integer"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+              },
+              "start-time" : {
+                "type" : "integer"
+              },
+              "end-time" : {
+                "type" : "integer"
+              },
+              "duration" : {
+                "type" : "integer"
+              },
+              "tasks" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "integer"
+                }
+              },
+              "metrics" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "properties" : {
+                  "read-bytes" : {
+                    "type" : "integer"
+                  },
+                  "read-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-bytes" : {
+                    "type" : "integer"
+                  },
+                  "write-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "read-records" : {
+                    "type" : "integer"
+                  },
+                  "read-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-records" : {
+                    "type" : "integer"
+                  },
+                  "write-records-complete" : {
+                    "type" : "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "status-counts" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer"
+          }
+        },
+        "plan" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid",
+    "method" : "PATCH",
+    "status-code" : "202 Accepted",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "mode",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/:jobid/accumulators",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "includeSerializedValue",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobAccumulatorsInfo",
+      "properties" : {
+        "job-accumulators" : {
+          "type" : "array",
+          "items" : {
+            "type" : "any"
+          }
+        },
+        "user-task-accumulators" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobAccumulatorsInfo:UserTaskAccumulator",
+            "properties" : {
+              "name" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string"
+              },
+              "value" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "serialized-user-task-accumulators" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "any"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/checkpoints",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics",
+      "properties" : {
+        "counts" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:Counts",
+          "properties" : {
+            "restored" : {
+              "type" : "integer"
+            },
+            "total" : {
+              "type" : "integer"
+            },
+            "in_progress" : {
+              "type" : "integer"
+            },
+            "completed" : {
+              "type" : "integer"
+            },
+            "failed" : {
+              "type" : "integer"
+            }
+          }
+        },
+        "summary" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:Summary",
+          "properties" : {
+            "state_size" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics",
+              "properties" : {
+                "min" : {
+                  "type" : "integer"
+                },
+                "max" : {
+                  "type" : "integer"
+                },
+                "avg" : {
+                  "type" : "integer"
+                }
+              }
+            },
+            "end_to_end_duration" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            },
+            "alignment_buffered" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            }
+          }
+        },
+        "latest" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:LatestCheckpoints",
+          "properties" : {
+            "completed" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:CompletedCheckpointStatistics",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "status" : {
+                  "type" : "string",
+                  "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+                },
+                "is_savepoint" : {
+                  "type" : "boolean"
+                },
+                "trigger_timestamp" : {
+                  "type" : "integer"
+                },
+                "latest_ack_timestamp" : {
+                  "type" : "integer"
+                },
+                "state_size" : {
+                  "type" : "integer"
+                },
+                "end_to_end_duration" : {
+                  "type" : "integer"
+                },
+                "alignment_buffered" : {
+                  "type" : "integer"
+                },
+                "num_subtasks" : {
+                  "type" : "integer"
+                },
+                "num_acknowledged_subtasks" : {
+                  "type" : "integer"
+                },
+                "tasks" : {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "object",
+                    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics",
+                    "properties" : {
+                      "id" : {
+                        "type" : "integer"
+                      },
+                      "status" : {
+                        "type" : "string",
+                        "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+                      },
+                      "latest_ack_timestamp" : {
+                        "type" : "integer"
+                      },
+                      "state_size" : {
+                        "type" : "integer"
+                      },
+                      "end_to_end_duration" : {
+                        "type" : "integer"
+                      },
+                      "alignment_buffered" : {
+                        "type" : "integer"
+                      },
+                      "num_subtasks" : {
+                        "type" : "integer"
+                      },
+                      "num_acknowledged_subtasks" : {
+                        "type" : "integer"
+                      }
+                    }
+                  }
+                },
+                "external_path" : {
+                  "type" : "string"
+                },
+                "discarded" : {
+                  "type" : "boolean"
+                }
+              }
+            },
+            "savepoint" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:CompletedCheckpointStatistics"
+            },
+            "failed" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:FailedCheckpointStatistics",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "status" : {
+                  "type" : "string",
+                  "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+                },
+                "is_savepoint" : {
+                  "type" : "boolean"
+                },
+                "trigger_timestamp" : {
+                  "type" : "integer"
+                },
+                "latest_ack_timestamp" : {
+                  "type" : "integer"
+                },
+                "state_size" : {
+                  "type" : "integer"
+                },
+                "end_to_end_duration" : {
+                  "type" : "integer"
+                },
+                "alignment_buffered" : {
+                  "type" : "integer"
+                },
+                "num_subtasks" : {
+                  "type" : "integer"
+                },
+                "num_acknowledged_subtasks" : {
+                  "type" : "integer"
+                },
+                "tasks" : {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "object",
+                    "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics"
+                  }
+                },
+                "failure_timestamp" : {
+                  "type" : "integer"
+                },
+                "failure_message" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "restored" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:RestoredCheckpointStatistics",
+              "properties" : {
+                "id" : {
+                  "type" : "integer"
+                },
+                "restore_timestamp" : {
+                  "type" : "integer"
+                },
+                "is_savepoint" : {
+                  "type" : "boolean"
+                },
+                "external_path" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "history" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics",
+            "properties" : {
+              "id" : {
+                "type" : "integer"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+              },
+              "is_savepoint" : {
+                "type" : "boolean"
+              },
+              "trigger_timestamp" : {
+                "type" : "integer"
+              },
+              "latest_ack_timestamp" : {
+                "type" : "integer"
+              },
+              "state_size" : {
+                "type" : "integer"
+              },
+              "end_to_end_duration" : {
+                "type" : "integer"
+              },
+              "alignment_buffered" : {
+                "type" : "integer"
+              },
+              "num_subtasks" : {
+                "type" : "integer"
+              },
+              "num_acknowledged_subtasks" : {
+                "type" : "integer"
+              },
+              "tasks" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "object",
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/checkpoints/config",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointConfigInfo",
+      "properties" : {
+        "mode" : {
+          "type" : "any"
+        },
+        "interval" : {
+          "type" : "integer"
+        },
+        "timeout" : {
+          "type" : "integer"
+        },
+        "min_pause" : {
+          "type" : "integer"
+        },
+        "max_concurrent" : {
+          "type" : "integer"
+        },
+        "externalization" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointConfigInfo:ExternalizedCheckpointInfo",
+          "properties" : {
+            "enabled" : {
+              "type" : "boolean"
+            },
+            "delete_on_cancellation" : {
+              "type" : "boolean"
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/checkpoints/details/:checkpointid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "checkpointid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics",
+      "properties" : {
+        "id" : {
+          "type" : "integer"
+        },
+        "status" : {
+          "type" : "string",
+          "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+        },
+        "is_savepoint" : {
+          "type" : "boolean"
+        },
+        "trigger_timestamp" : {
+          "type" : "integer"
+        },
+        "latest_ack_timestamp" : {
+          "type" : "integer"
+        },
+        "state_size" : {
+          "type" : "integer"
+        },
+        "end_to_end_duration" : {
+          "type" : "integer"
+        },
+        "alignment_buffered" : {
+          "type" : "integer"
+        },
+        "num_subtasks" : {
+          "type" : "integer"
+        },
+        "num_acknowledged_subtasks" : {
+          "type" : "integer"
+        },
+        "tasks" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics",
+            "properties" : {
+              "id" : {
+                "type" : "integer"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+              },
+              "latest_ack_timestamp" : {
+                "type" : "integer"
+              },
+              "state_size" : {
+                "type" : "integer"
+              },
+              "end_to_end_duration" : {
+                "type" : "integer"
+              },
+              "alignment_buffered" : {
+                "type" : "integer"
+              },
+              "num_subtasks" : {
+                "type" : "integer"
+              },
+              "num_acknowledged_subtasks" : {
+                "type" : "integer"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/checkpoints/details/:checkpointid/subtasks/:vertexid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "checkpointid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails",
+      "properties" : {
+        "id" : {
+          "type" : "integer"
+        },
+        "status" : {
+          "type" : "string",
+          "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+        },
+        "latest_ack_timestamp" : {
+          "type" : "integer"
+        },
+        "state_size" : {
+          "type" : "integer"
+        },
+        "end_to_end_duration" : {
+          "type" : "integer"
+        },
+        "alignment_buffered" : {
+          "type" : "integer"
+        },
+        "num_subtasks" : {
+          "type" : "integer"
+        },
+        "num_acknowledged_subtasks" : {
+          "type" : "integer"
+        },
+        "summary" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails:Summary",
+          "properties" : {
+            "state_size" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics",
+              "properties" : {
+                "min" : {
+                  "type" : "integer"
+                },
+                "max" : {
+                  "type" : "integer"
+                },
+                "avg" : {
+                  "type" : "integer"
+                }
+              }
+            },
+            "end_to_end_duration" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            },
+            "checkpoint_duration" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails:CheckpointDuration",
+              "properties" : {
+                "sync" : {
+                  "type" : "object",
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                },
+                "async" : {
+                  "type" : "object",
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                }
+              }
+            },
+            "alignment" : {
+              "type" : "object",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails:CheckpointAlignment",
+              "properties" : {
+                "buffered" : {
+                  "type" : "object",
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                },
+                "duration" : {
+                  "type" : "object",
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                }
+              }
+            }
+          }
+        },
+        "subtasks" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:SubtaskCheckpointStatistics",
+            "properties" : {
+              "index" : {
+                "type" : "integer"
+              },
+              "status" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/config",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/:jobid/exceptions",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobExceptionsInfo",
+      "properties" : {
+        "root-exception" : {
+          "type" : "string"
+        },
+        "timestamp" : {
+          "type" : "integer"
+        },
+        "all-exceptions" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobExceptionsInfo:ExecutionExceptionInfo",
+            "properties" : {
+              "exception" : {
+                "type" : "string"
+              },
+              "task" : {
+                "type" : "string"
+              },
+              "location" : {
+                "type" : "string"
+              },
+              "timestamp" : {
+                "type" : "integer"
+              }
+            }
+          }
+        },
+        "truncated" : {
+          "type" : "boolean"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/execution-result",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobExecutionResultResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:queue:QueueStatus",
+          "required" : true,
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "required" : true,
+              "enum" : [ "IN_PROGRESS", "COMPLETED" ]
+            }
+          }
+        },
+        "job-execution-result" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/:jobid/plan",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo",
+      "properties" : {
+        "plan" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/rescaling",
+    "method" : "PATCH",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "parallelism",
+        "mandatory" : true
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:TriggerResponse",
+      "properties" : {
+        "request-id" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/rescaling/:triggerid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "triggerid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
+      "properties" : {
+        "status" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:queue:QueueStatus",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "required" : true,
+              "enum" : [ "IN_PROGRESS", "COMPLETED" ]
+            }
+          }
+        },
+        "operation" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/savepoints",
+    "method" : "POST",
+    "status-code" : "202 Accepted",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:savepoints:SavepointTriggerRequestBody",
+      "properties" : {
+        "target-directory" : {
+          "type" : "string"
+        },
+        "cancel-job" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:TriggerResponse",
+      "properties" : {
+        "request-id" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/savepoints/:triggerid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "triggerid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
+      "properties" : {
+        "status" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:queue:QueueStatus",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "required" : true,
+              "enum" : [ "IN_PROGRESS", "COMPLETED" ]
+            }
+          }
+        },
+        "operation" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexDetailsInfo",
+      "properties" : {
+        "id" : {
+          "type" : "any"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "parallelism" : {
+          "type" : "integer"
+        },
+        "now" : {
+          "type" : "integer"
+        },
+        "subtasks" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexDetailsInfo:VertexTaskDetail",
+            "properties" : {
+              "subtask" : {
+                "type" : "integer"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+              },
+              "attempt" : {
+                "type" : "integer"
+              },
+              "host" : {
+                "type" : "string"
+              },
+              "start-time" : {
+                "type" : "integer"
+              },
+              "end-time" : {
+                "type" : "integer"
+              },
+              "duration" : {
+                "type" : "integer"
+              },
+              "metrics" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "properties" : {
+                  "read-bytes" : {
+                    "type" : "integer"
+                  },
+                  "read-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-bytes" : {
+                    "type" : "integer"
+                  },
+                  "write-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "read-records" : {
+                    "type" : "integer"
+                  },
+                  "read-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-records" : {
+                    "type" : "integer"
+                  },
+                  "write-records-complete" : {
+                    "type" : "boolean"
+                  }
+                }
+              },
+              "start_time" : {
+                "type" : "integer"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/accumulators",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexAccumulatorsInfo",
+      "properties" : {
+        "id" : {
+          "type" : "string"
+        },
+        "user-accumulators" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:UserAccumulator",
+            "properties" : {
+              "name" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string"
+              },
+              "value" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/backpressure",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexBackPressureInfo",
+      "properties" : {
+        "status" : {
+          "type" : "string",
+          "enum" : [ "deprecated", "ok" ]
+        },
+        "backpressure-level" : {
+          "type" : "string",
+          "enum" : [ "ok", "low", "high" ]
+        },
+        "end-timestamp" : {
+          "type" : "integer"
+        },
+        "subtasks" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexBackPressureInfo:SubtaskBackPressureInfo",
+            "properties" : {
+              "subtask" : {
+                "type" : "integer"
+              },
+              "backpressure-level" : {
+                "type" : "string",
+                "enum" : [ "ok", "low", "high" ]
+              },
+              "ratio" : {
+                "type" : "number"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/accumulators",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtasksAllAccumulatorsInfo",
+      "properties" : {
+        "id" : {
+          "type" : "any"
+        },
+        "parallelism" : {
+          "type" : "integer"
+        },
+        "subtasks" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtasksAllAccumulatorsInfo:SubtaskAccumulatorsInfo",
+            "properties" : {
+              "subtask" : {
+                "type" : "integer"
+              },
+              "attempt" : {
+                "type" : "integer"
+              },
+              "host" : {
+                "type" : "string"
+              },
+              "user-accumulators" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:UserAccumulator",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "type" : {
+                      "type" : "string"
+                    },
+                    "value" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      }, {
+        "key" : "agg",
+        "mandatory" : false
+      }, {
+        "key" : "subtasks",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      }, {
+        "key" : "subtaskindex"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptDetailsInfo",
+      "properties" : {
+        "subtask" : {
+          "type" : "integer"
+        },
+        "status" : {
+          "type" : "string",
+          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+        },
+        "attempt" : {
+          "type" : "integer"
+        },
+        "host" : {
+          "type" : "string"
+        },
+        "start-time" : {
+          "type" : "integer"
+        },
+        "end-time" : {
+          "type" : "integer"
+        },
+        "duration" : {
+          "type" : "integer"
+        },
+        "metrics" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+          "properties" : {
+            "read-bytes" : {
+              "type" : "integer"
+            },
+            "read-bytes-complete" : {
+              "type" : "boolean"
+            },
+            "write-bytes" : {
+              "type" : "integer"
+            },
+            "write-bytes-complete" : {
+              "type" : "boolean"
+            },
+            "read-records" : {
+              "type" : "integer"
+            },
+            "read-records-complete" : {
+              "type" : "boolean"
+            },
+            "write-records" : {
+              "type" : "integer"
+            },
+            "write-records-complete" : {
+              "type" : "boolean"
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/attempts/:attempt",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      }, {
+        "key" : "subtaskindex"
+      }, {
+        "key" : "attempt"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptDetailsInfo",
+      "properties" : {
+        "subtask" : {
+          "type" : "integer"
+        },
+        "status" : {
+          "type" : "string",
+          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+        },
+        "attempt" : {
+          "type" : "integer"
+        },
+        "host" : {
+          "type" : "string"
+        },
+        "start-time" : {
+          "type" : "integer"
+        },
+        "end-time" : {
+          "type" : "integer"
+        },
+        "duration" : {
+          "type" : "integer"
+        },
+        "metrics" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+          "properties" : {
+            "read-bytes" : {
+              "type" : "integer"
+            },
+            "read-bytes-complete" : {
+              "type" : "boolean"
+            },
+            "write-bytes" : {
+              "type" : "integer"
+            },
+            "write-bytes-complete" : {
+              "type" : "boolean"
+            },
+            "read-records" : {
+              "type" : "integer"
+            },
+            "read-records-complete" : {
+              "type" : "boolean"
+            },
+            "write-records" : {
+              "type" : "integer"
+            },
+            "write-records-complete" : {
+              "type" : "boolean"
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/attempts/:attempt/accumulators",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      }, {
+        "key" : "subtaskindex"
+      }, {
+        "key" : "attempt"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptAccumulatorsInfo",
+      "properties" : {
+        "subtask" : {
+          "type" : "integer"
+        },
+        "attempt" : {
+          "type" : "integer"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "user-accumulators" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:UserAccumulator",
+            "properties" : {
+              "name" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string"
+              },
+              "value" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      }, {
+        "key" : "subtaskindex"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasktimes",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:SubtasksTimesInfo",
+      "properties" : {
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "now" : {
+          "type" : "integer"
+        },
+        "subtasks" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:SubtasksTimesInfo:SubtaskTimeInfo",
+            "properties" : {
+              "subtask" : {
+                "type" : "integer"
+              },
+              "host" : {
+                "type" : "string"
+              },
+              "duration" : {
+                "type" : "integer"
+              },
+              "timestamps" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/taskmanagers",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexTaskManagersInfo",
+      "properties" : {
+        "id" : {
+          "type" : "any"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "now" : {
+          "type" : "integer"
+        },
+        "taskmanagers" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexTaskManagersInfo:TaskManagersInfo",
+            "properties" : {
+              "host" : {
+                "type" : "string"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+              },
+              "start-time" : {
+                "type" : "integer"
+              },
+              "end-time" : {
+                "type" : "integer"
+              },
+              "duration" : {
+                "type" : "integer"
+              },
+              "metrics" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "properties" : {
+                  "read-bytes" : {
+                    "type" : "integer"
+                  },
+                  "read-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-bytes" : {
+                    "type" : "integer"
+                  },
+                  "write-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "read-records" : {
+                    "type" : "integer"
+                  },
+                  "read-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-records" : {
+                    "type" : "integer"
+                  },
+                  "write-records-complete" : {
+                    "type" : "boolean"
+                  }
+                }
+              },
+              "status-counts" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/overview",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:legacy:messages:ClusterOverviewWithVersion",
+      "properties" : {
+        "taskmanagers" : {
+          "type" : "integer"
+        },
+        "slots-total" : {
+          "type" : "integer"
+        },
+        "slots-available" : {
+          "type" : "integer"
+        },
+        "jobs-running" : {
+          "type" : "integer"
+        },
+        "jobs-finished" : {
+          "type" : "integer"
+        },
+        "jobs-cancelled" : {
+          "type" : "integer"
+        },
+        "jobs-failed" : {
+          "type" : "integer"
+        },
+        "flink-version" : {
+          "type" : "string"
+        },
+        "flink-commit" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/savepoint-disposal",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:savepoints:SavepointDisposalRequest",
+      "properties" : {
+        "savepoint-path" : {
+          "type" : "string"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:TriggerResponse",
+      "properties" : {
+        "request-id" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/savepoint-disposal/:triggerid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "triggerid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
+      "properties" : {
+        "status" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:queue:QueueStatus",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "required" : true,
+              "enum" : [ "IN_PROGRESS", "COMPLETED" ]
+            }
+          }
+        },
+        "operation" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/taskmanagers",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagersInfo",
+      "properties" : {
+        "taskmanagers" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerInfo",
+            "properties" : {
+              "id" : {
+                "type" : "any"
+              },
+              "path" : {
+                "type" : "string"
+              },
+              "dataPort" : {
+                "type" : "integer"
+              },
+              "timeSinceLastHeartbeat" : {
+                "type" : "integer"
+              },
+              "slotsNumber" : {
+                "type" : "integer"
+              },
+              "freeSlots" : {
+                "type" : "integer"
+              },
+              "hardware" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
+                "properties" : {
+                  "cpuCores" : {
+                    "type" : "integer"
+                  },
+                  "physicalMemory" : {
+                    "type" : "integer"
+                  },
+                  "freeMemory" : {
+                    "type" : "integer"
+                  },
+                  "managedMemory" : {
+                    "type" : "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/taskmanagers/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      }, {
+        "key" : "agg",
+        "mandatory" : false
+      }, {
+        "key" : "taskmanagers",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/taskmanagers/:taskmanagerid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "taskmanagerid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerDetailsInfo",
+      "properties" : {
+        "id" : {
+          "type" : "any"
+        },
+        "path" : {
+          "type" : "string"
+        },
+        "dataPort" : {
+          "type" : "integer"
+        },
+        "timeSinceLastHeartbeat" : {
+          "type" : "integer"
+        },
+        "slotsNumber" : {
+          "type" : "integer"
+        },
+        "freeSlots" : {
+          "type" : "integer"
+        },
+        "hardware" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
+          "properties" : {
+            "cpuCores" : {
+              "type" : "integer"
+            },
+            "physicalMemory" : {
+              "type" : "integer"
+            },
+            "freeMemory" : {
+              "type" : "integer"
+            },
+            "managedMemory" : {
+              "type" : "integer"
+            }
+          }
+        },
+        "metrics" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerMetricsInfo",
+          "properties" : {
+            "heapUsed" : {
+              "type" : "integer"
+            },
+            "heapCommitted" : {
+              "type" : "integer"
+            },
+            "heapMax" : {
+              "type" : "integer"
+            },
+            "nonHeapUsed" : {
+              "type" : "integer"
+            },
+            "nonHeapCommitted" : {
+              "type" : "integer"
+            },
+            "nonHeapMax" : {
+              "type" : "integer"
+            },
+            "directCount" : {
+              "type" : "integer"
+            },
+            "directUsed" : {
+              "type" : "integer"
+            },
+            "directMax" : {
+              "type" : "integer"
+            },
+            "mappedCount" : {
+              "type" : "integer"
+            },
+            "mappedUsed" : {
+              "type" : "integer"
+            },
+            "mappedMax" : {
+              "type" : "integer"
+            },
+            "memorySegmentsAvailable" : {
+              "type" : "integer"
+            },
+            "memorySegmentsTotal" : {
+              "type" : "integer"
+            },
+            "garbageCollectors" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerMetricsInfo:GarbageCollectorInfo",
+                "properties" : {
+                  "name" : {
+                    "type" : "string"
+                  },
+                  "count" : {
+                    "type" : "integer"
+                  },
+                  "time" : {
+                    "type" : "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/taskmanagers/:taskmanagerid/metrics",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "taskmanagerid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "get",
+        "mandatory" : false
+      } ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  } ]
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a stability test for the REST API to prevent API breaking changes.

The test operates against an API snapshot (created by the test if `-Dgenerate-rest-snapshot` is set).

One snapshot is created for each `RestAPIVersion`, each being an array of all supported rest calls.

The test verifies the following:
* URLs are not modified
* Methods are not modified
* StatusCodes are not modified
* file-upload flags are not modified
* set of path parameters is identical
* query parameters are neither removed nor upgraded from optional to mandatory
* fields are not removed request/response bodies nor their type changed (bar some exceptions)

The implementation of these checks can be found in `CompatibilityRoutines`.