### PR TITLE
[FLINK-11923][metrics] MetricRegistryConfiguration provides MetricReporters Suppliers

### DIFF
--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.dropwizard;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.dropwizard.metrics.DropwizardMeterWrapper;
@@ -36,6 +35,7 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
@@ -45,6 +45,7 @@ import com.codahale.metrics.ScheduledReporter;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -82,16 +83,14 @@ public class ScheduledDropwizardReporterTest {
 		String taskManagerId = "tas:kMana::ger";
 		String counterName = "testCounter";
 
-		configuration.setString(
-				ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
-				"org.apache.flink.dropwizard.ScheduledDropwizardReporterTest$TestingScheduledDropwizardReporter");
-
 		configuration.setString(MetricOptions.SCOPE_NAMING_TASK, "<host>.<tm_id>.<job_name>");
 		configuration.setString(MetricOptions.SCOPE_DELIMITER, "_");
 
 		MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(configuration);
 
-		MetricRegistryImpl metricRegistry = new MetricRegistryImpl(metricRegistryConfiguration);
+		MetricRegistryImpl metricRegistry = new MetricRegistryImpl(
+			metricRegistryConfiguration,
+			Collections.singletonList(ReporterSetup.forReporter("test", new TestingScheduledDropwizardReporter())));
 
 		char delimiter = metricRegistry.getDelimiter();
 

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
@@ -19,12 +19,12 @@
 package org.apache.flink.dropwizard.metrics;
 
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.dropwizard.ScheduledDropwizardReporter;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.util.TestLogger;
 
@@ -39,6 +39,7 @@ import com.codahale.metrics.Timer;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,16 +100,16 @@ public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
 		long timeout = 30000;
 		int size = 10;
 		String histogramMetricName = "histogram";
-		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestingReporter.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, reportingInterval + " MILLISECONDS");
+
+		MetricConfig config = new MetricConfig();
+		config.setProperty(ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, reportingInterval + " MILLISECONDS");
 
 		MetricRegistryImpl registry = null;
 
-		MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
-
 		try {
-			registry = new MetricRegistryImpl(metricRegistryConfiguration);
+			registry = new MetricRegistryImpl(
+				MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+				Collections.singletonList(ReporterSetup.forReporter("test", config, new TestingReporter())));
 			DropwizardHistogramWrapper histogramWrapper = new DropwizardHistogramWrapper(
 				new com.codahale.metrics.Histogram(new SlidingWindowReservoir(size)));
 

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.metrics.influxdb;
 
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.util.TestLogger;
 
@@ -32,6 +32,8 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
@@ -117,15 +119,14 @@ public class InfluxdbReporterTest extends TestLogger {
 	}
 
 	private MetricRegistryImpl createMetricRegistry() {
-		String configPrefix = ConfigConstants.METRICS_REPORTER_PREFIX + "test.";
-		Configuration configuration = new Configuration();
-		configuration.setString(
-			configPrefix + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
-			InfluxdbReporter.class.getTypeName());
-		configuration.setString(configPrefix + "host", "localhost");
-		configuration.setString(configPrefix + "port", String.valueOf(wireMockRule.port()));
-		configuration.setString(configPrefix + "db", TEST_INFLUXDB_DB);
-		return new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(configuration));
+		MetricConfig metricConfig = new MetricConfig();
+		metricConfig.setProperty("host", "localhost");
+		metricConfig.setProperty("port", String.valueOf(wireMockRule.port()));
+		metricConfig.setProperty("db", TEST_INFLUXDB_DB);
+
+		return new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Collections.singletonList(ReporterSetup.forReporter("test", metricConfig, new InfluxdbReporter())));
 	}
 
 	private static Counter registerTestMetric(String metricName, MetricRegistry metricRegistry) {

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -18,17 +18,16 @@
 
 package org.apache.flink.metrics.jmx;
 
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
-import org.apache.flink.runtime.metrics.util.TestReporter;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -43,6 +42,8 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -98,15 +99,15 @@ public class JMXReporterTest extends TestLogger {
 	 */
 	@Test
 	public void testPortConflictHandling() throws Exception {
-		Configuration cfg = new Configuration();
+		MetricConfig metricConfig = new MetricConfig();
+		metricConfig.setProperty("port", "9020-9035");
 
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1.port", "9020-9035");
+		ReporterSetup reporterSetup1 = ReporterSetup.forReporter("test1", metricConfig, new JMXReporter());
+		ReporterSetup reporterSetup2 = ReporterSetup.forReporter("test2", metricConfig, new JMXReporter());
 
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2.port", "9020-9035");
-
-		MetricRegistryImpl reg = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+		MetricRegistryImpl reg = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Arrays.asList(reporterSetup1, reporterSetup2));
 
 		TaskManagerMetricGroup mg = new TaskManagerMetricGroup(reg, "host", "tm");
 
@@ -155,16 +156,15 @@ public class JMXReporterTest extends TestLogger {
 	 */
 	@Test
 	public void testJMXAvailability() throws Exception {
-		Configuration cfg = new Configuration();
-		cfg.setString(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter.class.getName());
+		MetricConfig metricConfig = new MetricConfig();
+		metricConfig.setProperty("port", "9040-9055");
 
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1.port", "9040-9055");
+		ReporterSetup reporterSetup1 = ReporterSetup.forReporter("test1", metricConfig, new JMXReporter());
+		ReporterSetup reporterSetup2 = ReporterSetup.forReporter("test2", metricConfig, new JMXReporter());
 
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
-		cfg.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2.port", "9040-9055");
-
-		MetricRegistryImpl reg = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+		MetricRegistryImpl reg = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Arrays.asList(reporterSetup1, reporterSetup2));
 
 		TaskManagerMetricGroup mg = new TaskManagerMetricGroup(reg, "host", "tm");
 
@@ -231,10 +231,9 @@ public class JMXReporterTest extends TestLogger {
 		String histogramName = "histogram";
 
 		try {
-			Configuration config = new Configuration();
-			config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "jmx_test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
-
-			registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+			registry = new MetricRegistryImpl(
+				MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+				Collections.singletonList(ReporterSetup.forReporter("test", new JMXReporter())));
 
 			TaskManagerMetricGroup metricGroup = new TaskManagerMetricGroup(registry, "localhost", "tmId");
 
@@ -280,10 +279,9 @@ public class JMXReporterTest extends TestLogger {
 		String meterName = "meter";
 
 		try {
-			Configuration config = new Configuration();
-			config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "jmx_test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
-
-			registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+			registry = new MetricRegistryImpl(
+				MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+				Collections.singletonList(ReporterSetup.forReporter("test", new JMXReporter())));
 
 			TaskManagerMetricGroup metricGroup = new TaskManagerMetricGroup(registry, "localhost", "tmId");
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -41,8 +41,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
-import static org.apache.flink.metrics.prometheus.PrometheusReporterTest.createConfigWithOneReporter;
+import static org.apache.flink.metrics.prometheus.PrometheusReporterTest.createReporterSetup;
 import static org.apache.flink.metrics.prometheus.PrometheusReporterTest.pollMetrics;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -80,7 +81,9 @@ public class PrometheusReporterTaskScopeTest {
 
 	@Before
 	public void setupReporter() {
-		registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9400-9500")));
+		registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Collections.singletonList(createReporterSetup("test1", "9400-9500")));
 		reporter = (PrometheusReporter) registry.getReporters().get(0);
 
 		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(registry, TASK_MANAGER_HOST, TASK_MANAGER_ID);

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -286,10 +286,10 @@ public class PrometheusReporterTest extends TestLogger {
 		String portRange = portRangeProvider.next();
 		final MetricRegistryImpl portRange1 = new MetricRegistryImpl(
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
-			Collections.singletonList(createReporterSetup("test1", portRangeProvider.next())));
+			Collections.singletonList(createReporterSetup("test1", portRange)));
 		final MetricRegistryImpl portRange2 = new MetricRegistryImpl(
 			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
-			Collections.singletonList(createReporterSetup("test2", portRangeProvider.next())));
+			Collections.singletonList(createReporterSetup("test2", portRange)));
 
 		assertThat(portRange1.getReporters(), hasSize(1));
 		assertThat(portRange2.getReporters(), hasSize(1));

--- a/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
+++ b/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.metrics.slf4j;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Gauge;
@@ -32,6 +31,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.util.TestLogger;
@@ -39,6 +39,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -63,11 +65,11 @@ public class Slf4jReporterTest extends TestLogger {
 		TestUtils.addTestAppenderForRootLogger();
 
 		Configuration configuration = new Configuration();
-		configuration.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "slf4j." +
-			ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, Slf4jReporter.class.getName());
 		configuration.setString(MetricOptions.SCOPE_NAMING_TASK, "<host>.<tm_id>.<job_name>");
 
-		registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(configuration));
+		registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(configuration),
+			Collections.singletonList(ReporterSetup.forReporter("slf4j", new Slf4jReporter())));
 		delimiter = registry.getDelimiter();
 
 		taskMetricGroup = new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER_ID)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -303,7 +304,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	}
 
 	protected MetricRegistryImpl createMetricRegistry(Configuration configuration) {
-		return new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(configuration));
+		return new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(configuration),
+			ReporterSetup.fromConfiguration(configuration));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
@@ -18,29 +18,14 @@
 
 package org.apache.flink.runtime.metrics;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.configuration.MetricOptions;
-import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.function.SupplierWithException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Configuration object for {@link MetricRegistryImpl}.
@@ -51,36 +36,21 @@ public class MetricRegistryConfiguration {
 
 	private static volatile MetricRegistryConfiguration defaultConfiguration;
 
-	// regex pattern to split the defined reporters
-	private static final Pattern reporterListPattern = Pattern.compile("\\s*,\\s*");
-
-	// regex pattern to extract the name from reporter configuration keys, e.g. "rep" from "metrics.reporter.rep.class"
-	private static final Pattern reporterClassPattern = Pattern.compile(
-		Pattern.quote(ConfigConstants.METRICS_REPORTER_PREFIX) +
-		// [\S&&[^.]] = intersection of non-whitespace and non-period character classes
-		"([\\S&&[^.]]*)\\." +
-		Pattern.quote(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX));
-
 	// scope formats for the different components
 	private final ScopeFormats scopeFormats;
 
 	// delimiter for the scope strings
 	private final char delimiter;
 
-	// contains for every configured reporter its name and the configuration object
-	private final List<ReporterSetup> reporterSetups;
-
 	private final long queryServiceMessageSizeLimit;
 
 	public MetricRegistryConfiguration(
 		ScopeFormats scopeFormats,
 		char delimiter,
-		List<ReporterSetup> reporterSetups,
 		long queryServiceMessageSizeLimit) {
 
 		this.scopeFormats = Preconditions.checkNotNull(scopeFormats);
 		this.delimiter = delimiter;
-		this.reporterSetups = Preconditions.checkNotNull(reporterSetups);
 		this.queryServiceMessageSizeLimit = queryServiceMessageSizeLimit;
 	}
 
@@ -94,10 +64,6 @@ public class MetricRegistryConfiguration {
 
 	public char getDelimiter() {
 		return delimiter;
-	}
-
-	public List<ReporterSetup> getReporterSetups() {
-		return reporterSetups;
 	}
 
 	public long getQueryServiceMessageSizeLimit() {
@@ -131,81 +97,12 @@ public class MetricRegistryConfiguration {
 			delim = '.';
 		}
 
-		String includedReportersString = configuration.getString(MetricOptions.REPORTERS_LIST, "");
-		Set<String> includedReporters = reporterListPattern.splitAsStream(includedReportersString)
-			.filter(r -> !r.isEmpty()) // splitting an empty string results in an empty string on jdk9+
-			.collect(Collectors.toSet());
-
-		// use a TreeSet to make the reporter order deterministic, which is useful for testing
-		Set<String> namedReporters = new TreeSet<>(String::compareTo);
-		// scan entire configuration for "metric.reporter" keys and parse individual reporter configurations
-		for (String key : configuration.keySet()) {
-			if (key.startsWith(ConfigConstants.METRICS_REPORTER_PREFIX)) {
-				Matcher matcher = reporterClassPattern.matcher(key);
-				if (matcher.matches()) {
-					String reporterName = matcher.group(1);
-					if (includedReporters.isEmpty() || includedReporters.contains(reporterName)) {
-						if (namedReporters.contains(reporterName)) {
-							LOG.warn("Duplicate class configuration detected for reporter {}.", reporterName);
-						} else {
-							namedReporters.add(reporterName);
-						}
-					} else {
-						LOG.info("Excluding reporter {}, not configured in reporter list ({}).", reporterName, includedReportersString);
-					}
-				}
-			}
-		}
-
-		List<Tuple2<String, Configuration>> reporterConfigurations;
-
-		if (namedReporters.isEmpty()) {
-			reporterConfigurations = Collections.emptyList();
-		} else {
-			reporterConfigurations = new ArrayList<>(namedReporters.size());
-
-			for (String namedReporter: namedReporters) {
-				DelegatingConfiguration delegatingConfiguration = new DelegatingConfiguration(
-					configuration,
-					ConfigConstants.METRICS_REPORTER_PREFIX + namedReporter + '.');
-
-				reporterConfigurations.add(Tuple2.of(namedReporter, (Configuration) delegatingConfiguration));
-			}
-		}
-
-		List<ReporterSetup> reporterArguments = new ArrayList<>(reporterConfigurations.size());
-		for (Tuple2<String, Configuration> reporterConfiguration: reporterConfigurations) {
-			String reporterName = reporterConfiguration.f0;
-			Configuration reporterConfig = reporterConfiguration.f1;
-
-			try {
-				final String reporterClassName = reporterConfig.getString(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, null);
-				if (reporterClassName == null) {
-					LOG.error("No reporter class set for reporter " + reporterName + ". Metrics might not be exposed/reported.");
-					continue;
-				}
-
-				final SupplierWithException<MetricReporter, Exception> supplier = () -> {
-					Class<?> reporterClass = Class.forName(reporterClassName);
-					return (MetricReporter) reporterClass.newInstance();
-				};
-
-				MetricConfig metricConfig = new MetricConfig();
-				reporterConfig.addAllToProperties(metricConfig);
-
-				reporterArguments.add(new ReporterSetup(reporterName, metricConfig, supplier));
-			}
-			catch (Throwable t) {
-				LOG.error("Could not instantiate metrics reporter {}. Metrics might not be exposed/reported.", reporterName, t);
-			}
-		}
-
 		final long maximumFrameSize = AkkaRpcServiceUtils.extractMaximumFramesize(configuration);
 
 		// padding to account for serialization overhead
 		final long messageSizeLimitPadding = 256;
 
-		return new MetricRegistryConfiguration(scopeFormats, delim, reporterArguments, maximumFrameSize - messageSizeLimitPadding);
+		return new MetricRegistryConfiguration(scopeFormats, delim, maximumFrameSize - messageSizeLimitPadding);
 	}
 
 	public static MetricRegistryConfiguration defaultMetricRegistryConfiguration() {
@@ -219,34 +116,6 @@ public class MetricRegistryConfiguration {
 		}
 
 		return defaultConfiguration;
-	}
-
-	/**
-	 * Encapsulates everything needed for the instantiation and configuration of a {@link MetricReporter}.
-	 */
-	public static class ReporterSetup {
-
-		private final String name;
-		private final MetricConfig configuration;
-		private final SupplierWithException<MetricReporter, Exception> supplier;
-
-		ReporterSetup(final String name, final MetricConfig configuration, SupplierWithException<MetricReporter, Exception> supplier) {
-			this.name = name;
-			this.configuration = configuration;
-			this.supplier = supplier;
-		}
-
-		public String getName() {
-			return name;
-		}
-
-		public MetricConfig getConfiguration() {
-			return configuration;
-		}
-
-		public SupplierWithException<MetricReporter, Exception> getSupplier() {
-			return supplier;
-		}
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -20,9 +20,7 @@ package org.apache.flink.runtime.metrics;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
@@ -101,7 +99,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 		// second, instantiate any custom configured reporters
 		this.reporters = new ArrayList<>(4);
 
-		List<Tuple2<String, Configuration>> reporterConfigurations = config.getReporterConfigurations();
+		List<MetricRegistryConfiguration.ReporterSetup> reporterConfigurations = config.getReporterSetups();
 
 		this.executor = Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("Flink-MetricRegistry"));
 
@@ -113,19 +111,12 @@ public class MetricRegistryImpl implements MetricRegistry {
 			// by default, don't report anything
 			LOG.info("No metrics reporter configured, no metrics will be exposed/reported.");
 		} else {
-			// we have some reporters so
-			for (Tuple2<String, Configuration> reporterConfiguration: reporterConfigurations) {
-				String namedReporter = reporterConfiguration.f0;
-				Configuration reporterConfig = reporterConfiguration.f1;
-
-				final String className = reporterConfig.getString(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, null);
-				if (className == null) {
-					LOG.error("No reporter class set for reporter " + namedReporter + ". Metrics might not be exposed/reported.");
-					continue;
-				}
+			for (MetricRegistryConfiguration.ReporterSetup reporterSetup : reporterConfigurations) {
+				final String namedReporter = reporterSetup.getName();
+				final MetricConfig metricConfig = reporterSetup.getConfiguration();
 
 				try {
-					String configuredPeriod = reporterConfig.getString(ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, null);
+					String configuredPeriod = metricConfig.getString(ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, null);
 					TimeUnit timeunit = TimeUnit.SECONDS;
 					long period = 10;
 
@@ -142,11 +133,9 @@ public class MetricRegistryImpl implements MetricRegistry {
 						}
 					}
 
-					Class<?> reporterClass = Class.forName(className);
-					MetricReporter reporterInstance = (MetricReporter) reporterClass.newInstance();
+					final MetricReporter reporterInstance = reporterSetup.getSupplier().get();
+					final String className = reporterInstance.getClass().getName();
 
-					MetricConfig metricConfig = new MetricConfig();
-					reporterConfig.addAllToProperties(metricConfig);
 					LOG.info("Configuring {} with {}.", namedReporter, metricConfig);
 					reporterInstance.open(metricConfig);
 
@@ -160,7 +149,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 					}
 					reporters.add(reporterInstance);
 
-					String delimiterForReporter = reporterConfig.getString(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, String.valueOf(globalDelimiter));
+					String delimiterForReporter = metricConfig.getString(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, String.valueOf(globalDelimiter));
 					if (delimiterForReporter.length() != 1) {
 						LOG.warn("Failed to parse delimiter '{}' for reporter '{}', using global delimiter '{}'.", delimiterForReporter, namedReporter, globalDelimiter);
 						delimiterForReporter = String.valueOf(globalDelimiter);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -93,7 +93,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 	/**
 	 * Creates a new MetricRegistry and starts the configured reporter.
 	 */
-	public MetricRegistryImpl(MetricRegistryConfiguration config, List<ReporterSetup> reporterConfigurations) {
+	public MetricRegistryImpl(MetricRegistryConfiguration config, Collection<ReporterSetup> reporterConfigurations) {
 		this.maximumFramesize = config.getQueryServiceMessageSizeLimit();
 		this.scopeFormats = config.getScopeFormats();
 		this.globalDelimiter = config.getDelimiter();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -65,11 +66,20 @@ public final class ReporterSetup {
 		this.reporter = reporter;
 	}
 
+	public Optional<String> getDelimiter() {
+		return Optional.ofNullable(configuration.getString(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, null));
+	}
+
+	public Optional<String> getIntervalSettings() {
+		return Optional.ofNullable(configuration.getString(ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, null));
+	}
+
 	public String getName() {
 		return name;
 	}
 
-	public MetricConfig getConfiguration() {
+	@VisibleForTesting
+	MetricConfig getConfiguration() {
 		return configuration;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DelegatingConfiguration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.reporter.MetricReporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulates everything needed for the instantiation and configuration of a {@link MetricReporter}.
+ */
+public final class ReporterSetup {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ReporterSetup.class);
+
+	// regex pattern to split the defined reporters
+	private static final Pattern reporterListPattern = Pattern.compile("\\s*,\\s*");
+
+	// regex pattern to extract the name from reporter configuration keys, e.g. "rep" from "metrics.reporter.rep.class"
+	private static final Pattern reporterClassPattern = Pattern.compile(
+		Pattern.quote(ConfigConstants.METRICS_REPORTER_PREFIX) +
+			// [\S&&[^.]] = intersection of non-whitespace and non-period character classes
+			"([\\S&&[^.]]*)\\." +
+			Pattern.quote(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX));
+
+	private final String name;
+	private final MetricConfig configuration;
+	private final MetricReporter reporter;
+
+	public ReporterSetup(final String name, final MetricConfig configuration, MetricReporter reporter) {
+		this.name = name;
+		this.configuration = configuration;
+		this.reporter = reporter;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public MetricConfig getConfiguration() {
+		return configuration;
+	}
+
+	public MetricReporter getReporter() {
+		return reporter;
+	}
+
+	@VisibleForTesting
+	public static ReporterSetup forReporter(String reporterName, MetricReporter reporter) {
+		return createReporterSetup(reporterName, new MetricConfig(), reporter);
+	}
+
+	@VisibleForTesting
+	public static ReporterSetup forReporter(String reporterName, MetricConfig metricConfig, MetricReporter reporter) {
+		return createReporterSetup(reporterName, metricConfig, reporter);
+	}
+
+	private static ReporterSetup createReporterSetup(String reporterName, MetricConfig metricConfig, MetricReporter reporter) {
+		LOG.info("Configuring {} with {}.", reporterName, metricConfig);
+		reporter.open(metricConfig);
+
+		return new ReporterSetup(reporterName, metricConfig, reporter);
+	}
+
+	public static List<ReporterSetup> fromConfiguration(final Configuration configuration) {
+		String includedReportersString = configuration.getString(MetricOptions.REPORTERS_LIST, "");
+		Set<String> includedReporters = reporterListPattern.splitAsStream(includedReportersString)
+			.filter(r -> !r.isEmpty()) // splitting an empty string results in an empty string on jdk9+
+			.collect(Collectors.toSet());
+
+		// use a TreeSet to make the reporter order deterministic, which is useful for testing
+		Set<String> namedReporters = new TreeSet<>(String::compareTo);
+		// scan entire configuration for "metric.reporter" keys and parse individual reporter configurations
+		for (String key : configuration.keySet()) {
+			if (key.startsWith(ConfigConstants.METRICS_REPORTER_PREFIX)) {
+				Matcher matcher = reporterClassPattern.matcher(key);
+				if (matcher.matches()) {
+					String reporterName = matcher.group(1);
+					if (includedReporters.isEmpty() || includedReporters.contains(reporterName)) {
+						if (namedReporters.contains(reporterName)) {
+							LOG.warn("Duplicate class configuration detected for reporter {}.", reporterName);
+						} else {
+							namedReporters.add(reporterName);
+						}
+					} else {
+						LOG.info("Excluding reporter {}, not configured in reporter list ({}).", reporterName, includedReportersString);
+					}
+				}
+			}
+		}
+
+		List<Tuple2<String, Configuration>> reporterConfigurations;
+
+		if (namedReporters.isEmpty()) {
+			reporterConfigurations = Collections.emptyList();
+		} else {
+			reporterConfigurations = new ArrayList<>(namedReporters.size());
+
+			for (String namedReporter: namedReporters) {
+				DelegatingConfiguration delegatingConfiguration = new DelegatingConfiguration(
+					configuration,
+					ConfigConstants.METRICS_REPORTER_PREFIX + namedReporter + '.');
+
+				reporterConfigurations.add(Tuple2.of(namedReporter, (Configuration) delegatingConfiguration));
+			}
+		}
+
+		List<ReporterSetup> reporterArguments = new ArrayList<>(reporterConfigurations.size());
+		for (Tuple2<String, Configuration> reporterConfiguration: reporterConfigurations) {
+			String reporterName = reporterConfiguration.f0;
+			Configuration reporterConfig = reporterConfiguration.f1;
+
+			try {
+				final String reporterClassName = reporterConfig.getString(ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, null);
+				if (reporterClassName == null) {
+					LOG.error("No reporter class set for reporter " + reporterName + ". Metrics might not be exposed/reported.");
+					continue;
+				}
+
+				Class<?> reporterClass = Class.forName(reporterClassName);
+				MetricReporter reporter = (MetricReporter) reporterClass.newInstance();
+
+				MetricConfig metricConfig = new MetricConfig();
+				reporterConfig.addAllToProperties(metricConfig);
+
+				reporterArguments.add(createReporterSetup(reporterName, metricConfig, reporter));
+			}
+			catch (Throwable t) {
+				LOG.error("Could not instantiate metrics reporter {}. Metrics might not be exposed/reported.", reporterName, t);
+			}
+		}
+		return reporterArguments;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -694,7 +695,9 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	 * @param config The configuration of the mini cluster
 	 */
 	protected MetricRegistryImpl createMetricRegistry(Configuration config) {
-		return new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		return new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(config),
+			ReporterSetup.fromConfiguration(config));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -132,7 +133,9 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		HeartbeatServices heartbeatServices = HeartbeatServices.fromConfiguration(configuration);
 
-		metricRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(configuration));
+		metricRegistry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(configuration),
+			ReporterSetup.fromConfiguration(configuration));
 
 		final RpcService metricQueryServiceRpcService = MetricUtils.startMetricsRpcService(configuration, rpcService.getAddress());
 		metricRegistry.startQueryService(metricQueryServiceRpcService, resourceId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -45,6 +45,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -112,64 +114,6 @@ public class MetricRegistryImplTest extends TestLogger {
 	}
 
 	/**
-	 * Verifies that multiple reporters are instantiated correctly.
-	 */
-	@Test
-	public void testMultipleReporterInstantiation() throws Exception {
-		Configuration config = new Configuration();
-
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter11.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter12.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter13.class.getName());
-
-		MetricRegistryImpl metricRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
-
-		assertTrue(metricRegistry.getReporters().size() == 3);
-
-		Assert.assertTrue(TestReporter11.wasOpened);
-		Assert.assertTrue(TestReporter12.wasOpened);
-		Assert.assertTrue(TestReporter13.wasOpened);
-
-		metricRegistry.shutdown().get();
-	}
-
-	/**
-	 * Reporter that exposes whether open() was called.
-	 */
-	protected static class TestReporter11 extends TestReporter {
-		public static boolean wasOpened = false;
-
-		@Override
-		public void open(MetricConfig config) {
-			wasOpened = true;
-		}
-	}
-
-	/**
-	 * Reporter that exposes whether open() was called.
-	 */
-	protected static class TestReporter12 extends TestReporter {
-		public static boolean wasOpened = false;
-
-		@Override
-		public void open(MetricConfig config) {
-			wasOpened = true;
-		}
-	}
-
-	/**
-	 * Reporter that exposes whether open() was called.
-	 */
-	protected static class TestReporter13 extends TestReporter {
-		public static boolean wasOpened = false;
-
-		@Override
-		public void open(MetricConfig config) {
-			wasOpened = true;
-		}
-	}
-
-	/**
 	 * Reporter that exposes the {@link MetricConfig} it was given.
 	 */
 	protected static class TestReporter2 extends TestReporter {
@@ -185,13 +129,13 @@ public class MetricRegistryImplTest extends TestLogger {
 	 */
 	@Test
 	public void testReporterScheduling() throws Exception {
-		Configuration config = new Configuration();
+		MetricConfig config = new MetricConfig();
+		config.setProperty("arg1", "hello");
+		config.setProperty(ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, "50 MILLISECONDS");
 
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter3.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg1", "hello");
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX, "50 MILLISECONDS");
-
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Collections.singletonList(ReporterSetup.forReporter("test", config, new TestReporter3())));
 
 		long start = System.currentTimeMillis();
 
@@ -239,7 +183,11 @@ public class MetricRegistryImplTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter6.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter7.class.getName());
 
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Arrays.asList(
+				ReporterSetup.forReporter("test1", new TestReporter6()),
+				ReporterSetup.forReporter("test2", new TestReporter7())));
 
 		TaskManagerMetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
 		root.counter("rootCounter");
@@ -333,7 +281,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		config.setString(MetricOptions.SCOPE_DELIMITER, "_");
 		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D.E");
 
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config), ReporterSetup.fromConfiguration(config));
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
 		assertEquals("A_B_C_D_E_name", tmGroup.getMetricIdentifier("name"));
@@ -343,15 +291,21 @@ public class MetricRegistryImplTest extends TestLogger {
 
 	@Test
 	public void testConfigurableDelimiterForReporters() throws Exception {
-		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "_");
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "-");
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "AA");
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter.class.getName());
+		MetricConfig config1 = new MetricConfig();
+		config1.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "_");
 
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricConfig config2 = new MetricConfig();
+		config2.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "-");
+
+		MetricConfig config3 = new MetricConfig();
+		config3.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "AA");
+
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Arrays.asList(
+				ReporterSetup.forReporter("test1", config1, new TestReporter()),
+				ReporterSetup.forReporter("test2", config2, new TestReporter()),
+				ReporterSetup.forReporter("test3", config3, new TestReporter())));
 
 		assertEquals(GLOBAL_DEFAULT_DELIMITER, registry.getDelimiter());
 		assertEquals('_', registry.getDelimiter(0));
@@ -365,7 +319,18 @@ public class MetricRegistryImplTest extends TestLogger {
 
 	@Test
 	public void testConfigurableDelimiterForReportersInGroup() throws Exception {
+		MetricConfig config1 = new MetricConfig();
+		config1.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "_");
+
+		MetricConfig config2 = new MetricConfig();
+		config2.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "-");
+
+		MetricConfig config3 = new MetricConfig();
+		config3.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "AA");
+
 		Configuration config = new Configuration();
+		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B");
+
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "_");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter8.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "-");
@@ -373,9 +338,15 @@ public class MetricRegistryImplTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "AA");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter8.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test4." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter8.class.getName());
-		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B");
 
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(config),
+			Arrays.asList(
+				ReporterSetup.forReporter("test1", config1, new TestReporter8()),
+				ReporterSetup.forReporter("test2", config2, new TestReporter8()),
+				ReporterSetup.forReporter("test3", config3, new TestReporter8()),
+				ReporterSetup.forReporter("test4", new TestReporter8())));
+
 		List<MetricReporter> reporters = registry.getReporters();
 		((TestReporter8) reporters.get(0)).expectedDelimiter = '_'; //test1  reporter
 		((TestReporter8) reporters.get(1)).expectedDelimiter = '-'; //test2 reporter
@@ -437,12 +408,11 @@ public class MetricRegistryImplTest extends TestLogger {
 
 	@Test
 	public void testExceptionIsolation() throws Exception {
-
-		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, FailingReporter.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter7.class.getName());
-
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Arrays.asList(
+				ReporterSetup.forReporter("test1", new FailingReporter()),
+				ReporterSetup.forReporter("test2", new TestReporter7())));
 
 		Counter metric = new SimpleCounter();
 		registry.register(metric, "counter", new MetricGroupTest.DummyAbstractMetricGroup(registry));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.util.TestReporter;
 import org.apache.flink.util.TestLogger;
@@ -28,14 +29,16 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for the {@link MetricRegistryConfiguration}.
+ * Tests for the {@link ReporterSetup}.
  */
-public class MetricRegistryConfigurationTest extends TestLogger {
+public class ReporterSetupTest extends TestLogger {
 
 	/**
 	 * TestReporter1 class only for type differentiation.
@@ -56,19 +59,19 @@ public class MetricRegistryConfigurationTest extends TestLogger {
 	public void testReporterArgumentForwarding() {
 		final Configuration config = new Configuration();
 
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, ReporterSetupTest.TestReporter1.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter.arg1", "value1");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter.arg2", "value2");
 
-		final MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
 
-		Assert.assertEquals(1, metricRegistryConfiguration.getReporterSetups().size());
+		Assert.assertEquals(1, reporterSetups.size());
 
-		final MetricRegistryConfiguration.ReporterSetup reporterSetup = metricRegistryConfiguration.getReporterSetups().get(0);
+		final ReporterSetup reporterSetup = reporterSetups.get(0);
 		Assert.assertEquals("reporter", reporterSetup.getName());
 		Assert.assertEquals("value1", reporterSetup.getConfiguration().getString("arg1", null));
 		Assert.assertEquals("value2", reporterSetup.getConfiguration().getString("arg2", null));
-		Assert.assertEquals(TestReporter1.class.getName(), reporterSetup.getConfiguration().getString("class", null));
+		Assert.assertEquals(ReporterSetupTest.TestReporter1.class.getName(), reporterSetup.getConfiguration().getString("class", null));
 	}
 
 	/**
@@ -78,35 +81,35 @@ public class MetricRegistryConfigurationTest extends TestLogger {
 	public void testSeveralReportersWithArgumentForwarding() {
 		final Configuration config = new Configuration();
 
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, ReporterSetupTest.TestReporter1.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter1.arg1", "value1");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter1.arg2", "value2");
 
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter2.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, ReporterSetupTest.TestReporter2.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter2.arg1", "value1");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter2.arg3", "value3");
 
-		final MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
 
-		Assert.assertEquals(2, metricRegistryConfiguration.getReporterSetups().size());
+		Assert.assertEquals(2, reporterSetups.size());
 
-		final Optional<MetricRegistryConfiguration.ReporterSetup> reporter1Config = metricRegistryConfiguration.getReporterSetups().stream()
+		final Optional<ReporterSetup> reporter1Config = reporterSetups.stream()
 			.filter(c -> "reporter1".equals(c.getName()))
 			.findFirst();
 		Assert.assertTrue(reporter1Config.isPresent());
 		Assert.assertEquals("reporter1", reporter1Config.get().getName());
 		Assert.assertEquals("value1", reporter1Config.get().getConfiguration().getString("arg1", ""));
 		Assert.assertEquals("value2", reporter1Config.get().getConfiguration().getString("arg2", ""));
-		Assert.assertEquals(TestReporter1.class.getName(), reporter1Config.get().getConfiguration().getString("class", null));
+		Assert.assertEquals(ReporterSetupTest.TestReporter1.class.getName(), reporter1Config.get().getConfiguration().getString("class", null));
 
-		final Optional<MetricRegistryConfiguration.ReporterSetup> reporter2Config = metricRegistryConfiguration.getReporterSetups().stream()
+		final Optional<ReporterSetup> reporter2Config = reporterSetups.stream()
 			.filter(c -> "reporter2".equals(c.getName()))
 			.findFirst();
 		Assert.assertTrue(reporter1Config.isPresent());
 		Assert.assertEquals("reporter2", reporter2Config.get().getName());
 		Assert.assertEquals("value1", reporter2Config.get().getConfiguration().getString("arg1", null));
 		Assert.assertEquals("value3", reporter2Config.get().getConfiguration().getString("arg3", null));
-		Assert.assertEquals(TestReporter2.class.getName(), reporter2Config.get().getConfiguration().getString("class", null));
+		Assert.assertEquals(ReporterSetupTest.TestReporter2.class.getName(), reporter2Config.get().getConfiguration().getString("class", null));
 	}
 
 	/**
@@ -126,11 +129,11 @@ public class MetricRegistryConfigurationTest extends TestLogger {
 
 		config.setString(MetricOptions.REPORTERS_LIST, "reporter2");
 
-		final MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
 
-		Assert.assertEquals(1, metricRegistryConfiguration.getReporterSetups().size());
+		Assert.assertEquals(1, reporterSetups.size());
 
-		final MetricRegistryConfiguration.ReporterSetup stringConfigurationTuple = metricRegistryConfiguration.getReporterSetups().get(0);
+		final ReporterSetup stringConfigurationTuple = reporterSetups.get(0);
 		Assert.assertEquals("reporter2", stringConfigurationTuple.getName());
 		Assert.assertEquals("value1", stringConfigurationTuple.getConfiguration().getString("arg1", null));
 		Assert.assertEquals("value3", stringConfigurationTuple.getConfiguration().getString("arg3", null));
@@ -143,13 +146,68 @@ public class MetricRegistryConfigurationTest extends TestLogger {
 
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
 
-		final MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
 
-		Assert.assertEquals(1, metricRegistryConfiguration.getReporterSetups().size());
+		Assert.assertEquals(1, reporterSetups.size());
 
-		final MetricRegistryConfiguration.ReporterSetup reporterSetup = metricRegistryConfiguration.getReporterSetups().get(0);
-		final MetricReporter metricReporter = reporterSetup.getSupplier().get();
+		final ReporterSetup reporterSetup = reporterSetups.get(0);
+		final MetricReporter metricReporter = reporterSetup.getReporter();
 		Assert.assertThat(metricReporter, instanceOf(TestReporter1.class));
+	}
 
+	/**
+	 * Verifies that multiple reporters are instantiated correctly.
+	 */
+	@Test
+	public void testMultipleReporterInstantiation() throws Exception {
+		Configuration config = new Configuration();
+
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter11.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter12.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter13.class.getName());
+
+		List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+
+		assertEquals(3, reporterSetups.size());
+
+		Assert.assertTrue(TestReporter11.wasOpened);
+		Assert.assertTrue(TestReporter12.wasOpened);
+		Assert.assertTrue(TestReporter13.wasOpened);
+	}
+
+	/**
+	 * Reporter that exposes whether open() was called.
+	 */
+	protected static class TestReporter11 extends TestReporter {
+		public static boolean wasOpened = false;
+
+		@Override
+		public void open(MetricConfig config) {
+			wasOpened = true;
+		}
+	}
+
+	/**
+	 * Reporter that exposes whether open() was called.
+	 */
+	protected static class TestReporter12 extends TestReporter {
+		public static boolean wasOpened = false;
+
+		@Override
+		public void open(MetricConfig config) {
+			wasOpened = true;
+		}
+	}
+
+	/**
+	 * Reporter that exposes whether open() was called.
+	 */
+	protected static class TestReporter13 extends TestReporter {
+		public static boolean wasOpened = false;
+
+		@Override
+		public void open(MetricConfig config) {
+			wasOpened = true;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -87,17 +87,15 @@ public class ReporterSetupTest extends TestLogger {
 			.filter(c -> "reporter1".equals(c.getName()))
 			.findFirst();
 
-		reporter1Config.ifPresentOrElse(
-			ReporterSetupTest::assertReporter1Configured,
-			Assert::fail);
+		Assert.assertTrue(reporter1Config.isPresent());
+		assertReporter1Configured(reporter1Config.get());
 
 		final Optional<ReporterSetup> reporter2Config = reporterSetups.stream()
 			.filter(c -> "reporter2".equals(c.getName()))
 			.findFirst();
 
-		reporter2Config.ifPresentOrElse(
-			ReporterSetupTest::assertReporter2Configured,
-			Assert::fail);
+		Assert.assertTrue(reporter2Config.isPresent());
+		assertReporter2Configured(reporter2Config.get());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -24,16 +24,20 @@ import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.metrics.util.TestReporter;
 
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -87,12 +91,23 @@ public class AbstractMetricGroupTest {
 	public void testScopeCachingForMultipleReporters() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
+
+		MetricConfig metricConfig1 = new MetricConfig();
+		metricConfig1.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "-");
+
+		MetricConfig metricConfig2 = new MetricConfig();
+		metricConfig2.setProperty(ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "!");
+
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "-");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter2.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "!");
 
-		MetricRegistryImpl testRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl testRegistry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(config),
+			Arrays.asList(
+				ReporterSetup.forReporter("test1", metricConfig1, new TestReporter1()),
+				ReporterSetup.forReporter("test2", metricConfig2, new TestReporter2())));
 		try {
 			MetricGroup tmGroup = new TaskManagerMetricGroup(testRegistry, "host", "id");
 			tmGroup.counter("1");
@@ -110,11 +125,11 @@ public class AbstractMetricGroupTest {
 
 	@Test
 	public void testLogicalScopeCachingForMultipleReporters() throws Exception {
-		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, LogicalScopeReporter1.class.getName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, LogicalScopeReporter2.class.getName());
-
-		MetricRegistryImpl testRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl testRegistry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Arrays.asList(
+				ReporterSetup.forReporter("test1", new LogicalScopeReporter1()),
+				ReporterSetup.forReporter("test2", new LogicalScopeReporter2())));
 		try {
 			MetricGroup tmGroup = new TaskManagerMetricGroup(testRegistry, "host", "id")
 				.addGroup("B")
@@ -238,7 +253,8 @@ public class AbstractMetricGroupTest {
 	public void testScopeGenerationWithoutReporters() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
-		MetricRegistryImpl testRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl testRegistry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.fromConfiguration(config));
 
 		try {
 			TaskManagerMetricGroup group = new TaskManagerMetricGroup(testRegistry, "host", "id");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.metrics.groups;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -28,11 +27,14 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.util.TestReporter;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,10 +47,9 @@ public class MetricGroupRegistrationTest extends TestLogger {
 	 */
 	@Test
 	public void testMetricInstantiation() throws Exception {
-		Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
-
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(
+			MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+			Collections.singletonList(ReporterSetup.forReporter("test", new TestReporter1())));
 
 		MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
 


### PR DESCRIPTION
## What is the purpose of the change

Refactors the `MetricRegistryConfiguration` to provide a `Supplier` for each `MetricReporter` instead of a configuration.

This will make it easier to support reporter factories and makes testing reporters in conjunction with a MetricRegistry significantly easier since you don't have to encode reporters into a Configuration beforehand.

## Brief change log

* Add `ReporterSetup` for encapsulating reporter-specific arguments for the `MetricRegistryImpl`
* Move reporter-loading code from `MetricRegistryImpl` to `MetricRegistryConfiguration`
* Update `MetricRegistryConfiguration`

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*