### PR TITLE
[FLINK-11950][dist]Add missing dependencies in NOTICE file of flink-d…

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -28,6 +28,7 @@ Copyright 2014-2019 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- com.data-artisans:frocksdbjni:5.17.2-artisans-1.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.twitter:chill_2.11:0.7.6

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- com.data-artisans:frocksdbjni:5.17.2-artisans-1.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.twitter:chill_2.11:0.7.6


### PR DESCRIPTION
## What is the purpose of the change

This pull request add the `frocksdbjni` dependency in NOTICE file of flink-dist. 


## Brief change log

  - Add `frocksdbjni` dependency in `flink-dist/src/main/resources/META-INF/NOTICE`
  - Add `frocksdbjni` dependency in `NOTICE-binary`

## Verifying this change

This change is without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not documented)
