### PR TITLE
[FLINK-11953] Introduce Plugin/Loading system and integrate it with FileSystem

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -124,16 +123,11 @@ public class CliFrontend {
 
 	public CliFrontend(
 			Configuration configuration,
-			List<CustomCommandLine<?>> customCommandLines) throws Exception {
+			List<CustomCommandLine<?>> customCommandLines) {
 		this.configuration = Preconditions.checkNotNull(configuration);
 		this.customCommandLines = Preconditions.checkNotNull(customCommandLines);
 
-		try {
-			FileSystem.initialize(this.configuration);
-		} catch (IOException e) {
-			throw new Exception("Error while setting the default " +
-				"filesystem scheme from configuration.", e);
-		}
+		FileSystem.initialize(this.configuration);
 
 		this.customCommandLineOptions = new Options();
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -39,6 +39,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
@@ -80,6 +81,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -127,7 +129,8 @@ public class CliFrontend {
 		this.configuration = Preconditions.checkNotNull(configuration);
 		this.customCommandLines = Preconditions.checkNotNull(customCommandLines);
 
-		FileSystem.initialize(this.configuration);
+		//TODO provide plugin path.
+		FileSystem.initialize(this.configuration, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 		this.customCommandLineOptions = new Options();
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -251,7 +251,7 @@ public abstract class FileSystem {
 	 *
 	 * @param config the configuration from where to fetch the parameter.
 	 */
-	public static void initialize(Configuration config) throws IOException, IllegalConfigurationException {
+	public static void initialize(Configuration config) throws IllegalConfigurationException {
 		LOCK.lock();
 		try {
 			// make sure file systems are re-instantiated after re-configuration

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.fs.local.LocalFileSystemFactory;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
@@ -44,12 +45,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -217,11 +220,8 @@ public abstract class FileSystem {
 	/** Cache for file systems, by scheme + authority. */
 	private static final HashMap<FSKey, FileSystem> CACHE = new HashMap<>();
 
-	/** All available file system factories. */
-	private static final List<FileSystemFactory> RAW_FACTORIES = loadFileSystems();
-
 	/** Mapping of file system schemes to the corresponding factories,
-	 * populated in {@link FileSystem#initialize(Configuration)}. */
+	 * populated in {@link FileSystem#initialize(Configuration, PluginManager)}. */
 	private static final HashMap<String, FileSystemFactory> FS_FACTORIES = new HashMap<>();
 
 	/** The default factory that is used when no scheme matches. */
@@ -249,17 +249,57 @@ public abstract class FileSystem {
 	 * A file path of {@code '/user/USERNAME/in.txt'} is interpreted as
 	 * {@code 'hdfs://localhost:9000/user/USERNAME/in.txt'}.
 	 *
+	 * @deprecated use {@link #initialize(Configuration, PluginManager)} instead.
+	 *
 	 * @param config the configuration from where to fetch the parameter.
 	 */
+	@Deprecated
 	public static void initialize(Configuration config) throws IllegalConfigurationException {
+		initializeWithoutPlugins(config);
+	}
+
+	private static void initializeWithoutPlugins(Configuration config) throws IllegalConfigurationException {
+		initialize(config, null);
+	}
+
+	/**
+	 * Initializes the shared file system settings.
+	 *
+	 * <p>The given configuration is passed to each file system factory to initialize the respective
+	 * file systems. Because the configuration of file systems may be different subsequent to the call
+	 * of this method, this method clears the file system instance cache.
+	 *
+	 * <p>This method also reads the default file system URI from the configuration key
+	 * {@link CoreOptions#DEFAULT_FILESYSTEM_SCHEME}. All calls to {@link FileSystem#get(URI)} where
+	 * the URI has no scheme will be interpreted as relative to that URI.
+	 * As an example, assume the default file system URI is set to {@code 'hdfs://localhost:9000/'}.
+	 * A file path of {@code '/user/USERNAME/in.txt'} is interpreted as
+	 * {@code 'hdfs://localhost:9000/user/USERNAME/in.txt'}.
+	 *
+	 * @param config the configuration from where to fetch the parameter.
+	 * @param pluginManager optional plugin manager that is used to initialized filesystems provided as plugins.
+	 */
+	public static void initialize(
+		Configuration config,
+		PluginManager pluginManager) throws IllegalConfigurationException {
+
 		LOCK.lock();
 		try {
 			// make sure file systems are re-instantiated after re-configuration
 			CACHE.clear();
 			FS_FACTORIES.clear();
 
+			Collection<Supplier<Iterator<FileSystemFactory>>> factorySuppliers = new ArrayList<>(2);
+			factorySuppliers.add(() -> ServiceLoader.load(FileSystemFactory.class).iterator());
+
+			if (pluginManager != null) {
+				factorySuppliers.add(() -> pluginManager.load(FileSystemFactory.class));
+			}
+
+			final List<FileSystemFactory> fileSystemFactories = loadFileSystemFactories(factorySuppliers);
+
 			// configure all file system factories
-			for (FileSystemFactory factory : RAW_FACTORIES) {
+			for (FileSystemFactory factory : fileSystemFactories) {
 				factory.configure(config);
 				String scheme = factory.getScheme();
 
@@ -384,7 +424,7 @@ public abstract class FileSystem {
 			// even when not configured with an explicit Flink configuration, like on
 			// JobManager or TaskManager setup
 			if (FS_FACTORIES.isEmpty()) {
-				initialize(new Configuration());
+				initializeWithoutPlugins(new Configuration());
 			}
 
 			// Try to create a new file system
@@ -944,7 +984,9 @@ public abstract class FileSystem {
 	 *
 	 * @return A map from the file system scheme to corresponding file system factory.
 	 */
-	private static List<FileSystemFactory> loadFileSystems() {
+	private static List<FileSystemFactory> loadFileSystemFactories(
+		Collection<Supplier<Iterator<FileSystemFactory>>> factoryIteratorsSuppliers) {
+
 		final ArrayList<FileSystemFactory> list = new ArrayList<>();
 
 		// by default, we always have the local file system factory
@@ -952,36 +994,37 @@ public abstract class FileSystem {
 
 		LOG.debug("Loading extension file systems via services");
 
-		try {
-			ServiceLoader<FileSystemFactory> serviceLoader = ServiceLoader.load(FileSystemFactory.class);
-			Iterator<FileSystemFactory> iter = serviceLoader.iterator();
-
-			// we explicitly use an iterator here (rather than for-each) because that way
-			// we can catch errors in individual service instantiations
-
-			//noinspection WhileLoopReplaceableByForEach
-			while (iter.hasNext()) {
-				try {
-					FileSystemFactory factory = iter.next();
-					list.add(factory);
-					LOG.debug("Added file system {}:{}", factory.getScheme(), factory.getClass().getName());
-				}
-				catch (Throwable t) {
-					// catching Throwable here to handle various forms of class loading
-					// and initialization errors
-					ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-					LOG.error("Failed to load a file system via services", t);
-				}
+		for (Supplier<Iterator<FileSystemFactory>> factoryIteratorsSupplier : factoryIteratorsSuppliers) {
+			try {
+				addAllFactoriesToList(factoryIteratorsSupplier.get(), list);
+			} catch (Throwable t) {
+				// catching Throwable here to handle various forms of class loading
+				// and initialization errors
+				ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+				LOG.error("Failed to load additional file systems via services", t);
 			}
-		}
-		catch (Throwable t) {
-			// catching Throwable here to handle various forms of class loading
-			// and initialization errors
-			ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-			LOG.error("Failed to load additional file systems via services", t);
 		}
 
 		return Collections.unmodifiableList(list);
+	}
+
+	private static void addAllFactoriesToList(Iterator<FileSystemFactory> iter, List<FileSystemFactory> list) {
+		// we explicitly use an iterator here (rather than for-each) because that way
+		// we can catch errors in individual service instantiations
+
+		while (iter.hasNext()) {
+			try {
+				FileSystemFactory factory = iter.next();
+				list.add(factory);
+				LOG.debug("Added file system {}:{}", factory.getScheme(), factory.getClass().getName());
+			}
+			catch (Throwable t) {
+				// catching Throwable here to handle various forms of class loading
+				// and initialization errors
+				ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+				LOG.error("Failed to load a file system via services", t);
+			}
+		}
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.fs;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.plugin.Plugin;
 
 import java.io.IOException;
 import java.net.URI;
@@ -31,21 +32,12 @@ import java.net.URI;
  * creating file systems via {@link #create(URI)}.
  */
 @PublicEvolving
-public interface FileSystemFactory {
+public interface FileSystemFactory extends Plugin {
 
 	/**
 	 * Gets the scheme of the file system created by this factory.
 	 */
 	String getScheme();
-
-	/**
-	 * Applies the given configuration to this factory. All future file system
-	 * instantiations via {@link #create(URI)} should take the configuration into
-	 * account.
-	 *
-	 * @param config The configuration to apply.
-	 */
-	void configure(Configuration config);
 
 	/**
 	 * Creates a new file system for the given file system URI.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/UnsupportedSchemeFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/UnsupportedSchemeFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.core.fs;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.Configuration;
 
 import javax.annotation.Nullable;
 
@@ -51,11 +50,6 @@ class UnsupportedSchemeFactory implements FileSystemFactory {
 	@Override
 	public String getScheme() {
 		return "n/a";
-	}
-
-	@Override
-	public void configure(Configuration config) {
-		// nothing to do here
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinder.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinder.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.util.function.FunctionUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+/**
+ * This class is used to create a collection of {@link PluginDescriptor} based on directory structure for a given plugin
+ * root folder.
+ *
+ * <p>The expected structure is as follows: the given plugins root folder, containing the plugins folder. One plugin folder
+ * contains all resources (jar files) belonging to a plugin. The name of the plugin folder becomes the plugin id.
+ * <pre>
+ * plugins-root-folder/
+ *            |------------plugin-a/ (folder of plugin a)
+ *            |                |-plugin-a-1.jar (the jars containing the classes of plugin a)
+ *            |                |-plugin-a-2.jar
+ *            |                |-...
+ *            |
+ *            |------------plugin-b/
+ *            |                |-plugin-b-1.jar
+ *           ...               |-...
+ * </pre>
+ */
+public class DirectoryBasedPluginFinder implements PluginFinder {
+
+	/** Pattern to match jar files in a directory. */
+	private static final String JAR_MATCHER_PATTERN = "glob:**.jar";
+
+	/** Root directory to the plugin folders. */
+	private final Path pluginsRootDir;
+
+	/** Matcher for jar files in the filesystem of the root folder. */
+	private final PathMatcher jarFileMatcher;
+
+	public DirectoryBasedPluginFinder(Path pluginsRootDir) {
+		this.pluginsRootDir = pluginsRootDir;
+		this.jarFileMatcher = pluginsRootDir.getFileSystem().getPathMatcher(JAR_MATCHER_PATTERN);
+	}
+
+	@Override
+	public Collection<PluginDescriptor> findPlugins() throws IOException {
+
+		if (!Files.isDirectory(pluginsRootDir)) {
+			throw new IOException("Plugins root directory [" + pluginsRootDir + "] does not exist!");
+		}
+
+		return Files.list(pluginsRootDir)
+			.filter((Path path) -> Files.isDirectory(path))
+			.map(FunctionUtils.uncheckedFunction(this::createPluginDescriptorForSubDirectory))
+			.collect(Collectors.toList());
+	}
+
+	private PluginDescriptor createPluginDescriptorForSubDirectory(Path subDirectory) throws IOException {
+		URL[] urls = createJarURLsFromDirectory(subDirectory);
+		Arrays.sort(urls, Comparator.comparing(URL::toString));
+		//TODO: This class could be extended to parse exclude-pattern from a optional text files in the plugin directories.
+		return new PluginDescriptor(
+				subDirectory.getFileName().toString(),
+				urls,
+				new String[0]);
+	}
+
+	private URL[] createJarURLsFromDirectory(Path subDirectory) throws IOException {
+		URL[] urls = Files.list(subDirectory)
+			.filter((Path p) -> Files.isRegularFile(p) && jarFileMatcher.matches(p))
+			.map(FunctionUtils.uncheckedFunction((Path p) -> p.toUri().toURL()))
+			.toArray(URL[]::new);
+
+		if (urls.length < 1) {
+			throw new IOException("Cannot find any jar files for plugin in directory [" + subDirectory + "]." +
+				" Please provide the jar files for the plugin or delete the directory.");
+		}
+
+		return urls;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/Plugin.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/Plugin.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.core.plugin;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.configuration.Configuration;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Interface for plugins. Plugins typically extend this interface in their SPI and the concrete implementations of a
+ * service then implement the SPI contract.
  */
 @PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public interface Plugin {
 
-	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
-	}
+	/**
+	 * Optional method for plugins to pick up settings from the configuration.
+	 *
+	 * @param config The configuration to apply to the plugin.
+	 */
+	default void configure(Configuration config) {}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginDescriptor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import java.net.URL;
+import java.util.Arrays;
+
+/**
+ * Descriptive meta information for a plugin.
+ */
+public class PluginDescriptor {
+
+	/** Unique identifier of the plugin. */
+	private final String pluginId;
+
+	/** URLs to the plugin resources code. Usually this contains URLs of the jars that will be loaded for the plugin. */
+	private final URL[] pluginResourceURLs;
+
+	/**
+	 * String patterns of classes that should be excluded from loading out of the plugin resources. See
+	 * {@link org.apache.flink.util.ChildFirstClassLoader}'s field alwaysParentFirstPatterns.
+	 */
+	private final String[] loaderExcludePatterns;
+
+	public PluginDescriptor(String pluginId, URL[] pluginResourceURLs, String[] loaderExcludePatterns) {
+		this.pluginId = pluginId;
+		this.pluginResourceURLs = pluginResourceURLs;
+		this.loaderExcludePatterns = loaderExcludePatterns;
+	}
+
+	public String getPluginId() {
+		return pluginId;
+	}
+
+	public URL[] getPluginResourceURLs() {
+		return pluginResourceURLs;
+	}
+
+	public String[] getLoaderExcludePatterns() {
+		return loaderExcludePatterns;
+	}
+
+	@Override
+	public String toString() {
+		return "PluginDescriptor{" +
+			"pluginId='" + pluginId + '\'' +
+			", pluginResourceURLs=" + Arrays.toString(pluginResourceURLs) +
+			", loaderExcludePatterns=" + Arrays.toString(loaderExcludePatterns) +
+			'}';
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginFinder.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginFinder.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.core.plugin;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import java.io.IOException;
+import java.util.Collection;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Implementations of this interface provide mechanisms to locate plugins and create corresponding
+ * {@link PluginDescriptor} objects. The result can then be used to initialize a {@link PluginLoader}.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public interface PluginFinder {
 
-	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
-	}
+	/**
+	 * Find plugins and return a corresponding collection of {@link PluginDescriptor} instances.
+	 *
+	 * @return a collection of {@link PluginDescriptor} instances for all found plugins.
+	 * @throws IOException thrown if a problem occurs during plugin search.
+	 */
+	Collection<PluginDescriptor> findPlugins() throws IOException;
 }

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.ChildFirstClassLoader;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * A {@link PluginLoader} is used by the {@link PluginManager} to load a single plugin. It is essentially a combination
+ * of a {@link ChildFirstClassLoader} and {@link ServiceLoader}. This class can locate and load service implementations
+ * from the plugin for a given SPI. The {@link PluginDescriptor}, which among other information contains the resource
+ * URLs, is provided at construction.
+ */
+@ThreadSafe
+public class PluginLoader {
+
+	/** Classloader which is used to load the plugin classes. We expect this classloader is thread-safe.*/
+	private final ClassLoader pluginClassLoader;
+
+	@VisibleForTesting
+	public PluginLoader(PluginDescriptor pluginDescriptor, ClassLoader parentClassLoader) {
+		this.pluginClassLoader =
+			new ChildFirstClassLoader(
+				pluginDescriptor.getPluginResourceURLs(),
+				parentClassLoader,
+				pluginDescriptor.getLoaderExcludePatterns());
+	}
+
+	/**
+	 * Returns in iterator over all available implementations of the given service interface (SPI) for the plugin.
+	 *
+	 * @param service the service interface (SPI) for which implementations are requested.
+	 * @param <P> Type of the requested plugin service.
+	 * @return An iterator of all implementations of the given service interface that could be loaded from the plugin.
+	 */
+	public <P extends Plugin> Iterator<P> load(Class<P> service) {
+		try (TemporaryClassLoaderContext classLoaderContext = new TemporaryClassLoaderContext(pluginClassLoader)) {
+			return new ContextClassLoaderSettingIterator<>(
+				ServiceLoader.load(service, pluginClassLoader).iterator(),
+				pluginClassLoader);
+		}
+	}
+
+	/**
+	 * Wrapper for the service iterator. The wrapper will set/unset the context classloader to the plugin classloader
+	 * around the point where elements are returned.
+	 *
+	 * @param <P> type of the iterated plugin element.
+	 */
+	static class ContextClassLoaderSettingIterator<P extends Plugin> implements Iterator<P> {
+
+		private final Iterator<P> delegate;
+		private final ClassLoader pluginClassLoader;
+
+		ContextClassLoaderSettingIterator(Iterator<P> delegate, ClassLoader pluginClassLoader) {
+			this.delegate = delegate;
+			this.pluginClassLoader = pluginClassLoader;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return delegate.hasNext();
+		}
+
+		@Override
+		public P next() {
+			try (TemporaryClassLoaderContext classLoaderContext = new TemporaryClassLoaderContext(pluginClassLoader)) {
+				return delegate.next();
+			}
+		}
+	}
+
+}

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Manager class and entry-point for the plugin mechanism in Flink.
+ */
+@Internal
+@ThreadSafe
+public class PluginManager {
+
+	/** Parent-classloader to all classloader that are used for plugin loading. We expect that this is thread-safe. */
+	private final ClassLoader parentClassLoader;
+
+	/** A collection of descriptions of all plugins known to this plugin manager. */
+	private final Collection<PluginDescriptor> pluginDescriptors;
+
+	public PluginManager(Collection<PluginDescriptor> pluginDescriptors) {
+		this(pluginDescriptors, PluginManager.class.getClassLoader());
+	}
+
+	public PluginManager(Collection<PluginDescriptor> pluginDescriptors, ClassLoader parentClassLoader) {
+		this.pluginDescriptors = pluginDescriptors;
+		this.parentClassLoader = parentClassLoader;
+	}
+
+	/**
+	 * Returns in iterator over all available implementations of the given service interface (SPI) in all the plugins
+	 * known to this plugin manager instance.
+	 *
+	 * @param service the service interface (SPI) for which implementations are requested.
+	 * @param <P> Type of the requested plugin service.
+	 * @return Iterator over all implementations of the given service that could be loaded from all known plugins.
+	 */
+	public <P extends Plugin> Iterator<P> load(Class<P> service) {
+		ArrayList<Iterator<P>> combinedIterators = new ArrayList<>(pluginDescriptors.size());
+		for (PluginDescriptor pluginDescriptor : pluginDescriptors) {
+			PluginLoader pluginLoader = new PluginLoader(pluginDescriptor, parentClassLoader);
+			combinedIterators.add(pluginLoader.load(service));
+		}
+		return Iterators.concat(combinedIterators.iterator());
+	}
+
+	@Override
+	public String toString() {
+		return "PluginManager{" +
+			"parentClassLoader=" + parentClassLoader +
+			", pluginDescriptors=" + pluginDescriptors +
+			'}';
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Utility functions for the plugin mechanism.
+ */
+public final class PluginUtils {
+
+	private PluginUtils() {
+		throw new AssertionError("Singleton class.");
+	}
+
+	public static PluginManager createPluginManagerFromRootFolder(Optional<Path> pluginsRootPath) {
+		Collection<PluginDescriptor> pluginDescriptorsForDirectory;
+
+		if (pluginsRootPath.isPresent()) {
+			try {
+				pluginDescriptorsForDirectory =
+					new DirectoryBasedPluginFinder(pluginsRootPath.get()).findPlugins();
+			} catch (IOException e) {
+				throw new FlinkRuntimeException("Exception when trying to initialize plugin system.", e);
+			}
+		} else {
+			pluginDescriptorsForDirectory = Collections.emptyList();
+		}
+
+		return new PluginManager(pluginDescriptorsForDirectory);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/TemporaryClassLoaderContext.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/TemporaryClassLoaderContext.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
-
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+package org.apache.flink.core.plugin;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Utility class to temporarily change the context classloader. The previous context classloader is restored on
+ * {@link #close()}.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public final class TemporaryClassLoaderContext implements AutoCloseable {
 
-	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
+	/** The previous context class loader to restore on {@link #close()}. */
+	private final ClassLoader toRestore;
+
+	public TemporaryClassLoaderContext(ClassLoader temporaryContextClassLoader) {
+		this.toRestore = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(temporaryContextClassLoader);
 	}
 
 	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
+	public void close() {
+		Thread.currentThread().setContextClassLoader(toRestore);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/ChildFirstClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ChildFirstClassLoader.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A variant of the URLClassLoader that first loads from the URLs and only after that from the parent.
+ *
+ * <p>{@link #getResourceAsStream(String)} uses {@link #getResource(String)} internally so we
+ * don't override that.
+ */
+public final class ChildFirstClassLoader extends URLClassLoader {
+
+	/**
+	 * The classes that should always go through the parent ClassLoader. This is relevant
+	 * for Flink classes, for example, to avoid loading Flink classes that cross the
+	 * user-code/system-code barrier in the user-code ClassLoader.
+	 */
+	private final String[] alwaysParentFirstPatterns;
+
+	public ChildFirstClassLoader(URL[] urls, ClassLoader parent, String[] alwaysParentFirstPatterns) {
+		super(urls, parent);
+		this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
+	}
+
+	@Override
+	protected synchronized Class<?> loadClass(
+		String name, boolean resolve) throws ClassNotFoundException {
+
+		// First, check if the class has already been loaded
+		Class<?> c = findLoadedClass(name);
+
+		if (c == null) {
+			// check whether the class should go parent-first
+			for (String alwaysParentFirstPattern : alwaysParentFirstPatterns) {
+				if (name.startsWith(alwaysParentFirstPattern)) {
+					return super.loadClass(name, resolve);
+				}
+			}
+
+			try {
+				// check the URLs
+				c = findClass(name);
+			} catch (ClassNotFoundException e) {
+				// let URLClassLoader do it, which will eventually call the parent
+				c = super.loadClass(name, resolve);
+			}
+		}
+
+		if (resolve) {
+			resolveClass(c);
+		}
+
+		return c;
+	}
+
+	@Override
+	public URL getResource(String name) {
+		// first, try and find it via the URLClassloader
+		URL urlClassLoaderResource = findResource(name);
+
+		if (urlClassLoaderResource != null) {
+			return urlClassLoaderResource;
+		}
+
+		// delegate to super
+		return super.getResource(name);
+	}
+
+	@Override
+	public Enumeration<URL> getResources(String name) throws IOException {
+		// first get resources from URLClassloader
+		Enumeration<URL> urlClassLoaderResources = findResources(name);
+
+		final List<URL> result = new ArrayList<>();
+
+		while (urlClassLoaderResources.hasMoreElements()) {
+			result.add(urlClassLoaderResources.nextElement());
+		}
+
+		// get parent urls
+		Enumeration<URL> parentResources = getParent().getResources(name);
+
+		while (parentResources.hasMoreElements()) {
+			result.add(parentResources.nextElement());
+		}
+
+		return new Enumeration<URL>() {
+			Iterator<URL> iter = result.iterator();
+
+			public boolean hasMoreElements() {
+				return iter.hasNext();
+			}
+
+			public URL nextElement() {
+				return iter.next();
+			}
+		};
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/LambdaUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/LambdaUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.core.plugin.TemporaryClassLoaderContext;
 import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.util.function.ThrowingRunnable;
@@ -76,15 +77,8 @@ public final class LambdaUtil {
 			final ClassLoader cl,
 			final ThrowingRunnable<E> r) throws E {
 
-		final Thread currentThread = Thread.currentThread();
-		final ClassLoader oldClassLoader = currentThread.getContextClassLoader();
-
-		try {
-			currentThread.setContextClassLoader(cl);
+		try (TemporaryClassLoaderContext tmpCl = new TemporaryClassLoaderContext(cl)) {
 			r.run();
-		}
-		finally {
-			currentThread.setContextClassLoader(oldClassLoader);
 		}
 	}
 
@@ -99,15 +93,8 @@ public final class LambdaUtil {
 			final ClassLoader cl,
 			final SupplierWithException<R, E> s) throws E {
 
-		final Thread currentThread = Thread.currentThread();
-		final ClassLoader oldClassLoader = currentThread.getContextClassLoader();
-
-		try {
-			currentThread.setContextClassLoader(cl);
+		try (TemporaryClassLoaderContext tmpCl = new TemporaryClassLoaderContext(cl)) {
 			return s.get();
-		}
-		finally {
-			currentThread.setContextClassLoader(oldClassLoader);
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Test for {@link DirectoryBasedPluginFinder}.
+ */
+public class DirectoryBasedPluginFinderTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void createPluginDescriptorsForDirectory() throws Exception {
+		File rootFolder = temporaryFolder.newFolder();
+		PluginFinder descriptorsFactory =
+			new DirectoryBasedPluginFinder(rootFolder.toPath());
+		Collection<PluginDescriptor> actual = descriptorsFactory.findPlugins();
+
+		Assert.assertTrue("empty root dir -> expected no actual", actual.isEmpty());
+
+		List<File> subDirs = Stream.of("A", "B", "C")
+			.map(s -> new File(rootFolder, s))
+			.collect(Collectors.toList());
+
+		for (File subDir : subDirs) {
+			Preconditions.checkState(subDir.mkdirs());
+		}
+
+		try {
+			descriptorsFactory.findPlugins();
+			fail("all empty plugin sub-dirs");
+		} catch (RuntimeException expected) {
+			Assert.assertTrue(expected.getCause() instanceof IOException);
+		}
+
+		for (File subDir : subDirs) {
+			// we create a file and another subfolder to check that they are ignored
+			Preconditions.checkState(new File(subDir, "ignore-test.zip").createNewFile());
+			Preconditions.checkState(new File(subDir, "ignore-dir").mkdirs());
+		}
+
+		try {
+			descriptorsFactory.findPlugins();
+			fail("still no jars in plugin sub-dirs");
+		} catch (RuntimeException expected) {
+			Assert.assertTrue(expected.getCause() instanceof IOException);
+		}
+
+		List<PluginDescriptor> expected = new ArrayList<>(3);
+
+		for (int i = 0; i < subDirs.size(); ++i) {
+			File subDir = subDirs.get(i);
+			URL[] jarURLs = new URL[i + 1];
+
+			for (int j = 0; j <= i; ++j) {
+				File file = new File(subDir, "jar-file-" + j + ".jar");
+				Preconditions.checkState(file.createNewFile());
+				jarURLs[j] = file.toURI().toURL();
+			}
+
+			Arrays.sort(jarURLs, Comparator.comparing(URL::toString));
+			expected.add(new PluginDescriptor(subDir.getName(), jarURLs, new String[0]));
+		}
+
+		actual = descriptorsFactory.findPlugins();
+
+		Assert.assertTrue(equalsIgnoreOrder(expected, new ArrayList<>(actual)));
+	}
+
+	private boolean equalsIgnoreOrder(List<PluginDescriptor> a, List<PluginDescriptor> b) {
+
+		if (a.size() != b.size()) {
+			return false;
+		}
+
+		final Comparator<PluginDescriptor> comparator = Comparator.comparing(PluginDescriptor::getPluginId);
+
+		a.sort(comparator);
+		b.sort(comparator);
+
+		final Iterator<PluginDescriptor> iterA = a.iterator();
+		final Iterator<PluginDescriptor> iterB = b.iterator();
+
+		while (iterA.hasNext()) {
+			if (!equals(iterA.next(), iterB.next())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean equals(@Nonnull PluginDescriptor a, @Nonnull PluginDescriptor b) {
+		return a.getPluginId().equals(b.getPluginId())
+			&& Arrays.deepEquals(a.getPluginResourceURLs(), b.getPluginResourceURLs())
+			&& Arrays.deepEquals(a.getLoaderExcludePatterns(), b.getLoaderExcludePatterns());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/plugin/TemporaryClassLoaderContextTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/plugin/TemporaryClassLoaderContextTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.plugin;
+
+import org.apache.flink.util.ChildFirstClassLoader;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+
+/**
+ * Test for {@link TemporaryClassLoaderContext}.
+ */
+public class TemporaryClassLoaderContextTest {
+
+	@Test
+	public void testTemporaryClassLoaderContext() {
+		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+		final ChildFirstClassLoader temporaryClassLoader =
+			new ChildFirstClassLoader(new URL[0], contextClassLoader, new String[0]);
+
+		try (TemporaryClassLoaderContext classLoaderContext = new TemporaryClassLoaderContext(temporaryClassLoader)) {
+			Assert.assertEquals(temporaryClassLoader, Thread.currentThread().getContextClassLoader());
+		}
+
+		Assert.assertEquals(contextClassLoader, Thread.currentThread().getContextClassLoader());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/testutils/EntropyInjectingTestFileSystem.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/EntropyInjectingTestFileSystem.java
@@ -19,7 +19,6 @@
 
 package org.apache.flink.testutils;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.EntropyInjectingFileSystem;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
@@ -51,10 +50,6 @@ public class EntropyInjectingTestFileSystem extends LocalFileSystem implements E
 		@Override
 		public String getScheme() {
 			return "test-entropy";
-		}
-
-		@Override
-		public void configure(final Configuration config) {
 		}
 
 		@Override

--- a/flink-core/src/test/java/org/apache/flink/testutils/TestFileSystem.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestFileSystem.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.testutils;
 
-import java.io.IOException;
-import java.net.URI;
-
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
@@ -29,6 +25,9 @@ import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileStatus;
 import org.apache.flink.core.fs.local.LocalFileSystem;
+
+import java.io.IOException;
+import java.net.URI;
 
 /**
  * A test file system. This also has a service entry in the test
@@ -89,9 +88,6 @@ public class TestFileSystem extends LocalFileSystem {
 		public String getScheme() {
 			return SCHEME;
 		}
-
-		@Override
-		public void configure(Configuration config) {}
 
 		@Override
 		public FileSystem create(URI fsUri) throws IOException {

--- a/flink-filesystems/flink-mapr-fs/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFsFactory.java
+++ b/flink-filesystems/flink-mapr-fs/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFsFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.fs.maprfs;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
 
@@ -45,11 +44,6 @@ public class MapRFsFactory implements FileSystemFactory {
 	@Override
 	public String getScheme() {
 		return "maprfs";
-	}
-
-	@Override
-	public void configure(Configuration config) {
-		// nothing to configure based on the configuration here
 	}
 
 	@Override

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.mesos.entrypoint;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The entry point for running a TaskManager in a Mesos container.
@@ -85,7 +87,8 @@ public class MesosTaskExecutorRunner {
 		final Map<String, String> envs = System.getenv();
 
 		// configure the filesystems
-		FileSystem.initialize(configuration);
+		//TODO provide plugin path.
+		FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 		// tell akka to die in case of an error
 		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -40,7 +40,6 @@ import org.apache.commons.cli.PosixParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
 
@@ -86,11 +85,7 @@ public class MesosTaskExecutorRunner {
 		final Map<String, String> envs = System.getenv();
 
 		// configure the filesystems
-		try {
-			FileSystem.initialize(configuration);
-		} catch (IOException e) {
-			throw new IOException("Error while configuring the filesystems.", e);
-		}
+		FileSystem.initialize(configuration);
 
 		// tell akka to die in case of an error
 		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -109,11 +109,7 @@ public class HistoryServer {
 		LOG.info("Loading configuration from {}", configDir);
 		final Configuration flinkConfig = GlobalConfiguration.loadConfiguration(configDir);
 
-		try {
-			FileSystem.initialize(flinkConfig);
-		} catch (IOException e) {
-			throw new Exception("Error while setting the default filesystem scheme from configuration.", e);
-		}
+		FileSystem.initialize(flinkConfig);
 
 		// run the history server
 		SecurityUtils.install(new SecurityConfiguration(flinkConfig));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HistoryServerOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.history.FsJobArchivist;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -57,6 +58,7 @@ import java.nio.file.Files;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -109,7 +111,8 @@ public class HistoryServer {
 		LOG.info("Loading configuration from {}", configDir);
 		final Configuration flinkConfig = GlobalConfiguration.loadConfiguration(configDir);
 
-		FileSystem.initialize(flinkConfig);
+		//TODO provide plugin path.
+		FileSystem.initialize(flinkConfig, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 		// run the history server
 		SecurityUtils.install(new SecurityConfiguration(flinkConfig));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -181,15 +181,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 		}
 	}
 
-	private void configureFileSystems(Configuration configuration) throws Exception {
+	private void configureFileSystems(Configuration configuration) {
 		LOG.info("Install default filesystem.");
-
-		try {
-			FileSystem.initialize(configuration);
-		} catch (IOException e) {
-			throw new IOException("Error while setting the default " +
-				"filesystem scheme from configuration.", e);
-		}
+		FileSystem.initialize(configuration);
 	}
 
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -30,6 +30,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -75,6 +76,7 @@ import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -153,6 +155,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 		LOG.info("Starting {}.", getClass().getSimpleName());
 
 		try {
+
 			configureFileSystems(configuration);
 
 			SecurityContext securityContext = installSecurityContext(configuration);
@@ -183,7 +186,8 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
 	private void configureFileSystems(Configuration configuration) {
 		LOG.info("Install default filesystem.");
-		FileSystem.initialize(configuration);
+		//TODO provide plugin path
+		FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 	}
 
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
@@ -18,13 +18,10 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
-import java.io.IOException;
+import org.apache.flink.util.ChildFirstClassLoader;
+
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.List;
 
 /**
  * Gives the URLClassLoader a nicer name for debugging purposes.
@@ -83,102 +80,6 @@ public class FlinkUserCodeClassLoaders {
 
 		ParentFirstClassLoader(URL[] urls, ClassLoader parent) {
 			super(urls, parent);
-		}
-	}
-
-	/**
-	 * A variant of the URLClassLoader that first loads from the URLs and only after that from the parent.
-	 *
-	 * <p>{@link #getResourceAsStream(String)} uses {@link #getResource(String)} internally so we
-	 * don't override that.
-	 */
-	static final class ChildFirstClassLoader extends URLClassLoader {
-
-		/**
-		 * The classes that should always go through the parent ClassLoader. This is relevant
-		 * for Flink classes, for example, to avoid loading Flink classes that cross the
-		 * user-code/system-code barrier in the user-code ClassLoader.
-		 */
-		private final String[] alwaysParentFirstPatterns;
-
-		public ChildFirstClassLoader(URL[] urls, ClassLoader parent, String[] alwaysParentFirstPatterns) {
-			super(urls, parent);
-			this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
-		}
-
-		@Override
-		protected synchronized Class<?> loadClass(
-			String name, boolean resolve) throws ClassNotFoundException {
-
-			// First, check if the class has already been loaded
-			Class<?> c = findLoadedClass(name);
-
-			if (c == null) {
-				// check whether the class should go parent-first
-				for (String alwaysParentFirstPattern : alwaysParentFirstPatterns) {
-					if (name.startsWith(alwaysParentFirstPattern)) {
-						return super.loadClass(name, resolve);
-					}
-				}
-
-				try {
-					// check the URLs
-					c = findClass(name);
-				} catch (ClassNotFoundException e) {
-					// let URLClassLoader do it, which will eventually call the parent
-					c = super.loadClass(name, resolve);
-				}
-			}
-
-			if (resolve) {
-				resolveClass(c);
-			}
-
-			return c;
-		}
-
-		@Override
-		public URL getResource(String name) {
-			// first, try and find it via the URLClassloader
-			URL urlClassLoaderResource = findResource(name);
-
-			if (urlClassLoaderResource != null) {
-				return urlClassLoaderResource;
-			}
-
-			// delegate to super
-			return super.getResource(name);
-		}
-
-		@Override
-		public Enumeration<URL> getResources(String name) throws IOException {
-			// first get resources from URLClassloader
-			Enumeration<URL> urlClassLoaderResources = findResources(name);
-
-			final List<URL> result = new ArrayList<>();
-
-			while (urlClassLoaderResources.hasMoreElements()) {
-				result.add(urlClassLoaderResources.nextElement());
-			}
-
-			// get parent urls
-			Enumeration<URL> parentResources = getParent().getResources(name);
-
-			while (parentResources.hasMoreElements()) {
-				result.add(parentResources.nextElement());
-			}
-
-			return new Enumeration<URL>() {
-				Iterator<URL> iter = result.iterator();
-
-				public boolean hasMoreElements() {
-					return iter.hasNext();
-				}
-
-				public URL nextElement() {
-					return iter.next();
-				}
-			};
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -61,7 +61,6 @@ import org.apache.flink.util.ExecutorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -278,12 +277,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		final Configuration configuration = loadConfiguration(args);
 
-		try {
-			FileSystem.initialize(configuration);
-		} catch (IOException e) {
-			throw new IOException("Error while setting the default " +
-				"filesystem scheme from configuration.", e);
-		}
+		FileSystem.initialize(configuration);
 
 		SecurityUtils.install(new SecurityConfiguration(configuration));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -65,6 +66,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -277,7 +279,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		final Configuration configuration = loadConfiguration(args);
 
-		FileSystem.initialize(configuration);
+		//TODO provide plugin path.
+		FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 		SecurityUtils.install(new SecurityConfiguration(configuration));
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -23,7 +23,7 @@ import java.lang.management.ManagementFactory
 import java.net.{BindException, InetAddress, InetSocketAddress, ServerSocket}
 import java.util
 import java.util.concurrent.{Callable, TimeUnit, TimeoutException}
-import java.util.{Collections, UUID}
+import java.util.{Collections, Optional, UUID}
 
 import _root_.akka.actor._
 import _root_.akka.pattern.ask
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration._
 import org.apache.flink.core.fs.FileSystem
+import org.apache.flink.core.plugin.PluginUtils
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
 import org.apache.flink.runtime.akka.{AkkaUtils, DefaultQuarantineHandler, QuarantineMonitor}
 import org.apache.flink.runtime.blob.BlobCacheService
@@ -1666,7 +1667,10 @@ object TaskManager {
     }
 
     try {
-      FileSystem.initialize(conf)
+     //TODO provide path.
+      FileSystem.initialize(
+        conf,
+        PluginUtils.createPluginManagerFromRootFolder(Optional.empty()))
     }
     catch {
       case e: IOException => {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -29,6 +29,7 @@ import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.plugin.TemporaryClassLoaderContext;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
@@ -185,12 +186,8 @@ public class ExecutionContext<T> {
 	 * Executes the given supplier using the execution context's classloader as thread classloader.
 	 */
 	public <R> R wrapClassLoader(Supplier<R> supplier) {
-		final ClassLoader previousClassloader = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader(classLoader);
-		try {
+		try (TemporaryClassLoaderContext tmpCl = new TemporaryClassLoaderContext(classLoader)){
 			return supplier.get();
-		} finally {
-			Thread.currentThread().setContextClassLoader(previousClassloader);
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -110,12 +110,7 @@ public class LocalExecutor implements Executor {
 			this.flinkConfig = GlobalConfiguration.loadConfiguration(flinkConfigDir);
 
 			// initialize default file system
-			try {
-				FileSystem.initialize(this.flinkConfig);
-			} catch (IOException e) {
-				throw new SqlClientException(
-					"Error while setting the default filesystem scheme from configuration.", e);
-			}
+			FileSystem.initialize(this.flinkConfig);
 
 			// load command lines for deployment
 			this.commandLines = CliFrontend.loadCustomCommandLines(flinkConfig, flinkConfigDir);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.table.api.QueryConfig;
 import org.apache.flink.table.api.Table;
@@ -67,6 +68,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Executor that performs the Flink communication locally. The calls are blocking depending on the
@@ -110,7 +112,8 @@ public class LocalExecutor implements Executor {
 			this.flinkConfig = GlobalConfiguration.loadConfiguration(flinkConfigDir);
 
 			// initialize default file system
-			FileSystem.initialize(this.flinkConfig);
+			//TODO provide plugin path.
+			FileSystem.initialize(flinkConfig, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 			// load command lines for deployment
 			this.commandLines = CliFrontend.loadCustomCommandLines(flinkConfig, flinkConfigDir);

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -412,6 +412,37 @@ under the License.
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
+
+					<execution>
+						<id>create-plugin-a-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>plugin-a</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-plugin-a-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>create-plugin-b-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>plugin-b</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-plugin-b-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+
 					<execution>
 						<id>create-kmeans-jar</id>
 						<phase>process-test-classes</phase>

--- a/flink-tests/src/test/assembly/test-plugin-a-assembly.xml
+++ b/flink-tests/src/test/assembly/test-plugin-a-assembly.xml
@@ -1,0 +1,43 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!-- the service impl -->
+			<includes>
+				<include>org/apache/flink/test/plugin/jar/plugina/TestServiceA.class</include>
+				<include>org/apache/flink/test/plugin/jar/plugina/DynamicClassA.class</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<!-- declaring the service impl -->
+			<directory>${project.basedir}/src/test/resources/plugin-test/plugin-a</directory>
+			<outputDirectory>/META-INF/services</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-tests/src/test/assembly/test-plugin-b-assembly.xml
+++ b/flink-tests/src/test/assembly/test-plugin-b-assembly.xml
@@ -1,0 +1,43 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!-- the service impl -->
+			<includes>
+				<include>org/apache/flink/test/plugin/jar/pluginb/TestServiceB.class</include>
+				<include>org/apache/flink/test/plugin/jar/pluginb/OtherTestServiceB.class</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<!-- declaring the service impl -->
+			<directory>${project.basedir}/src/test/resources/plugin-test/plugin-b</directory>
+			<outputDirectory>/META-INF/services</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/OtherTestSpi.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/OtherTestSpi.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.test.plugin;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.core.plugin.Plugin;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Another service interface for tests of plugin mechanism.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
-
-	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
-	}
+public interface OtherTestSpi extends Plugin {
+	String otherTestMethod();
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/PluginLoaderTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/PluginLoaderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.plugin;
+
+import org.apache.flink.core.plugin.PluginDescriptor;
+import org.apache.flink.core.plugin.PluginLoader;
+import org.apache.flink.test.plugin.jar.plugina.TestServiceA;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Iterator;
+
+/**
+ * Test for {@link PluginLoader}.
+ */
+public class PluginLoaderTest extends PluginTestBase{
+
+	@Test
+	public void testPluginLoading() throws Exception {
+
+		final URL classpathA = createPluginJarURLFromString(PLUGIN_A);
+
+		PluginDescriptor pluginDescriptorA = new PluginDescriptor("A", new URL[]{classpathA}, new String[0]);
+		final PluginLoader pluginLoaderA = new PluginLoader(pluginDescriptorA, PARENT_CLASS_LOADER);
+
+		Iterator<TestSpi> testSpiIteratorA = pluginLoaderA.load(TestSpi.class);
+
+		Assert.assertTrue(testSpiIteratorA.hasNext());
+
+		TestSpi testSpiA = testSpiIteratorA.next();
+
+		Assert.assertFalse(testSpiIteratorA.hasNext());
+
+		Assert.assertNotNull(testSpiA.testMethod());
+
+		Assert.assertEquals(TestServiceA.class.getCanonicalName(), testSpiA.getClass().getCanonicalName());
+		Assert.assertNotEquals(PARENT_CLASS_LOADER, testSpiA.getClass().getClassLoader());
+
+		// Looks strange, but we want to ensure that those classes are not instance of each other because they were
+		// loaded by different classloader instances because the plugin loader uses child-before-parent order.
+		Assert.assertFalse(testSpiA instanceof TestServiceA);
+
+		// In the following we check for isolation of classes between different plugin loaders.
+		final PluginLoader secondPluginLoaderA = new PluginLoader(pluginDescriptorA, PARENT_CLASS_LOADER);
+
+		TestSpi secondTestSpiA = secondPluginLoaderA.load(TestSpi.class).next();
+		Assert.assertNotNull(secondTestSpiA.testMethod());
+
+		// Again, this looks strange, but we expect classes with the same name, that are not equal.
+		Assert.assertEquals(testSpiA.getClass().getCanonicalName(), secondTestSpiA.getClass().getCanonicalName());
+		Assert.assertNotEquals(testSpiA.getClass(), secondTestSpiA.getClass());
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/PluginManagerTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/PluginManagerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.plugin;
+
+import org.apache.flink.core.plugin.DirectoryBasedPluginFinder;
+import org.apache.flink.core.plugin.PluginDescriptor;
+import org.apache.flink.core.plugin.PluginFinder;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Test for {@link PluginManager}.
+ */
+public class PluginManagerTest extends PluginTestBase {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private Collection<PluginDescriptor> descriptors;
+
+	@Before
+	public void setup() throws Exception {
+		/*
+		 * We setup a plugin directory hierarchy and utilize DirectoryBasedPluginFinder to create the
+		 * descriptors:
+		 *
+		 * <pre>
+		 * tmp/plugins-root/
+		 *          |-------------A/
+		 *          |             |-plugin-a.jar
+		 *          |
+		 *          |-------------B/
+		 *                        |-plugin-b.jar
+		 * </pre>
+		 */
+		final File pluginRootFolder = temporaryFolder.newFolder();
+		final Path pluginRootFolderPath = pluginRootFolder.toPath();
+		final File pluginAFolder = new File(pluginRootFolder, "A");
+		final File pluginBFolder = new File(pluginRootFolder, "B");
+		Preconditions.checkState(pluginAFolder.mkdirs());
+		Preconditions.checkState(pluginBFolder.mkdirs());
+		Files.copy(locateJarFile(PLUGIN_A).toPath(), Paths.get(pluginAFolder.toString(), PLUGIN_A));
+		Files.copy(locateJarFile(PLUGIN_B).toPath(), Paths.get(pluginBFolder.toString(), PLUGIN_B));
+		final PluginFinder descriptorsFactory = new DirectoryBasedPluginFinder(pluginRootFolderPath);
+		descriptors = descriptorsFactory.findPlugins();
+		Preconditions.checkState(descriptors.size() == 2);
+	}
+
+	@Test
+	public void testPluginLoading() {
+
+		final PluginManager pluginManager = new PluginManager(descriptors, PARENT_CLASS_LOADER);
+		final List<TestSpi> serviceImplList = Lists.newArrayList(pluginManager.load(TestSpi.class));
+		Assert.assertEquals(2, serviceImplList.size());
+
+		// check that all impl have unique classloader
+		final Set<ClassLoader> classLoaders = Collections.newSetFromMap(new IdentityHashMap<>(3));
+		classLoaders.add(PARENT_CLASS_LOADER);
+		for (TestSpi testSpi : serviceImplList) {
+			Assert.assertNotNull(testSpi.testMethod());
+			Assert.assertTrue(classLoaders.add(testSpi.getClass().getClassLoader()));
+		}
+
+		final List<OtherTestSpi> otherServiceImplList = Lists.newArrayList(pluginManager.load(OtherTestSpi.class));
+		Assert.assertEquals(1, otherServiceImplList.size());
+		for (OtherTestSpi otherTestSpi : otherServiceImplList) {
+			Assert.assertNotNull(otherTestSpi.otherTestMethod());
+			Assert.assertTrue(classLoaders.add(otherTestSpi.getClass().getClassLoader()));
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/PluginTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/PluginTestBase.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.plugin;
+
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Base class for some tests related to the plugin mechanism. Provides access to some common test resources.
+ */
+abstract class PluginTestBase extends TestLogger {
+
+	/** Optional prefix to the jar folder if run from an IDE. */
+	private static final String OPT_PREFIX = "target/";
+
+	static final String PLUGIN_A = "plugin-a-test-jar.jar";
+	static final String PLUGIN_B = "plugin-b-test-jar.jar";
+	static final ClassLoader PARENT_CLASS_LOADER = PluginTestBase.class.getClassLoader();
+
+	URL createPluginJarURLFromString(String fileString) throws MalformedURLException {
+		File file = locateJarFile(fileString);
+		return file.toURI().toURL();
+	}
+
+	static File locateJarFile(String fileString) {
+		File file = new File(fileString);
+		if (!file.exists()) {
+			file = new File(OPT_PREFIX + fileString);
+		}
+		Preconditions.checkState(file.exists(), "Unable to locate jar file for test: " + fileString);
+		return file;
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/TestSpi.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/TestSpi.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.test.plugin;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.core.plugin.Plugin;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Service interface for tests of plugin mechanism.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
-
-	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
-	}
+public interface TestSpi extends Plugin {
+	String testMethod();
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/plugina/DynamicClassA.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/plugina/DynamicClassA.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.test.plugin.jar.plugina;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.test.plugin.TestSpi;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * This class exists in the test to validate that dynamic classloading ({@link Class#forName(String)} works inside of
+ * plugin code.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public class DynamicClassA implements TestSpi {
 
 	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
+	public String testMethod() {
+		return getClass().getName();
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/plugina/TestServiceA.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/plugina/TestServiceA.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.test.plugin.jar.plugina;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.test.plugin.TestSpi;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * First implementation of {@link TestSpi}.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public class TestServiceA implements TestSpi {
 
-	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
+	private final TestSpi dynamicDelegate;
+
+	public TestServiceA() {
+		try {
+			dynamicDelegate = (TestSpi) Class.forName(DynamicClassA.class.getName()).newInstance();
+		} catch (Exception e) {
+			throw new IllegalStateException("Unable to load dynamic class.");
+		}
 	}
 
 	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
+	public String testMethod() {
+		return getClass().getName() + "(" + dynamicDelegate.testMethod() + ")";
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/pluginb/OtherTestServiceB.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/pluginb/OtherTestServiceB.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.test.plugin.jar.pluginb;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.test.plugin.OtherTestSpi;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Implementation of {@link OtherTestSpi}.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public class OtherTestServiceB implements OtherTestSpi {
 
 	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
+	public String otherTestMethod() {
+		return getClass().getName();
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/pluginb/TestServiceB.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/plugin/jar/pluginb/TestServiceB.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.fs.local;
+package org.apache.flink.test.plugin.jar.pluginb;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemFactory;
-
-import java.net.URI;
+import org.apache.flink.test.plugin.TestSpi;
 
 /**
- * A factory for the {@link LocalFileSystem}.
+ * Second implementation of {@link TestSpi}.
  */
-@PublicEvolving
-public class LocalFileSystemFactory implements FileSystemFactory {
+public class TestServiceB implements TestSpi {
 
 	@Override
-	public String getScheme() {
-		return LocalFileSystem.getLocalFsURI().getScheme();
-	}
-
-	@Override
-	public FileSystem create(URI fsUri) {
-		return LocalFileSystem.getSharedInstance();
+	public String testMethod() {
+		return getClass().getName();
 	}
 }

--- a/flink-tests/src/test/resources/plugin-test/plugin-a/org.apache.flink.test.plugin.TestSpi
+++ b/flink-tests/src/test/resources/plugin-test/plugin-a/org.apache.flink.test.plugin.TestSpi
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.test.plugin.jar.plugina.TestServiceA

--- a/flink-tests/src/test/resources/plugin-test/plugin-b/org.apache.flink.test.plugin.OtherTestSpi
+++ b/flink-tests/src/test/resources/plugin-test/plugin-b/org.apache.flink.test.plugin.OtherTestSpi
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.test.plugin.jar.pluginb.OtherTestServiceB

--- a/flink-tests/src/test/resources/plugin-test/plugin-b/org.apache.flink.test.plugin.TestSpi
+++ b/flink-tests/src/test/resources/plugin-test/plugin-b/org.apache.flink.test.plugin.TestSpi
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.test.plugin.jar.pluginb.TestServiceB

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -34,6 +34,7 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -97,6 +98,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
@@ -661,7 +663,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		// ------------------ Initialize the file systems -------------------------
 
-		org.apache.flink.core.fs.FileSystem.initialize(configuration);
+		//TODO provide plugin path.
+		org.apache.flink.core.fs.FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 		// initialize file system
 		// Copy the application master jar to the filesystem

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -661,12 +661,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		// ------------------ Initialize the file systems -------------------------
 
-		try {
-			org.apache.flink.core.fs.FileSystem.initialize(configuration);
-		} catch (IOException e) {
-			throw new IOException("Error while setting the default " +
-					"filesystem scheme from configuration.", e);
-		}
+		org.apache.flink.core.fs.FileSystem.initialize(configuration);
 
 		// initialize file system
 		// Copy the application master jar to the filesystem

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -45,6 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 /**
@@ -92,7 +94,9 @@ public class YarnTaskExecutorRunner {
 			LOG.info("Current working Directory: {}", currDir);
 
 			final Configuration configuration = GlobalConfiguration.loadConfiguration(currDir);
-			FileSystem.initialize(configuration);
+
+			//TODO provide path.
+			FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(Optional.empty()));
 
 			setupConfigurationAndInstallSecurityContext(configuration, currDir, ENV);
 


### PR DESCRIPTION
## What is the purpose of the change

We want to change the general architecture for loading FileSystems in Flink to a plugin architecture. The advantage of this change is that it would invert the classloading from parent-first to child-first and therefore enables us to move away from shading to avoid class/version conflics.

Note that this general approach could also be used in other places for Flink in the future, but this task is targetting only the file systems for now. Furthermore, this is the first PR, introducing the general mechanism. We still need followup work with changes to the build and shipping/providing the plugin folder.

## Brief change log
- Made ``ChildFirstClassLoader`` a toplevel class.and move to flink core.
- Introduce ``Plugin`` interface, ``PluginLoader`` ``PluginManager`` for basic plugin mechanism.
- Introduce init of plugin manager singleton to process entry points.
- Integrate plugin mechanism with ``FileSystem``.

## Verifying this change

Added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (feature not yet compelted)
