### PR TITLE
[FLINK-11928][Connectors / FileSystem]Create a Compression string writer for flink-connectors-filesystem

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriter.java
@@ -1,0 +1,71 @@
+package org.apache.flink.streaming.connectors.fs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.compress.CodecPool;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.io.compress.Compressor;
+
+import java.io.IOException;
+
+/**
+ * A base class that compresses the input element and write them to the filesystem. Default serialization is to
+ * write events separates by newline.
+ * Extends the class and override write() to make custom writing
+ */
+public class CompressionStringWriter<T> extends StreamWriterBase<T> implements Writer<T>{
+
+	private String codecName;
+
+	private transient CompressionOutputStream compressedOutputStream;
+
+	public CompressionStringWriter(String codecName) {
+		this.codecName = codecName;
+	}
+
+	protected CompressionStringWriter(CompressionStringWriter<T> other) {
+		super(other);
+		this.codecName = other.codecName;
+	}
+
+	@Override
+	public void open(FileSystem fs, Path path) throws IOException {
+		super.open(fs, path);
+		Configuration conf = fs.getConf();
+		if (!codecName.equals("None")) {
+			CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
+			CompressionCodec codec = codecFactory.getCodecByName(codecName);
+			if (codec == null) {
+				throw new RuntimeException("Codec " + codecName + " not found");
+			}
+			Compressor compressor = CodecPool.getCompressor(codec, conf);
+			compressedOutputStream = codec.createOutputStream(getStream(), compressor);
+
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (compressedOutputStream != null) {
+			compressedOutputStream.close();
+			compressedOutputStream = null;
+		} else {
+			super.close();
+		}
+	}
+
+	@Override
+	public void write(Object element) throws IOException {
+		getStream();
+		compressedOutputStream.write(element.toString().getBytes());
+		compressedOutputStream.write('\n');
+	}
+
+	@Override
+	public CompressionStringWriter<T> duplicate() {
+		return new CompressionStringWriter<>(this);
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriter.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriter.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.connectors.fs;
 
 import org.apache.hadoop.conf.Configuration;

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.fs;
 
 import org.junit.Test;
+
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
@@ -1,0 +1,26 @@
+package org.apache.flink.streaming.connectors.fs;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+// import static junit.framework.TestCase.assertTrue;
+
+/**
+ * Tests for {@link CompressionStringWriter}.
+ */
+public class CompressionStringWriterTest {
+
+	@Test
+	public void testDuplicate() {
+		CompressionStringWriter<String> writer = new CompressionStringWriter<>("Gzip", "\n");
+		writer.setSyncOnFlush(true);
+		CompressionStringWriter<String> other = writer.duplicate();
+
+		assertTrue(StreamWriterBaseComparator.equals(writer, other));
+		writer.setSyncOnFlush(false);
+		assertFalse(StreamWriterBaseComparator.equals(writer, other));
+	}
+
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.connectors.fs;
 
 import org.junit.Test;

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/CompressionStringWriterTest.java
@@ -19,11 +19,8 @@
 package org.apache.flink.streaming.connectors.fs;
 
 import org.junit.Test;
-
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
-
-// import static junit.framework.TestCase.assertTrue;
 
 /**
  * Tests for {@link CompressionStringWriter}.

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/StreamWriterBaseComparator.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/StreamWriterBaseComparator.java
@@ -57,4 +57,12 @@ public class StreamWriterBaseComparator {
 		return equals((StreamWriterBase) writer1, (StreamWriterBase) writer2) &&
 			Objects.equals(writer1.getCharsetName(), writer2.getCharsetName());
 	}
+
+	public static<T> boolean equals(
+		CompressionStringWriter<T> writer1,
+		CompressionStringWriter<T> writer2) {
+		return equals((StreamWriterBase) writer1, (StreamWriterBase) writer2) &&
+			Objects.equals(writer1.getCodecName(), writer2.getCodecName()) &&
+			Objects.equals(writer1.getSeparator(), writer2.getSeparator());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request is to create a CompressedStringWriter which allows user to use it or its subclass to compressed the stream to filesystem.

## Brief change log

*(for example:)*
  - A new compressed string writer is created to write compressed stream to file system

## Verifying this change

This change added tests and can be verified as follows:
  - *Manually verified the change by running a compressed streaming job which sinks to HDFS by using 10-node flink on yarn.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  JavaDocs
