### PR TITLE
[hotfix][runtime] Remove unused local variable in ExecutionGraphBuilder

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -280,9 +280,6 @@ public class ExecutionGraphBuilder {
 					snapshotSettings.getCheckpointCoordinatorConfiguration(),
 					metrics);
 
-			// The default directory for externalized checkpoints
-			String externalizedCheckpointsDir = jobManagerConfig.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
-
 			// load the state backend from the application settings
 			final StateBackend applicationConfiguredBackend;
 			final SerializedValue<StateBackend> serializedAppConfigured = snapshotSettings.getDefaultStateBackend();


### PR DESCRIPTION
Remove unused local variable in ExecutionGraphBuilder