### PR TITLE
[FLINK-11068][table] Convert the API classes of *Table to interfaces

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.table.sinks.BatchTableSink;
-import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
 /**
@@ -59,7 +58,7 @@ public class CollectBatchTableSink implements BatchTableSink<Row> {
 	}
 
 	@Override
-	public TableSink<Row> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+	public CollectBatchTableSink configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		final CollectBatchTableSink copy = new CollectBatchTableSink(accumulatorName, serializer);
 		copy.fieldNames = fieldNames;
 		copy.fieldTypes = fieldTypes;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.experimental.CollectSink;
 import org.apache.flink.table.sinks.RetractStreamTableSink;
-import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
 import java.net.InetAddress;
@@ -60,7 +59,7 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 	}
 
 	@Override
-	public TableSink<Tuple2<Boolean, Row>> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+	public CollectStreamTableSink configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		final CollectStreamTableSink copy = new CollectStreamTableSink(targetAddress, targetPort, serializer);
 		copy.fieldNames = fieldNames;
 		copy.fieldTypes = fieldTypes;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -419,7 +419,9 @@ public class LocalExecutor implements Executor {
 		try {
 			// writing to a sink requires an optimization step that might reference UDFs during code compilation
 			context.wrapClassLoader(() -> {
-				table.writeToSink(result.getTableSink(), envInst.getQueryConfig());
+				envInst
+					.getTableEnvironment()
+					.writeToSink(table, result.getTableSink(), envInst.getQueryConfig());
 				return null;
 			});
 			jobGraph = envInst.createJobGraph(jobName);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -60,7 +60,7 @@ public class ResultStore {
 	 */
 	public <T> DynamicResult<T> createResult(Environment env, TableSchema schema, ExecutionConfig config) {
 
-		final RowTypeInfo outputType = (RowTypeInfo) Types.ROW_NAMED(schema.getFieldNames(), schema.getFieldTypes());
+		final RowTypeInfo outputType = new RowTypeInfo(schema.getFieldTypes(), schema.getFieldNames());
 
 		if (env.getExecution().isStreamingExecution()) {
 			// determine gateway address (and port if possible)

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.net.ConnectionUtils;
@@ -33,7 +33,6 @@ import org.apache.flink.table.client.gateway.local.result.ChangelogCollectStream
 import org.apache.flink.table.client.gateway.local.result.DynamicResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedCollectBatchResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedCollectStreamResult;
-import org.apache.flink.types.Row;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -61,7 +60,7 @@ public class ResultStore {
 	 */
 	public <T> DynamicResult<T> createResult(Environment env, TableSchema schema, ExecutionConfig config) {
 
-		final TypeInformation<Row> outputType = Types.ROW_NAMED(schema.getFieldNames(), schema.getFieldTypes());
+		final RowTypeInfo outputType = (RowTypeInfo) Types.ROW_NAMED(schema.getFieldNames(), schema.getFieldTypes());
 
 		if (env.getExecution().isStreamingExecution()) {
 			// determine gateway address (and port if possible)

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
 
@@ -38,7 +38,7 @@ public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> impl
 	private List<Tuple2<Boolean, Row>> changeRecordBuffer;
 	private static final int CHANGE_RECORD_BUFFER_SIZE = 5_000;
 
-	public ChangelogCollectStreamResult(TypeInformation<Row> outputType, ExecutionConfig config,
+	public ChangelogCollectStreamResult(RowTypeInfo outputType, ExecutionConfig config,
 			InetAddress gatewayAddress, int gatewayPort) {
 		super(outputType, config, gatewayAddress, gatewayPort);
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -73,9 +73,8 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 
 		// create table sink
 		// pass binding address and port such that sink knows where to send to
-		collectTableSink =
-			(CollectStreamTableSink) new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer)
-				.configure(outputType.getFieldNames(), outputType.getFieldTypes());
+		collectTableSink = new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer)
+			.configure(outputType.getFieldNames(), outputType.getFieldTypes());
 		retrievalThread = new ResultRetrievalThread();
 		monitoringThread = new JobMonitoringThread();
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.experimental.SocketStreamIterator;
@@ -54,7 +55,7 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 	protected final Object resultLock;
 	protected SqlExecutionException executionException;
 
-	public CollectStreamResult(TypeInformation<Row> outputType, ExecutionConfig config,
+	public CollectStreamResult(RowTypeInfo outputType, ExecutionConfig config,
 			InetAddress gatewayAddress, int gatewayPort) {
 		this.outputType = outputType;
 
@@ -72,7 +73,9 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 
 		// create table sink
 		// pass binding address and port such that sink knows where to send to
-		collectTableSink = new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer);
+		collectTableSink =
+			(CollectStreamTableSink) new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer)
+				.configure(outputType.getFieldNames(), outputType.getFieldTypes());
 		retrievalThread = new ResultRetrievalThread();
 		monitoringThread = new JobMonitoringThread();
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -58,9 +58,8 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 		this.outputType = outputType;
 
 		accumulatorName = new AbstractID().toString();
-		tableSink =
-			(CollectBatchTableSink) new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config))
-				.configure(outputType.getFieldNames(), outputType.getFieldTypes());
+		tableSink = new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config))
+			.configure(outputType.getFieldNames(), outputType.getFieldTypes());
 		resultLock = new Object();
 		retrievalThread = new ResultRetrievalThread();
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.client.gateway.local.CollectBatchTableSink;
@@ -53,11 +54,13 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 
 	private volatile boolean snapshotted = false;
 
-	public MaterializedCollectBatchResult(TypeInformation<Row> outputType, ExecutionConfig config) {
+	public MaterializedCollectBatchResult(RowTypeInfo outputType, ExecutionConfig config) {
 		this.outputType = outputType;
 
 		accumulatorName = new AbstractID().toString();
-		tableSink = new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config));
+		tableSink =
+			(CollectBatchTableSink) new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config))
+				.configure(outputType.getFieldNames(), outputType.getFieldTypes());
 		resultLock = new Object();
 		retrievalThread = new ResultRetrievalThread();
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -20,8 +20,8 @@ package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
@@ -90,7 +90,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 
 	@VisibleForTesting
 	public MaterializedCollectStreamResult(
-			TypeInformation<Row> outputType,
+			RowTypeInfo outputType,
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
 			int gatewayPort,
@@ -117,7 +117,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 	}
 
 	public MaterializedCollectStreamResult(
-			TypeInformation<Row> outputType,
+			RowTypeInfo outputType,
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
 			int gatewayPort,

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -42,7 +42,7 @@ public class MaterializedCollectStreamResultTest {
 
 	@Test
 	public void testSnapshot() throws UnknownHostException {
-		final RowTypeInfo type = (RowTypeInfo) Types.ROW(Types.STRING, Types.LONG);
+		final RowTypeInfo type = new RowTypeInfo(Types.STRING, Types.LONG);
 
 		TestMaterializedCollectStreamResult<?> result = null;
 		try {
@@ -90,7 +90,7 @@ public class MaterializedCollectStreamResultTest {
 
 	@Test
 	public void testLimitedSnapshot() throws UnknownHostException {
-		final RowTypeInfo type = (RowTypeInfo) Types.ROW(Types.STRING, Types.LONG);
+		final RowTypeInfo type = new RowTypeInfo(Types.STRING, Types.LONG);
 
 		TestMaterializedCollectStreamResult<?> result = null;
 		try {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -19,9 +19,9 @@
 package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
 
@@ -42,7 +42,7 @@ public class MaterializedCollectStreamResultTest {
 
 	@Test
 	public void testSnapshot() throws UnknownHostException {
-		final TypeInformation<Row> type = Types.ROW(Types.STRING, Types.LONG);
+		final RowTypeInfo type = (RowTypeInfo) Types.ROW(Types.STRING, Types.LONG);
 
 		TestMaterializedCollectStreamResult<?> result = null;
 		try {
@@ -90,7 +90,7 @@ public class MaterializedCollectStreamResultTest {
 
 	@Test
 	public void testLimitedSnapshot() throws UnknownHostException {
-		final TypeInformation<Row> type = Types.ROW(Types.STRING, Types.LONG);
+		final RowTypeInfo type = (RowTypeInfo) Types.ROW(Types.STRING, Types.LONG);
 
 		TestMaterializedCollectStreamResult<?> result = null;
 		try {
@@ -145,7 +145,7 @@ public class MaterializedCollectStreamResultTest {
 		public boolean isRetrieving;
 
 		public TestMaterializedCollectStreamResult(
-				TypeInformation<Row> outputType,
+				RowTypeInfo outputType,
 				ExecutionConfig config,
 				InetAddress gatewayAddress,
 				int gatewayPort,
@@ -162,7 +162,7 @@ public class MaterializedCollectStreamResultTest {
 		}
 
 		public TestMaterializedCollectStreamResult(
-				TypeInformation<Row> outputType,
+				RowTypeInfo outputType,
 				ExecutionConfig config,
 				InetAddress gatewayAddress,
 				int gatewayPort,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupWindowedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupWindowedTable.java
@@ -57,7 +57,7 @@ public interface GroupWindowedTable {
 	 * <p>Aggregations are performed per group and defined by a subsequent {@code select(...)}
 	 * clause similar to SQL SELECT-GROUP-BY query.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {code

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupWindowedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupWindowedTable.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.expressions.Expression;
+
+/**
+ * A table that has been windowed for {@link GroupWindow}s.
+ */
+@PublicEvolving
+public interface GroupWindowedTable {
+
+	/**
+	 * Groups the elements by a mandatory window and one or more optional grouping attributes.
+	 * The window is specified by referring to its alias.
+	 *
+	 * <p>If no additional grouping attribute is specified and if the input is a streaming table,
+	 * the aggregation will be performed by a single task, i.e., with parallelism 1.
+	 *
+	 * <p>Aggregations are performed per group and defined by a subsequent {@code select(...)}
+	 * clause similar to SQL SELECT-GROUP-BY query.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {code
+	 *   tab.window([groupWindow].as("w")).groupBy("w, key").select("key, value.avg")
+	 * }
+	 * </pre>
+	 */
+	WindowGroupedTable groupBy(String fields);
+
+	/**
+	 * Groups the elements by a mandatory window and one or more optional grouping attributes.
+	 * The window is specified by referring to its alias.
+	 *
+	 * <p>If no additional grouping attribute is specified and if the input is a streaming table,
+	 * the aggregation will be performed by a single task, i.e., with parallelism 1.
+	 *
+	 * <p>Aggregations are performed per group and defined by a subsequent {@code select(...)}
+	 * clause similar to SQL SELECT-GROUP-BY query.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {code
+	 *   tab.window([groupWindow] as 'w)).groupBy('w, 'key).select('key, 'value.avg)
+	 * }
+	 * </pre>
+	 */
+	WindowGroupedTable groupBy(Expression... fields);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupedTable.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.expressions.Expression;
+
+/**
+ * A table that has been grouped on a set of grouping keys.
+ */
+@PublicEvolving
+public interface GroupedTable {
+
+	/**
+	 * Performs a selection operation on a grouped table. Similar to an SQL SELECT statement.
+	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy("key").select("key, value.avg + ' The average' as average")
+	 * }
+	 * </pre>
+	 */
+	Table select(String fields);
+
+	/**
+	 * Performs a selection operation on a grouped table. Similar to an SQL SELECT statement.
+	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy('key).select('key, 'value.avg + " The average" as 'average)
+	 * }
+	 * </pre>
+	 */
+	Table select(Expression... fields);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupedTable.java
@@ -45,7 +45,7 @@ public interface GroupedTable {
 	 * Performs a selection operation on a grouped table. Similar to an SQL SELECT statement.
 	 * The field expressions can contain complex expressions and aggregations.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowedTable.java
@@ -49,7 +49,7 @@ public interface OverWindowedTable {
 	 * Performs a selection operation on a over windowed table. Similar to an SQL SELECT statement.
 	 * The field expressions can contain complex expressions and aggregations.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowedTable.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.expressions.Expression;
+
+/**
+ * A table that has been windowed for {@link OverWindow}s.
+ *
+ * <p>Unlike group windows, which are specified in the
+ * {@code GROUP BY} clause, over windows do not collapse rows. Instead over window aggregates
+ * compute an aggregate for each input row over a range of its neighboring rows.
+ */
+@PublicEvolving
+public interface OverWindowedTable {
+
+	/**
+	 * Performs a selection operation on a over windowed table. Similar to an SQL SELECT statement.
+	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   overWindowedTable.select("c, b.count over ow, e.sum over ow")
+	 * }
+	 * </pre>
+	 */
+	Table select(String fields);
+
+	/**
+	 * Performs a selection operation on a over windowed table. Similar to an SQL SELECT statement.
+	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   overWindowedTable.select('c, 'b.count over 'ow, 'e.sum over 'ow)
+	 * }
+	 * </pre>
+	 */
+	Table select(Expression... fields);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -69,7 +69,6 @@ import org.apache.flink.table.sinks.TableSink;
  * <p>Operations such as {@code join}, {@code select}, {@code where} and {@code groupBy} either
  * take arguments in a Scala DSL or as an expression String. Please refer to the documentation for
  * the expression syntax.
- *
  */
 @PublicEvolving
 public interface Table {
@@ -102,7 +101,7 @@ public interface Table {
 	 * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
 	 * can contain complex expressions and aggregations.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -172,7 +171,7 @@ public interface Table {
 	 * Renames the fields of the expression result. Use this to disambiguate fields before
 	 * joining to operations.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -200,7 +199,7 @@ public interface Table {
 	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
 	 * clause.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -228,7 +227,7 @@ public interface Table {
 	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
 	 * clause.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -256,7 +255,7 @@ public interface Table {
 	 * Groups the elements on some grouping keys. Use this before a selection with aggregations
 	 * to perform the aggregation on a per-group basis. Similar to a SQL GROUP BY statement.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -290,7 +289,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.join(right).where('a === 'b && 'c > 3).select('a, 'b, 'd)
+	 *   left.join(right).where("a = b && c > 3").select("a, b, d")
 	 * }
 	 * </pre>
 	 */
@@ -318,7 +317,7 @@ public interface Table {
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -339,7 +338,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.leftOuterJoin(right).select('a, 'b, 'd)
+	 *   left.leftOuterJoin(right).select("a, b, d")
 	 * }
 	 * </pre>
 	 */
@@ -369,7 +368,7 @@ public interface Table {
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
 	 * {@code TableConfig} must have null check enabled (default).
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -390,7 +389,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.rightOuterJoin(right, "a = b").select('a, 'b, 'd)
+	 *   left.rightOuterJoin(right, "a = b").select("a, b, d")
 	 * }
 	 * </pre>
 	 */
@@ -403,7 +402,7 @@ public interface Table {
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
 	 * {@code TableConfig} must have null check enabled (default).
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -424,7 +423,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.fullOuterJoin(right, "a = b").select('a, 'b, 'd)
+	 *   left.fullOuterJoin(right, "a = b").select("a, b, d")
 	 * }
 	 * </pre>
 	 */
@@ -437,7 +436,7 @@ public interface Table {
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
 	 * {@code TableConfig} must have null check enabled (default).
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -475,7 +474,7 @@ public interface Table {
 	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
 	 * table is joined with all rows produced by the table function.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -520,7 +519,7 @@ public interface Table {
 	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
 	 * table is joined with all rows produced by the table function.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -567,7 +566,7 @@ public interface Table {
 	 * the table is joined with all rows produced by the table function. If the table function does
 	 * not produce any row, the outer row is padded with nulls.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -614,7 +613,7 @@ public interface Table {
 	 * the table is joined with all rows produced by the table function. If the table function does
 	 * not produce any row, the outer row is padded with nulls.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -754,7 +753,7 @@ public interface Table {
 	 * Sorts the given {@link Table}. Similar to SQL ORDER BY.
 	 * The resulting Table is globally sorted across all parallel partitions.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -769,81 +768,42 @@ public interface Table {
 	 * Similar to a SQL OFFSET clause. Offset is technically part of the Order By operator and
 	 * thus must be preceded by it.
 	 *
-	 * {@link Table#offset(Integer offset)} can be combined with a subsequent
-	 * {@link Table#fetch(Integer fetch)} call to return n rows after skipping the first o rows.
+	 * {@link Table#offset(int offset)} can be combined with a subsequent
+	 * {@link Table#fetch(int fetch)} call to return n rows after skipping the first o rows.
 	 *
 	 * <pre>
 	 * {@code
 	 *   // skips the first 3 rows and returns all following rows.
-	 *   tab.orderBy('name.desc).offset(3)
+	 *   tab.orderBy("name.desc").offset(3)
 	 *   // skips the first 10 rows and returns the next 5 rows.
-	 *   tab.orderBy('name.desc).offset(10).fetch(5)
+	 *   tab.orderBy("name.desc").offset(10).fetch(5)
 	 * }
 	 * </pre>
 	 *
 	 * @param offset number of records to skip
 	 */
-	Table offset(Integer offset);
+	Table offset(int offset);
 
 	/**
 	 * Limits a sorted result to the first n rows.
 	 * Similar to a SQL FETCH clause. Fetch is technically part of the Order By operator and
 	 * thus must be preceded by it.
 	 *
-	 * {@link Table#fetch(Integer fetch)} can be combined with a preceding
-	 * {@link Table#offset(Integer offset)} call to return n rows after skipping the first o rows.
+	 * {@link Table#fetch(int fetch)} can be combined with a preceding
+	 * {@link Table#offset(int offset)} call to return n rows after skipping the first o rows.
 	 *
 	 * <pre>
 	 * {@code
 	 *   // returns the first 3 records.
-	 *   tab.orderBy('name.desc).fetch(3)
+	 *   tab.orderBy("name.desc").fetch(3)
 	 *   // skips the first 10 rows and returns the next 5 rows.
-	 *   tab.orderBy('name.desc).offset(10).fetch(5)
+	 *   tab.orderBy("name.desc").offset(10).fetch(5)
 	 * }
 	 * </pre>
 	 *
 	 * @param fetch the number of records to return. Fetch must be >= 0.
 	 */
-	Table fetch(Integer fetch);
-
-	/**
-	 * Writes the {@link Table} to a {@link TableSink}. A {@link TableSink} defines an external
-	 * storage location.
-	 *
-	 * <p>A batch {@link Table} can only be written to a
-	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
-	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
-	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
-	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
-	 *
-	 * @param sink The {@link TableSink} to which the {@link Table} is written.
-	 * @tparam T The data type that the {@link TableSink} expects.
-	 *
-	 * @deprecated Will be removed in a future release. Please register the TableSink and use
-	 *             {@link Table#insertInto(String tableName)}.
-	 */
-	@Deprecated
-	<T> void writeToSink(TableSink<T> sink);
-
-	/**
-	 * Writes the {@link Table} to a {@link TableSink}. A {@link TableSink} defines an external
-	 * storage location.
-	 *
-	 * <p>A batch {@link Table} can only be written to a
-	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
-	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
-	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
-	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
-	 *
-	 * @param sink The {@link TableSink} to which the {@link Table} is written.
-	 * @param conf The configuration for the query that writes to the sink.
-	 * @tparam T The data type that the {@link TableSink} expects.
-	 *
-	 * @deprecated Will be removed in a future release. Please register the TableSink and use
-	 *             {@link Table#insertInto(String tableName, QueryConfig conf)}.
-	 */
-	@Deprecated
-	<T> void writeToSink(TableSink<T> sink, QueryConfig conf);
+	Table fetch(int fetch);
 
 	/**
 	 * Writes the {@link Table} to a {@link TableSink} that was registered under the specified name.
@@ -882,7 +842,7 @@ public interface Table {
 	 * <p>For batch tables of finite size, windowing essentially provides shortcuts for time-based
 	 * groupBy.
 	 *
-	 * <p>__Note__: Computing windowed aggregates on a streaming table is only a parallel operation
+	 * <p><b>Note</b>: Computing windowed aggregates on a streaming table is only a parallel operation
 	 * if additional grouping attributes are added to the {@code groupBy(...)} clause.
 	 * If the {@code groupBy(...)} only references a GroupWindow alias, the streamed table will be
 	 * processed by a single task, i.e., with parallelism 1.
@@ -908,11 +868,11 @@ public interface Table {
 	 * }
 	 * </pre>
 	 *
-	 * <p>__Note__: Computing over window aggregates on a streaming table is only a parallel
+	 * <p><b>Note</b>: Computing over window aggregates on a streaming table is only a parallel
 	 * operation if the window is partitioned. Otherwise, the whole stream will be processed by a
 	 * single task, i.e., with parallelism 1.
 	 *
-	 * <p>__Note__: Over-windows for batch tables are currently not supported.
+	 * <p><b>Note</b>: Over-windows for batch tables are currently not supported.
 	 *
 	 * @param overWindows windows that specify the record interval over which aggregations are
 	 *                    computed.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1,0 +1,922 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.TemporalTableFunction;
+import org.apache.flink.table.sinks.TableSink;
+
+/**
+ * A Table is the core component of the Table API.
+ * Similar to how the batch and streaming APIs have DataSet and DataStream,
+ * the Table API is built around {@link Table}.
+ *
+ * <p>Use the methods of {@link Table} to transform data. Use {@code TableEnvironment} to convert a
+ * {@link Table} back to a {@code DataSet} or {@code DataStream}.
+ *
+ * <p>When using Scala a {@link Table} can also be converted using implicit conversions.
+ *
+ * <p>Java Example:
+ *
+ * <pre>
+ * {@code
+ *   ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+ *   BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
+ *
+ *   DataSet<Tuple2<String, Integer>> set = ...
+ *   tEnv.registerTable("MyTable", set, "a, b");
+ *
+ *   Table table = tEnv.scan("MyTable").select(...);
+ *   ...
+ *   Table table2 = ...
+ *   DataSet<MyType> set2 = tEnv.toDataSet(table2, MyType.class);
+ * }
+ * </pre>
+ *
+ * <p>Scala Example:
+ *
+ * <pre>
+ * {@code
+ *   val env = ExecutionEnvironment.getExecutionEnvironment
+ *   val tEnv = BatchTableEnvironment.create(env)
+ *
+ *   val set: DataSet[(String, Int)] = ...
+ *   val table = set.toTable(tEnv, 'a, 'b)
+ *   ...
+ *   val table2 = ...
+ *   val set2: DataSet[MyType] = table2.toDataSet[MyType]
+ * }
+ * </pre>
+ *
+ * <p>Operations such as {@code join}, {@code select}, {@code where} and {@code groupBy} either
+ * take arguments in a Scala DSL or as an expression String. Please refer to the documentation for
+ * the expression syntax.
+ *
+ */
+@PublicEvolving
+public interface Table {
+
+	/**
+	 * Returns the schema of this table.
+	 */
+	TableSchema getSchema();
+
+	/**
+	 * Prints the schema of this table to the console in a tree format.
+	 */
+	void printSchema();
+
+	/**
+	 * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
+	 * can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.select("key, value.avg + ' The average' as average")
+	 * }
+	 * </pre>
+	 */
+	Table select(String fields);
+
+	/**
+	 * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
+	 * can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.select('key, 'value.avg + " The average" as 'average)
+	 * }
+	 * </pre>
+	 */
+	Table select(Expression... fields);
+
+	/**
+	 * Creates {@link TemporalTableFunction} backed up by this table as a history table.
+	 * Temporal Tables represent a concept of a table that changes over time and for which
+	 * Flink keeps track of those changes. {@link TemporalTableFunction} provides a way how to
+	 * access those data.
+	 *
+	 * <p>For more information please check Flink's documentation on Temporal Tables.
+	 *
+	 * <p>Currently {@link TemporalTableFunction}s are only supported in streaming.
+	 *
+	 * @param timeAttribute Must points to a time attribute. Provides a way to compare which
+	 *                      records are a newer or older version.
+	 * @param primaryKey    Defines the primary key. With primary key it is possible to update
+	 *                      a row or to delete it.
+	 * @return {@link TemporalTableFunction} which is an instance of {@link TableFunction}.
+	 *        It takes one single argument, the {@code timeAttribute}, for which it returns
+	 *        matching version of the {@link Table}, from which {@link TemporalTableFunction}
+	 *        was created.
+	 */
+	TemporalTableFunction createTemporalTableFunction(String timeAttribute, String primaryKey);
+
+	/**
+	 * Creates {@link TemporalTableFunction} backed up by this table as a history table.
+	 * Temporal Tables represent a concept of a table that changes over time and for which
+	 * Flink keeps track of those changes. {@link TemporalTableFunction} provides a way how to
+	 * access those data.
+	 *
+	 * <p>For more information please check Flink's documentation on Temporal Tables.
+	 *
+	 * <p>Currently {@link TemporalTableFunction}s are only supported in streaming.
+	 *
+	 * @param timeAttribute Must points to a time indicator. Provides a way to compare which
+	 *                      records are a newer or older version.
+	 * @param primaryKey    Defines the primary key. With primary key it is possible to update
+	 *                      a row or to delete it.
+	 * @return {@link TemporalTableFunction} which is an instance of {@link TableFunction}.
+	 *        It takes one single argument, the {@code timeAttribute}, for which it returns
+	 *        matching version of the {@link Table}, from which {@link TemporalTableFunction}
+	 *        was created.
+	 */
+	TemporalTableFunction createTemporalTableFunction(Expression timeAttribute, Expression primaryKey);
+
+	/**
+	 * Renames the fields of the expression result. Use this to disambiguate fields before
+	 * joining to operations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.as("a, b")
+	 * }
+	 * </pre>
+	 */
+	Table as(String fields);
+
+	/**
+	 * Renames the fields of the expression result. Use this to disambiguate fields before
+	 * joining to operations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.as('a, 'b)
+	 * }
+	 * </pre>
+	 */
+	Table as(Expression... fields);
+
+	/**
+	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
+	 * clause.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.filter("name = 'Fred'")
+	 * }
+	 * </pre>
+	 */
+	Table filter(String predicate);
+
+	/**
+	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
+	 * clause.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.filter('name === "Fred")
+	 * }
+	 * </pre>
+	 */
+	Table filter(Expression predicate);
+
+	/**
+	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
+	 * clause.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.where("name = 'Fred'")
+	 * }
+	 * </pre>
+	 */
+	Table where(String predicate);
+
+	/**
+	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
+	 * clause.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.where('name === "Fred")
+	 * }
+	 * </pre>
+	 */
+	Table where(Expression predicate);
+
+	/**
+	 * Groups the elements on some grouping keys. Use this before a selection with aggregations
+	 * to perform the aggregation on a per-group basis. Similar to a SQL GROUP BY statement.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy("key").select("key, value.avg")
+	 * }
+	 * </pre>
+	 */
+	GroupedTable groupBy(String fields);
+
+	/**
+	 * Groups the elements on some grouping keys. Use this before a selection with aggregations
+	 * to perform the aggregation on a per-group basis. Similar to a SQL GROUP BY statement.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy('key).select('key, 'value.avg)
+	 * }
+	 * </pre>
+	 */
+	GroupedTable groupBy(Expression... fields);
+
+	/**
+	 * Removes duplicate values and returns only distinct (different) values.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.select("key, value").distinct()
+	 * }
+	 * </pre>
+	 */
+	Table distinct();
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary. You can use
+	 * where and select clauses after a join to further specify the behaviour of the join.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.join(right).where('a === 'b && 'c > 3).select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table join(Table right);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.join(right, "a = b")
+	 * }
+	 * </pre>
+	 */
+	Table join(Table right, String joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.join(right, 'a === 'b).select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table join(Table right, Expression joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL left outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.leftOuterJoin(right).select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoin(Table right);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL left outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.leftOuterJoin(right, "a = b").select("a, b, d")
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoin(Table right, String joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL left outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.leftOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoin(Table right, Expression joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL right outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.rightOuterJoin(right, "a = b").select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table rightOuterJoin(Table right, String joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL right outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.rightOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table rightOuterJoin(Table right, Expression joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL full outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.fullOuterJoin(right, "a = b").select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table fullOuterJoin(Table right, String joinPredicate);
+
+	/**
+	 * Joins two {@link Table}s. Similar to an SQL full outer join. The fields of the two joined
+	 * operations must not overlap, use {@code as} to rename fields if necessary.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
+	 * {@code TableConfig} must have null check enabled (default).
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.fullOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
+	 * }
+	 * </pre>
+	 */
+	Table fullOuterJoin(Table right, Expression joinPredicate);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
+	 * table is joined with all rows produced by the table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   tableEnv.registerFunction("split", split);
+	 *   table.joinLateral("split(c) as (s)").select("a, b, c, s");
+	 * }
+	 * </pre>
+	 */
+	Table joinLateral(String tableFunctionCall);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
+	 * table is joined with all rows produced by the table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction[String] {
+	 *     def eval(str: String): Unit = {
+	 *       str.split("#").foreach(collect)
+	 *     }
+	 *   }
+	 *
+	 *   val split = new MySplitUDTF()
+	 *   table.joinLateral(split('c) as ('s)).select('a, 'b, 'c, 's)
+	 * }
+	 * </pre>
+	 */
+	Table joinLateral(Expression tableFunctionCall);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
+	 * table is joined with all rows produced by the table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   tableEnv.registerFunction("split", split);
+	 *   table.joinLateral("split(c) as (s)", "a = s").select("a, b, c, s");
+	 * }
+	 * </pre>
+	 */
+	Table joinLateral(String tableFunctionCall, String joinPredicate);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
+	 * table is joined with all rows produced by the table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction[String] {
+	 *     def eval(str: String): Unit = {
+	 *       str.split("#").foreach(collect)
+	 *     }
+	 *   }
+	 *
+	 *   val split = new MySplitUDTF()
+	 *   table.joinLateral(split('c) as ('s), 'a === 's).select('a, 'b, 'c, 's)
+	 * }
+	 * </pre>
+	 */
+	Table joinLateral(Expression tableFunctionCall, Expression joinPredicate);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL left outer join with ON TRUE predicate but works with a table function. Each row of
+	 * the table is joined with all rows produced by the table function. If the table function does
+	 * not produce any row, the outer row is padded with nulls.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   tableEnv.registerFunction("split", split);
+	 *   table.leftOuterJoinLateral("split(c) as (s)").select("a, b, c, s");
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoinLateral(String tableFunctionCall);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL left outer join with ON TRUE predicate but works with a table function. Each row of
+	 * the table is joined with all rows produced by the table function. If the table function does
+	 * not produce any row, the outer row is padded with nulls.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction[String] {
+	 *     def eval(str: String): Unit = {
+	 *       str.split("#").foreach(collect)
+	 *     }
+	 *   }
+	 *
+	 *   val split = new MySplitUDTF()
+	 *   table.leftOuterJoinLateral(split('c) as ('s)).select('a, 'b, 'c, 's)
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoinLateral(Expression tableFunctionCall);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL left outer join with ON TRUE predicate but works with a table function. Each row of
+	 * the table is joined with all rows produced by the table function. If the table function does
+	 * not produce any row, the outer row is padded with nulls.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   tableEnv.registerFunction("split", split);
+	 *   table.leftOuterJoinLateral("split(c) as (s)", "a = s").select("a, b, c, s");
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoinLateral(String tableFunctionCall, String joinPredicate);
+
+	/**
+	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
+	 * a SQL left outer join with ON TRUE predicate but works with a table function. Each row of
+	 * the table is joined with all rows produced by the table function. If the table function does
+	 * not produce any row, the outer row is padded with nulls.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction[String] {
+	 *     def eval(str: String): Unit = {
+	 *       str.split("#").foreach(collect)
+	 *     }
+	 *   }
+	 *
+	 *   val split = new MySplitUDTF()
+	 *   table.leftOuterJoinLateral(split('c) as ('s), 'a === 's).select('a, 'b, 'c, 's)
+	 * }
+	 * </pre>
+	 */
+	Table leftOuterJoinLateral(Expression tableFunctionCall, Expression joinPredicate);
+
+	/**
+	 * Minus of two {@link Table}s with duplicate records removed.
+	 * Similar to a SQL EXCEPT clause. Minus returns records from the left table that do not
+	 * exist in the right table. Duplicate records in the left table are returned
+	 * exactly once, i.e., duplicates are removed. Both tables must have identical field types.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.minus(right)
+	 * }
+	 * </pre>
+	 */
+	Table minus(Table right);
+
+	/**
+	 * Minus of two {@link Table}s. Similar to an SQL EXCEPT ALL.
+	 * Similar to a SQL EXCEPT ALL clause. MinusAll returns the records that do not exist in
+	 * the right table. A record that is present n times in the left table and m times
+	 * in the right table is returned (n - m) times, i.e., as many duplicates as are present
+	 * in the right table are removed. Both tables must have identical field types.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.minusAll(right)
+	 * }
+	 * </pre>
+	 */
+	Table minusAll(Table right);
+
+	/**
+	 * Unions two {@link Table}s with duplicate records removed.
+	 * Similar to an SQL UNION. The fields of the two union operations must fully overlap.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.union(right)
+	 * }
+	 * </pre>
+	 */
+	Table union(Table right);
+
+	/**
+	 * Unions two {@link Table}s. Similar to an SQL UNION ALL. The fields of the two union
+	 * operations must fully overlap.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.unionAll(right)
+	 * }
+	 * </pre>
+	 */
+	Table unionAll(Table right);
+
+	/**
+	 * Intersects two {@link Table}s with duplicate records removed. Intersect returns records that
+	 * exist in both tables. If a record is present in one or both tables more than once, it is
+	 * returned just once, i.e., the resulting table has no duplicate records. Similar to an
+	 * SQL INTERSECT. The fields of the two intersect operations must fully overlap.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.intersect(right)
+	 * }
+	 * </pre>
+	 */
+	Table intersect(Table right);
+
+	/**
+	 * Intersects two {@link Table}s. IntersectAll returns records that exist in both tables.
+	 * If a record is present in both tables more than once, it is returned as many times as it
+	 * is present in both tables, i.e., the resulting table might have duplicate records. Similar
+	 * to an SQL INTERSECT ALL. The fields of the two intersect operations must fully overlap.
+	 *
+	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.intersectAll(right)
+	 * }
+	 * </pre>
+	 */
+	Table intersectAll(Table right);
+
+	/**
+	 * Sorts the given {@link Table}. Similar to SQL ORDER BY.
+	 * The resulting Table is sorted globally sorted across all parallel partitions.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.orderBy("name.desc")
+	 * }
+	 * </pre>
+	 */
+	Table orderBy(String fields);
+
+	/**
+	 * Sorts the given {@link Table}. Similar to SQL ORDER BY.
+	 * The resulting Table is globally sorted across all parallel partitions.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.orderBy('name.desc)
+	 * }
+	 * </pre>
+	 */
+	Table orderBy(Expression... fields);
+
+	/**
+	 * Limits a sorted result from an offset position.
+	 * Similar to a SQL OFFSET clause. Offset is technically part of the Order By operator and
+	 * thus must be preceded by it.
+	 *
+	 * {@link Table#offset(Integer offset)} can be combined with a subsequent
+	 * {@link Table#fetch(Integer fetch)} call to return n rows after skipping the first o rows.
+	 *
+	 * <pre>
+	 * {@code
+	 *   // skips the first 3 rows and returns all following rows.
+	 *   tab.orderBy('name.desc).offset(3)
+	 *   // skips the first 10 rows and returns the next 5 rows.
+	 *   tab.orderBy('name.desc).offset(10).fetch(5)
+	 * }
+	 * </pre>
+	 *
+	 * @param offset number of records to skip
+	 */
+	Table offset(Integer offset);
+
+	/**
+	 * Limits a sorted result to the first n rows.
+	 * Similar to a SQL FETCH clause. Fetch is technically part of the Order By operator and
+	 * thus must be preceded by it.
+	 *
+	 * {@link Table#fetch(Integer fetch)} can be combined with a preceding
+	 * {@link Table#offset(Integer offset)} call to return n rows after skipping the first o rows.
+	 *
+	 * <pre>
+	 * {@code
+	 *   // returns the first 3 records.
+	 *   tab.orderBy('name.desc).fetch(3)
+	 *   // skips the first 10 rows and returns the next 5 rows.
+	 *   tab.orderBy('name.desc).offset(10).fetch(5)
+	 * }
+	 * </pre>
+	 *
+	 * @param fetch the number of records to return. Fetch must be >= 0.
+	 */
+	Table fetch(Integer fetch);
+
+	/**
+	 * Writes the {@link Table} to a {@link TableSink}. A {@link TableSink} defines an external
+	 * storage location.
+	 *
+	 * <p>A batch {@link Table} can only be written to a
+	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
+	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
+	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
+	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
+	 *
+	 * @param sink The {@link TableSink} to which the {@link Table} is written.
+	 * @tparam T The data type that the {@link TableSink} expects.
+	 *
+	 * @deprecated Will be removed in a future release. Please register the TableSink and use
+	 *             {@link Table#insertInto(String tableName)}.
+	 */
+	@Deprecated
+	<T> void writeToSink(TableSink<T> sink);
+
+	/**
+	 * Writes the {@link Table} to a {@link TableSink}. A {@link TableSink} defines an external
+	 * storage location.
+	 *
+	 * <p>A batch {@link Table} can only be written to a
+	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
+	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
+	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
+	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
+	 *
+	 * @param sink The {@link TableSink} to which the {@link Table} is written.
+	 * @param conf The configuration for the query that writes to the sink.
+	 * @tparam T The data type that the {@link TableSink} expects.
+	 *
+	 * @deprecated Will be removed in a future release. Please register the TableSink and use
+	 *             {@link Table#insertInto(String tableName, QueryConfig conf)}.
+	 */
+	@Deprecated
+	<T> void writeToSink(TableSink<T> sink, QueryConfig conf);
+
+	/**
+	 * Writes the {@link Table} to a {@link TableSink} that was registered under the specified name.
+	 *
+	 * <p>A batch {@link Table} can only be written to a
+	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
+	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
+	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
+	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
+	 *
+	 * @param tableName Name of the registered {@link TableSink} to which the {@link Table} is
+	 *                  written.
+	 */
+	void insertInto(String tableName);
+
+	/**
+	 * Writes the {@link Table} to a {@link TableSink} that was registered under the specified name.
+	 *
+	 * <p>A batch {@link Table} can only be written to a
+	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
+	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
+	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
+	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
+	 *
+	 * @param tableName Name of the {@link TableSink} to which the {@link Table} is written.
+	 * @param conf The {@link QueryConfig} to use.
+	 */
+	void insertInto(String tableName, QueryConfig conf);
+
+	/**
+	 * Groups the records of a table by assigning them to windows defined by a time or row interval.
+	 *
+	 * <p>For streaming tables of infinite size, grouping into windows is required to define finite
+	 * groups on which group-based aggregates can be computed.
+	 *
+	 * <p>For batch tables of finite size, windowing essentially provides shortcuts for time-based
+	 * groupBy.
+	 *
+	 * <p>__Note__: Computing windowed aggregates on a streaming table is only a parallel operation
+	 * if additional grouping attributes are added to the {@code groupBy(...)} clause.
+	 * If the {@code groupBy(...)} only references a GroupWindow alias, the streamed table will be
+	 * processed by a single task, i.e., with parallelism 1.
+	 *
+	 * @param groupWindow groupWindow that specifies how elements are grouped.
+	 * @return A windowed table.
+	 */
+	GroupWindowedTable window(GroupWindow groupWindow);
+
+	/**
+	 * Defines over-windows on the records of a table.
+	 *
+	 * <p>An over-window defines for each record an interval of records over which aggregation
+	 * functions can be computed.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   table
+	 *     .window(Over partitionBy 'c orderBy 'rowTime preceding 10.seconds as 'ow)
+	 *     .select('c, 'b.count over 'ow, 'e.sum over 'ow)
+	 * }
+	 * </pre>
+	 *
+	 * <p>__Note__: Computing over window aggregates on a streaming table is only a parallel
+	 * operation if the window is partitioned. Otherwise, the whole stream will be processed by a
+	 * single task, i.e., with parallelism 1.
+	 *
+	 * <p>__Note__: Over-windows for batch tables are currently not supported.
+	 *
+	 * @param overWindows windows that specify the record interval over which aggregations are
+	 *                    computed.
+	 * @return An OverWindowedTable to specify the aggregations.
+	 */
+	OverWindowedTable window(OverWindow... overWindows);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
@@ -45,7 +45,7 @@ public interface WindowGroupedTable {
 	 * Performs a selection operation on a window grouped table. Similar to an SQL SELECT statement.
 	 * The field expressions can contain complex expressions and aggregations.
 	 *
-	 * <p>Example:
+	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.expressions.Expression;
+
+/**
+ * A table that has been windowed and grouped for {@link GroupWindow}s.
+ */
+@PublicEvolving
+public interface WindowGroupedTable {
+
+	/**
+	 * Performs a selection operation on a window grouped table. Similar to an SQL SELECT statement.
+	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   windowGroupedTable.select("key, window.start, value.avg as valavg")
+	 * }
+	 * </pre>
+	 */
+	Table select(String fields);
+
+	/**
+	 * Performs a selection operation on a window grouped table. Similar to an SQL SELECT statement.
+	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   windowGroupedTable.select('key, 'window.start, 'value.avg as 'valavg)
+	 * }
+	 * </pre>
+	 */
+	Table select(Expression... fields);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TemporalTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TemporalTableFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.types.Row;
+
+/**
+ * Class representing temporal table function over some history table. A
+ * {@link TemporalTableFunction} is also an instance of {@link TableFunction}.
+ *
+ * <p>Currently {@link TemporalTableFunction}s are only supported in streaming.
+ */
+@PublicEvolving
+public abstract class TemporalTableFunction extends TableFunction<Row> {
+
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -355,7 +355,7 @@ abstract class BatchTableEnvironment(
     * @param extended Flag to include detailed optimizer estimates.
     */
   private[flink] def explain(table: Table, extended: Boolean): String = {
-    val ast = table.getRelNode
+    val ast = table.asInstanceOf[TableImpl].getRelNode
     val optimizedPlan = optimize(ast)
     val dataSet = translate[Row](optimizedPlan, ast.getRowType, queryConfig) (
       new GenericTypeInfo (classOf[Row]))
@@ -471,7 +471,7 @@ abstract class BatchTableEnvironment(
   protected def translate[A](
       table: Table,
       queryConfig: BatchQueryConfig)(implicit tpe: TypeInformation[A]): DataSet[A] = {
-    val relNode = table.getRelNode
+    val relNode = table.asInstanceOf[TableImpl].getRelNode
     val dataSetPlan = optimize(relNode)
     translate(dataSetPlan, relNode.getRowType, queryConfig)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -319,10 +319,11 @@ abstract class StreamTableEnvironment(
     * @tparam T The expected type of the [[DataStream]] which represents the [[Table]].
     */
   override private[flink] def writeToSink[T](
-      table: Table,
+      inputTable: Table,
       sink: TableSink[T],
       queryConfig: QueryConfig): Unit = {
 
+    val table = inputTable.asInstanceOf[TableImpl]
     // Check query configuration
     val streamQueryConfig = queryConfig match {
       case streamConfig: StreamQueryConfig => streamConfig
@@ -859,7 +860,7 @@ abstract class StreamTableEnvironment(
       queryConfig: StreamQueryConfig,
       updatesAsRetraction: Boolean,
       withChangeFlag: Boolean)(implicit tpe: TypeInformation[A]): DataStream[A] = {
-    val relNode = table.getRelNode
+    val relNode = table.asInstanceOf[TableImpl].getRelNode
     val dataStreamPlan = optimize(relNode, updatesAsRetraction)
 
     val rowType = getResultType(relNode, dataStreamPlan)
@@ -1000,7 +1001,7 @@ abstract class StreamTableEnvironment(
     * @param table The table for which the AST and execution plan will be returned.
     */
   def explain(table: Table): String = {
-    val ast = table.getRelNode
+    val ast = table.asInstanceOf[TableImpl].getRelNode
     val optimizedPlan = optimize(ast, updatesAsRetraction = false)
     val dataStream = translateToCRow(optimizedPlan, queryConfig)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -512,13 +512,13 @@ abstract class TableEnvironment(val config: TableConfig) {
   def registerTable(name: String, table: Table): Unit = {
 
     // check that table belongs to this table environment
-    if (table.tableEnv != this) {
+    if (table.asInstanceOf[TableImpl].tableEnv != this) {
       throw new TableException(
         "Only tables that belong to this TableEnvironment can be registered.")
     }
 
     checkValidTableName(name)
-    val tableTable = new RelTable(table.getRelNode)
+    val tableTable = new RelTable(table.asInstanceOf[TableImpl].getRelNode)
     registerTableInternal(name, tableTable)
   }
 
@@ -656,7 +656,7 @@ abstract class TableEnvironment(val config: TableConfig) {
       val tableName = tablePath(tablePath.length - 1)
       val table = schema.getTable(tableName)
       if (table != null) {
-        return Some(new Table(this, CatalogNode(tablePath, table.getRowType(typeFactory))))
+        return Some(new TableImpl(this, CatalogNode(tablePath, table.getRowType(typeFactory))))
       }
     }
     None
@@ -739,7 +739,7 @@ abstract class TableEnvironment(val config: TableConfig) {
       val validated = planner.validate(parsed)
       // transform to a relational tree
       val relational = planner.rel(validated)
-      new Table(this, LogicalRelNode(relational.rel))
+      new TableImpl(this, LogicalRelNode(relational.rel))
     } else {
       throw new TableException(
         "Unsupported SQL query! sqlQuery() only accepts SQL queries of type " +
@@ -801,7 +801,7 @@ abstract class TableEnvironment(val config: TableConfig) {
         val validatedQuery = planner.validate(query)
 
         // get query result as Table
-        val queryResult = new Table(this, LogicalRelNode(planner.rel(validatedQuery).rel))
+        val queryResult = new TableImpl(this, LogicalRelNode(planner.rel(validatedQuery).rel))
 
         // get name of sink table
         val targetTableName = insert.getTargetTable.asInstanceOf[SqlIdentifier].names.get(0)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/TableConversions.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/TableConversions.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api.scala
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.DataStream
-import org.apache.flink.table.api.{BatchQueryConfig, StreamQueryConfig, Table, TableException}
+import org.apache.flink.table.api.{BatchQueryConfig, StreamQueryConfig, Table, TableException, TableImpl}
 import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv}
 import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTableEnv}
 
@@ -30,7 +30,7 @@ import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTa
   *
   * @param table The table to convert.
   */
-class TableConversions(table: Table) {
+class TableConversions(table: TableImpl) {
 
   /**
     * Converts the given [[Table]] into a [[DataSet]] of a specified type.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/package.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/scala/package.scala
@@ -67,7 +67,7 @@ import _root_.scala.language.implicitConversions
 package object scala extends ImplicitExpressionConversions {
 
   implicit def table2TableConversions(table: Table): TableConversions = {
-    new TableConversions(table)
+    new TableConversions(table.asInstanceOf[TableImpl])
   }
 
   implicit def dataSet2DataSetConversions[T](set: DataSet[T]): DataSetConversions[T] = {
@@ -75,7 +75,7 @@ package object scala extends ImplicitExpressionConversions {
   }
 
   implicit def table2RowDataSet(table: Table): DataSet[Row] = {
-    val tableEnv = table.tableEnv.asInstanceOf[ScalaBatchTableEnv]
+    val tableEnv = table.asInstanceOf[TableImpl].tableEnv.asInstanceOf[ScalaBatchTableEnv]
     tableEnv.toDataSet[Row](table)
   }
 
@@ -84,7 +84,7 @@ package object scala extends ImplicitExpressionConversions {
   }
 
   implicit def table2RowDataStream(table: Table): DataStream[Row] = {
-    val tableEnv = table.tableEnv.asInstanceOf[ScalaStreamTableEnv]
+    val tableEnv = table.asInstanceOf[TableImpl].tableEnv.asInstanceOf[ScalaStreamTableEnv]
     tableEnv.toAppendStream[Row](table)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
@@ -56,15 +56,15 @@ class TableImpl(
 
   def getRelNode: RelNode = logicalPlan.toRelNode(relBuilder)
 
-  def getSchema: TableSchema = tableSchema
+  override def getSchema: TableSchema = tableSchema
 
-  def printSchema(): Unit = print(tableSchema.toString)
+  override def printSchema(): Unit = print(tableSchema.toString)
 
-  def select(fields: String): Table = {
+  override def select(fields: String): Table = {
     select(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def select(fields: Expression*): Table = {
+  override def select(fields: Expression*): Table = {
     selectInternal(fields.map(expressionBridge.bridge))
   }
 
@@ -93,7 +93,7 @@ class TableImpl(
     }
   }
 
-  def createTemporalTableFunction(
+  override def createTemporalTableFunction(
       timeAttribute: String,
       primaryKey: String)
     : TemporalTableFunction = {
@@ -102,7 +102,7 @@ class TableImpl(
       ExpressionParser.parseExpression(primaryKey))
   }
 
-  def createTemporalTableFunction(
+  override def createTemporalTableFunction(
       timeAttribute: Expression,
       primaryKey: Expression)
     : TemporalTableFunction = {
@@ -135,11 +135,11 @@ class TableImpl(
     }
   }
 
-  def as(fields: String): Table = {
+  override def as(fields: String): Table = {
     as(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def as(fields: Expression*): Table = {
+  override def as(fields: Expression*): Table = {
     asInternal(fields.map(tableEnv.expressionBridge.bridge))
   }
 
@@ -147,11 +147,11 @@ class TableImpl(
     new TableImpl(tableEnv, AliasNode(fields, logicalPlan).validate(tableEnv))
   }
 
-  def filter(predicate: String): Table = {
+  override def filter(predicate: String): Table = {
     filter(ExpressionParser.parseExpression(predicate))
   }
 
-  def filter(predicate: Expression): Table = {
+  override def filter(predicate: Expression): Table = {
     filterInternal(expressionBridge.bridge(predicate))
   }
 
@@ -159,19 +159,19 @@ class TableImpl(
     new TableImpl(tableEnv, Filter(predicate, logicalPlan).validate(tableEnv))
   }
 
-  def where(predicate: String): Table = {
+  override def where(predicate: String): Table = {
     filter(predicate)
   }
 
-  def where(predicate: Expression): Table = {
+  override def where(predicate: Expression): Table = {
     filter(predicate)
   }
 
-  def groupBy(fields: String): GroupedTable = {
+  override def groupBy(fields: String): GroupedTable = {
     groupBy(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def groupBy(fields: Expression*): GroupedTable = {
+  override def groupBy(fields: Expression*): GroupedTable = {
     groupByInternal(fields.map(expressionBridge.bridge))
   }
 
@@ -179,47 +179,47 @@ class TableImpl(
     new GroupedTableImpl(this, fields)
   }
 
-  def distinct(): Table = {
+  override def distinct(): Table = {
     new TableImpl(tableEnv, Distinct(logicalPlan).validate(tableEnv))
   }
 
-  def join(right: Table): Table = {
+  override def join(right: Table): Table = {
     joinInternal(right, None, JoinType.INNER)
   }
 
-  def join(right: Table, joinPredicate: String): Table = {
+  override def join(right: Table, joinPredicate: String): Table = {
     join(right, ExpressionParser.parseExpression(joinPredicate))
   }
 
-  def join(right: Table, joinPredicate: Expression): Table = {
+  override def join(right: Table, joinPredicate: Expression): Table = {
     joinInternal(right, Some(expressionBridge.bridge(joinPredicate)), JoinType.INNER)
   }
 
-  def leftOuterJoin(right: Table): Table = {
+  override def leftOuterJoin(right: Table): Table = {
     joinInternal(right, None, JoinType.LEFT_OUTER)
   }
 
-  def leftOuterJoin(right: Table, joinPredicate: String): Table = {
+  override def leftOuterJoin(right: Table, joinPredicate: String): Table = {
     leftOuterJoin(right, ExpressionParser.parseExpression(joinPredicate))
   }
 
-  def leftOuterJoin(right: Table, joinPredicate: Expression): Table = {
+  override def leftOuterJoin(right: Table, joinPredicate: Expression): Table = {
     joinInternal(right, Some(expressionBridge.bridge(joinPredicate)), JoinType.LEFT_OUTER)
   }
 
-  def rightOuterJoin(right: Table, joinPredicate: String): Table = {
+  override def rightOuterJoin(right: Table, joinPredicate: String): Table = {
     rightOuterJoin(right, ExpressionParser.parseExpression(joinPredicate))
   }
 
-  def rightOuterJoin(right: Table, joinPredicate: Expression): Table = {
+  override def rightOuterJoin(right: Table, joinPredicate: Expression): Table = {
     joinInternal(right, Some(expressionBridge.bridge(joinPredicate)), JoinType.RIGHT_OUTER)
   }
 
-  def fullOuterJoin(right: Table, joinPredicate: String): Table = {
+  override def fullOuterJoin(right: Table, joinPredicate: String): Table = {
     fullOuterJoin(right, ExpressionParser.parseExpression(joinPredicate))
   }
 
-  def fullOuterJoin(right: Table, joinPredicate: Expression): Table = {
+  override def fullOuterJoin(right: Table, joinPredicate: Expression): Table = {
     joinInternal(right, Some(expressionBridge.bridge(joinPredicate)), JoinType.FULL_OUTER)
   }
 
@@ -244,42 +244,43 @@ class TableImpl(
         correlated = false).validate(tableEnv))
   }
 
-  def joinLateral(tableFunctionCall: String): Table = {
+  override def joinLateral(tableFunctionCall: String): Table = {
     joinLateral(ExpressionParser.parseExpression(tableFunctionCall))
   }
 
-  def joinLateral(tableFunctionCall: Expression): Table = {
+  override def joinLateral(tableFunctionCall: Expression): Table = {
     joinLateralInternal(expressionBridge.bridge(tableFunctionCall), None, JoinType.INNER)
   }
 
-  def joinLateral(tableFunctionCall: String, joinPredicate: String): Table = {
+  override def joinLateral(tableFunctionCall: String, joinPredicate: String): Table = {
     joinLateral(
       ExpressionParser.parseExpression(tableFunctionCall),
       ExpressionParser.parseExpression(joinPredicate))
   }
 
-  def joinLateral(tableFunctionCall: Expression, joinPredicate: Expression): Table = {
+  override def joinLateral(tableFunctionCall: Expression, joinPredicate: Expression): Table = {
     joinLateralInternal(
       expressionBridge.bridge(tableFunctionCall),
       Some(expressionBridge.bridge(joinPredicate)),
       JoinType.INNER)
   }
 
-  def leftOuterJoinLateral(tableFunctionCall: String): Table = {
+  override def leftOuterJoinLateral(tableFunctionCall: String): Table = {
     leftOuterJoinLateral(ExpressionParser.parseExpression(tableFunctionCall))
   }
 
-  def leftOuterJoinLateral(tableFunctionCall: Expression): Table = {
+  override def leftOuterJoinLateral(tableFunctionCall: Expression): Table = {
     joinLateralInternal(expressionBridge.bridge(tableFunctionCall), None, JoinType.LEFT_OUTER)
   }
 
-  def leftOuterJoinLateral(tableFunctionCall: String, joinPredicate: String): Table = {
+  override def leftOuterJoinLateral(tableFunctionCall: String, joinPredicate: String): Table = {
     leftOuterJoinLateral(
       ExpressionParser.parseExpression(tableFunctionCall),
       ExpressionParser.parseExpression(joinPredicate))
   }
 
-  def leftOuterJoinLateral(tableFunctionCall: Expression, joinPredicate: Expression): Table = {
+  override def leftOuterJoinLateral(
+    tableFunctionCall: Expression, joinPredicate: Expression): Table = {
     joinLateralInternal(
       expressionBridge.bridge(tableFunctionCall),
       Some(expressionBridge.bridge(joinPredicate)),
@@ -313,7 +314,7 @@ class TableImpl(
       ).validate(tableEnv))
   }
 
-  def minus(right: Table): Table = {
+  override def minus(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.asInstanceOf[TableImpl].tableEnv != this.tableEnv) {
       throw new ValidationException("Only tables from the same TableEnvironment can be " +
@@ -325,7 +326,7 @@ class TableImpl(
   }
 
 
-  def minusAll(right: Table): Table = {
+  override def minusAll(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.asInstanceOf[TableImpl].tableEnv != this.tableEnv) {
       throw new ValidationException("Only tables from the same TableEnvironment can be " +
@@ -337,7 +338,7 @@ class TableImpl(
   }
 
 
-  def union(right: Table): Table = {
+  override def union(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.asInstanceOf[TableImpl].tableEnv != this.tableEnv) {
       throw new ValidationException("Only tables from the same TableEnvironment can be unioned.")
@@ -347,7 +348,7 @@ class TableImpl(
         .validate(tableEnv))
   }
 
-  def unionAll(right: Table): Table = {
+  override def unionAll(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.asInstanceOf[TableImpl].tableEnv != this.tableEnv) {
       throw new ValidationException("Only tables from the same TableEnvironment can be unioned.")
@@ -357,7 +358,7 @@ class TableImpl(
         .validate(tableEnv))
   }
 
-  def intersect(right: Table): Table = {
+  override def intersect(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.asInstanceOf[TableImpl].tableEnv != this.tableEnv) {
       throw new ValidationException(
@@ -368,7 +369,7 @@ class TableImpl(
         .validate(tableEnv))
   }
 
-  def intersectAll(right: Table): Table = {
+  override def intersectAll(right: Table): Table = {
     // check that right table belongs to the same TableEnvironment
     if (right.asInstanceOf[TableImpl].tableEnv != this.tableEnv) {
       throw new ValidationException(
@@ -379,11 +380,11 @@ class TableImpl(
         .validate(tableEnv))
   }
 
-  def orderBy(fields: String): Table = {
+  override def orderBy(fields: String): Table = {
     orderBy(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def orderBy(fields: Expression*): Table = {
+  override def orderBy(fields: Expression*): Table = {
     orderByInternal(fields.map(expressionBridge.bridge))
   }
 
@@ -395,11 +396,11 @@ class TableImpl(
     new TableImpl(tableEnv, Sort(order, logicalPlan).validate(tableEnv))
   }
 
-  def offset(offset: Int): Table = {
+  override def offset(offset: Int): Table = {
     new TableImpl(tableEnv, Limit(offset, -1, logicalPlan).validate(tableEnv))
   }
 
-  def fetch(fetch: Int): Table = {
+  override def fetch(fetch: Int): Table = {
     if (fetch < 0) {
       throw new ValidationException("FETCH count must be equal or larger than 0.")
     }
@@ -414,19 +415,19 @@ class TableImpl(
     }
   }
 
-  def insertInto(tableName: String): Unit = {
+  override def insertInto(tableName: String): Unit = {
     insertInto(tableName, tableEnv.queryConfig)
   }
 
-  def insertInto(tableName: String, conf: QueryConfig): Unit = {
+  override def insertInto(tableName: String, conf: QueryConfig): Unit = {
     tableEnv.insertInto(this, tableName, conf)
   }
 
-  def window(window: GroupWindow): GroupWindowedTable = {
+  override def window(window: GroupWindow): GroupWindowedTable = {
     new GroupWindowedTableImpl(this, window)
   }
 
-  def window(overWindows: OverWindow*): OverWindowedTable = {
+  override def window(overWindows: OverWindow*): OverWindowedTable = {
 
     if (tableEnv.isInstanceOf[BatchTableEnvironment]) {
       throw new TableException("Over-windows for batch tables are currently not supported.")
@@ -462,11 +463,11 @@ class GroupedTableImpl(
 
   val tableImpl = table.asInstanceOf[TableImpl]
 
-  def select(fields: String): Table = {
+  override def select(fields: String): Table = {
     select(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def select(fields: Expression*): Table = {
+  override def select(fields: Expression*): Table = {
     selectInternal(fields.map(tableImpl.expressionBridge.bridge))
   }
 
@@ -498,11 +499,11 @@ class GroupWindowedTableImpl(
     private[flink] val window: GroupWindow)
   extends GroupWindowedTable {
 
-  def groupBy(fields: String): WindowGroupedTable = {
+  override def groupBy(fields: String): WindowGroupedTable = {
     groupBy(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def groupBy(fields: Expression*): WindowGroupedTable = {
+  override def groupBy(fields: Expression*): WindowGroupedTable = {
     val fieldsWithoutWindow = fields.filterNot(window.getAlias.equals(_))
     if (fields.size != fieldsWithoutWindow.size + 1) {
       throw new ValidationException("GroupBy must contain exactly one window alias.")
@@ -524,11 +525,11 @@ class WindowGroupedTableImpl(
 
   val tableImpl = table.asInstanceOf[TableImpl]
 
-  def select(fields: String): Table = {
+  override def select(fields: String): Table = {
     select(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def select(fields: Expression*): Table = {
+  override def select(fields: Expression*): Table = {
     selectInternal(
       groupKeys.map(tableImpl.expressionBridge.bridge),
       createLogicalWindow(),
@@ -595,11 +596,11 @@ class OverWindowedTableImpl(
 
   val tableImpl = table.asInstanceOf[TableImpl]
 
-  def select(fields: String): Table = {
+  override def select(fields: String): Table = {
     select(ExpressionParser.parseExpressionList(fields): _*)
   }
 
-  def select(fields: Expression*): Table = {
+  override def select(fields: Expression*): Table = {
     selectInternal(
       fields.map(tableImpl.expressionBridge.bridge),
       overWindows.map(createLogicalWindow))

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
@@ -18,9 +18,8 @@
 package org.apache.flink.table.api
 
 import org.apache.calcite.rel.RelNode
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.operators.join.JoinType
-import org.apache.flink.table.calcite.{FlinkRelBuilder, FlinkTypeFactory}
+import org.apache.flink.table.calcite.FlinkRelBuilder
 import org.apache.flink.table.expressions.{Alias, Asc, Expression, ExpressionBridge, ExpressionParser, Ordering, PlannerExpression, ResolvedFieldReference, UnresolvedAlias, WindowProperty}
 import org.apache.flink.table.functions.{TemporalTableFunction, TemporalTableFunctionImpl}
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
@@ -29,7 +28,6 @@ import org.apache.flink.table.plan.logical.{Minus, _}
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.util.JavaScalaConversionUtil
 
-import _root_.scala.collection.JavaConverters._
 import _root_.scala.collection.JavaConversions._
 
 /**
@@ -124,7 +122,7 @@ class TableImpl(
     * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
     * can contain complex expressions and aggregations.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.select('key, 'value.avg + " The average" as 'average)
@@ -257,7 +255,7 @@ class TableImpl(
     * Renames the fields of the expression result. Use this to disambiguate fields before
     * joining to operations.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.as('a, 'b)
@@ -289,7 +287,7 @@ class TableImpl(
     * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
     * clause.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.filter('name === "Fred")
@@ -321,7 +319,7 @@ class TableImpl(
     * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
     * clause.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.where('name === "Fred")
@@ -349,7 +347,7 @@ class TableImpl(
     * Groups the elements on some grouping keys. Use this before a selection with aggregations
     * to perform the aggregation on a per-group basis. Similar to a SQL GROUP BY statement.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.groupBy('key).select('key, 'value.avg)
@@ -386,7 +384,7 @@ class TableImpl(
     * Example:
     *
     * {{{
-    *   left.join(right).where('a === 'b && 'c > 3).select('a, 'b, 'd)
+    *   left.join(right).where("a = b && c > 3").select("a, b, d")
     * }}}
     */
   def join(right: Table): Table = {
@@ -415,7 +413,7 @@ class TableImpl(
     *
     * Note: Both tables must be bound to the same [[TableEnvironment]].
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   left.join(right, 'a === 'b).select('a, 'b, 'd)
@@ -435,7 +433,7 @@ class TableImpl(
     * Example:
     *
     * {{{
-    *   left.leftOuterJoin(right).select('a, 'b, 'd)
+    *   left.leftOuterJoin(right).select("a, b, d")
     * }}}
     */
   def leftOuterJoin(right: Table): Table = {
@@ -466,7 +464,7 @@ class TableImpl(
     * Note: Both tables must be bound to the same [[TableEnvironment]] and its [[TableConfig]] must
     * have null check enabled (default).
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   left.leftOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
@@ -486,7 +484,7 @@ class TableImpl(
     * Example:
     *
     * {{{
-    *   left.rightOuterJoin(right, "a = b").select('a, 'b, 'd)
+    *   left.rightOuterJoin(right, "a = b").select("a, b, d")
     * }}}
     */
   def rightOuterJoin(right: Table, joinPredicate: String): Table = {
@@ -500,7 +498,7 @@ class TableImpl(
     * Note: Both tables must be bound to the same [[TableEnvironment]] and its [[TableConfig]] must
     * have null check enabled (default).
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   left.rightOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
@@ -520,7 +518,7 @@ class TableImpl(
     * Example:
     *
     * {{{
-    *   left.fullOuterJoin(right, "a = b").select('a, 'b, 'd)
+    *   left.fullOuterJoin(right, "a = b").select("a, b, d")
     * }}}
     */
   def fullOuterJoin(right: Table, joinPredicate: String): Table = {
@@ -534,7 +532,7 @@ class TableImpl(
     * Note: Both tables must be bound to the same [[TableEnvironment]] and its [[TableConfig]] must
     * have null check enabled (default).
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   left.fullOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
@@ -592,7 +590,7 @@ class TableImpl(
     * This join is similar to a SQL inner join with ON TRUE predicate but works with a
     * table function. Each row of the table is joined with all rows produced by the table function.
     *
-    * Example:
+    * Scala Example:
     * {{{
     *   class MySplitUDTF extends TableFunction[String] {
     *     def eval(str: String): Unit = {
@@ -637,7 +635,7 @@ class TableImpl(
     * This join is similar to a SQL inner join with ON TRUE predicate but works with a
     * table function. Each row of the table is joined with all rows produced by the table function.
     *
-    * Example:
+    * Scala Example:
     * {{{
     *   class MySplitUDTF extends TableFunction[String] {
     *     def eval(str: String): Unit = {
@@ -685,7 +683,7 @@ class TableImpl(
     * table function. Each row of the table is joined with all rows produced by the table
     * function. If the table function does not produce any row, the outer row is padded with nulls.
     *
-    * Example:
+    * Scala Example:
     * {{{
     *   class MySplitUDTF extends TableFunction[String] {
     *     def eval(str: String): Unit = {
@@ -732,7 +730,7 @@ class TableImpl(
     * table function. Each row of the table is joined with all rows produced by the table
     * function. If the table function does not produce any row, the outer row is padded with nulls.
     *
-    * Example:
+    * Scala Example:
     * {{{
     *   class MySplitUDTF extends TableFunction[String] {
     *     def eval(str: String): Unit = {
@@ -941,7 +939,7 @@ class TableImpl(
     * Sorts the given [[Table]]. Similar to SQL ORDER BY.
     * The resulting Table is globally sorted across all parallel partitions.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.orderBy('name.desc)
@@ -969,14 +967,14 @@ class TableImpl(
     *
     * {{{
     *   // skips the first 3 rows and returns all following rows.
-    *   tab.orderBy('name.desc).offset(3)
+    *   tab.orderBy("name.desc").offset(3)
     *   // skips the first 10 rows and returns the next 5 rows.
-    *   tab.orderBy('name.desc).offset(10).fetch(5)
+    *   tab.orderBy("name.desc").offset(10).fetch(5)
     * }}}
     *
     * @param offset number of records to skip
     */
-  def offset(offset: Integer): Table = {
+  def offset(offset: Int): Table = {
     new TableImpl(tableEnv, Limit(offset, -1, logicalPlan).validate(tableEnv))
   }
 
@@ -990,14 +988,14 @@ class TableImpl(
     *
     * {{{
     *   // returns the first 3 records.
-    *   tab.orderBy('name.desc).fetch(3)
+    *   tab.orderBy("name.desc").fetch(3)
     *   // skips the first 10 rows and returns the next 5 rows.
-    *   tab.orderBy('name.desc).offset(10).fetch(5)
+    *   tab.orderBy("name.desc").offset(10).fetch(5)
     * }}}
     *
     * @param fetch the number of records to return. Fetch must be >= 0.
     */
-  def fetch(fetch: Integer): Table = {
+  def fetch(fetch: Int): Table = {
     if (fetch < 0) {
       throw new ValidationException("FETCH count must be equal or larger than 0.")
     }
@@ -1010,70 +1008,6 @@ class TableImpl(
       case _ =>
         new TableImpl(tableEnv, Limit(0, fetch, logicalPlan).validate(tableEnv))
     }
-  }
-
-  /**
-    * Writes the [[Table]] to a [[TableSink]]. A [[TableSink]] defines an external storage location.
-    *
-    * A batch [[Table]] can only be written to a
-    * [[org.apache.flink.table.sinks.BatchTableSink]], a streaming [[Table]] requires a
-    * [[org.apache.flink.table.sinks.AppendStreamTableSink]], a
-    * [[org.apache.flink.table.sinks.RetractStreamTableSink]], or an
-    * [[org.apache.flink.table.sinks.UpsertStreamTableSink]].
-    *
-    * @param sink The [[TableSink]] to which the [[Table]] is written.
-    * @tparam T The data type that the [[TableSink]] expects.
-    *
-    * @deprecated Will be removed in a future release. Please register the TableSink and use
-    *             Table.insertInto().
-    */
-  @deprecated("This method will be removed. Please register the TableSink and use " +
-    "Table.insertInto().", "1.7.0")
-  @Deprecated
-  def writeToSink[T](sink: TableSink[T]): Unit = {
-    val queryConfig = Option(this.tableEnv) match {
-      case None => null
-      case _ => this.tableEnv.queryConfig
-    }
-    writeToSink(sink, queryConfig)
-  }
-
-  /**
-    * Writes the [[Table]] to a [[TableSink]]. A [[TableSink]] defines an external storage location.
-    *
-    * A batch [[Table]] can only be written to a
-    * [[org.apache.flink.table.sinks.BatchTableSink]], a streaming [[Table]] requires a
-    * [[org.apache.flink.table.sinks.AppendStreamTableSink]], a
-    * [[org.apache.flink.table.sinks.RetractStreamTableSink]], or an
-    * [[org.apache.flink.table.sinks.UpsertStreamTableSink]].
-    *
-    * @param sink The [[TableSink]] to which the [[Table]] is written.
-    * @param conf The configuration for the query that writes to the sink.
-    * @tparam T The data type that the [[TableSink]] expects.
-    *
-    * @deprecated Will be removed in a future release. Please register the TableSink and use
-    *             Table.insertInto().
-    */
-  @deprecated("This method will be removed. Please register the TableSink and use " +
-    "Table.insertInto().", "1.7.0")
-  @Deprecated
-  def writeToSink[T](sink: TableSink[T], conf: QueryConfig): Unit = {
-    // get schema information of table
-    val rowType = getRelNode.getRowType
-    val fieldNames: Array[String] = rowType.getFieldNames.asScala.toArray
-    val fieldTypes: Array[TypeInformation[_]] = rowType.getFieldList.asScala
-      .map(field => FlinkTypeFactory.toTypeInfo(field.getType))
-      .map {
-        // replace time indicator types by SQL_TIMESTAMP
-        case t: TypeInformation[_] if FlinkTypeFactory.isTimeIndicatorType(t) => Types.SQL_TIMESTAMP
-        case t: TypeInformation[_] => t
-      }.toArray
-
-    // configure the table sink
-    val configuredSink = sink.configure(fieldNames, fieldTypes)
-
-    // emit the table to the configured table sink
-    tableEnv.writeToSink(this, configuredSink, conf)
   }
 
   /**
@@ -1206,7 +1140,7 @@ class GroupedTableImpl(
     * Performs a selection operation on a grouped table. Similar to an SQL SELECT statement.
     * The field expressions can contain complex expressions and aggregations.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.groupBy('key).select('key, 'value.avg + " The average" as 'average)
@@ -1274,7 +1208,7 @@ class GroupWindowedTableImpl(
     * Aggregations are performed per group and defined by a subsequent `select(...)` clause similar
     * to SQL SELECT-GROUP-BY query.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   tab.window([window] as 'w)).groupBy('w, 'key).select('key, 'value.avg)
@@ -1319,7 +1253,7 @@ class WindowGroupedTableImpl(
     * Performs a selection operation on a window grouped table. Similar to an SQL SELECT statement.
     * The field expressions can contain complex expressions and aggregations.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   windowGroupedTable.select('key, 'window.start, 'value.avg as 'valavg)
@@ -1410,7 +1344,7 @@ class OverWindowedTableImpl(
     * Performs a selection operation on an over-windowed table. Similar to an SQL SELECT statement.
     * The field expressions can contain complex expressions and aggregations.
     *
-    * Example:
+    * Scala Example:
     *
     * {{{
     *   overWindowedTable.select('c, 'b.count over 'ow, 'e.sum over 'ow)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/subquery.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/subquery.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.api.Table
+import org.apache.flink.table.api.TableImpl
 import org.apache.flink.table.typeutils.TypeCheckUtils._
 import org.apache.flink.table.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
 
@@ -39,7 +39,7 @@ case class In(expression: PlannerExpression, elements: Seq[PlannerExpression])
     // check if this is a sub-query expression or an element list
     elements.head match {
 
-      case TableReference(_, table: Table) =>
+      case TableReference(_, table: TableImpl) =>
         RexSubQuery.in(table.getRelNode, ImmutableList.of(expression.toRexNode))
 
       case _ =>
@@ -51,7 +51,7 @@ case class In(expression: PlannerExpression, elements: Seq[PlannerExpression])
     // check if this is a sub-query expression or an element list
     elements.head match {
 
-      case TableReference(name, table: Table) =>
+      case TableReference(name, table: TableImpl) =>
         if (elements.length != 1) {
           return ValidationFailure("IN operator supports only one table reference.")
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/TemporalTableFunctionImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/functions/TemporalTableFunctionImpl.scala
@@ -23,7 +23,6 @@ import java.sql.Timestamp
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.Table
 import org.apache.flink.table.expressions.PlannerExpression
-import org.apache.flink.types.Row
 
 /**
   * Class representing temporal table function over some history table.
@@ -33,12 +32,12 @@ import org.apache.flink.types.Row
   * This function shouldn't be evaluated. Instead calls to it should be rewritten by the optimiser
   * into other operators (like Temporal Table Join).
   */
-class TemporalTableFunction private(
+class TemporalTableFunctionImpl private(
     @transient private val underlyingHistoryTable: Table,
     private val timeAttribute: PlannerExpression,
     private val primaryKey: String,
     private val resultType: RowTypeInfo)
-  extends TableFunction[Row] {
+  extends TemporalTableFunction {
 
   def eval(row: Timestamp): Unit = {
     throw new IllegalStateException("This should never be called")
@@ -64,12 +63,12 @@ class TemporalTableFunction private(
   }
 }
 
-object TemporalTableFunction {
+object TemporalTableFunctionImpl {
   private[flink] def create(
       table: Table,
       timeAttribute: PlannerExpression,
       primaryKey: String): TemporalTableFunction = {
-    new TemporalTableFunction(
+    new TemporalTableFunctionImpl(
       table,
       timeAttribute,
       primaryKey,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
@@ -19,10 +19,9 @@ package org.apache.flink.table.api.stream.sql
 
 import org.apache.calcite.rel.logical.LogicalJoin
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.{TableImpl, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.calcite.RelTimeIndicatorConverter
-import org.apache.flink.table.plan.logical.TumblingGroupWindow
 import org.apache.flink.table.runtime.join.WindowJoinUtil
 import org.apache.flink.table.utils.TableTestUtil.{term, _}
 import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
@@ -989,7 +988,7 @@ class JoinTest extends TableTestBase {
 
     val resultTable = streamUtil.tableEnv.sqlQuery(query)
     val relNode = RelTimeIndicatorConverter.convert(
-      resultTable.getRelNode,
+      resultTable.asInstanceOf[TableImpl].getRelNode,
       streamUtil.tableEnv.getRelBuilder.getRexBuilder)
     val joinNode = relNode.getInput(0).asInstanceOf[LogicalJoin]
     val (windowBounds, _) =
@@ -1014,7 +1013,7 @@ class JoinTest extends TableTestBase {
 
     val resultTable = streamUtil.tableEnv.sqlQuery(query)
     val relNode = RelTimeIndicatorConverter.convert(
-      resultTable.getRelNode,
+      resultTable.asInstanceOf[TableImpl].getRelNode,
       streamUtil.tableEnv.getRelBuilder.getRexBuilder)
     val joinNode = relNode.getInput(0).asInstanceOf[LogicalJoin]
     val (_, remainCondition) =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.{TableSchema, ValidationException}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.stream.table.TemporalTableJoinTest._
 import org.apache.flink.table.expressions.ResolvedFieldReference
-import org.apache.flink.table.functions.TemporalTableFunction
+import org.apache.flink.table.functions.{TemporalTableFunction, TemporalTableFunctionImpl}
 import org.apache.flink.table.plan.logical.rel.LogicalTemporalTableJoin._
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils._
@@ -153,8 +153,9 @@ class TemporalTableJoinTest extends TableTestBase {
 
   private def assertRatesFunction(
       expectedSchema: TableSchema,
-      rates: TemporalTableFunction,
+      inputRates: TemporalTableFunction,
       proctime: Boolean = false): Unit = {
+    val rates = inputRates.asInstanceOf[TemporalTableFunctionImpl]
     assertEquals("currency", rates.getPrimaryKey)
     assertTrue(rates.getTimeAttribute.isInstanceOf[ResolvedFieldReference])
     assertEquals(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
@@ -38,7 +38,7 @@ import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.fs.Path
 import org.apache.flink.table.api.scala.BatchTableEnvironment
-import org.apache.flink.table.api.{TableConfig, TableEnvironment}
+import org.apache.flink.table.api.{TableConfig, TableEnvironment, TableImpl}
 import org.apache.flink.table.calcite.FlinkPlannerImpl
 import org.apache.flink.table.codegen.{Compiler, FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
@@ -201,6 +201,7 @@ abstract class ExpressionTestBase {
     val converted = env
       .scan(tableName)
       .select(tableApiExpr)
+      .asInstanceOf[TableImpl]
       .getRelNode
 
     val optimized = env.optimize(converted)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/RetractionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/RetractionRulesTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.plan
 
 import org.apache.calcite.rel.RelNode
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.{Table, Tumble}
+import org.apache.flink.table.api.{Table, TableImpl, Tumble}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.plan.nodes.datastream._
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.CountDistinct
@@ -506,7 +506,7 @@ class StreamTableTestForRetractionUtil extends StreamTableTestUtil {
   }
 
   def verifyTableTrait(resultTable: Table, expected: String): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = tableEnv.optimize(relNode, updatesAsRetraction = false)
     val actual = TraitUtil.toString(optimized)
     assertEquals(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/UpdatingPlanCheckerTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/UpdatingPlanCheckerTest.scala
@@ -18,12 +18,12 @@
 
 package org.apache.flink.table.plan
 
-import org.apache.flink.table.api.{Table, Tumble}
+import org.apache.flink.table.api.scala._
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{Table, TableImpl, Tumble}
 import org.apache.flink.table.plan.util.UpdatingPlanChecker
 import org.apache.flink.table.utils.StreamTableTestUtil
 import org.junit.Assert._
-import org.apache.flink.table.api.scala._
-import org.apache.flink.api.scala._
 import org.junit.Test
 
 class UpdatingPlanCheckerTest {
@@ -316,7 +316,7 @@ class UpdatePlanCheckerUtil extends StreamTableTestUtil {
   }
 
   def getKeyGroups(resultTable: Table): Option[Seq[(String, String)]] = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = tableEnv.optimize(relNode, updatesAsRetraction = false)
     UpdatingPlanChecker.getUniqueKeyGroups(optimized)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -24,13 +24,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.{LocalEnvironment, DataSet => JDataSet}
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.streaming.api.TimeCharacteristic
-import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment}
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.java.{BatchTableEnvironment => JavaBatchTableEnv, StreamTableEnvironment => JavaStreamTableEnv}
 import org.apache.flink.table.api.scala.{BatchTableEnvironment => ScalaBatchTableEnv, StreamTableEnvironment => ScalaStreamTableEnv}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{Table, TableSchema}
+import org.apache.flink.table.api.{Table, TableImpl, TableSchema}
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
 import org.junit.Assert.assertEquals
@@ -62,8 +62,10 @@ class TableTestBase {
   def verifyTableEquals(expected: Table, actual: Table): Unit = {
     assertEquals(
       "Logical plans do not match",
-      LogicalPlanFormatUtils.formatTempTableId(RelOptUtil.toString(expected.getRelNode)),
-      LogicalPlanFormatUtils.formatTempTableId(RelOptUtil.toString(actual.getRelNode)))
+      LogicalPlanFormatUtils.formatTempTableId(RelOptUtil.toString(
+        expected.asInstanceOf[TableImpl].getRelNode)),
+      LogicalPlanFormatUtils.formatTempTableId(RelOptUtil.toString(
+        actual.asInstanceOf[TableImpl].getRelNode)))
   }
 }
 
@@ -87,7 +89,7 @@ abstract class TableTestUtil {
   def verifyTable(resultTable: Table, expected: String): Unit
 
   def verifySchema(resultTable: Table, fields: Seq[(String, TypeInformation[_])]): Unit = {
-    val actual = resultTable.getSchema
+    val actual = resultTable.asInstanceOf[TableImpl].getSchema
     val expected = new TableSchema(fields.map(_._1).toArray, fields.map(_._2).toArray)
     assertEquals(expected, actual)
   }
@@ -240,7 +242,7 @@ case class BatchTableTestUtil() extends TableTestUtil {
   }
 
   def verifyTable(resultTable: Table, expected: String): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = tableEnv.optimize(relNode)
     verifyString(expected, optimized)
   }
@@ -250,13 +252,13 @@ case class BatchTableTestUtil() extends TableTestUtil {
   }
 
   def verifyJavaTable(resultTable: Table, expected: String): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = javaTableEnv.optimize(relNode)
     verifyString(expected, optimized)
   }
 
   def printTable(resultTable: Table): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = tableEnv.optimize(relNode)
     println(RelOptUtil.toString(optimized))
   }
@@ -323,15 +325,15 @@ case class StreamTableTestUtil() extends TableTestUtil {
   }
 
   def verifyTable(resultTable: Table, expected: String): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = tableEnv.optimize(relNode, updatesAsRetraction = false)
     verifyString(expected, optimized)
   }
 
   def verify2Tables(resultTable1: Table, resultTable2: Table): Unit = {
-    val relNode1 = resultTable1.getRelNode
+    val relNode1 = resultTable1.asInstanceOf[TableImpl].getRelNode
     val optimized1 = tableEnv.optimize(relNode1, updatesAsRetraction = false)
-    val relNode2 = resultTable2.getRelNode
+    val relNode2 = resultTable2.asInstanceOf[TableImpl].getRelNode
     val optimized2 = tableEnv.optimize(relNode2, updatesAsRetraction = false)
     assertEquals(RelOptUtil.toString(optimized1), RelOptUtil.toString(optimized2))
   }
@@ -341,14 +343,14 @@ case class StreamTableTestUtil() extends TableTestUtil {
   }
 
   def verifyJavaTable(resultTable: Table, expected: String): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = javaTableEnv.optimize(relNode, updatesAsRetraction = false)
     verifyString(expected, optimized)
   }
 
   // the print methods are for debugging purposes only
   def printTable(resultTable: Table): Unit = {
-    val relNode = resultTable.getRelNode
+    val relNode = resultTable.asInstanceOf[TableImpl].getRelNode
     val optimized = tableEnv.optimize(relNode, updatesAsRetraction = false)
     println(RelOptUtil.toString(optimized))
   }


### PR DESCRIPTION
## What is the purpose of the change

This pull request convert table related classes into interface.


## Brief change log

  - Convert Table, GroupedTable, GroupWindowedTable, OverWindowedTable, WindowGroupedTable into interface.
  - Port TemporalTableFunction into flink-common. I add no methods in TemporalTableFunction. It seems we don't need to add methods in `TemporalTableFunction` for now. We can add it later if we find it necessary. It's easier and safer for adding methods than removing methods.


## Verifying this change

This change is already covered by existing tests, such as tests for tableApi. And changes for temporal table has been covered by TemporalTableJoin UT/IT test cases.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
