### PR TITLE
[FLINK-10019][SQL/Planner] Fix singleton row type objects returned from expression cannot be chained with other operators

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
@@ -330,6 +330,18 @@ object Func22 extends ScalarFunction {
   }
 }
 
+object Func23 extends ScalarFunction {
+  def eval(row: Row): Row = {
+    row
+  }
+
+  override def getParameterTypes(signature: Array[Class[_]]): Array[TypeInformation[_]] =
+    Array(Types.ROW(Types.INT))
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    Types.ROW(Types.INT)
+}
+
 class SplitUDF(deterministic: Boolean) extends ScalarFunction {
   def eval(x: String, sep: String, index: Int): String = {
     val splits = StringUtils.splitByWholeSeparator(x, sep)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -25,10 +25,10 @@ import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.scala._
 import org.apache.flink.table.descriptors.{Rowtime, Schema}
-import org.apache.flink.table.expressions.utils.Func15
+import org.apache.flink.table.expressions.utils.{Func15, Func23}
 import org.apache.flink.table.runtime.stream.sql.SqlITCase.TimestampAndWatermarkWithOffset
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.MultiArgCount
 import org.apache.flink.table.runtime.utils.TimeTestUtil.EventTimeSourceFunction
@@ -219,6 +219,34 @@ class SqlITCase extends StreamingWithStateTestBase {
     env.execute()
 
     val expected = List("Hello,Worlds,1","Hello again,Worlds,2")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowTypeResultSingletonCollectionChainedWithOperation(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = StreamTableEnvironment.create(env)
+    StreamITCase.clear
+
+    val data = List(
+      Row.of(
+        Row.of(12.asInstanceOf[Integer]),
+        "second_field"))
+
+    val stream = env.fromCollection(data)(Types.ROW(
+      Types.ROW(Types.INT),
+      Types.STRING
+    ))
+    val table = stream.toTable(tEnv, 'a, 'b)
+    tEnv.registerFunction("func", Func23)
+    tEnv.registerTable("t", table)
+
+    val results = tEnv.sqlQuery("SELECT func(a) as myRow FROM t").toAppendStream[Row]
+    results.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = List("12")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
     


### PR DESCRIPTION
## What is the purpose of the change

This PR adds tests to ensure that singleton Row type returned objects from expression, such as a UDF, should be successfully parsed and executed. 

For example: 
`MyUDF(myArg).f0` should not fail if MyUDF returns singleton Row. such as `Row.of(1)`

See [CALCITE-2468](https://issues.apache.org/jira/browse/CALCITE-2468).


## Brief change log

  - This PR adds test/ITCase for the above mentioned example.


## Verifying this change

This change only adds tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
