### PR TITLE
[FLINK-11980] Improve efficiency of iterating KeySelectionListener on notification

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -23,8 +23,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
-import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -204,12 +202,6 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	@Override
 	public TypeSerializer<K> getKeySerializer() {
 		return keySerializerProvider.currentSchemaSerializer();
-	}
-
-	public TypeSerializerSchemaCompatibility<K> checkKeySerializerSchemaCompatibility(
-			TypeSerializerSnapshot<K> previousKeySerializerSnapshot) {
-
-		return keySerializerProvider.setPreviousSerializerSnapshotForRestoredState(previousKeySerializerSnapshot);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -515,7 +515,7 @@ public abstract class TtlStateTestBase {
 		// trigger more cleanup by doing something out side of INC_CLEANUP_ALL_KEYS
 		for (int i = INC_CLEANUP_ALL_KEYS; i < INC_CLEANUP_ALL_KEYS * 2; i++) {
 			sbetc.setCurrentKey(Integer.toString(i));
-			if (i / 2 == 0) {
+			if (i % 2 == 0) {
 				ctx().get();
 			} else {
 				ctx().update(ctx().updateEmpty);


### PR DESCRIPTION
## What is the purpose of the change

`KeySelectionListener` was introduced for incremental TTL state cleanup as a driver of the cleanup process. Listeners are notified whenever the current key in the backend is set (i.e. for every event). The current implementation of the collection that holds the listener is a `HashSet`, iterated via `forEach` on each key change. This method comes with the overhead of creating temporaray objects, e.g. iterators, on every invocation and even if there is no listener registered. We should rather use an `ArrayList` with for-loop iteration in this hot code path to i) minimize overhead and ii) minimize costs for the very likely case that there is no listener at all.

## Brief change log

Replaced `HashSet` with `ArrayList`. Using `for` loop instead of anything involving iterators.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
