### PR TITLE
[FLINK-11958][on-yarn] fix flink on windows yarn deploy failed

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -1555,7 +1555,15 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		ContainerLaunchContext amContainer = Records.newRecord(ContainerLaunchContext.class);
 
 		final  Map<String, String> startCommandValues = new HashMap<>();
-		startCommandValues.put("java", "$JAVA_HOME/bin/java");
+		String osName = System.getProperty("os.name");
+		String javaHome;
+		if (osName.startsWith("Windows")) {
+			javaHome = "%JAVA_HOME%";
+		} else {
+			javaHome = "$JAVA_HOME";
+		}
+		String javaCommand = javaHome + "/bin/java";
+		startCommandValues.put("java", javaCommand);
 
 		int heapSize = Utils.calculateHeapSize(jobManagerMemoryMb, flinkConfiguration);
 		String jvmHeapMem = String.format("-Xms%sm -Xmx%sm", heapSize, heapSize);


### PR DESCRIPTION
## What is the purpose of the change

* fix flink on windows yarn deploy failed

## Brief change log

* fix JAVA_HOME variable on windows

## Verifying this change

   * Manually verified the change by deploy a flink on yarn cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
