### PR TITLE
[FLINK-11820][serialization] SimpleStringSchema handle message record which value is null

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
@@ -72,7 +72,7 @@ public class SimpleStringSchema implements DeserializationSchema<String>, Serial
 
 	@Override
 	public String deserialize(byte[] message) {
-		return new String(message, charset);
+		return message != null ? new String(message, charset) : null;
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/serialization/SimpleStringSchemaTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/serialization/SimpleStringSchemaTest.java
@@ -50,4 +50,12 @@ public class SimpleStringSchemaTest {
 
 		assertEquals(schema.getCharset(), copy.getCharset());
 	}
+
+	@Test
+	public void testDeserializeWithNullValue() throws Exception {
+		final SimpleStringSchema schema = new SimpleStringSchema();
+		final String value = schema.deserialize(null);
+
+		assertEquals(value, null);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

when kafka msg queue contains some records which value is null, `SimpleStringSchema` can't process these records.

for example, msg queue like bellow.
<table class="table table-bordered table-striped table-condensed">
    <tr>
        <td>msg</td>
        <td>null</td>
        <td>msg</td>
        <td>msg</td>
        <td>msg</td>
    </tr>
</table>

 for normal, use **SimpleStringSchema** to process msg queue data
```
env.addSource(new FlinkKafkaConsumer010("topic", new SimpleStringSchema(), properties));
```
 but, will get NullPointerException

```
java.lang.NullPointerException
	at java.lang.String.<init>(String.java:515)
	at org.apache.flink.api.common.serialization.SimpleStringSchema.deserialize(SimpleStringSchema.java:75)
	at org.apache.flink.api.common.serialization.SimpleStringSchema.deserialize(SimpleStringSchema.java:36)
```

