### PR TITLE
[FLINK-11946][table-planner-blink] Introduce ExecNode to blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/nodes/exec/ExecNodeVisitor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/plan/nodes/exec/ExecNodeVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.exec;
+
+/**
+ * Visitor pattern for traversing a dag of {@link ExecNode} objects.
+ */
+public interface ExecNodeVisitor {
+
+	/**
+	 * Visits a node during a traversal.
+	 *
+	 * @param node ExecNode to visit
+	 */
+	void visit(ExecNode<?, ?> node);
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/BatchExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/BatchExecNode.scala
@@ -20,8 +20,10 @@ package org.apache.flink.table.plan.nodes.exec
 
 import org.apache.flink.runtime.operators.DamBehavior
 import org.apache.flink.table.api.BatchTableEnvironment
-import org.apache.flink.table.dataformat.BaseRow
 
+/**
+  * Base class for batch ExecNode.
+  */
 trait BatchExecNode[T] extends ExecNode[BatchTableEnvironment, T] {
 
   /**
@@ -30,5 +32,3 @@ trait BatchExecNode[T] extends ExecNode[BatchTableEnvironment, T] {
   def getDamBehavior: DamBehavior
 
 }
-
-trait RowBatchExecNode extends BatchExecNode[BaseRow]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/BatchExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/BatchExecNode.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.exec
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.table.api.BatchTableEnvironment
+import org.apache.flink.table.dataformat.BaseRow
+
+trait BatchExecNode[T] extends ExecNode[BatchTableEnvironment, T] {
+
+  /**
+    * Returns [[DamBehavior]] of this node.
+    */
+  def getDamBehavior: DamBehavior
+
+}
+
+trait RowBatchExecNode extends BatchExecNode[BaseRow]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/ExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/ExecNode.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.exec
+
+import org.apache.flink.streaming.api.transformations.StreamTransformation
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.plan.nodes.physical.FlinkPhysicalRel
+
+import java.util
+
+/**
+  * The representation of execution information for a [[FlinkPhysicalRel]].
+  *
+  * @tparam E The TableEnvironment
+  * @tparam T The type of the elements that result from this [[StreamTransformation]]
+  */
+trait ExecNode[E <: TableEnvironment, T] {
+
+  /**
+    * The [[StreamTransformation]] translated from this node.
+    */
+  private var transformation: StreamTransformation[T] = _
+
+  /**
+    * Translates this node into a Flink operator.
+    *
+    * <p>NOTE: returns same translate result if called multiple times.
+    *
+    * @param tableEnv The [[TableEnvironment]] of the translated Table.
+    */
+  def translateToPlan(tableEnv: E): StreamTransformation[T] = {
+    if (transformation == null) {
+      transformation = translateToPlanInternal(tableEnv)
+    }
+    transformation
+  }
+
+  /**
+    * Internal method, translates this node into a Flink operator.
+    *
+    * @param tableEnv The [[TableEnvironment]] of the translated Table.
+    */
+  protected def translateToPlanInternal(tableEnv: E): StreamTransformation[T]
+
+  /**
+    * Returns an array of this node's inputs. If there are no inputs,
+    * returns an empty list, not null.
+    *
+    * @return Array of this node's inputs
+    */
+  def getInputNodes: util.List[ExecNode[E, _]]
+
+  /**
+    * Accepts a visit from a [[ExecNodeVisitor]].
+    *
+    * @param visitor ExecNodeVisitor
+    */
+  def accept(visitor: ExecNodeVisitor): Unit = {
+    visitor.visit(this)
+  }
+
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/StreamExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/StreamExecNode.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.exec
+
+import org.apache.flink.table.api.StreamTableEnvironment
+import org.apache.flink.table.dataformat.BaseRow
+
+trait StreamExecNode[T] extends ExecNode[StreamTableEnvironment, T]
+
+trait RowStreamExecNode extends StreamExecNode[BaseRow]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/StreamExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/plan/nodes/exec/StreamExecNode.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.plan.nodes.exec
 
 import org.apache.flink.table.api.StreamTableEnvironment
-import org.apache.flink.table.dataformat.BaseRow
 
+/**
+  * Base class for stream ExecNode.
+  */
 trait StreamExecNode[T] extends ExecNode[StreamTableEnvironment, T]
-
-trait RowStreamExecNode extends StreamExecNode[BaseRow]


### PR DESCRIPTION
[##](url) What is the purpose of the change

*The pr introduce ExecNode. ExecNode and FlinkPhysicalRel plays different role. FlinkPhysicalRel is a physical relational expression, while ExecNode is a representation of execution information, such as how much resource the node will take, how to convert to StreamTransformation. 
It should be noticed that FlinkPhysicalRel and ExecNode could be implemented by a same concrete physical node, such as StreamExecCalc, StreamExecScan, etc. The interface exposed by a concrete physical node is different at different stages. A FlinkPhysicalRel DAG is generated after physical optimization, then translate the plan to ExecNode DAG. All post processors all apply on ExecNode DAG, such as detect deadlock, set heap/memory/cpu, etc. *

## Brief change log

  - * Add ExecNode *
  - * Add BatchExecNode, StreamExecNode*
  - * Add ExecNodeVisitor to visit a ExecNode graph*

## Verifying this change

This change only introduce interfaces, not add any implementation yet, so the pr without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
