### PR TITLE
[FLINK-11871][table-runtime-blink] Introduce LongHybridHashTable to improve performance when join key fits in long

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryFormat.java
@@ -42,7 +42,7 @@ public abstract class BinaryFormat {
 	 * To get the mark in highest bit of long.
 	 * Form: 10000000 00000000 ... (8 bytes)
 	 *
-	 * This is used to decide whether the data is stored in fixed-length part or variable-length
+	 * <p>This is used to decide whether the data is stored in fixed-length part or variable-length
 	 * part. see {@link #MAX_FIX_PART_DATA_SIZE} for more information.
 	 */
 	private static final long HIGHEST_FIRST_BIT = 0x80L << 56;
@@ -51,7 +51,7 @@ public abstract class BinaryFormat {
 	 * To get the 7 bits length in second bit to eighth bit out of a long.
 	 * Form: 01111111 00000000 ... (8 bytes)
 	 *
-	 * This is used to get the length of the data which is stored in this long.
+	 * <p>This is used to get the length of the data which is stored in this long.
 	 * see {@link #MAX_FIX_PART_DATA_SIZE} for more information.
 	 */
 	private static final long HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryFormat.java
@@ -29,24 +29,30 @@ public abstract class BinaryFormat {
 	 * It decides whether to put data in FixLenPart or VarLenPart. See more in {@link BinaryRow}.
 	 *
 	 * <p>If len is less than 8, its binary format is:
-	 * 1bit mark(1) = 1, 7bits len, and 7bytes data.
+	 * 1-bit mark(1) = 1, 7-bits len, and 7-bytes data.
 	 * Data is stored in fix-length part.
 	 *
 	 * <p>If len is greater or equal to 8, its binary format is:
-	 * 1bit mark(1) = 0, 31bits offset, and 4bytes len.
+	 * 1-bit mark(1) = 0, 31-bits offset to the data, and 4-bytes length of data.
 	 * Data is stored in variable-length part.
 	 */
 	static final int MAX_FIX_PART_DATA_SIZE = 7;
 
 	/**
-	 * To get the mark in highest first bit.
-	 * Form: 1000 0000 0000 0000 ...
+	 * To get the mark in highest bit of long.
+	 * Form: 10000000 00000000 ... (8 bytes)
+	 *
+	 * This is used to decide whether the data is stored in fixed-length part or variable-length
+	 * part. see {@link #MAX_FIX_PART_DATA_SIZE} for more information.
 	 */
-	private static final long HIGHEST_FIRST_BIT = Long.MIN_VALUE;
+	private static final long HIGHEST_FIRST_BIT = 0x80L << 56;
 
 	/**
-	 * To get the 7 bits length in second bit to eighth bit.
-	 * Form: 0111 1111 0000 0000 ...
+	 * To get the 7 bits length in second bit to eighth bit out of a long.
+	 * Form: 01111111 00000000 ... (8 bytes)
+	 *
+	 * This is used to get the length of the data which is stored in this long.
+	 * see {@link #MAX_FIX_PART_DATA_SIZE} for more information.
 	 */
 	private static final long HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
@@ -337,8 +337,13 @@ public class BinaryHashPartition extends AbstractPagedInputView implements Seeka
 			// close the channel.
 			this.buildSideChannel.close();
 
-			this.probeSideBuffer = FileChannelUtil.createOutputView(ioAccess, probeChannelEnumerator.next(),
-																	compressionEnable, compressionCodecFactory, compressionBlockSize, memorySegmentSize);
+			this.probeSideBuffer = FileChannelUtil.createOutputView(
+					ioAccess,
+					probeChannelEnumerator.next(),
+					compressionEnable,
+					compressionCodecFactory,
+					compressionBlockSize,
+					memorySegmentSize);
 			return 1;
 		} else {
 			return 0;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -653,10 +653,6 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		}
 	}
 
-//	public void append(long key, BinaryRow row) throws IOException {
-//		insertIntoTable(key, hashLong(key, recursionLevel), row);
-//	}
-
 	// ------------------ PagedInputView for read end --------------------
 
 	/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -140,18 +140,20 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			double estimatedRowCount,
 			int maxSegs,
 			int recursionLevel) {
-		this(longTable,
-			 partitionNum,
-			 buildSideSerializer,
-			 getBucketBuffersByRowCount((long) estimatedRowCount, maxSegs, longTable.pageSize()),
-			 recursionLevel,
-			 null,
-			 0);
+		this(
+				longTable,
+				partitionNum,
+				buildSideSerializer,
+				getBucketBuffersByRowCount((long) estimatedRowCount, maxSegs, longTable.pageSize()),
+				recursionLevel,
+				null,
+				0);
 		this.buildSideWriteBuffer = new BuildSideBuffer(longTable.nextSegment());
 	}
 
 	/**
-	 * Entrance 2: build table from spilled partition when the partition fits entirely into main memory.
+	 * Entrance 2: build table from spilled partition when the partition fits entirely into main
+	 * memory.
 	 */
 	LongHashPartition(
 			LongHybridHashTable longTable,
@@ -288,7 +290,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 			int size,
 			MemorySegment dataSegment,
 			int currentPositionInSegment) throws IOException {
-		assert(numKeys <= numBuckets / 2);
+		assert (numKeys <= numBuckets / 2);
 		int bucketId = hashCode & numBucketsMask;
 
 		// each bucket occupied 16 bytes (long key + long pointer to data address)
@@ -468,10 +470,13 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 
 	/**
 	 * After build phase.
+	 *
 	 * @return build spill return buffer, if have spilled, it returns the current write buffer,
 	 * because it was used all the time in build phase, so it can only be returned at this time.
 	 */
-	int finalizeBuildPhase(IOManager ioAccess, FileIOChannel.Enumerator probeChannelEnumerator) throws IOException {
+	int finalizeBuildPhase(
+			IOManager ioAccess,
+			FileIOChannel.Enumerator probeChannelEnumerator) throws IOException {
 		this.finalBufferLimit = this.buildSideWriteBuffer.getCurrentPositionInSegment();
 		this.partitionBuffers = this.buildSideWriteBuffer.close();
 
@@ -551,7 +556,9 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		return buildSideChannel == null;
 	}
 
-	final void insertIntoProbeBuffer(BinaryRowSerializer probeSer, BinaryRow record) throws IOException {
+	final void insertIntoProbeBuffer(
+			BinaryRowSerializer probeSer,
+			BinaryRow record) throws IOException {
 		probeSer.serialize(record, this.probeSideBuffer);
 		this.probeSideRecordCounter++;
 	}
@@ -887,7 +894,8 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		reuse.pointTo(segment, 0, length);
 	}
 
-	void iteratorToDenseBucket(MemorySegment[] denseBuckets, long addressOffset, long globalMinKey) {
+	void iteratorToDenseBucket(MemorySegment[] denseBuckets, long addressOffset,
+			long globalMinKey) {
 		int bucketOffset = 0;
 		MemorySegment segment = buckets[bucketOffset];
 		int segOffset = 0;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -1,0 +1,939 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.hashtable;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.SeekableDataInputView;
+import org.apache.flink.runtime.io.disk.iomanager.AbstractChannelWriterOutputView;
+import org.apache.flink.runtime.io.disk.iomanager.BlockChannelWriter;
+import org.apache.flink.runtime.io.disk.iomanager.BulkBlockChannelReader;
+import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;
+import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.memory.AbstractPagedInputView;
+import org.apache.flink.runtime.memory.AbstractPagedOutputView;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.table.runtime.util.RowIterator;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.apache.flink.table.runtime.hashtable.LongHybridHashTable.hashLong;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Partition for {@link LongHybridHashTable}.
+ *
+ * <p>The layout of the buckets inside a memory segment is as follows:</p>
+ *
+ * <p>Hash mode:
+ * +----------------------------- Bucket area ----------------------------
+ * | long key (8 bytes) | address (8 bytes) |
+ * | long key (8 bytes) | address (8 bytes) |
+ * | long key (8 bytes) | address (8 bytes) |
+ * | ...
+ * +----------------------------- Data area --------------------------
+ * | size & address of next row with the same key (8bytes) | binary row |
+ * | size & address of next row with the same key (8bytes) | binary row |
+ * | size & address of next row with the same key (8bytes) | binary row |
+ * | ...
+ *
+ * <p>Dense mode:
+ * +----------------------------- Bucket area ----------------------------
+ * | address1 (8 bytes) | address2 (8 bytes) | address3 (8 bytes) | ...
+ * Directly addressed by the index of the corresponding array of key values.
+ */
+public class LongHashPartition extends AbstractPagedInputView implements SeekableDataInputView {
+
+	private static final Logger LOG = LoggerFactory.getLogger(LongHashPartition.class);
+
+	// The number of bits for size in address
+	private static final int SIZE_BITS = 28;
+	private static final int SIZE_MASK = 0xfffffff;
+
+	// bucket element size in sparse mode: long key (8 bytes) + address pointer (8 bytes)
+	private static final int SPARSE_BUCKET_ELEMENT_SIZE_IN_BYTES = 16;
+
+	static final long INVALID_ADDRESS = 0x00000FFFFFFFFFL;
+
+	private final LongHybridHashTable longTable;
+
+	// segment size related properties
+	private final int segmentSize;
+	private final int segmentSizeBits;
+	private final int segmentSizeMask;
+
+	private int partitionNum;
+	private final BinaryRowSerializer buildSideSerializer;
+	private final BinaryRow buildReuseRow;
+	private int recursionLevel;
+
+	// The minimum key
+	private long minKey = Long.MAX_VALUE;
+
+	// The maximum key
+	private long maxKey = Long.MIN_VALUE;
+
+	// The bucket area for this partition
+	private MemorySegment[] buckets;
+	private int numBuckets;
+	private int numBucketsMask;
+
+	// The in-memory data area for this partition
+	private MemorySegment[] partitionBuffers;
+
+	private int finalBufferLimit;
+	private int currentBufferNum;
+	private BuildSideBuffer buildSideWriteBuffer;
+	AbstractChannelWriterOutputView probeSideBuffer;
+	long probeSideRecordCounter; // number of probe-side records in this partition
+
+	// The number of unique keys.
+	private long numKeys;
+
+	private final MatchIterator iterator;
+
+	// the channel writer for the build side, if partition is spilled
+	private BlockChannelWriter<MemorySegment> buildSideChannel;
+
+	// number of build-side records in this partition
+	private long buildSideRecordCounter;
+
+	int probeNumBytesInLastSeg;
+
+	/**
+	 * Entrance 1: Init LongHashPartition for new insert and search.
+	 */
+	LongHashPartition(
+			LongHybridHashTable longTable,
+			int partitionNum,
+			BinaryRowSerializer buildSideSerializer,
+			double estimatedRowCount,
+			int maxSegs,
+			int recursionLevel) {
+		this(longTable,
+			 partitionNum,
+			 buildSideSerializer,
+			 getBucketBuffersByRowCount((long) estimatedRowCount, maxSegs, longTable.pageSize()),
+			 recursionLevel,
+			 null,
+			 0);
+		this.buildSideWriteBuffer = new BuildSideBuffer(longTable.nextSegment());
+	}
+
+	/**
+	 * Entrance 2: build table from spilled partition when the partition fits entirely into main memory.
+	 */
+	LongHashPartition(
+			LongHybridHashTable longTable,
+			int partitionNum,
+			BinaryRowSerializer buildSideSerializer,
+			int bucketNumSegs,
+			int recursionLevel,
+			List<MemorySegment> buffers,
+			int lastSegmentLimit) {
+		this(longTable, buildSideSerializer, listToArray(buffers));
+		this.partitionNum = partitionNum;
+		this.recursionLevel = recursionLevel;
+
+		int numBuckets = MathUtils.roundDownToPowerOf2(bucketNumSegs * segmentSize / 16);
+		MemorySegment[] buckets = new MemorySegment[bucketNumSegs];
+		for (int i = 0; i < bucketNumSegs; i++) {
+			buckets[i] = longTable.nextSegment();
+		}
+		setNewBuckets(buckets, numBuckets);
+		this.finalBufferLimit = lastSegmentLimit;
+	}
+
+	/**
+	 * Entrance 3: dense mode for just data search (bucket in LongHybridHashTable of dense mode).
+	 */
+	LongHashPartition(
+			LongHybridHashTable longTable,
+			BinaryRowSerializer buildSideSerializer,
+			MemorySegment[] partitionBuffers) {
+		super(0);
+		this.longTable = longTable;
+		this.buildSideSerializer = buildSideSerializer;
+		this.buildReuseRow = buildSideSerializer.createInstance();
+		this.segmentSize = longTable.pageSize();
+		Preconditions.checkArgument(segmentSize % 16 == 0);
+		this.partitionBuffers = partitionBuffers;
+		this.segmentSizeBits = MathUtils.log2strict(segmentSize);
+		this.segmentSizeMask = segmentSize - 1;
+		this.finalBufferLimit = segmentSize;
+		this.iterator = new MatchIterator();
+	}
+
+	private static MemorySegment[] listToArray(List<MemorySegment> list) {
+		if (list != null) {
+			return list.toArray(new MemorySegment[list.size()]);
+		}
+		return null;
+	}
+
+	private static int getBucketBuffersByRowCount(long rowCount, int maxSegs, int segmentSize) {
+		int minNumBuckets = (int) Math.ceil((rowCount / 0.5));
+		Preconditions.checkArgument(segmentSize % 16 == 0);
+		return MathUtils.roundDownToPowerOf2((int) Math.max(1,
+				Math.min(maxSegs, Math.ceil(((double) minNumBuckets) * 16 / segmentSize))));
+	}
+
+	private void setNewBuckets(MemorySegment[] buckets, int numBuckets) {
+		for (MemorySegment segment : buckets) {
+			for (int i = 0; i < segmentSize; i += 16) {
+				// Maybe we don't need init key, cause always verify address
+				segment.putLong(i, 0);
+				segment.putLong(i + 8, INVALID_ADDRESS);
+			}
+		}
+		this.buckets = buckets;
+		checkArgument(MathUtils.isPowerOf2(numBuckets));
+		this.numBuckets = numBuckets;
+		this.numBucketsMask = numBuckets - 1;
+		this.numKeys = 0;
+	}
+
+	static long toAddrAndLen(long address, int size) {
+		return (address << SIZE_BITS) | size;
+	}
+
+	static long toAddress(long addrAndLen) {
+		return addrAndLen >>> SIZE_BITS;
+	}
+
+	static int toLength(long addrAndLen) {
+		return (int) (addrAndLen & SIZE_MASK);
+	}
+
+	/**
+	 * Returns an iterator of BinaryRow for multiple linked values.
+	 */
+	MatchIterator valueIter(long address) {
+		iterator.set(address);
+		return iterator;
+	}
+
+//	public MatchIterator get(long key) {
+//		return get(key, hashLong(key, recursionLevel));
+//	}
+
+	/**
+	 * Returns an iterator for all the values for the given key, or null if no value found.
+	 */
+	public MatchIterator get(long key, int hashCode) {
+		int bucket = hashCode & numBucketsMask;
+
+		int bucketOffset = bucket << 4;
+		MemorySegment segment = buckets[bucketOffset >>> segmentSizeBits];
+		int segOffset = bucketOffset & segmentSizeMask;
+
+		while (true) {
+			long address = segment.getLong(segOffset + 8);
+			if (address != INVALID_ADDRESS) {
+				if (segment.getLong(segOffset) == key) {
+					return valueIter(address);
+				} else {
+					bucket = (bucket + 1) & numBucketsMask;
+					if (segOffset + 16 < segmentSize) {
+						segOffset += 16;
+					} else {
+						bucketOffset = bucket << 4;
+						segOffset = bucketOffset & segmentSizeMask;
+						segment = buckets[bucketOffset >>> segmentSizeBits];
+					}
+				}
+			} else {
+				return valueIter(INVALID_ADDRESS);
+			}
+		}
+	}
+
+	/**
+	 * Update the address in array for given key.
+	 */
+	private void updateIndex(
+			long key,
+			int hashCode,
+			long address,
+			int size,
+			MemorySegment dataSegment,
+			int currentPositionInSegment) throws IOException {
+		assert(numKeys <= numBuckets / 2);
+		int bucketId = hashCode & numBucketsMask;
+
+		// each bucket occupied 16 bytes (long key + long pointer to data address)
+		int bucketOffset = bucketId * SPARSE_BUCKET_ELEMENT_SIZE_IN_BYTES;
+		MemorySegment segment = buckets[bucketOffset >>> segmentSizeBits];
+		int segOffset = bucketOffset & segmentSizeMask;
+		long currAddress;
+
+		while (true) {
+			currAddress = segment.getLong(segOffset + 8);
+			if (segment.getLong(segOffset) != key && currAddress != INVALID_ADDRESS) {
+				// hash conflicts, the bucket is occupied by another key
+
+				// TODO test Conflict resolution:
+				// now:    +1 +1 +1... cache friendly but more conflict, so we set factor to 0.5
+				// other1: +1 +2 +3... less conflict, factor can be 0.75
+				// other2: Secondary hashCode... less and less conflict, but need compute hash again
+				bucketId = (bucketId + 1) & numBucketsMask;
+				if (segOffset + SPARSE_BUCKET_ELEMENT_SIZE_IN_BYTES < segmentSize) {
+					// if the new bucket still in current segment, we only need to update offset
+					// within this segment
+					segOffset += SPARSE_BUCKET_ELEMENT_SIZE_IN_BYTES;
+				} else {
+					// otherwise, we should re-calculate segment and offset
+					bucketOffset = bucketId * 16;
+					segment = buckets[bucketOffset >>> segmentSizeBits];
+					segOffset = bucketOffset & segmentSizeMask;
+				}
+			} else {
+				break;
+			}
+		}
+		if (currAddress == INVALID_ADDRESS) {
+			// this is the first value for this key, put the address in array.
+			segment.putLong(segOffset, key);
+			segment.putLong(segOffset + 8, address);
+			numKeys += 1;
+			// dataSegment may be null if we only have to rehash bucket area
+			if (dataSegment != null) {
+				dataSegment.putLong(currentPositionInSegment, toAddrAndLen(INVALID_ADDRESS, size));
+			}
+			if (numKeys * 2 > numBuckets) {
+				resize();
+			}
+		} else {
+			// there are some values for this key, put the address in the front of them.
+			dataSegment.putLong(currentPositionInSegment, toAddrAndLen(currAddress, size));
+			segment.putLong(segOffset + 8, address);
+		}
+	}
+
+	private void resize() throws IOException {
+		MemorySegment[] oldBuckets = this.buckets;
+		int oldNumBuckets = numBuckets;
+		int newNumSegs = oldBuckets.length * 2;
+		int newNumBuckets = MathUtils.roundDownToPowerOf2(newNumSegs * segmentSize / 16);
+
+		// request new buckets.
+		MemorySegment[] newBuckets = new MemorySegment[newNumSegs];
+		for (int i = 0; i < newNumSegs; i++) {
+			MemorySegment seg = longTable.getNextBuffer();
+			if (seg == null) {
+				final int spilledPart = longTable.spillPartition();
+				if (spilledPart == partitionNum) {
+					// this bucket is no longer in-memory
+					// free new segments.
+					longTable.returnAll(Arrays.asList(newBuckets));
+					return;
+				}
+				seg = longTable.getNextBuffer();
+				if (seg == null) {
+					throw new RuntimeException(
+							"Bug in HybridHashJoin: No memory became available after spilling a partition.");
+				}
+			}
+			newBuckets[i] = seg;
+		}
+
+		setNewBuckets(newBuckets, newNumBuckets);
+		reHash(oldBuckets, oldNumBuckets);
+	}
+
+	private void reHash(MemorySegment[] oldBuckets, int oldNumBuckets) throws IOException {
+		long reHashStartTime = System.currentTimeMillis();
+		int bucketOffset = 0;
+		MemorySegment segment = oldBuckets[bucketOffset];
+		int segOffset = 0;
+		for (int i = 0; i < oldNumBuckets; i++) {
+			long address = segment.getLong(segOffset + 8);
+			if (address != INVALID_ADDRESS) {
+				long key = segment.getLong(segOffset);
+				// size/dataSegment/currentPositionInSegment should never be used.
+				updateIndex(key, hashLong(key, recursionLevel), address, 0, null, 0);
+			}
+
+			// not last bucket, move to next.
+			if (i != oldNumBuckets - 1) {
+				if (segOffset + 16 < segmentSize) {
+					segOffset += 16;
+				} else {
+					segment = oldBuckets[++bucketOffset];
+					segOffset = 0;
+				}
+			}
+		}
+
+		longTable.returnAll(Arrays.asList(oldBuckets));
+		LOG.info("The rehash take {} ms for {} segments", (System.currentTimeMillis() - reHashStartTime), numBuckets);
+	}
+
+	public MemorySegment[] getBuckets() {
+		return buckets;
+	}
+
+	int getBuildSideBlockCount() {
+		return this.partitionBuffers == null ? this.buildSideWriteBuffer.getBlockCount()
+				: this.partitionBuffers.length;
+	}
+
+	int getProbeSideBlockCount() {
+		return this.probeSideBuffer == null ? -1 : this.probeSideBuffer.getBlockCount();
+	}
+
+	BlockChannelWriter<MemorySegment> getBuildSideChannel() {
+		return this.buildSideChannel;
+	}
+
+	FileIOChannel.ID getProbeSideChannelID() {
+		return probeSideBuffer.getChannel().getChannelID();
+	}
+
+	int getPartitionNumber() {
+		return this.partitionNum;
+	}
+
+	MemorySegment[] getPartitionBuffers() {
+		return partitionBuffers;
+	}
+
+	int getRecursionLevel() {
+		return this.recursionLevel;
+	}
+
+	int getNumOccupiedMemorySegments() {
+		// either the number of memory segments, or one for spilling
+		final int numPartitionBuffers = this.partitionBuffers != null ?
+				this.partitionBuffers.length
+				: this.buildSideWriteBuffer.getNumOccupiedMemorySegments();
+		return numPartitionBuffers + buckets.length;
+	}
+
+	int spillPartition(IOManager ioAccess, FileIOChannel.ID targetChannel,
+			LinkedBlockingQueue<MemorySegment> bufferReturnQueue) throws IOException {
+		// sanity checks
+		if (!isInMemory()) {
+			throw new RuntimeException("Bug in Hybrid Hash Join: " +
+					"Request to spill a partition that has already been spilled.");
+		}
+		if (getNumOccupiedMemorySegments() < 2) {
+			throw new RuntimeException("Bug in Hybrid Hash Join: " +
+					"Request to spill a partition with less than two buffers.");
+		}
+
+		// create the channel block writer and spill the current buffers
+		// that keep the build side buffers current block, as it is most likely not full, yet
+		// we return the number of blocks that become available
+		this.buildSideChannel = FileChannelUtil.createBlockChannelWriter(
+				ioAccess,
+				targetChannel,
+				bufferReturnQueue,
+				longTable.compressionEnable(),
+				longTable.compressionCodecFactory(),
+				longTable.compressionBlockSize(),
+				segmentSize);
+		return this.buildSideWriteBuffer.spill(this.buildSideChannel);
+	}
+
+	/**
+	 * After build phase.
+	 * @return build spill return buffer, if have spilled, it returns the current write buffer,
+	 * because it was used all the time in build phase, so it can only be returned at this time.
+	 */
+	int finalizeBuildPhase(IOManager ioAccess, FileIOChannel.Enumerator probeChannelEnumerator) throws IOException {
+		this.finalBufferLimit = this.buildSideWriteBuffer.getCurrentPositionInSegment();
+		this.partitionBuffers = this.buildSideWriteBuffer.close();
+
+		if (!isInMemory()) {
+			// close the channel.
+			this.buildSideChannel.close();
+
+			this.probeSideBuffer = FileChannelUtil.createOutputView(
+					ioAccess,
+					probeChannelEnumerator.next(),
+					longTable.compressionEnable(),
+					longTable.compressionCodecFactory(),
+					longTable.compressionBlockSize(),
+					segmentSize);
+			return 1;
+		} else {
+			return 0;
+		}
+	}
+
+	void finalizeProbePhase(List<LongHashPartition> spilledPartitions) throws IOException {
+		if (isInMemory()) {
+			releaseBuckets();
+			longTable.returnAll(Arrays.asList(partitionBuffers));
+			this.partitionBuffers = null;
+		} else {
+			if (this.probeSideRecordCounter == 0) {
+				// delete the spill files
+				this.probeSideBuffer.close();
+				this.buildSideChannel.deleteChannel();
+				this.probeSideBuffer.getChannel().deleteChannel();
+			} else {
+				// flush the last probe side buffer and register this partition as pending
+				probeNumBytesInLastSeg = this.probeSideBuffer.close();
+				spilledPartitions.add(this);
+			}
+		}
+	}
+
+	final PartitionIterator newPartitionIterator() {
+		return new PartitionIterator();
+	}
+
+	final int getLastSegmentLimit() {
+		return this.finalBufferLimit;
+	}
+
+	// ------------------ PagedInputView for read --------------------
+
+	@Override
+	public void setReadPosition(long pointer) {
+		final int bufferNum = (int) (pointer >>> this.segmentSizeBits);
+		final int offset = (int) (pointer & segmentSizeMask);
+
+		this.currentBufferNum = bufferNum;
+
+		seekInput(this.partitionBuffers[bufferNum], offset,
+				bufferNum < partitionBuffers.length - 1 ? segmentSize : finalBufferLimit);
+	}
+
+	@Override
+	protected MemorySegment nextSegment(MemorySegment current) throws IOException {
+		this.currentBufferNum++;
+		if (this.currentBufferNum < this.partitionBuffers.length) {
+			return this.partitionBuffers[this.currentBufferNum];
+		} else {
+			throw new EOFException();
+		}
+	}
+
+	@Override
+	protected int getLimitForSegment(MemorySegment segment) {
+		return segment == partitionBuffers[partitionBuffers.length - 1] ? finalBufferLimit : segmentSize;
+	}
+
+	boolean isInMemory() {
+		return buildSideChannel == null;
+	}
+
+	final void insertIntoProbeBuffer(BinaryRowSerializer probeSer, BinaryRow record) throws IOException {
+		probeSer.serialize(record, this.probeSideBuffer);
+		this.probeSideRecordCounter++;
+	}
+
+	long getBuildSideRecordCount() {
+		return buildSideRecordCounter;
+	}
+
+	long getMinKey() {
+		return minKey;
+	}
+
+	long getMaxKey() {
+		return maxKey;
+	}
+
+	private void updateMinMax(long key) {
+		if (key < minKey) {
+			minKey = key;
+		}
+		if (key > maxKey) {
+			maxKey = key;
+		}
+	}
+
+	void insertIntoBucket(long key, int hashCode, int size, long address) throws IOException {
+		this.buildSideRecordCounter++;
+		updateMinMax(key);
+
+		final int bufferNum = (int) (address >>> this.segmentSizeBits);
+		final int offset = (int) (address & (this.segmentSize - 1));
+		updateIndex(key, hashCode, address, size, partitionBuffers[bufferNum], offset);
+	}
+
+	void insertIntoTable(long key, int hashCode, BinaryRow row) throws IOException {
+		this.buildSideRecordCounter++;
+		updateMinMax(key);
+		int sizeInBytes = row.getSizeInBytes();
+		if (sizeInBytes >= (1 << SIZE_BITS)) {
+			throw new UnsupportedOperationException("Does not support row that is larger than 256M");
+		}
+		if (isInMemory()) {
+			checkWriteAdvance();
+			// after advance, we may run out memory and spill this partition, check still in memory
+			// again
+			if (isInMemory()) {
+				updateIndex(
+						key,
+						hashCode,
+						buildSideWriteBuffer.getCurrentPointer(),
+						sizeInBytes,
+						buildSideWriteBuffer.getCurrentSegment(),
+						buildSideWriteBuffer.getCurrentPositionInSegment());
+			} else {
+				buildSideWriteBuffer.getCurrentSegment().putLong(
+						buildSideWriteBuffer.getCurrentPositionInSegment(),
+						toAddrAndLen(INVALID_ADDRESS, sizeInBytes));
+			}
+
+			buildSideWriteBuffer.skipBytesToWrite(8);
+			if (row.getSegments().length == 1) {
+				buildSideWriteBuffer.write(row.getSegments()[0], row.getOffset(), sizeInBytes);
+			} else {
+				buildSideSerializer.serializeToPagesWithoutLength(row, buildSideWriteBuffer);
+			}
+		} else {
+			serializeToPages(row);
+		}
+	}
+
+	public void serializeToPages(BinaryRow row) throws IOException {
+
+		int sizeInBytes = row.getSizeInBytes();
+		checkWriteAdvance();
+
+		buildSideWriteBuffer.getCurrentSegment().putLong(
+				buildSideWriteBuffer.getCurrentPositionInSegment(),
+				toAddrAndLen(INVALID_ADDRESS, row.getSizeInBytes()));
+		buildSideWriteBuffer.skipBytesToWrite(8);
+
+		if (row.getSegments().length == 1) {
+			buildSideWriteBuffer.write(row.getSegments()[0], row.getOffset(), sizeInBytes);
+		} else {
+			buildSideSerializer.serializeToPagesWithoutLength(row, buildSideWriteBuffer);
+		}
+	}
+
+	void releaseBuckets() {
+		if (buckets != null) {
+			longTable.returnAll(Arrays.asList(buckets));
+			buckets = null;
+		}
+	}
+
+//	public void append(long key, BinaryRow row) throws IOException {
+//		insertIntoTable(key, hashLong(key, recursionLevel), row);
+//	}
+
+	// ------------------ PagedInputView for read end --------------------
+
+	/**
+	 * Write Buffer.
+	 */
+	private class BuildSideBuffer extends AbstractPagedOutputView {
+
+		private final ArrayList<MemorySegment> targetList;
+		private int currentBlockNumber;
+		private BlockChannelWriter<MemorySegment> writer;
+
+		private BuildSideBuffer(MemorySegment segment) {
+			super(segment, segment.size(), 0);
+			this.targetList = new ArrayList<>();
+		}
+
+		@Override
+		protected MemorySegment nextSegment(
+				MemorySegment current,
+				int positionInCurrent) throws IOException {
+			final MemorySegment next;
+			if (this.writer == null) {
+				// Must first add current segment:
+				// This may happen when you need to spill:
+				// A partition called nextSegment, can not get memory, need to spill, the result
+				// give itself to the spill, Since it is switching currentSeg, it is necessary
+				// to give the previous currSeg to spill.
+				this.targetList.add(current);
+				next = longTable.nextSegment();
+			} else {
+				this.writer.writeBlock(current);
+				try {
+					next = this.writer.getReturnQueue().take();
+				} catch (InterruptedException iex) {
+					throw new IOException("Hash Join Partition was interrupted while " +
+							"grabbing a new write-behind buffer.");
+				}
+			}
+
+			this.currentBlockNumber++;
+			return next;
+		}
+
+		long getCurrentPointer() {
+			return (((long) this.currentBlockNumber) << segmentSizeBits) + getCurrentPositionInSegment();
+		}
+
+		int getBlockCount() {
+			return this.currentBlockNumber + 1;
+		}
+
+		int getNumOccupiedMemorySegments() {
+			// return the current segment + all filled segments
+			return this.targetList.size() + 1;
+		}
+
+		int spill(BlockChannelWriter<MemorySegment> writer) throws IOException {
+			this.writer = writer;
+			final int numSegments = this.targetList.size();
+			for (MemorySegment segment : this.targetList) {
+				this.writer.writeBlock(segment);
+			}
+			this.targetList.clear();
+			return numSegments;
+		}
+
+		MemorySegment[] close() throws IOException {
+			final MemorySegment current = getCurrentSegment();
+			if (current == null) {
+				throw new IllegalStateException("Illegal State in LongHashTable: " +
+						"No current buffer when finalizing build side.");
+			}
+			clear();
+
+			if (this.writer == null) {
+				this.targetList.add(current);
+				MemorySegment[] buffers =
+						this.targetList.toArray(new MemorySegment[this.targetList.size()]);
+				this.targetList.clear();
+				return buffers;
+			} else {
+				writer.writeBlock(current);
+				return null;
+			}
+		}
+	}
+
+	/**
+	 * Iterator for probe match.
+	 */
+	public class MatchIterator implements RowIterator<BinaryRow> {
+		private long address;
+
+		public void set(long address) {
+			this.address = address;
+		}
+
+		@Override
+		public boolean advanceNext() {
+			if (address != INVALID_ADDRESS) {
+				setReadPosition(address);
+				long addrAndLen = getCurrentSegment().getLong(getCurrentPositionInSegment());
+				this.address = toAddress(addrAndLen);
+				int size = toLength(addrAndLen);
+				try {
+					skipBytesToRead(8);
+					buildSideSerializer.pointTo(size, buildReuseRow, LongHashPartition.this);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+				return true;
+			}
+			return false;
+		}
+
+		@Override
+		public BinaryRow getRow() {
+			return buildReuseRow;
+		}
+	}
+
+	void clearAllMemory(List<MemorySegment> target) {
+		// return current buffers from build side and probe side
+		if (this.buildSideWriteBuffer != null) {
+			if (this.buildSideWriteBuffer.getCurrentSegment() != null) {
+				target.add(this.buildSideWriteBuffer.getCurrentSegment());
+			}
+			target.addAll(this.buildSideWriteBuffer.targetList);
+			this.buildSideWriteBuffer.targetList.clear();
+			this.buildSideWriteBuffer = null;
+		}
+		releaseBuckets();
+
+		// return the partition buffers
+		if (this.partitionBuffers != null) {
+			Collections.addAll(target, this.partitionBuffers);
+			this.partitionBuffers = null;
+		}
+
+		// clear the channels
+		try {
+			if (this.buildSideChannel != null) {
+				this.buildSideChannel.close();
+				this.buildSideChannel.deleteChannel();
+			}
+			if (this.probeSideBuffer != null) {
+				this.probeSideBuffer.getChannel().closeAndDelete();
+				this.probeSideBuffer = null;
+			}
+		} catch (IOException ioex) {
+			throw new RuntimeException("Error deleting the partition files. " +
+					"Some temporary files might not be removed.", ioex);
+		}
+	}
+
+	/**
+	 * For spilled partition to rebuild index and hashcode when memory can
+	 * store all the build side data.
+	 * (After bulk load to memory, see {@link BulkBlockChannelReader}).
+	 */
+	final class PartitionIterator implements RowIterator<BinaryRow> {
+
+		private long currentPointer;
+
+		private BinaryRow reuse;
+
+		private PartitionIterator() {
+			this.reuse = buildSideSerializer.createInstance();
+			setReadPosition(0);
+		}
+
+		@Override
+		public boolean advanceNext() {
+			try {
+				checkReadAdvance();
+
+				int pos = getCurrentPositionInSegment();
+				this.currentPointer = (((long) currentBufferNum) << segmentSizeBits) + pos;
+
+				long addrAndLen = getCurrentSegment().getLong(pos);
+				skipBytesToRead(8);
+				buildSideSerializer.pointTo(toLength(addrAndLen), reuse, LongHashPartition.this);
+				return true;
+			} catch (EOFException e) {
+				return false;
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		final long getPointer() {
+			return this.currentPointer;
+		}
+
+		@Override
+		public BinaryRow getRow() {
+			return this.reuse;
+		}
+	}
+
+	private void checkWriteAdvance() throws IOException {
+		if (shouldAdvance(
+				buildSideWriteBuffer.getSegmentSize() - buildSideWriteBuffer.getCurrentPositionInSegment(),
+				buildSideSerializer)) {
+			buildSideWriteBuffer.advance();
+		}
+	}
+
+	private void checkReadAdvance() throws IOException {
+		if (shouldAdvance(getCurrentSegmentLimit() - getCurrentPositionInSegment(), buildSideSerializer)) {
+			advance();
+		}
+	}
+
+	private static boolean shouldAdvance(int available, BinaryRowSerializer serializer) {
+		return available < 8 + serializer.getFixedLengthPartSize();
+	}
+
+	static void deserializeFromPages(BinaryRow reuse, ChannelReaderInputView inView,
+			BinaryRowSerializer buildSideSerializer) throws IOException {
+		if (shouldAdvance(
+				inView.getCurrentSegmentLimit() - inView.getCurrentPositionInSegment(),
+				buildSideSerializer)) {
+			inView.advance();
+		}
+		MemorySegment segment = (reuse.getSegments() != null) ? reuse.getSegments()[0] : null;
+
+		int length = toLength(inView.getCurrentSegment().getLong(inView.getCurrentPositionInSegment()));
+		inView.skipBytesToRead(8);
+
+		if (segment == null || segment.size() < length) {
+			segment = MemorySegmentFactory.wrap(new byte[length]);
+		}
+		inView.readFully(segment.getHeapMemory(), 0, length);
+		reuse.pointTo(segment, 0, length);
+	}
+
+	void iteratorToDenseBucket(MemorySegment[] denseBuckets, long addressOffset, long globalMinKey) {
+		int bucketOffset = 0;
+		MemorySegment segment = buckets[bucketOffset];
+		int segOffset = 0;
+		for (int i = 0; i < numBuckets; i++) {
+			long address = segment.getLong(segOffset + 8);
+			if (address != INVALID_ADDRESS) {
+				long key = segment.getLong(segOffset);
+				long denseBucket = key - globalMinKey;
+				long denseBucketOffset = denseBucket << 3;
+				int denseSegIndex = (int) (denseBucketOffset >>> segmentSizeBits);
+				int denseSegOffset = (int) (denseBucketOffset & segmentSizeMask);
+				denseBuckets[denseSegIndex].putLong(denseSegOffset, address + addressOffset);
+			}
+
+			// not last bucket, move to next.
+			if (i != numBuckets - 1) {
+				if (segOffset + 16 < segmentSize) {
+					segOffset += 16;
+				} else {
+					segment = buckets[++bucketOffset];
+					segOffset = 0;
+				}
+			}
+		}
+	}
+
+	void updateDenseAddressOffset(long addressOffset) {
+		if (addressOffset != 0) {
+			setReadPosition(0);
+			while (true) {
+				try {
+					checkReadAdvance();
+					long addrAndLen = getCurrentSegment().getLong(getCurrentPositionInSegment());
+					long address = LongHashPartition.toAddress(addrAndLen);
+					int len = LongHashPartition.toLength(addrAndLen);
+					if (address != INVALID_ADDRESS) {
+						getCurrentSegment().putLong(getCurrentPositionInSegment(),
+								LongHashPartition.toAddrAndLen(address + addressOffset, len));
+					}
+					skipBytesToRead(8 + len);
+				} catch (EOFException e) {
+					break;
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
@@ -1,0 +1,541 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.hashtable;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.ChannelReaderInputViewIterator;
+import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.compression.BlockCompressionFactory;
+import org.apache.flink.table.runtime.io.ChannelWithMeta;
+import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.MathUtils;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.hashtable.LongHashPartition.INVALID_ADDRESS;
+
+/**
+ * Special optimized hashTable with key long.
+ *
+ * <p>See {@link LongHashPartition}.
+ * TODO add min max long filter and bloomFilter to spilled partition.
+ */
+public abstract class LongHybridHashTable extends BaseHybridHashTable {
+
+	private final BinaryRowSerializer buildSideSerializer;
+	private final BinaryRowSerializer probeSideSerializer;
+	private final ArrayList<LongHashPartition> partitionsBeingBuilt;
+	private final ArrayList<LongHashPartition> partitionsPending;
+	private ProbeIterator probeIterator;
+	private LongHashPartition.MatchIterator matchIterator;
+
+	private boolean denseMode = false;
+	private long minKey;
+	private long maxKey;
+	private MemorySegment[] denseBuckets;
+	private LongHashPartition densePartition;
+
+	public LongHybridHashTable(
+			Configuration conf,
+			Object owner,
+			BinaryRowSerializer buildSideSerializer,
+			BinaryRowSerializer probeSideSerializer,
+			MemoryManager memManager,
+			long reservedMemorySize,
+			long preferredMemorySize,
+			long perRequestMemorySize,
+			IOManager ioManager,
+			int avgRecordLen,
+			long buildRowCount) {
+		super(conf, owner, memManager, reservedMemorySize, preferredMemorySize, perRequestMemorySize,
+				ioManager, avgRecordLen, buildRowCount, false);
+		this.buildSideSerializer = buildSideSerializer;
+		this.probeSideSerializer = probeSideSerializer;
+
+		this.partitionsBeingBuilt = new ArrayList<>();
+		this.partitionsPending = new ArrayList<>();
+
+		createPartitions(initPartitionFanOut, 0);
+	}
+
+	// ---------------------- interface to join operator ---------------------------------------
+
+	public void putBuildRow(BinaryRow row) throws IOException {
+		long key = getBuildLongKey(row);
+		final int hashCode = hashLong(key, 0);
+		insertIntoTable(key, hashCode, row);
+	}
+
+	public void endBuild() throws IOException {
+		int buildWriteBuffers = 0;
+		for (LongHashPartition p : this.partitionsBeingBuilt) {
+			buildWriteBuffers += p.finalizeBuildPhase(this.ioManager, this.currentEnumerator);
+		}
+		buildSpillRetBufferNumbers += buildWriteBuffers;
+
+		// the first prober is the probe-side input, but the input is null at beginning
+		this.probeIterator = new ProbeIterator(this.probeSideSerializer.createInstance());
+
+		tryDenseMode();
+	}
+
+	public boolean tryProbe(BaseRow record) throws IOException {
+		long probeKey = getProbeLongKey(record);
+
+		if (denseMode) {
+			this.probeIterator.setInstance(record);
+
+			if (probeKey >= minKey && probeKey <= maxKey) {
+				long denseBucket = probeKey - minKey;
+				long denseBucketOffset = denseBucket << 3;
+				int denseSegIndex = (int) (denseBucketOffset >>> segmentSizeBits);
+				int denseSegOffset = (int) (denseBucketOffset & segmentSizeMask);
+
+				long address = denseBuckets[denseSegIndex].getLong(denseSegOffset);
+				this.matchIterator = densePartition.valueIter(address);
+			} else {
+				this.matchIterator = densePartition.valueIter(INVALID_ADDRESS);
+			}
+
+			return true;
+		} else {
+			if (!this.probeIterator.hasSource()) {
+				// set the current probe value when probeIterator is null at the begging.
+				this.probeIterator.setInstance(record);
+			}
+			final int hash = hashLong(probeKey, this.currentRecursionDepth);
+
+			LongHashPartition p = this.partitionsBeingBuilt.get(hash % partitionsBeingBuilt.size());
+
+			// for an in-memory partition, process set the return iterators, else spill the probe records
+			if (p.isInMemory()) {
+				this.matchIterator = p.get(probeKey, hash);
+				return true;
+			} else {
+				p.insertIntoProbeBuffer(probeSideSerializer, probeToBinary(record));
+				return false;
+			}
+		}
+	}
+
+	public boolean nextMatching() throws IOException {
+		return !denseMode && (processProbeIter() || prepareNextPartition());
+	}
+
+	public BaseRow getCurrentProbeRow() {
+		return this.probeIterator.current();
+	}
+
+	public LongHashPartition.MatchIterator getBuildSideIterator() {
+		return matchIterator;
+	}
+
+	@Override
+	public void close() {
+		if (denseMode) {
+			closed.compareAndSet(false, true);
+		} else {
+			super.close();
+		}
+	}
+
+	@Override
+	public void free() {
+		if (denseMode) {
+			returnAll(Arrays.asList(denseBuckets));
+			returnAll(Arrays.asList(densePartition.getPartitionBuffers()));
+		}
+		super.free();
+	}
+
+	// ---------------------- interface to join operator end -----------------------------------
+
+	/**
+	 * After build end, try to use dense mode.
+	 */
+	private void tryDenseMode() {
+
+		if (numSpillFiles != 0) {
+			return;
+		}
+
+		long minKey = Long.MAX_VALUE;
+		long maxKey = Long.MIN_VALUE;
+		long recordCount = 0;
+		for (LongHashPartition p : this.partitionsBeingBuilt) {
+			long partitionRecords = p.getBuildSideRecordCount();
+			recordCount += partitionRecords;
+			if (partitionRecords > 0) {
+				if (p.getMinKey() < minKey) {
+					minKey = p.getMinKey();
+				}
+				if (p.getMaxKey() > maxKey) {
+					maxKey = p.getMaxKey();
+				}
+			}
+		}
+
+		if (buildSpillRetBufferNumbers != 0) {
+			throw new RuntimeException("buildSpillRetBufferNumbers should be 0: " + buildSpillRetBufferNumbers);
+		}
+
+		long range = maxKey - minKey + 1;
+		if (range <= recordCount * 4 || range <= segmentSize / 8) {
+
+			// try to request memory.
+			int buffers = (int) Math.ceil(((double) (range * 8)) / segmentSize);
+
+			// TODO MemoryManager needs to support flexible larger segment, so that the index area of the
+			// build side is placed on a segment to avoid the overhead of addressing.
+			MemorySegment[] denseBuckets = new MemorySegment[buffers];
+			for (int i = 0; i < buffers; i++) {
+				MemorySegment seg = getNextBuffer();
+				if (seg == null) {
+					returnAll(Arrays.asList(denseBuckets));
+					return;
+				}
+				denseBuckets[i] = seg;
+				for (int j = 0; j < segmentSize; j += 8) {
+					seg.putLong(j, INVALID_ADDRESS);
+				}
+			}
+
+			denseMode = true;
+			LOG.info("LongHybridHashTable: Use dense mode!");
+			this.minKey = minKey;
+			this.maxKey = maxKey;
+			buildSpillReturnBuffers.drainTo(availableMemory);
+
+			ArrayList<MemorySegment> dataBuffers = new ArrayList<>();
+
+			long addressOffset = 0;
+			for (LongHashPartition p : this.partitionsBeingBuilt) {
+				p.iteratorToDenseBucket(denseBuckets, addressOffset, minKey);
+				p.updateDenseAddressOffset(addressOffset);
+
+				dataBuffers.addAll(Arrays.asList(p.getPartitionBuffers()));
+				addressOffset += (p.getPartitionBuffers().length << segmentSizeBits);
+				returnAll(Arrays.asList(p.getBuckets()));
+			}
+
+			this.denseBuckets = denseBuckets;
+			this.densePartition = new LongHashPartition(this, buildSideSerializer,
+					dataBuffers.toArray(new MemorySegment[dataBuffers.size()]));
+			freeCurrent();
+		}
+	}
+
+	private void createPartitions(int numPartitions, int recursionLevel) {
+		ensureNumBuffersReturned(numPartitions);
+
+		this.currentEnumerator = this.ioManager.createChannelEnumerator();
+
+		this.partitionsBeingBuilt.clear();
+		double numRecordPerPartition = (double) buildRowCount / numPartitions;
+		int maxBuffer = maxInitBufferOfBucketArea(numPartitions);
+		for (int i = 0; i < numPartitions; i++) {
+			LongHashPartition p = new LongHashPartition(this, i, buildSideSerializer,
+					numRecordPerPartition, maxBuffer, recursionLevel);
+			this.partitionsBeingBuilt.add(p);
+		}
+	}
+
+	/**
+	 * For code gen get build side long key.
+	 */
+	public abstract long getBuildLongKey(BaseRow row);
+
+	/**
+	 * For code gen get probe side long key.
+	 */
+	public abstract long getProbeLongKey(BaseRow row);
+
+	/**
+	 * For code gen probe side to BinaryRow.
+	 */
+	public abstract BinaryRow probeToBinary(BaseRow row);
+
+	private void insertIntoTable(long key, int hashCode, BinaryRow row) throws IOException {
+		LongHashPartition p = partitionsBeingBuilt.get(hashCode % partitionsBeingBuilt.size());
+		p.insertIntoTable(key, hashCode, row);
+	}
+
+	static int hashLong(long key, int level) {
+		long h = key * 0x9E3779B9L;
+		int hash = (int) (h ^ (h >> 32));
+		return BaseHybridHashTable.hash(hash, level);
+	}
+
+	private boolean processProbeIter() throws IOException {
+
+		// the prober's source is null at the begging.
+		if (this.probeIterator.hasSource()) {
+			final ProbeIterator probeIter = this.probeIterator;
+
+			BinaryRow next;
+			while ((next = probeIter.next()) != null) {
+				long probeKey = getProbeLongKey(next);
+				final int hash = hashLong(probeKey, this.currentRecursionDepth);
+
+				final LongHashPartition p = this.partitionsBeingBuilt.get(hash % partitionsBeingBuilt.size());
+
+				// for an in-memory partition, process set the return iterators, else spill the probe records
+				if (p.isInMemory()) {
+					this.matchIterator = p.get(probeKey, hash);
+					return true;
+				} else {
+					p.insertIntoProbeBuffer(probeSideSerializer, next);
+				}
+			}
+
+			return false;
+		} else {
+			return false;
+		}
+	}
+
+	private boolean prepareNextPartition() throws IOException {
+		// finalize and cleanup the partitions of the current table
+		for (final LongHashPartition p : this.partitionsBeingBuilt) {
+			p.finalizeProbePhase(this.partitionsPending);
+		}
+
+		this.partitionsBeingBuilt.clear();
+
+		if (this.currentSpilledProbeSide != null) {
+			this.currentSpilledProbeSide.getChannel().closeAndDelete();
+			this.currentSpilledProbeSide = null;
+		}
+
+		if (this.partitionsPending.isEmpty()) {
+			// no more data
+			return false;
+		}
+
+		// there are pending partitions
+		final LongHashPartition p = this.partitionsPending.get(0);
+		LOG.info(String.format("Begin to process spilled partition [%d]", p.getPartitionNumber()));
+
+		if (p.probeSideRecordCounter == 0) {
+			this.partitionsPending.remove(0);
+			return prepareNextPartition();
+		}
+
+		// build the next table; memory must be allocated after this call
+		buildTableFromSpilledPartition(p);
+
+		// set the probe side
+		ChannelWithMeta channelWithMeta = new ChannelWithMeta(
+				p.probeSideBuffer.getChannel().getChannelID(),
+				p.probeSideBuffer.getBlockCount(),
+				p.probeNumBytesInLastSeg);
+		this.currentSpilledProbeSide = FileChannelUtil.createInputView(ioManager, channelWithMeta, new ArrayList<>(),
+				compressionEnable, compressionCodecFactory, compressionBlockSize, segmentSize);
+
+		ChannelReaderInputViewIterator<BinaryRow> probeReader = new ChannelReaderInputViewIterator(
+				this.currentSpilledProbeSide, new ArrayList<>(), this.probeSideSerializer);
+		this.probeIterator.set(probeReader);
+		this.probeIterator.setReuse(probeSideSerializer.createInstance());
+
+		// unregister the pending partition
+		this.partitionsPending.remove(0);
+		this.currentRecursionDepth = p.getRecursionLevel() + 1;
+
+		// recursively get the next
+		return nextMatching();
+	}
+
+	private void buildTableFromSpilledPartition(
+			final LongHashPartition p) throws IOException {
+
+		final int nextRecursionLevel = p.getRecursionLevel() + 1;
+		if (nextRecursionLevel == 2) {
+			LOG.info("Recursive hash join: partition number is " + p.getPartitionNumber());
+		} else if (nextRecursionLevel > MAX_RECURSION_DEPTH) {
+			throw new RuntimeException("Hash join exceeded maximum number of recursions, without reducing "
+					+ "partitions enough to be memory resident. Probably cause: Too many duplicate keys.");
+		}
+
+		if (p.getBuildSideBlockCount() > p.getProbeSideBlockCount()) {
+			LOG.info(String.format(
+					"Hash join: Partition(%d) " +
+							"build side block [%d] more than probe side block [%d]",
+					p.getPartitionNumber(),
+					p.getBuildSideBlockCount(),
+					p.getProbeSideBlockCount()));
+		}
+
+		// we distinguish two cases here:
+		// 1) The partition fits entirely into main memory. That is the case if we have enough buffers for
+		//    all partition segments, plus enough buffers to hold the table structure.
+		//    --> We read the partition in as it is and create a hashtable that references only
+		//        that single partition.
+		// 2) We can not guarantee that enough memory segments are available and read the partition
+		//    in, distributing its data among newly created partitions.
+		final int totalBuffersAvailable = this.availableMemory.size() + this.buildSpillRetBufferNumbers;
+		if (totalBuffersAvailable != this.reservedNumBuffers + this.allocatedFloatingNum) {
+			throw new RuntimeException(String.format("Hash Join bug in memory management: Memory buffers leaked." +
+							" availableMemory(%s), buildSpillRetBufferNumbers(%s), reservedNumBuffers(%s), allocatedFloatingNum(%s)",
+					availableMemory.size(), buildSpillRetBufferNumbers, reservedNumBuffers, allocatedFloatingNum));
+		}
+
+		int maxBucketAreaBuffers = MathUtils.roundUpToPowerOfTwo(
+				(int) Math.max(1, Math.ceil(
+						Math.ceil((p.getBuildSideRecordCount() / 0.5)) * 16 / segmentSize)));
+
+		final long totalBuffersNeeded = maxBucketAreaBuffers + p.getBuildSideBlockCount() + 2;
+
+		if (totalBuffersNeeded < totalBuffersAvailable) {
+			LOG.info(String.format("Build in memory hash table from spilled partition [%d]",
+					p.getPartitionNumber()));
+
+			// first read the partition in
+			final List<MemorySegment> partitionBuffers = readAllBuffers(
+					p.getBuildSideChannel().getChannelID(),
+					p.getBuildSideBlockCount());
+			final LongHashPartition newPart = new LongHashPartition(
+					this,
+					0,
+					this.buildSideSerializer,
+					maxBucketAreaBuffers,
+					nextRecursionLevel,
+					partitionBuffers,
+					p.getLastSegmentLimit());
+
+			this.partitionsBeingBuilt.add(newPart);
+
+			// now, index the partition through a hash table
+			final LongHashPartition.PartitionIterator pIter = newPart.newPartitionIterator();
+
+			while (pIter.advanceNext()) {
+				long key = getBuildLongKey(pIter.getRow());
+				final int hashCode = hashLong(key, nextRecursionLevel);
+				final int pointer = (int) pIter.getPointer();
+				newPart.insertIntoBucket(key, hashCode, pIter.getRow().getSizeInBytes(), pointer);
+			}
+		} else {
+			// go over the complete input and insert every element into the hash table
+			// compute in how many splits, we'd need to partition the result
+			final int splits = (int) (totalBuffersNeeded / totalBuffersAvailable) + 1;
+			final int partitionFanOut = Math.min(Math.min(10 * splits, MAX_NUM_PARTITIONS), maxNumPartition());
+
+			createPartitions(partitionFanOut, nextRecursionLevel);
+			LOG.info(String.format("Build hybrid hash table from spilled partition [%d] with recursion level [%d]",
+					p.getPartitionNumber(), nextRecursionLevel));
+
+			ChannelReaderInputView inView = createInputView(p.getBuildSideChannel().getChannelID(), p.getBuildSideBlockCount(), p.getLastSegmentLimit());
+			BinaryRow rec = this.buildSideSerializer.createInstance();
+			while (true) {
+				try {
+					LongHashPartition.deserializeFromPages(rec, inView, buildSideSerializer);
+					long key = getBuildLongKey(rec);
+					insertIntoTable(key, hashLong(key, nextRecursionLevel), rec);
+				} catch (EOFException e) {
+					break;
+				}
+			}
+			inView.getChannel().closeAndDelete();
+
+			// finalize the partitions
+			int buildWriteBuffers = 0;
+			for (LongHashPartition part : this.partitionsBeingBuilt) {
+				buildWriteBuffers += part.finalizeBuildPhase(this.ioManager, this.currentEnumerator);
+			}
+			buildSpillRetBufferNumbers += buildWriteBuffers;
+		}
+	}
+
+	@Override
+	public int spillPartition() throws IOException {
+		// find the largest partition
+		int largestNumBlocks = 0;
+		int largestPartNum = -1;
+
+		for (int i = 0; i < partitionsBeingBuilt.size(); i++) {
+			LongHashPartition p = partitionsBeingBuilt.get(i);
+			if (p.isInMemory() && p.getNumOccupiedMemorySegments() > largestNumBlocks) {
+				largestNumBlocks = p.getNumOccupiedMemorySegments();
+				largestPartNum = i;
+			}
+		}
+		final LongHashPartition p = partitionsBeingBuilt.get(largestPartNum);
+
+		// spill the partition
+		int numBuffersFreed = p.spillPartition(this.ioManager,
+				this.currentEnumerator.next(), this.buildSpillReturnBuffers);
+		p.releaseBuckets();
+		this.buildSpillRetBufferNumbers += numBuffersFreed;
+
+		LOG.info(String.format("Grace hash join: Ran out memory, choosing partition " +
+						"[%d] to spill, %d memory segments being freed",
+				largestPartNum, numBuffersFreed));
+
+		// grab as many buffers as are available directly
+		MemorySegment currBuff;
+		while (this.buildSpillRetBufferNumbers > 0 && (currBuff = this.buildSpillReturnBuffers.poll()) != null) {
+			this.availableMemory.add(currBuff);
+			this.buildSpillRetBufferNumbers--;
+		}
+		numSpillFiles++;
+		spillInBytes += numBuffersFreed * segmentSize;
+		return largestPartNum;
+	}
+
+	@Override
+	protected void clearPartitions() {
+		this.probeIterator = null;
+
+		for (int i = this.partitionsBeingBuilt.size() - 1; i >= 0; --i) {
+			final LongHashPartition p = this.partitionsBeingBuilt.get(i);
+			try {
+				p.clearAllMemory(this.availableMemory);
+			} catch (Exception e) {
+				LOG.error("Error during partition cleanup.", e);
+			}
+		}
+		this.partitionsBeingBuilt.clear();
+
+		// clear the partitions that are still to be done (that have files on disk)
+		for (final LongHashPartition p : this.partitionsPending) {
+			p.clearAllMemory(this.availableMemory);
+		}
+	}
+
+	public boolean compressionEnable() {
+		return compressionEnable;
+	}
+
+	public BlockCompressionFactory compressionCodecFactory() {
+		return compressionCodecFactory;
+	}
+
+	public int compressionBlockSize() {
+		return compressionBlockSize;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryArraySerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryArraySerializer.java
@@ -65,7 +65,7 @@ public class BinaryArraySerializer extends TypeSerializerSingleton<BinaryArray> 
 	@Override
 	public void serialize(BinaryArray record, DataOutputView target) throws IOException {
 		target.writeInt(record.getSizeInBytes());
-		SegmentsUtil.copyBytesToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
+		SegmentsUtil.copyToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryGenericSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryGenericSerializer.java
@@ -77,7 +77,7 @@ public final class BinaryGenericSerializer<T> extends TypeSerializer<BinaryGener
 	@Override
 	public void serialize(BinaryGeneric<T> record, DataOutputView target) throws IOException {
 		target.writeInt(record.getSizeInBytes());
-		SegmentsUtil.copyBytesToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
+		SegmentsUtil.copyToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryMapSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryMapSerializer.java
@@ -65,7 +65,7 @@ public class BinaryMapSerializer extends TypeSerializerSingleton<BinaryMap> {
 	@Override
 	public void serialize(BinaryMap record, DataOutputView target) throws IOException {
 		target.writeInt(record.getSizeInBytes());
-		SegmentsUtil.copyBytesToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
+		SegmentsUtil.copyToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryStringSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/typeutils/BinaryStringSerializer.java
@@ -70,7 +70,7 @@ public final class BinaryStringSerializer extends TypeSerializerSingleton<Binary
 	public void serialize(BinaryString record, DataOutputView target) throws IOException {
 		record.ensureMaterialized();
 		target.writeInt(record.getSizeInBytes());
-		SegmentsUtil.copyBytesToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
+		SegmentsUtil.copyToView(record.getSegments(), record.getOffset(), record.getSizeInBytes(), target);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/util/SegmentsUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/util/SegmentsUtil.java
@@ -195,7 +195,7 @@ public class SegmentsUtil {
 			if (curSegRemain > 0) {
 				int copySize = Math.min(curSegRemain, sizeInBytes);
 
-				byte[] bytes = new byte[copySize];
+				byte[] bytes = allocateReuseBytes(copySize);
 				sourceSegment.get(offset, bytes);
 				target.write(bytes);
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/util/SegmentsUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/util/SegmentsUtil.java
@@ -196,8 +196,8 @@ public class SegmentsUtil {
 				int copySize = Math.min(curSegRemain, sizeInBytes);
 
 				byte[] bytes = allocateReuseBytes(copySize);
-				sourceSegment.get(offset, bytes);
-				target.write(bytes);
+				sourceSegment.get(offset, bytes, 0, copySize);
+				target.write(bytes, 0, copySize);
 
 				sizeInBytes -= copySize;
 				offset = 0;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/util/SegmentsUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/util/SegmentsUtil.java
@@ -126,9 +126,22 @@ public class SegmentsUtil {
 		}
 	}
 
+	/**
+	 * Copy segments to target unsafe pointer.
+	 *
+	 * @param segments Source segments.
+	 * @param offset   The position where the bytes are started to be read from these memory
+	 *                 segments.
+	 * @param target   The unsafe memory to copy the bytes to.
+	 * @param pointer  The position in the target unsafe memory to copy the chunk to.
+	 * @param numBytes the number bytes to copy.
+	 */
 	public static void copyToUnsafe(
-			MemorySegment[] segments, int offset,
-			Object target, int pointer, int numBytes) {
+			MemorySegment[] segments,
+			int offset,
+			Object target,
+			int pointer,
+			int numBytes) {
 		if (inFirstSegment(segments, offset, numBytes)) {
 			segments[0].copyToUnsafe(offset, target, pointer, numBytes);
 		} else {
@@ -137,8 +150,11 @@ public class SegmentsUtil {
 	}
 
 	private static void copyMultiSegmentsToUnsafe(
-			MemorySegment[] segments, int offset,
-			Object target, int pointer, int numBytes) {
+			MemorySegment[] segments,
+			int offset,
+			Object target,
+			int pointer,
+			int numBytes) {
 		int remainSize = numBytes;
 		for (MemorySegment segment : segments) {
 			int remain = segment.size() - offset;
@@ -156,6 +172,47 @@ public class SegmentsUtil {
 				// now the offset = offset - segmentSize (-remain)
 				offset = -remain;
 			}
+		}
+	}
+
+
+	/**
+	 * Copy bytes of segments to output view.
+	 * Note: It just copies the data in, not include the length.
+	 *
+	 * @param segments    source segments
+	 * @param offset      offset for segments
+	 * @param sizeInBytes size in bytes
+	 * @param target      target output view
+	 */
+	public static void copyToView(
+			MemorySegment[] segments,
+			int offset,
+			int sizeInBytes,
+			DataOutputView target) throws IOException {
+		for (MemorySegment sourceSegment : segments) {
+			int curSegRemain = sourceSegment.size() - offset;
+			if (curSegRemain > 0) {
+				int copySize = Math.min(curSegRemain, sizeInBytes);
+
+				byte[] bytes = new byte[copySize];
+				sourceSegment.get(offset, bytes);
+				target.write(bytes);
+
+				sizeInBytes -= copySize;
+				offset = 0;
+			} else {
+				offset -= sourceSegment.size();
+			}
+
+			if (sizeInBytes == 0) {
+				return;
+			}
+		}
+
+		if (sizeInBytes != 0) {
+			throw new RuntimeException("No copy finished, this should be a bug, " +
+					"The remaining length is: " + sizeInBytes);
 		}
 	}
 
@@ -930,41 +987,4 @@ public class SegmentsUtil {
 		segment.put(segOffset, (byte) (LITTLE_ENDIAN ? b2 : b1));
 	}
 
-	/**
-	 * Copy bytes of segments to output view.
-	 * Note: It just copies the data in, not include the length.
-	 *
-	 * @param segments source segments
-	 * @param offset offset for segments
-	 * @param sizeInBytes size in bytes
-	 * @param target target output view
-	 */
-	public static void copyBytesToView(MemorySegment[] segments, int offset,
-			int sizeInBytes, DataOutputView target) throws IOException {
-		for (MemorySegment sourceSegment : segments) {
-			int curSegRemain = sourceSegment.size() - offset;
-			if (curSegRemain > 0) {
-				int copySize = Math.min(curSegRemain, sizeInBytes);
-
-				// TODO after FLINK-11724
-				byte[] bytes = new byte[copySize];
-				sourceSegment.get(offset, bytes);
-				target.write(bytes);
-
-				sizeInBytes -= copySize;
-				offset = 0;
-			} else {
-				offset -= sourceSegment.size();
-			}
-
-			if (sizeInBytes == 0) {
-				return;
-			}
-		}
-
-		if (sizeInBytes != 0) {
-			throw new RuntimeException("No copy finished, this should be a bug, " +
-					"The remaining length is: " + sizeInBytes);
-		}
-	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/hashtable/LongHashTableTest.java
@@ -1,0 +1,578 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.hashtable;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.UnionIterator;
+import org.apache.flink.table.api.TableConfigOptions;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.runtime.util.RowIterator;
+import org.apache.flink.table.runtime.util.UniformBinaryRowGenerator;
+import org.apache.flink.table.typeutils.BinaryRowSerializer;
+import org.apache.flink.util.MutableObjectIterator;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Test for {@link LongHashPartition}.
+ */
+@RunWith(Parameterized.class)
+public class LongHashTableTest {
+
+	private static final int PAGE_SIZE = 32 * 1024;
+	private IOManager ioManager;
+	private BinaryRowSerializer buildSideSerializer;
+	private BinaryRowSerializer probeSideSerializer;
+	private MemoryManager memManager = new MemoryManager(896 * PAGE_SIZE, 1);
+
+	private boolean useCompress;
+	private Configuration conf;
+
+	public LongHashTableTest(boolean useCompress) {
+		this.useCompress = useCompress;
+	}
+
+	@Parameterized.Parameters(name = "useCompress-{0}")
+	public static List<Boolean> getVarSeg() {
+		return Arrays.asList(true, false);
+	}
+
+	@Before
+	public void init() {
+		TypeInformation[] types = new TypeInformation[]{Types.INT, Types.INT};
+		this.buildSideSerializer = new BinaryRowSerializer(types.length);
+		this.probeSideSerializer = new BinaryRowSerializer(types.length);
+		this.ioManager = new IOManagerAsync();
+
+		conf = new Configuration();
+		conf.setBoolean(TableConfigOptions.SQL_EXEC_SPILL_COMPRESSION_ENABLED, useCompress);
+	}
+
+	private class MyHashTable extends LongHybridHashTable {
+
+		public MyHashTable(long memorySize) {
+			super(conf, LongHashTableTest.this, buildSideSerializer, probeSideSerializer, memManager, memorySize,
+					memorySize, 0, LongHashTableTest.this.ioManager,
+					24, 200000);
+		}
+
+		@Override
+		public long getBuildLongKey(BaseRow row) {
+			return row.getInt(0);
+		}
+
+		@Override
+		public long getProbeLongKey(BaseRow row) {
+			return row.getInt(0);
+		}
+
+		@Override
+		public BinaryRow probeToBinary(BaseRow row) {
+			return (BinaryRow) row;
+		}
+	}
+
+	@Test
+	public void testInMemory() throws IOException {
+		final int numKeys = 100000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+
+		final MyHashTable table = new MyHashTable(500 * PAGE_SIZE);
+
+		int numRecordsInJoinResult = join(table, buildInput, probeInput);
+		Assert.assertEquals("Wrong number of records in join result.", numKeys * buildValsPerKey * probeValsPerKey, numRecordsInJoinResult);
+
+		table.close();
+
+		table.free();
+	}
+
+	@Test
+	public void testSpillingHashJoinOneRecursion() throws IOException {
+		final int numKeys = 100000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+
+		final MyHashTable table = new MyHashTable(300 * PAGE_SIZE);
+
+		int numRecordsInJoinResult = join(table, buildInput, probeInput);
+
+		Assert.assertEquals("Wrong number of records in join result.", numKeys * buildValsPerKey * probeValsPerKey, numRecordsInJoinResult);
+
+		table.close();
+
+		// ----------------------------------------------------------------------------------------
+
+		table.free();
+	}
+
+	/**
+	 * Non partition in memory in level 0.
+	 */
+	@Test
+	public void testSpillingHashJoinOneRecursionPerformance() throws IOException {
+		final int numKeys = 1000000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+
+		final MyHashTable table = new MyHashTable(100 * PAGE_SIZE);
+
+		int numRecordsInJoinResult = join(table, buildInput, probeInput);
+
+		Assert.assertEquals("Wrong number of records in join result.", numKeys * buildValsPerKey * probeValsPerKey, numRecordsInJoinResult);
+
+		table.close();
+
+		// ----------------------------------------------------------------------------------------
+
+		table.free();
+	}
+
+	@Test
+	public void testSpillingHashJoinOneRecursionValidity() throws IOException {
+		final int numKeys = 1000000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+
+		// create the map for validating the results
+		HashMap<Integer, Long> map = new HashMap<>(numKeys);
+
+		// ----------------------------------------------------------------------------------------
+		final MyHashTable table = new MyHashTable(100 * PAGE_SIZE);
+
+		BinaryRow buildRow = buildSideSerializer.createInstance();
+		while ((buildRow = buildInput.next(buildRow)) != null) {
+			table.putBuildRow(buildRow);
+		}
+		table.endBuild();
+
+		BinaryRow probeRow = probeSideSerializer.createInstance();
+		while ((probeRow = probeInput.next(probeRow)) != null) {
+			if (table.tryProbe(probeRow)) {
+				testJoin(table, map);
+			}
+		}
+
+		while (table.nextMatching()) {
+			testJoin(table, map);
+		}
+
+		table.close();
+
+		Assert.assertEquals("Wrong number of keys", numKeys, map.size());
+		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+			long val = entry.getValue();
+			int key = entry.getKey();
+
+			Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
+					probeValsPerKey * buildValsPerKey, val);
+		}
+
+		// ----------------------------------------------------------------------------------------
+
+		table.free();
+	}
+
+	@Test
+	public void testSpillingHashJoinWithMassiveCollisions() throws IOException {
+		// the following two values are known to have a hash-code collision on the initial level.
+		// we use them to make sure one partition grows over-proportionally large
+		final int repeatedValue1 = 40559;
+		final int repeatedValue2 = 92882;
+		final int repeatedValueCountBuild = 200000;
+		final int repeatedValueCountProbe = 5;
+
+		final int numKeys = 1000000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
+		MutableObjectIterator<BinaryRow> build1 = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+		MutableObjectIterator<BinaryRow> build2 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
+		MutableObjectIterator<BinaryRow> build3 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
+		List<MutableObjectIterator<BinaryRow>> builds = new ArrayList<>();
+		builds.add(build1);
+		builds.add(build2);
+		builds.add(build3);
+		MutableObjectIterator<BinaryRow> buildInput = new UnionIterator<>(builds);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probe1 = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+		MutableObjectIterator<BinaryRow> probe2 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
+		MutableObjectIterator<BinaryRow> probe3 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
+		List<MutableObjectIterator<BinaryRow>> probes = new ArrayList<>();
+		probes.add(probe1);
+		probes.add(probe2);
+		probes.add(probe3);
+		MutableObjectIterator<BinaryRow> probeInput = new UnionIterator<>(probes);
+
+		// create the map for validating the results
+		HashMap<Integer, Long> map = new HashMap<>(numKeys);
+
+		final MyHashTable table = new MyHashTable(896 * PAGE_SIZE);
+
+		BinaryRow buildRow = buildSideSerializer.createInstance();
+		while ((buildRow = buildInput.next(buildRow)) != null) {
+			table.putBuildRow(buildRow);
+		}
+		table.endBuild();
+
+		BinaryRow probeRow = probeSideSerializer.createInstance();
+		while ((probeRow = probeInput.next(probeRow)) != null) {
+			if (table.tryProbe(probeRow)) {
+				testJoin(table, map);
+			}
+		}
+
+		while (table.nextMatching()) {
+			testJoin(table, map);
+		}
+
+		table.close();
+
+		Assert.assertEquals("Wrong number of keys", numKeys, map.size());
+		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+			long val = entry.getValue();
+			int key = entry.getKey();
+
+			Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
+					(key == repeatedValue1 || key == repeatedValue2) ?
+							(probeValsPerKey + repeatedValueCountProbe) * (buildValsPerKey + repeatedValueCountBuild) :
+							probeValsPerKey * buildValsPerKey, val);
+		}
+
+		// ----------------------------------------------------------------------------------------
+
+		table.free();
+	}
+
+	@Test
+	public void testSpillingHashJoinWithTwoRecursions() throws IOException {
+		// the following two values are known to have a hash-code collision on the first recursion level.
+		// we use them to make sure one partition grows over-proportionally large
+		final int repeatedValue1 = 40559;
+		final int repeatedValue2 = 92882;
+		final int repeatedValueCountBuild = 200000;
+		final int repeatedValueCountProbe = 5;
+
+		final int numKeys = 1000000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
+		MutableObjectIterator<BinaryRow> build1 = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+		MutableObjectIterator<BinaryRow> build2 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCountBuild);
+		MutableObjectIterator<BinaryRow> build3 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCountBuild);
+		List<MutableObjectIterator<BinaryRow>> builds = new ArrayList<>();
+		builds.add(build1);
+		builds.add(build2);
+		builds.add(build3);
+		MutableObjectIterator<BinaryRow> buildInput = new UnionIterator<>(builds);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probe1 = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+		MutableObjectIterator<BinaryRow> probe2 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, 5);
+		MutableObjectIterator<BinaryRow> probe3 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, 5);
+		List<MutableObjectIterator<BinaryRow>> probes = new ArrayList<>();
+		probes.add(probe1);
+		probes.add(probe2);
+		probes.add(probe3);
+		MutableObjectIterator<BinaryRow> probeInput = new UnionIterator<>(probes);
+
+		// create the map for validating the results
+		HashMap<Integer, Long> map = new HashMap<>(numKeys);
+
+		final MyHashTable table = new MyHashTable(896 * PAGE_SIZE);
+
+		BinaryRow buildRow = buildSideSerializer.createInstance();
+		while ((buildRow = buildInput.next(buildRow)) != null) {
+			table.putBuildRow(buildRow);
+		}
+		table.endBuild();
+
+		BinaryRow probeRow = probeSideSerializer.createInstance();
+		while ((probeRow = probeInput.next(probeRow)) != null) {
+			if (table.tryProbe(probeRow)) {
+				testJoin(table, map);
+			}
+		}
+
+		while (table.nextMatching()) {
+			testJoin(table, map);
+		}
+
+		table.close();
+
+		Assert.assertEquals("Wrong number of keys", numKeys, map.size());
+		for (Map.Entry<Integer, Long> entry : map.entrySet()) {
+			long val = entry.getValue();
+			int key = entry.getKey();
+
+			Assert.assertEquals("Wrong number of values in per-key cross product for key " + key,
+					(key == repeatedValue1 || key == repeatedValue2) ?
+							(probeValsPerKey + repeatedValueCountProbe) * (buildValsPerKey + repeatedValueCountBuild) :
+							probeValsPerKey * buildValsPerKey, val);
+		}
+
+		// ----------------------------------------------------------------------------------------
+
+		table.free();
+	}
+
+	/*
+	 * This test is basically identical to the "testSpillingHashJoinWithMassiveCollisions" test, only that the number
+	 * of repeated values (causing bucket collisions) are large enough to make sure that their target partition no longer
+	 * fits into memory by itself and needs to be repartitioned in the recursion again.
+	 */
+	@Test
+	public void testFailingHashJoinTooManyRecursions() throws IOException {
+		// the following two values are known to have a hash-code collision on the first recursion level.
+		// we use them to make sure one partition grows over-proportionally large
+		final int repeatedValue1 = 40559;
+		final int repeatedValue2 = 92882;
+		final int repeatedValueCount = 3000000;
+
+		final int numKeys = 1000000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 3 million pairs with 3 values sharing the same key, plus 400k pairs with two colliding keys
+		MutableObjectIterator<BinaryRow> build1 = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+		MutableObjectIterator<BinaryRow> build2 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCount);
+		MutableObjectIterator<BinaryRow> build3 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCount);
+		List<MutableObjectIterator<BinaryRow>> builds = new ArrayList<>();
+		builds.add(build1);
+		builds.add(build2);
+		builds.add(build3);
+		MutableObjectIterator<BinaryRow> buildInput = new UnionIterator<>(builds);
+
+		// create a probe input that gives 10 million pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probe1 = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+		MutableObjectIterator<BinaryRow> probe2 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue1, 17, repeatedValueCount);
+		MutableObjectIterator<BinaryRow> probe3 = new BinaryHashTableTest.ConstantsKeyValuePairsIterator(repeatedValue2, 23, repeatedValueCount);
+		List<MutableObjectIterator<BinaryRow>> probes = new ArrayList<>();
+		probes.add(probe1);
+		probes.add(probe2);
+		probes.add(probe3);
+		MutableObjectIterator<BinaryRow> probeInput = new UnionIterator<>(probes);
+		final MyHashTable table = new MyHashTable(896 * PAGE_SIZE);
+
+		try {
+			join(table, buildInput, probeInput);
+			fail("Hash Join must have failed due to too many recursions.");
+		} catch (Exception ex) {
+			// expected
+		}
+
+		table.close();
+
+		// ----------------------------------------------------------------------------------------
+
+		table.free();
+	}
+
+	@Test
+	public void testSparseProbeSpilling() throws IOException, MemoryAllocationException {
+		final int numBuildKeys = 1000000;
+		final int numBuildVals = 1;
+		final int numProbeKeys = 20;
+		final int numProbeVals = 1;
+
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(
+				numBuildKeys, numBuildVals, false);
+		final MyHashTable table = new MyHashTable(100 * PAGE_SIZE);
+
+		int expectedNumResults = (Math.min(numProbeKeys, numBuildKeys) * numBuildVals)
+				* numProbeVals;
+
+		int numRecordsInJoinResult = join(table, buildInput, new UniformBinaryRowGenerator(numProbeKeys, numProbeVals, true));
+
+		Assert.assertEquals("Wrong number of records in join result.", expectedNumResults, numRecordsInJoinResult);
+
+		table.close();
+
+		table.free();
+	}
+
+	@Test
+	public void validateSpillingDuringInsertion() throws IOException, MemoryAllocationException {
+		final int numBuildKeys = 500000;
+		final int numBuildVals = 1;
+		final int numProbeKeys = 10;
+		final int numProbeVals = 1;
+
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numBuildKeys, numBuildVals, false);
+		final MyHashTable table = new MyHashTable(85 * PAGE_SIZE);
+
+		int expectedNumResults = (Math.min(numProbeKeys, numBuildKeys) * numBuildVals)
+				* numProbeVals;
+
+		int numRecordsInJoinResult = join(table, buildInput, new UniformBinaryRowGenerator(numProbeKeys, numProbeVals, true));
+
+		Assert.assertEquals("Wrong number of records in join result.", expectedNumResults, numRecordsInJoinResult);
+
+		table.close();
+
+		table.free();
+	}
+
+	@Test
+	public void testBucketsNotFulfillSegment() throws Exception {
+		final int numKeys = 10000;
+		final int buildValsPerKey = 3;
+		final int probeValsPerKey = 10;
+
+		// create a build input that gives 30000 pairs with 3 values sharing the same key
+		MutableObjectIterator<BinaryRow> buildInput = new UniformBinaryRowGenerator(numKeys, buildValsPerKey, false);
+
+		// create a probe input that gives 100000 pairs with 10 values sharing a key
+		MutableObjectIterator<BinaryRow> probeInput = new UniformBinaryRowGenerator(numKeys, probeValsPerKey, true);
+
+		// ----------------------------------------------------------------------------------------
+
+		final MyHashTable table = new MyHashTable(35 * PAGE_SIZE);
+
+		int numRecordsInJoinResult = join(table, buildInput, probeInput);
+
+		Assert.assertEquals("Wrong number of records in join result.", numKeys * buildValsPerKey * probeValsPerKey, numRecordsInJoinResult);
+
+		table.close();
+		table.free();
+	}
+
+	private void testJoin(MyHashTable table, HashMap<Integer, Long> map) throws IOException {
+		BinaryRow record;
+		int numBuildValues = 0;
+
+		final BaseRow probeRec = table.getCurrentProbeRow();
+		int key = probeRec.getInt(0);
+
+		RowIterator<BinaryRow> buildSide = table.getBuildSideIterator();
+		if (buildSide.advanceNext()) {
+			numBuildValues = 1;
+			record = buildSide.getRow();
+			assertEquals("Probe-side key was different than build-side key.", key, record.getInt(0));
+		} else {
+			fail("No build side values found for a probe key.");
+		}
+		while (buildSide.advanceNext()) {
+			numBuildValues++;
+			record = buildSide.getRow();
+			assertEquals("Probe-side key was different than build-side key.", key, record.getInt(0));
+		}
+
+		Long contained = map.get(key);
+		if (contained == null) {
+			contained = (long) numBuildValues;
+		} else {
+			contained = contained + numBuildValues;
+		}
+
+		map.put(key, contained);
+	}
+
+	private int join(
+			MyHashTable table,
+			MutableObjectIterator<BinaryRow> buildInput,
+			MutableObjectIterator<BinaryRow> probeInput) throws IOException {
+		int count = 0;
+
+		BinaryRow reuseBuildSizeRow = buildSideSerializer.createInstance();
+		BinaryRow buildRow;
+		while ((buildRow = buildInput.next(reuseBuildSizeRow)) != null) {
+			table.putBuildRow(buildRow);
+		}
+		table.endBuild();
+
+		BinaryRow probeRow = probeSideSerializer.createInstance();
+		while ((probeRow = probeInput.next(probeRow)) != null) {
+			if (table.tryProbe(probeRow)){
+				count += joinWithNextKey(table);
+			}
+		}
+
+		while (table.nextMatching()){
+			count += joinWithNextKey(table);
+		}
+		return count;
+	}
+
+	private int joinWithNextKey(MyHashTable table) throws IOException {
+		int count = 0;
+		final RowIterator<BinaryRow> buildIterator = table.getBuildSideIterator();
+		final BaseRow probeRow = table.getCurrentProbeRow();
+		BinaryRow buildRow;
+
+		buildRow = buildIterator.advanceNext() ? buildIterator.getRow() : null;
+		// get the first build side value
+		if (probeRow != null && buildRow != null) {
+			count++;
+			while (buildIterator.advanceNext()) {
+				count++;
+			}
+		}
+		return count;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/resources/log4j-test.properties
+++ b/flink-table/flink-table-runtime-blink/src/test/resources/log4j-test.properties
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=OFF, testlogger
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

We can do further optimizations if we know the join key fits in long, a single long field or two integer fields are both ok. For example, we can combine the hash code and actual key into one field, there will be no hash collision, can save a lot of unnecessary logic.


## Brief change log

  - Introduce a new data structure: LongHybridHashTable


## Verifying this change

This change added some unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
