### PR TITLE
[FLINK-11996] Remove the warning about case class maximum of 22 fields in the documentation

### DIFF
--- a/docs/dev/types_serialization.md
+++ b/docs/dev/types_serialization.md
@@ -89,7 +89,7 @@ Internally, Flink makes the following distinctions between types:
 
   * Flink Java Tuples (part of the Flink Java API): max 25 fields, null fields not supported
 
-  * Scala *case classes* (including Scala tuples): max 22 fields, null fields not supported
+  * Scala *case classes* (including Scala tuples): null fields not supported
 
   * Row: tuples with arbitrary number of fields and support for null fields
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request removed the warning about case class maximum of 22 fields in the documentation*

## Brief change log

  - *Remove the warning about case class maximum of 22 fields in the documentation*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
