### PR TITLE
[FLINK-5018] Make source idle timeout user configurable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -58,4 +58,21 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 			return this;
 		}
 	}
+
+	public DataStreamSource<T> setIdleTimeout(long idleTimeout) {
+		if (idleTimeout < 0 && idleTimeout != -1) {
+			throw new IllegalArgumentException("The idle timeout " + idleTimeout + " is illegal, it should be larger " +
+				"than 0 or just set to -1.");
+		}
+
+		if (getTransformation() instanceof SourceTransformation) {
+			SourceTransformation sourceTransformation = (SourceTransformation) getTransformation();
+			sourceTransformation.getOperator().setIdleTimeout(idleTimeout);
+
+			return this;
+		} else {
+			throw new IllegalStateException("Can not get a SourceTransformation from DataStreamSource");
+		}
+	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -47,10 +47,20 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 
 	private transient volatile boolean canceledOrStopped = false;
 
+	private long idleTimeout = -1;
+
 	public StreamSource(SRC sourceFunction) {
 		super(sourceFunction);
 
 		this.chainingStrategy = ChainingStrategy.HEAD;
+	}
+
+	public long getIdleTimeout() {
+		return idleTimeout;
+	}
+
+	public void setIdleTimeout(long idleTimeout) {
+		this.idleTimeout = idleTimeout;
 	}
 
 	public void run(final Object lockingObject, final StreamStatusMaintainer streamStatusMaintainer) throws Exception {
@@ -87,7 +97,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>> extends Abstract
 			streamStatusMaintainer,
 			collector,
 			watermarkInterval,
-			-1);
+			getIdleTimeout());
 
 		try {
 			userFunction.run(ctx);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -65,6 +65,7 @@ import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.ProcessOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.streaming.api.windowing.triggers.CountTrigger;
@@ -1354,6 +1355,20 @@ public class DataStreamTest extends TestLogger {
 				Assert.assertEquals(10000L, (long) value);
 			}
 		});
+	}
+
+	@Test
+	public void testSetIdleTimeout() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStream<Long> input1 = env.generateSequence(0, 0).setIdleTimeout(1000L);
+
+		if (input1.getTransformation() instanceof SourceTransformation) {
+			SourceTransformation sourceTransformation = (SourceTransformation) input1.getTransformation();
+			assertEquals(1000, sourceTransformation.getOperator().getIdleTimeout());
+		} else {
+			fail("Can not get a SourceTransformation from DataStreamSource");
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes source idle timeout user configurable*

## Brief change log

  - *Provide setIdleTimeout method for DataStreamSource and getter/setter of idleTimeout for StreamSource*

## Verifying this change

This change is already covered by existing tests, such as *DataStreamTest#testSetIdleTimeout*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
