### PR TITLE
[FLINK-11155][fs][hadoop] Fix hadoop-free factory tests on Java 9 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ClassLoaderUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ClassLoaderUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+
+/**
+ * Collection of class-loading utilities.
+ */
+public final class ClassLoaderUtils {
+
+	public static URL[] getClasspathURLs() {
+		final String[] cp = System.getProperty("java.class.path").split(File.pathSeparator);
+
+		return Arrays.stream(cp)
+			.filter(str -> !str.isEmpty())
+			.map(ClassLoaderUtils::parse)
+			.toArray(URL[]::new);
+	}
+
+	private static URL parse(String fileName) {
+		try {
+			return new File(fileName).toURI().toURL();
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private ClassLoaderUtils() {}
+}

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeFsFactoryTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeFsFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.fs.hdfs;
 
+import org.apache.flink.util.ClassLoaderUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -25,6 +26,7 @@ import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.net.URLClassLoader;
 
 /**
@@ -43,8 +45,10 @@ public class HadoopFreeFsFactoryTest extends TestLogger {
 
 		final String testClassName = "org.apache.flink.runtime.fs.hdfs.HadoopFreeTests";
 
-		URLClassLoader parent = (URLClassLoader) getClass().getClassLoader();
-		ClassLoader hadoopFreeClassLoader = new HadoopFreeClassLoader(parent);
+		final URL[] urls = ClassLoaderUtils.getClasspathURLs();
+
+		ClassLoader parent = getClass().getClassLoader();
+		ClassLoader hadoopFreeClassLoader = new HadoopFreeClassLoader(urls, parent);
 		Class<?> testClass = Class.forName(testClassName, false, hadoopFreeClassLoader);
 		Method m = testClass.getDeclaredMethod("test");
 
@@ -62,8 +66,8 @@ public class HadoopFreeFsFactoryTest extends TestLogger {
 
 		private final ClassLoader properParent;
 
-		HadoopFreeClassLoader(URLClassLoader parent) {
-			super(parent.getURLs(), null);
+		HadoopFreeClassLoader(URL[] urls, ClassLoader parent) {
+			super(urls, null);
 			properParent = parent;
 		}
 

--- a/flink-filesystems/flink-mapr-fs/src/test/java/org/apache/flink/runtime/fs/maprfs/MapRFsFactoryTest.java
+++ b/flink-filesystems/flink-mapr-fs/src/test/java/org/apache/flink/runtime/fs/maprfs/MapRFsFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.fs.maprfs;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.util.ClassLoaderUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLClassLoader;
 
 import static org.junit.Assert.assertEquals;
@@ -50,8 +52,10 @@ public class MapRFsFactoryTest extends TestLogger {
 
 		final String testClassName = "org.apache.flink.runtime.fs.maprfs.MapRFreeTests";
 
-		URLClassLoader parent = (URLClassLoader) getClass().getClassLoader();
-		ClassLoader maprFreeClassLoader = new MapRFreeClassLoader(parent);
+		final URL[] urls = ClassLoaderUtils.getClasspathURLs();
+
+		ClassLoader parent = getClass().getClassLoader();
+		ClassLoader maprFreeClassLoader = new MapRFreeClassLoader(urls, parent);
 		Class<?> testClass = Class.forName(testClassName, false, maprFreeClassLoader);
 		Method m = testClass.getDeclaredMethod("test");
 
@@ -95,8 +99,8 @@ public class MapRFsFactoryTest extends TestLogger {
 
 		private final ClassLoader properParent;
 
-		MapRFreeClassLoader(URLClassLoader parent) {
-			super(parent.getURLs(), null);
+		MapRFreeClassLoader(URL[] urls, ClassLoader parent) {
+			super(urls, null);
 			properParent = parent;
 		}
 

--- a/tools/travis/stage.sh
+++ b/tools/travis/stage.sh
@@ -98,8 +98,6 @@ flink-connectors/flink-connector-rabbitmq,\
 flink-connectors/flink-connector-twitter"
 
 MODULES_CONNECTORS_JDK9_EXCLUSIONS="\
-!flink-filesystems/flink-hadoop-fs,\
-!flink-filesystems/flink-mapr-fs,\
 !flink-filesystems/flink-s3-fs-hadoop,\
 !flink-filesystems/flink-s3-fs-presto,\
 !flink-formats/flink-avro,\


### PR DESCRIPTION
## What is the purpose of the change

On Java 9 the default classloader is not a URLClassLoader, a behavior that we've been relying on so far.
This PR updates the hadoop-free (mapr) filesystem tests to instead use the ClassGraph library to determine the current classpath.
