### PR TITLE
[FLINK-11966] [table-planner-blink] Add support for generating optimized logical plan for simple query(Project, Filter, Values and Union all)

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkBatchProgram.scala
@@ -90,7 +90,7 @@ object FlinkBatchProgram {
     chainedProgram.addLast(
       LOGICAL,
       FlinkVolcanoProgramBuilder.newBuilder
-        .add(FlinkBatchRuleSets.BATCH_EXEC_LOGICAL_OPT_RULES)
+        .add(FlinkBatchRuleSets.LOGICAL_OPT_RULES)
         .setRequiredOutputTraits(Array(FlinkConventions.LOGICAL))
         .build())
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/optimize/program/FlinkStreamProgram.scala
@@ -67,7 +67,7 @@ object FlinkStreamProgram {
       FlinkHepRuleSetProgramBuilder.newBuilder
         .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-        .add(FlinkStreamRuleSets.STREAM_EXEC_DEFAULT_REWRITE_RULES)
+        .add(FlinkStreamRuleSets.DEFAULT_REWRITE_RULES)
         .build())
 
     // rule based optimization: push down predicate(s) in where clause, so it only needs to read
@@ -93,7 +93,7 @@ object FlinkStreamProgram {
     chainedProgram.addLast(
       LOGICAL,
       FlinkVolcanoProgramBuilder.newBuilder
-        .add(FlinkStreamRuleSets.STREAM_EXEC_LOGICAL_OPT_RULES)
+        .add(FlinkStreamRuleSets.LOGICAL_OPT_RULES)
         .setRequiredOutputTraits(Array(FlinkConventions.LOGICAL))
         .build())
 
@@ -101,7 +101,7 @@ object FlinkStreamProgram {
     chainedProgram.addLast(
       PHYSICAL,
       FlinkVolcanoProgramBuilder.newBuilder
-        .add(FlinkStreamRuleSets.STREAM_EXEC_OPT_RULES)
+        .add(FlinkStreamRuleSets.PHYSICAL_OPT_RULES)
         .setRequiredOutputTraits(Array(FlinkConventions.STREAM_PHYSICAL))
         .build())
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecCalcRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecCalcRule.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCalc
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecCalc
+
+import org.apache.calcite.plan.RelOptRule
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+/**
+  * Rule that converts [[FlinkLogicalCalc]] to [[BatchExecCalc]].
+  */
+class BatchExecCalcRule
+  extends ConverterRule(
+    classOf[FlinkLogicalCalc],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.BATCH_PHYSICAL,
+    "BatchExecCalcRule") {
+
+  def convert(rel: RelNode): RelNode = {
+    val calc = rel.asInstanceOf[FlinkLogicalCalc]
+    val newTrait = rel.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+    val newInput = RelOptRule.convert(calc.getInput, FlinkConventions.BATCH_PHYSICAL)
+
+    new BatchExecCalc(
+      rel.getCluster,
+      newTrait,
+      newInput,
+      calc.getProgram,
+      rel.getRowType)
+  }
+}
+
+object BatchExecCalcRule {
+  val INSTANCE: RelOptRule = new BatchExecCalcRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecUnionRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecUnionRule.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecUnion
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalUnion
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule that converts [[FlinkLogicalUnion]] to [[BatchExecUnion]].
+  */
+class BatchExecUnionRule
+  extends ConverterRule(
+    classOf[FlinkLogicalUnion],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.BATCH_PHYSICAL,
+    "BatchExecUnionRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    call.rel(0).asInstanceOf[FlinkLogicalUnion].all
+  }
+
+  def convert(rel: RelNode): RelNode = {
+    val union = rel.asInstanceOf[FlinkLogicalUnion]
+    val traitSet = rel.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+    val newInputs = union.getInputs.map(RelOptRule.convert(_, FlinkConventions.BATCH_PHYSICAL))
+
+    new BatchExecUnion(
+      rel.getCluster,
+      traitSet,
+      newInputs,
+      union.all,
+      rel.getRowType)
+  }
+}
+
+object BatchExecUnionRule {
+  val INSTANCE: RelOptRule = new BatchExecUnionRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecValuesRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/batch/BatchExecValuesRule.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.batch
+
+import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.physical.batch.BatchExecValues
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalValues
+
+/**
+  * Rule that converts [[FlinkLogicalValues]] to [[BatchExecValues]].
+  */
+class BatchExecValuesRule extends ConverterRule(
+  classOf[FlinkLogicalValues],
+  FlinkConventions.LOGICAL,
+  FlinkConventions.BATCH_PHYSICAL,
+  "BatchExecValuesRule") {
+
+  def convert(rel: RelNode): RelNode = {
+    val values: FlinkLogicalValues = rel.asInstanceOf[FlinkLogicalValues]
+    val providedTraitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+
+    new BatchExecValues(
+      rel.getCluster,
+      providedTraitSet,
+      values.getTuples,
+      rel.getRowType)
+  }
+}
+
+object BatchExecValuesRule {
+  val INSTANCE: RelOptRule = new BatchExecValuesRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecCalcRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecCalcRule.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.stream
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCalc
+import org.apache.flink.table.plan.nodes.physical.stream.StreamExecCalc
+
+import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+/**
+  * Rule that converts [[FlinkLogicalCalc]] to [[StreamExecCalc]].
+  */
+class StreamExecCalcRule
+  extends ConverterRule(
+    classOf[FlinkLogicalCalc],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.STREAM_PHYSICAL,
+    "StreamExecCalcRule") {
+
+  def convert(rel: RelNode): RelNode = {
+    val calc: FlinkLogicalCalc = rel.asInstanceOf[FlinkLogicalCalc]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+    val newInput = RelOptRule.convert(calc.getInput, FlinkConventions.STREAM_PHYSICAL)
+
+    new StreamExecCalc(
+      rel.getCluster,
+      traitSet,
+      newInput,
+      calc.getProgram,
+      rel.getRowType)
+  }
+}
+
+object StreamExecCalcRule {
+  val INSTANCE: RelOptRule = new StreamExecCalcRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecUnionRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecUnionRule.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.stream
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalUnion
+import org.apache.flink.table.plan.nodes.physical.stream.StreamExecUnion
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule that converts [[FlinkLogicalUnion]] to [[StreamExecUnion]].
+  */
+class StreamExecUnionRule
+  extends ConverterRule(
+    classOf[FlinkLogicalUnion],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.STREAM_PHYSICAL,
+    "StreamExecUnionRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    call.rel(0).asInstanceOf[FlinkLogicalUnion].all
+  }
+
+  def convert(rel: RelNode): RelNode = {
+    val union: FlinkLogicalUnion = rel.asInstanceOf[FlinkLogicalUnion]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+    val newInputs = union.getInputs.map(RelOptRule.convert(_, FlinkConventions.STREAM_PHYSICAL))
+
+    new StreamExecUnion(
+      rel.getCluster,
+      traitSet,
+      newInputs,
+      union.all,
+      rel.getRowType)
+  }
+}
+
+object StreamExecUnionRule {
+  val INSTANCE: RelOptRule = new StreamExecUnionRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecValuesRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/rules/physical/stream/StreamExecValuesRule.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.physical.stream
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalValues
+import org.apache.flink.table.plan.nodes.physical.stream.StreamExecValues
+
+import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+/**
+  * Rule that converts [[FlinkLogicalValues]] to [[StreamExecValues]].
+  */
+class StreamExecValuesRule
+  extends ConverterRule(
+    classOf[FlinkLogicalValues],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.STREAM_PHYSICAL,
+    "StreamExecValuesRule") {
+
+  def convert(rel: RelNode): RelNode = {
+    val values: FlinkLogicalValues = rel.asInstanceOf[FlinkLogicalValues]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+
+    new StreamExecValues(
+      rel.getCluster,
+      traitSet,
+      values.getTuples,
+      rel.getRowType)
+  }
+}
+
+object StreamExecValuesRule {
+  val INSTANCE: RelOptRule = new StreamExecValuesRule
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/FlinkRelOptUtil.scala
@@ -48,13 +48,15 @@ object FlinkRelOptUtil {
     * @param withIdPrefix       whether including ID of RelNode as prefix
     * @param withRetractTraits  whether including Retraction Traits of RelNode (only apply to
     *                           StreamPhysicalRel node at present)
+    * @param withRowType        whether including output rowType
     * @return explain plan of RelNode
     */
   def toString(
       rel: RelNode,
       detailLevel: SqlExplainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
       withIdPrefix: Boolean = false,
-      withRetractTraits: Boolean = false): String = {
+      withRetractTraits: Boolean = false,
+      withRowType: Boolean = false): String = {
     if (rel == null) {
       return null
     }
@@ -63,7 +65,8 @@ object FlinkRelOptUtil {
       new PrintWriter(sw),
       detailLevel,
       withIdPrefix,
-      withRetractTraits)
+      withRetractTraits,
+      withRowType)
     rel.explain(planWriter)
     sw.toString
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RelTreeWriterImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/util/RelTreeWriterImpl.scala
@@ -37,7 +37,8 @@ class RelTreeWriterImpl(
     pw: PrintWriter,
     explainLevel: SqlExplainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
     withIdPrefix: Boolean = false,
-    withRetractTraits: Boolean = false)
+    withRetractTraits: Boolean = false,
+    withRowType: Boolean = false)
   extends RelWriterImpl(pw, explainLevel, withIdPrefix) {
 
   var lastChildren: Seq[Boolean] = Nil
@@ -97,6 +98,10 @@ class RelTreeWriterImpl(
           s.append(value.left).append("=[").append(value.right).append("]")
       }
       if (j > 0) s.append(")")
+    }
+
+    if (withRowType) {
+      s.append(", rowType=[").append(rel.getRowType.toString).append("]")
     }
 
     if (explainLevel == SqlExplainLevel.ALL_ATTRIBUTES) {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/CalcTest.xml
@@ -1,0 +1,360 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testArrayType">
+    <Resource name="sql">
+      <![CDATA[SELECT ARRAY['Hi', 'Hello', c] FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ARRAY(_UTF-16LE'Hi', _UTF-16LE'Hello', $2)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ARRAY(_UTF-16LE'Hi', _UTF-16LE'Hello', c) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testConjunctiveFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a < 10 AND b > 20]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[AND(<($0, 10), >($1, 20))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[AND(<(a, 10), >(b, 20))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDisjunctiveFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a < 10 OR a > 20]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(<($0, 10), >($0, 20))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[OR(<(a, 10), >(a, 20))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterWithDateType">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable3
+WHERE b = DATE '1984-07-12' AND c = TIME '14:34:24' AND d = TIMESTAMP '1984-07-12 14:34:24'
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[AND(=($1, 1984-07-12), =($2, 14:34:24), =($3, 1984-07-12 14:34:24))])
+   +- LogicalTableScan(table=[[MyTable3, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, d], where=[AND(=(b, 1984-07-12), =(c, 14:34:24), =(d, 1984-07-12 14:34:24))])
++- TableSourceScan(table=[[MyTable3, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE b IN (1, 3, 4, 5, 6) AND c = 'xx']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[AND(OR(=($1, 1), =($1, 3), =($1, 4), =($1, 5), =($1, 6)), =($2, _UTF-16LE'xx'))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[AND(OR(=(b, 1), =(b, 3), =(b, 4), =(b, 5), =(b, 6)), =(c, _UTF-16LE'xx'))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMixedType">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable5 WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ROW($0, $1, $2)], EXPR$1=[ARRAY(12, $1)], EXPR$2=[MAP($0, $2)])
++- LogicalFilter(condition=[=(ROW($0, $1, $2), CAST(ROW(_UTF-16LE'foo', 12, 1984-07-12 14:34:24)):RecordType(VARCHAR(65536) CHARACTER SET "UTF-16LE" COLLATE "ISO-8859-1$en_US$primary" EXPR$0, INTEGER EXPR$1, TIMESTAMP(3) EXPR$2) NOT NULL)])
+   +- LogicalTableScan(table=[[MyTable5, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ROW(a, b, c) AS EXPR$0, ARRAY(12, b) AS EXPR$1, MAP(a, c) AS EXPR$2], where=[=(ROW(a, b, c), CAST(ROW(_UTF-16LE'foo', 12, 1984-07-12 14:34:24)))])
++- TableSourceScan(table=[[MyTable5, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiFilters">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (SELECT * FROM MyTable WHERE b > 0) t WHERE a < 50]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[<($0, 50)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalFilter(condition=[>($1, 0)])
+         +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[AND(>(b, 0), <(a, 50))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultipleFlattening">
+    <Resource name="sql">
+      <![CDATA[SELECT MyTable2.a.*, c, MyTable2.b.* FROM MyTable2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(_1=[$0._1], _2=[$0._2], c=[$2], _10=[$1._1], _20=[$1._2])
++- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a._1 AS _1, a._2 AS _2, c, b._1 AS _10, b._2 AS _20])
++- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiProjects">
+    <Resource name="sql">
+      <![CDATA[SELECT c FROM (SELECT a, c FROM MyTable)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonPrimitiveMapType">
+    <Resource name="sql">
+      <![CDATA[SELECT MAP[a, c] FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[MAP($0, $2)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[MAP(a, c) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNotIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(NOT(OR(=($1, 1), =($1, 3), =($1, 4), =($1, 5), =($1, 6))), =($2, _UTF-16LE'xx'))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[OR(AND(<>(b, 1), <>(b, 3), <>(b, 4), <>(b, 5), <>(b, 6)), =(c, _UTF-16LE'xx'))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE b > 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[>($1, 0)])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[>(b, 0)])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPojoType">
+    <Resource name="sql">
+      <![CDATA[SELECT a FROM MyTable4]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalTableScan(table=[[MyTable4, source: [TestTableSource(a)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[MyTable4, source: [TestTableSource(a)]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPrimitiveMapType">
+    <Resource name="sql">
+      <![CDATA[SELECT MAP[b, 30, 10, a] FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[MAP($1, 30, 10, $0)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[MAP(b, 30, 10, a) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectAndFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b + 1 FROM MyTable WHERE b > 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
++- LogicalFilter(condition=[>($1, 2)])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, +(b, 1) AS EXPR$1], where=[>(b, 2)])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithDateType">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b, c,
+ DATE '1984-07-12',
+ TIME '14:34:24',
+ TIMESTAMP '1984-07-12 14:34:24'
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], EXPR$3=[1984-07-12], EXPR$4=[14:34:24], EXPR$5=[1984-07-12 14:34:24])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, 1984-07-12 AS EXPR$3, 14:34:24 AS EXPR$4, 1984-07-12 14:34:24 AS EXPR$5])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithNaming">
+    <Resource name="sql">
+      <![CDATA[SELECT `1-_./Ü`, b, c FROM (SELECT a as `1-_./Ü`, b, c FROM MyTable)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(1-_./Ü=[$0], b=[$1], c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowType">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(1, 'Hi', a) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ROW(1, _UTF-16LE'Hi', $0)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ROW(1, _UTF-16LE'Hi', a) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/UnionTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/UnionTest.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testUnionAll">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, c FROM (
+ SELECT a, c FROM MyTable1
+ UNION ALL
+ SELECT a, c FROM MyTable2
+ UNION ALL
+ SELECT a, c FROM MyTable3
+) WHERE a > 2
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$1])
++- LogicalFilter(condition=[>($0, 2)])
+   +- LogicalUnion(all=[true])
+      :- LogicalUnion(all=[true])
+      :  :- LogicalProject(a=[$0], c=[$2])
+      :  :  +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      :  +- LogicalProject(a=[$0], c=[$2])
+      :     +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+      +- LogicalProject(a=[$0], c=[$2])
+         +- LogicalTableScan(table=[[MyTable3, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[a, c])
+:- Union(all=[true], union=[a, c])
+:  :- Calc(select=[a, c], where=[>(a, 2)])
+:  :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+:  +- Calc(select=[a, c], where=[>(a, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- Calc(select=[a, c], where=[>(a, 2)])
+   +- TableSourceScan(table=[[MyTable3, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionAllDiffType">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+ SELECT a, b FROM MyTable1
+ UNION ALL
+ SELECT a, CAST(0 aS DECIMAL(2, 1)) FROM MyTable2)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
++- LogicalUnion(all=[true]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
+   :- LogicalProject(a=[$0], b=[$1]), rowType=[RecordType(INTEGER a, BIGINT b)]
+   :  +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
+   +- LogicalProject(a=[$0], EXPR$1=[0]), rowType=[RecordType(INTEGER a, DECIMAL(2, 1) EXPR$1)]
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[a, b]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
+:- Calc(select=[a, CAST(b) AS b]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
+:  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
++- Calc(select=[a, CAST(0) AS EXPR$1]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) EXPR$1)]
+   +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/ValuesTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/batch/sql/ValuesTest.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testDiffTypes">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
++- LogicalUnion(all=[true]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+   :- LogicalProject(EXPR$0=[1], EXPR$1=[2.0]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(2, 1) EXPR$1)]
+   :  +- LogicalValues(tuples=[[{ 0 }]]), rowType=[RecordType(INTEGER ZERO)]
+   +- LogicalProject(EXPR$0=[3], EXPR$1=[4]), rowType=[RecordType(INTEGER EXPR$0, BIGINT EXPR$1)]
+      +- LogicalValues(tuples=[[{ 0 }]]), rowType=[RecordType(INTEGER ZERO)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[EXPR$0, EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+:- Calc(select=[1 AS EXPR$0, 2.0 AS EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+:  +- Values(tuples=[[{ 0 }]], values=[ZERO]), rowType=[RecordType(INTEGER ZERO)]
++- Calc(select=[3 AS EXPR$0, 4 AS EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+   +- Values(tuples=[[{ 0 }]], values=[ZERO]), rowType=[RecordType(INTEGER ZERO)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleRow">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES (1, 2, 3)) AS T(a, b, c)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalValues(tuples=[[{ 1, 2, 3 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Values(tuples=[[{ 1, 2, 3 }]], values=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiRows">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES (1, 2), (3, CAST(NULL AS INT)), (4, 5)) AS T(a, b)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalUnion(all=[true])
+   :- LogicalProject(EXPR$0=[1], EXPR$1=[2])
+   :  +- LogicalValues(tuples=[[{ 0 }]])
+   :- LogicalProject(EXPR$0=[3], EXPR$1=[null])
+   :  +- LogicalValues(tuples=[[{ 0 }]])
+   +- LogicalProject(EXPR$0=[4], EXPR$1=[5])
+      +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[EXPR$0, EXPR$1])
+:- Calc(select=[1 AS EXPR$0, CAST(2) AS EXPR$1])
+:  +- Values(tuples=[[{ 0 }]], values=[ZERO])
+:- Calc(select=[3 AS EXPR$0, null AS EXPR$1])
+:  +- Values(tuples=[[{ 0 }]], values=[ZERO])
++- Calc(select=[4 AS EXPR$0, CAST(5) AS EXPR$1])
+   +- Values(tuples=[[{ 0 }]], values=[ZERO])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNullValues">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES CAST(NULL AS INT))]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[null])
++- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[null AS EXPR$0])
++- Values(tuples=[[{ 0 }]], values=[ZERO])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/CalcTest.xml
@@ -1,0 +1,360 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testArrayType">
+    <Resource name="sql">
+      <![CDATA[SELECT ARRAY['Hi', 'Hello', c] FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ARRAY(_UTF-16LE'Hi', _UTF-16LE'Hello', $2)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ARRAY(_UTF-16LE'Hi', _UTF-16LE'Hello', c) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testConjunctiveFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a < 10 AND b > 20]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[AND(<($0, 10), >($1, 20))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[AND(<(a, 10), >(b, 20))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDisjunctiveFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a < 10 OR a > 20]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(<($0, 10), >($0, 20))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[OR(<(a, 10), >(a, 20))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFilterWithDateType">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable3
+WHERE b = DATE '1984-07-12' AND c = TIME '14:34:24' AND d = TIMESTAMP '1984-07-12 14:34:24'
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[AND(=($1, 1984-07-12), =($2, 14:34:24), =($3, 1984-07-12 14:34:24))])
+   +- LogicalTableScan(table=[[MyTable3, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, d], where=[AND(=(b, 1984-07-12), =(c, 14:34:24), =(d, 1984-07-12 14:34:24))])
++- TableSourceScan(table=[[MyTable3, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE b IN (1, 3, 4, 5, 6) AND c = 'xx']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[AND(OR(=($1, 1), =($1, 3), =($1, 4), =($1, 5), =($1, 6)), =($2, _UTF-16LE'xx'))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[AND(OR(=(b, 1), =(b, 3), =(b, 4), =(b, 5), =(b, 6)), =(c, _UTF-16LE'xx'))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMixedType">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable5 WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ROW($0, $1, $2)], EXPR$1=[ARRAY(12, $1)], EXPR$2=[MAP($0, $2)])
++- LogicalFilter(condition=[=(ROW($0, $1, $2), CAST(ROW(_UTF-16LE'foo', 12, 1984-07-12 14:34:24)):RecordType(VARCHAR(65536) CHARACTER SET "UTF-16LE" COLLATE "ISO-8859-1$en_US$primary" EXPR$0, INTEGER EXPR$1, TIMESTAMP(3) EXPR$2) NOT NULL)])
+   +- LogicalTableScan(table=[[MyTable5, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ROW(a, b, c) AS EXPR$0, ARRAY(12, b) AS EXPR$1, MAP(a, c) AS EXPR$2], where=[=(ROW(a, b, c), CAST(ROW(_UTF-16LE'foo', 12, 1984-07-12 14:34:24)))])
++- TableSourceScan(table=[[MyTable5, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiFilters">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (SELECT * FROM MyTable WHERE b > 0) t WHERE a < 50]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[<($0, 50)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalFilter(condition=[>($1, 0)])
+         +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[AND(>(b, 0), <(a, 50))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultipleFlattening">
+    <Resource name="sql">
+      <![CDATA[SELECT MyTable2.a.*, c, MyTable2.b.* FROM MyTable2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(_1=[$0._1], _2=[$0._2], c=[$2], _10=[$1._1], _20=[$1._2])
++- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a._1 AS _1, a._2 AS _2, c, b._1 AS _10, b._2 AS _20])
++- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiProjects">
+    <Resource name="sql">
+      <![CDATA[SELECT c FROM (SELECT a, c FROM MyTable)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonPrimitiveMapType">
+    <Resource name="sql">
+      <![CDATA[SELECT MAP[a, c] FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[MAP($0, $2)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[MAP(a, c) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNotIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(NOT(OR(=($1, 1), =($1, 3), =($1, 4), =($1, 5), =($1, 6))), =($2, _UTF-16LE'xx'))])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[OR(AND(<>(b, 1), <>(b, 3), <>(b, 4), <>(b, 5), <>(b, 6)), =(c, _UTF-16LE'xx'))])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE b > 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[>($1, 0)])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[>(b, 0)])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyProject">
+    <Resource name="sql">
+      <![CDATA[SELECT a, c FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, c])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPojoType">
+    <Resource name="sql">
+      <![CDATA[SELECT a FROM MyTable4]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalTableScan(table=[[MyTable4, source: [TestTableSource(a)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[MyTable4, source: [TestTableSource(a)]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPrimitiveMapType">
+    <Resource name="sql">
+      <![CDATA[SELECT MAP[b, 30, 10, a] FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[MAP($1, 30, 10, $0)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[MAP(b, 30, 10, a) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectAndFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b + 1 FROM MyTable WHERE b > 2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
++- LogicalFilter(condition=[>($1, 2)])
+   +- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, +(b, 1) AS EXPR$1], where=[>(b, 2)])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithDateType">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b, c,
+ DATE '1984-07-12',
+ TIME '14:34:24',
+ TIMESTAMP '1984-07-12 14:34:24'
+FROM MyTable
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], EXPR$3=[1984-07-12], EXPR$4=[14:34:24], EXPR$5=[1984-07-12 14:34:24])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c, 1984-07-12 AS EXPR$3, 14:34:24 AS EXPR$4, 1984-07-12 14:34:24 AS EXPR$5])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithNaming">
+    <Resource name="sql">
+      <![CDATA[SELECT `1-_./Ü`, b, c FROM (SELECT a as `1-_./Ü`, b, c FROM MyTable)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(1-_./Ü=[$0], b=[$1], c=[$2])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowType">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(1, 'Hi', a) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ROW(1, _UTF-16LE'Hi', $0)])
++- LogicalTableScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ROW(1, _UTF-16LE'Hi', a) AS EXPR$0])
++- TableSourceScan(table=[[MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/UnionTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/UnionTest.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testUnionAll">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, c FROM (
+ SELECT a, c FROM MyTable1
+ UNION ALL
+ SELECT a, c FROM MyTable2
+ UNION ALL
+ SELECT a, c FROM MyTable3
+) WHERE a > 2
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$1])
++- LogicalFilter(condition=[>($0, 2)])
+   +- LogicalUnion(all=[true])
+      :- LogicalUnion(all=[true])
+      :  :- LogicalProject(a=[$0], c=[$2])
+      :  :  +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]])
+      :  +- LogicalProject(a=[$0], c=[$2])
+      :     +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]])
+      +- LogicalProject(a=[$0], c=[$2])
+         +- LogicalTableScan(table=[[MyTable3, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[a, c])
+:- Union(all=[true], union=[a, c])
+:  :- Calc(select=[a, c], where=[>(a, 2)])
+:  :  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+:  +- Calc(select=[a, c], where=[>(a, 2)])
+:     +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- Calc(select=[a, c], where=[>(a, 2)])
+   +- TableSourceScan(table=[[MyTable3, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionAllDiffType">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+ SELECT a, b FROM MyTable1
+ UNION ALL
+ SELECT a, CAST(0 aS DECIMAL(2, 1)) FROM MyTable2)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
++- LogicalUnion(all=[true]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
+   :- LogicalProject(a=[$0], b=[$1]), rowType=[RecordType(INTEGER a, BIGINT b)]
+   :  +- LogicalTableScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
+   +- LogicalProject(a=[$0], EXPR$1=[0]), rowType=[RecordType(INTEGER a, DECIMAL(2, 1) EXPR$1)]
+      +- LogicalTableScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[a, b]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
+:- Calc(select=[a, CAST(b) AS b]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
+:  +- TableSourceScan(table=[[MyTable1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
++- Calc(select=[a, CAST(0) AS EXPR$1]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) EXPR$1)]
+   +- TableSourceScan(table=[[MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c]), rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(65536) c)]
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/ValuesTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/plan/stream/sql/ValuesTest.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testDiffTypes">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1]), rowType=[RecordType(INTEGER a, DECIMAL(20, 1) b)]
++- LogicalUnion(all=[true]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+   :- LogicalProject(EXPR$0=[1], EXPR$1=[2.0]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(2, 1) EXPR$1)]
+   :  +- LogicalValues(tuples=[[{ 0 }]]), rowType=[RecordType(INTEGER ZERO)]
+   +- LogicalProject(EXPR$0=[3], EXPR$1=[4]), rowType=[RecordType(INTEGER EXPR$0, BIGINT EXPR$1)]
+      +- LogicalValues(tuples=[[{ 0 }]]), rowType=[RecordType(INTEGER ZERO)]
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[EXPR$0, EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+:- Calc(select=[1 AS EXPR$0, 2.0 AS EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+:  +- Values(tuples=[[{ 0 }]]), rowType=[RecordType(INTEGER ZERO)]
++- Calc(select=[3 AS EXPR$0, 4 AS EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, DECIMAL(20, 1) EXPR$1)]
+   +- Values(tuples=[[{ 0 }]]), rowType=[RecordType(INTEGER ZERO)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleRow">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES (1, 2, 3)) AS T(a, b, c)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalValues(tuples=[[{ 1, 2, 3 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Values(tuples=[[{ 1, 2, 3 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiRows">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES (1, 2), (3, CAST(NULL AS INT)), (4, 5)) AS T(a, b)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalUnion(all=[true])
+   :- LogicalProject(EXPR$0=[1], EXPR$1=[2])
+   :  +- LogicalValues(tuples=[[{ 0 }]])
+   :- LogicalProject(EXPR$0=[3], EXPR$1=[null])
+   :  +- LogicalValues(tuples=[[{ 0 }]])
+   +- LogicalProject(EXPR$0=[4], EXPR$1=[5])
+      +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[EXPR$0, EXPR$1])
+:- Calc(select=[1 AS EXPR$0, CAST(2) AS EXPR$1])
+:  +- Values(tuples=[[{ 0 }]])
+:- Calc(select=[3 AS EXPR$0, null AS EXPR$1])
+:  +- Values(tuples=[[{ 0 }]])
++- Calc(select=[4 AS EXPR$0, CAST(5) AS EXPR$1])
+   +- Values(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNullValues">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES CAST(NULL AS INT))]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[null])
++- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[null AS EXPR$0])
++- Values(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/CalcTest.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.plan.util.MyPojo
+import org.apache.flink.table.util.TableTestBase
+
+import org.junit.Test
+
+import java.sql.{Date, Time, Timestamp}
+
+class CalcTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+  util.addTableSource[(Long, Int, String)]("MyTable", 'a, 'b, 'c)
+
+  @Test
+  def testOnlyProject(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithNaming(): Unit = {
+    util.verifyPlan("SELECT `1-_./Ü`, b, c FROM (SELECT a as `1-_./Ü`, b, c FROM MyTable)")
+  }
+
+  @Test
+  def testMultiProjects(): Unit = {
+    util.verifyPlan("SELECT c FROM (SELECT a, c FROM MyTable)")
+  }
+
+  @Test
+  def testOnlyFilter(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE b > 0")
+  }
+
+  @Test
+  def testDisjunctiveFilter(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE a < 10 OR a > 20")
+  }
+
+  @Test
+  def testConjunctiveFilter(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE a < 10 AND b > 20")
+  }
+
+  @Test
+  def testMultiFilters(): Unit = {
+    util.verifyPlan("SELECT * FROM (SELECT * FROM MyTable WHERE b > 0) t WHERE a < 50")
+  }
+
+  @Test
+  def testProjectAndFilter(): Unit = {
+    util.verifyPlan("SELECT a, b + 1 FROM MyTable WHERE b > 2")
+  }
+
+  @Test
+  def testIn(): Unit = {
+    val sql = s"SELECT * FROM MyTable WHERE b IN (1, 3, 4, 5, 6) AND c = 'xx'"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testNotIn(): Unit = {
+    val sql = s"SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx'"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testMultipleFlattening(): Unit = {
+    util.addTableSource[((Int, Long), (String, Boolean), String)]("MyTable2", 'a, 'b, 'c)
+    util.verifyPlan("SELECT MyTable2.a.*, c, MyTable2.b.* FROM MyTable2")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidFields(): Unit = {
+    util.tableEnv.sqlQuery("SELECT a, foo FROM MyTable")
+  }
+
+  @Test
+  def testPrimitiveMapType(): Unit = {
+    util.verifyPlan("SELECT MAP[b, 30, 10, a] FROM MyTable")
+  }
+
+  @Test
+  def testNonPrimitiveMapType(): Unit = {
+    util.verifyPlan("SELECT MAP[a, c] FROM MyTable")
+  }
+
+  @Test
+  def testRowType(): Unit = {
+    util.verifyPlan("SELECT ROW(1, 'Hi', a) FROM MyTable")
+  }
+
+  @Test
+  def testArrayType(): Unit = {
+    util.verifyPlan("SELECT ARRAY['Hi', 'Hello', c] FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithDateType(): Unit = {
+    val sql =
+      """
+        |SELECT a, b, c,
+        | DATE '1984-07-12',
+        | TIME '14:34:24',
+        | TIMESTAMP '1984-07-12 14:34:24'
+        |FROM MyTable
+      """.stripMargin
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testFilterWithDateType(): Unit = {
+    util.addTableSource[(Long, Date, Time, Timestamp)]("MyTable3", 'a, 'b, 'c, 'd)
+    val sql =
+      """
+        |SELECT * FROM MyTable3
+        |WHERE b = DATE '1984-07-12' AND c = TIME '14:34:24' AND d = TIMESTAMP '1984-07-12 14:34:24'
+      """.stripMargin
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testPojoType(): Unit = {
+    util.addTableSource(
+      "MyTable4",
+      Array[TypeInformation[_]](TypeExtractor.createTypeInfo(classOf[MyPojo])),
+      Array("a"))
+    util.verifyPlan("SELECT a FROM MyTable4")
+  }
+
+  @Test
+  def testMixedType(): Unit = {
+    util.addTableSource[(String, Int, Timestamp)]("MyTable5", 'a, 'b, 'c)
+    util.verifyPlan("SELECT ROW(a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable5 " +
+      "WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')")
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/UnionTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.util.TableTestBase
+
+import org.apache.calcite.sql.SqlExplainLevel
+import org.junit.{Before, Test}
+
+// TODO add more union case after aggregation and join supported
+class UnionTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def before(): Unit = {
+    util.addTableSource[(Int, Long, String)]("MyTable1", 'a, 'b, 'c)
+    util.addTableSource[(Int, Long, String)]("MyTable2", 'a, 'b, 'c)
+    util.addTableSource[(Int, Long, String)]("MyTable3", 'a, 'b, 'c)
+  }
+
+  @Test
+  def testUnionAll(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT a, c FROM (
+        | SELECT a, c FROM MyTable1
+        | UNION ALL
+        | SELECT a, c FROM MyTable2
+        | UNION ALL
+        | SELECT a, c FROM MyTable3
+        |) WHERE a > 2
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testUnionAllDiffType(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT * FROM (
+        | SELECT a, b FROM MyTable1
+        | UNION ALL
+        | SELECT a, CAST(0 aS DECIMAL(2, 1)) FROM MyTable2)
+      """.stripMargin
+    util.doVerifyPlan(sqlQuery,
+      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      withRowType = true,
+      printPlanBefore = true)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/ValuesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/batch/sql/ValuesTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.batch.sql
+
+import org.apache.flink.table.util.TableTestBase
+
+import org.apache.calcite.sql.SqlExplainLevel
+import org.junit.Test
+
+class ValuesTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Test
+  def testNullValues(): Unit = {
+    util.verifyPlan("SELECT * FROM (VALUES CAST(NULL AS INT))")
+  }
+
+  @Test
+  def testSingleRow(): Unit = {
+    util.verifyPlan("SELECT * FROM (VALUES (1, 2, 3)) AS T(a, b, c)")
+  }
+
+  @Test
+  def testMultiRows(): Unit = {
+    util.verifyPlan("SELECT * FROM (VALUES (1, 2), (3, CAST(NULL AS INT)), (4, 5)) AS T(a, b)")
+  }
+
+  @Test
+  def testDiffTypes(): Unit = {
+    val sql = "SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)"
+    util.doVerifyPlan(
+      sql,
+      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      withRowType = true,
+      printPlanBefore = true)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/CalcTest.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.stream.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.plan.util.MyPojo
+import org.apache.flink.table.util.TableTestBase
+
+import org.junit.Test
+
+import java.sql.{Date, Time, Timestamp}
+
+class CalcTest extends TableTestBase {
+  private val util = streamTestUtil()
+  util.addTableSource[(Long, Int, String)]("MyTable", 'a, 'b, 'c)
+
+  @Test
+  def testOnlyProject(): Unit = {
+    util.verifyPlan("SELECT a, c FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithNaming(): Unit = {
+    util.verifyPlan("SELECT `1-_./Ü`, b, c FROM (SELECT a as `1-_./Ü`, b, c FROM MyTable)")
+  }
+
+  @Test
+  def testMultiProjects(): Unit = {
+    util.verifyPlan("SELECT c FROM (SELECT a, c FROM MyTable)")
+  }
+
+  @Test
+  def testOnlyFilter(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE b > 0")
+  }
+
+  @Test
+  def testDisjunctiveFilter(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE a < 10 OR a > 20")
+  }
+
+  @Test
+  def testConjunctiveFilter(): Unit = {
+    util.verifyPlan("SELECT * FROM MyTable WHERE a < 10 AND b > 20")
+  }
+
+  @Test
+  def testMultiFilters(): Unit = {
+    util.verifyPlan("SELECT * FROM (SELECT * FROM MyTable WHERE b > 0) t WHERE a < 50")
+  }
+
+  @Test
+  def testProjectAndFilter(): Unit = {
+    util.verifyPlan("SELECT a, b + 1 FROM MyTable WHERE b > 2")
+  }
+
+  @Test
+  def testIn(): Unit = {
+    val sql = s"SELECT * FROM MyTable WHERE b IN (1, 3, 4, 5, 6) AND c = 'xx'"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testNotIn(): Unit = {
+    val sql = s"SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx'"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testMultipleFlattening(): Unit = {
+    util.addTableSource[((Int, Long), (String, Boolean), String)]("MyTable2", 'a, 'b, 'c)
+    util.verifyPlan("SELECT MyTable2.a.*, c, MyTable2.b.* FROM MyTable2")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInvalidFields(): Unit = {
+    util.tableEnv.sqlQuery("SELECT a, foo FROM MyTable")
+  }
+
+  @Test
+  def testPrimitiveMapType(): Unit = {
+    util.verifyPlan("SELECT MAP[b, 30, 10, a] FROM MyTable")
+  }
+
+  @Test
+  def testNonPrimitiveMapType(): Unit = {
+    util.verifyPlan("SELECT MAP[a, c] FROM MyTable")
+  }
+
+  @Test
+  def testRowType(): Unit = {
+    util.verifyPlan("SELECT ROW(1, 'Hi', a) FROM MyTable")
+  }
+
+  @Test
+  def testArrayType(): Unit = {
+    util.verifyPlan("SELECT ARRAY['Hi', 'Hello', c] FROM MyTable")
+  }
+
+  @Test
+  def testProjectWithDateType(): Unit = {
+    val sql =
+      """
+        |SELECT a, b, c,
+        | DATE '1984-07-12',
+        | TIME '14:34:24',
+        | TIMESTAMP '1984-07-12 14:34:24'
+        |FROM MyTable
+      """.stripMargin
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testFilterWithDateType(): Unit = {
+    util.addTableSource[(Long, Date, Time, Timestamp)]("MyTable3", 'a, 'b, 'c, 'd)
+    val sql =
+      """
+        |SELECT * FROM MyTable3
+        |WHERE b = DATE '1984-07-12' AND c = TIME '14:34:24' AND d = TIMESTAMP '1984-07-12 14:34:24'
+      """.stripMargin
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testPojoType(): Unit = {
+    util.addTableSource(
+      "MyTable4",
+      Array[TypeInformation[_]](TypeExtractor.createTypeInfo(classOf[MyPojo])),
+      Array("a"))
+    util.verifyPlan("SELECT a FROM MyTable4")
+  }
+
+  @Test
+  def testMixedType(): Unit = {
+    util.addTableSource[(String, Int, Timestamp)]("MyTable5", 'a, 'b, 'c)
+    util.verifyPlan("SELECT ROW(a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable5 " +
+      "WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')")
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/UnionTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.util.TableTestBase
+
+import org.apache.calcite.sql.SqlExplainLevel
+import org.junit.{Before, Test}
+
+// TODO add more union case after aggregation and join supported
+class UnionTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def before(): Unit = {
+    util.addTableSource[(Int, Long, String)]("MyTable1", 'a, 'b, 'c)
+    util.addTableSource[(Int, Long, String)]("MyTable2", 'a, 'b, 'c)
+    util.addTableSource[(Int, Long, String)]("MyTable3", 'a, 'b, 'c)
+  }
+
+  @Test
+  def testUnionAll(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT a, c FROM (
+        | SELECT a, c FROM MyTable1
+        | UNION ALL
+        | SELECT a, c FROM MyTable2
+        | UNION ALL
+        | SELECT a, c FROM MyTable3
+        |) WHERE a > 2
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testUnionAllDiffType(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT * FROM (
+        | SELECT a, b FROM MyTable1
+        | UNION ALL
+        | SELECT a, CAST(0 aS DECIMAL(2, 1)) FROM MyTable2)
+      """.stripMargin
+    util.doVerifyPlan(sqlQuery,
+      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      withRowType = true,
+      printPlanBefore = true)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/ValuesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/stream/sql/ValuesTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stream.sql
+
+import org.apache.flink.table.util.TableTestBase
+
+import org.apache.calcite.sql.SqlExplainLevel
+import org.junit.Test
+
+class ValuesTest extends TableTestBase {
+
+  private val util = streamTestUtil()
+
+  @Test
+  def testNullValues(): Unit = {
+    util.verifyPlan("SELECT * FROM (VALUES CAST(NULL AS INT))")
+  }
+
+  @Test
+  def testSingleRow(): Unit = {
+    util.verifyPlan("SELECT * FROM (VALUES (1, 2, 3)) AS T(a, b, c)")
+  }
+
+  @Test
+  def testMultiRows(): Unit = {
+    util.verifyPlan("SELECT * FROM (VALUES (1, 2), (3, CAST(NULL AS INT)), (4, 5)) AS T(a, b)")
+  }
+
+  @Test
+  def testDiffTypes(): Unit = {
+    val sql = "SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)"
+    util.doVerifyPlan(
+      sql,
+      explainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
+      withRowType = true,
+      printPlanBefore = true)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/pojos.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/plan/util/pojos.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.util
+
+class MyPojo() {
+  var f1: Int = 0
+  var f2: String = ""
+
+  def this(f1: Int, f2: String) {
+    this()
+    this.f1 = f1
+    this.f2 = f2
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MyPojo =>
+      (that canEqual this) &&
+        f1 == that.f1 &&
+        f2 == that.f2
+    case _ => false
+  }
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[MyPojo]
+
+  override def toString = s"MyPojo($f1, $f2)"
+}


### PR DESCRIPTION

## What is the purpose of the change

*Add support for generating optimized logical plan for simple query(Project, Filter, Values and Union all)*

## Brief change log

  - *supports SELECT and WHERE queries*
  - *supports VALUES queries*
  - *supports UNION ALL queries*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added CalcTest that validates SELECT and WHERE queries*
  - *Added ValuesTest that validates VALUES queries*
  - *Added UnionTest that validates UNION ALL queries*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( not documented)
