### PR TITLE
[FLINK-11907][types] Normalize String/BigInteger in GenericTypeInfoTest

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/misc/GenericTypeInfoTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/GenericTypeInfoTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.test.operators.util.CollectionDataSets;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Test TypeInfo serializer tree.
@@ -40,39 +40,27 @@ public class GenericTypeInfoTest {
 				(TypeInformation<CollectionDataSets.PojoWithCollectionGeneric>)
 						TypeExtractor.createTypeInfo(CollectionDataSets.PojoWithCollectionGeneric.class);
 
-		String serTree = Utils.getSerializerTree(ti);
-		// We can not test against the entire output because the fields of 'String' differ
-		// between java versions
-		Assert.assertThat(serTree, startsWith("GenericTypeInfo (PojoWithCollectionGeneric)\n" +
+		final String serTree = Utils.getSerializerTree(ti)
+			// normalize String/BigInteger representations as they vary across java versions
+			// do 2 passes for BigInteger since they occur at different indentations
+			.replaceAll("(java\\.lang\\.String\\R)( {12}\\S*\\R)+", "$1")
+			.replaceAll("( {4}[a-zA-Z]+:java\\.math\\.BigInteger\\R)( {8}\\S*\\R)+", "$1")
+			.replaceAll("( {8}[a-zA-Z]+:java\\.math\\.BigInteger\\R)( {12}\\S*\\R)+", "$1");
+
+		Assert.assertThat(serTree, equalTo("GenericTypeInfo (PojoWithCollectionGeneric)\n" +
 				"    pojos:java.util.List\n" +
 				"    key:int\n" +
 				"    sqlDate:java.sql.Date\n" +
 				"    bigInt:java.math.BigInteger\n" +
-				"        signum:int\n" +
-				"        mag:[I\n" +
-				"        bitCount:int\n" +
-				"        bitLength:int\n" +
-				"        lowestSetBit:int\n" +
-				"        firstNonzeroIntNum:int\n" +
 				"    bigDecimalKeepItNull:java.math.BigDecimal\n" +
 				"        intVal:java.math.BigInteger\n" +
-				"            signum:int\n" +
-				"            mag:[I\n" +
-				"            bitCount:int\n" +
-				"            bitLength:int\n" +
-				"            lowestSetBit:int\n" +
-				"            firstNonzeroIntNum:int\n" +
 				"        scale:int\n" +
 				"    scalaBigInt:scala.math.BigInt\n" +
 				"        bigInteger:java.math.BigInteger\n" +
-				"            signum:int\n" +
-				"            mag:[I\n" +
-				"            bitCount:int\n" +
-				"            bitLength:int\n" +
-				"            lowestSetBit:int\n" +
-				"            firstNonzeroIntNum:int\n" +
 				"    mixed:java.util.List\n" +
 				"    makeMeGeneric:org.apache.flink.test.operators.util.CollectionDataSets$PojoWithDateAndEnum\n" +
-				"        group:java.lang.String\n"));
+				"        group:java.lang.String\n" +
+				"        date:java.util.Date\n" +
+				"        cat:org.apache.flink.test.operators.util.CollectionDataSets$Category (is enum)\n"));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies modifies the `GenericTypeInfoTest` to run on Java 9. The test struggles with java version-specific representations of Strings and BigIntegers, so we're normalizing these now before doing the assertion.


