### PR TITLE
[FLINK-11818] Provide pipe transformation function for DataSet API

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
@@ -92,6 +92,33 @@ package object utils {
       }
     }
 
+    /**
+      * Return an DataSet created by piping elements to a forked external process.
+      *
+      * @param command the command which will invoke by the external process.
+      * @return The result data set collect the output from the external process.
+      */
+    def pipe(command: String): DataSet[T] = {
+      wrap(jutils.pipe(self.javaSet, command))
+    }
+
+    /**
+      * Return an DataSet created by piping elements to a forked external process.
+      *
+      * @param command    the command which will invoke by the external process.
+      * @param envVars    the customized user defined environment variables.
+      * @param encoding   the encoding for the input of the external process.
+      * @param bufferSize the buffer size used by the external process reading the input.
+      * @return The result data set collect the output from the external process.
+      */
+    def pipe(
+        command: java.util.List[String],
+        envVars: java.util.Map[String, String],
+        encoding: String,
+        bufferSize: Int): DataSet[T] = {
+      wrap(jutils.pipe(self.javaSet, command, envVars, encoding, bufferSize))
+    }
+
     // --------------------------------------------------------------------------------------------
     //  Sample
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*This pull request Provide pipe transformation function for DataSetUtils*

## Brief change log

  - *Provide two pipe methods*
  - *Implement `PipeFunction` by extending `RichMapPartitionFunction`*
  - *Add three test cases*


## Verifying this change

This change is already covered by existing tests, such as *DataSetUtilsITCase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
