### PR TITLE
[FLINK-5490] prevent ContextEnvironment#getExecutionPlan() from clear…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -65,7 +65,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public String getExecutionPlan() throws Exception {
-		Plan plan = createProgramPlan("unnamed job");
+		Plan plan = createProgramPlan("unnamed job", false);
 
 		OptimizedPlan op = ClusterClient.getOptimizedPlan(client.compiler, plan, getParallelism());
 		PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanConsecutiveCallsContextEnvTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanConsecutiveCallsContextEnvTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program;
+
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.optimizer.plan.OptimizedPlan;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import static junit.framework.TestCase.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that verifies consecutive calls to {@link ContextEnvironment#getExecutionPlan()} do not cause any exceptions.
+ * {@link ContextEnvironment#getExecutionPlan()} must not modify the state of the plan
+ */
+@SuppressWarnings("serial") @RunWith(PowerMockRunner.class) @PrepareForTest(ClusterClient.class)
+public class ExecutionPlanConsecutiveCallsContextEnvTest extends TestLogger implements Serializable {
+
+	@Test public void testExecuteAfterGetExecutionPlanContextEnvironment() {
+		final OptimizedPlan optimizedPlan = mock(OptimizedPlan.class);
+		final ClusterClient clusterClient = mock(ClusterClient.class);
+
+		PowerMockito.mockStatic(ClusterClient.class);
+		when(ClusterClient.getOptimizedPlan(any(), (Plan) any(), anyInt())).thenReturn(optimizedPlan);
+		ExecutionEnvironment env = new ContextEnvironment(clusterClient, new ArrayList<>(), new ArrayList<>(), null, null);
+		env.getConfig().disableSysoutLogging();
+
+		DataSet<Integer> baseSet = env.fromElements(1, 2);
+
+		DataSet<Integer> result = baseSet.map((MapFunction<Integer, Integer>) value -> value * 2);
+		result.output(new DiscardingOutputFormat<>());
+
+		try {
+			env.getExecutionPlan();
+			env.getExecutionPlan();
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Consecutive #getExecutionPlan calls caused an exception.");
+		}
+	}
+}


### PR DESCRIPTION
…ing the sinks

## What is the purpose of the change

This pull request prevents ContextEnvironment#getExecutionPlan() from clearing the sinks. It allows for consecutive calls of ContextEnvironment#getExecutionPlan() or subsequent calls of ContextEnvironment#getExecutionPlan() and ExecutionEnvironment#execute(), which isn't currently possible because an exception about having no defined sinks is thrown.

## Brief change log

* ContextEnvironment#getExecutionPlan() now calls ExecutionEnvironment#createProgramPlan() with the clearSinks flag explicitly set to "false" (it defaults to "true" if not set)


## Verifying this change

This change added tests and can be verified as follows:

* Added a unit test which performs two consecutive calls to ContextEnvironment#getExecutionPlan(). This test throws an exception if t he execution plan is cleared in-between calls. It is failing with the current code and succeeding with this patch.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
