### PR TITLE
 [FLINK-12006][tests] Wait for Curator background operation finished

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
@@ -199,10 +199,13 @@ public class ZooKeeperHaServicesTest extends TestLogger {
 			final LeaderElectionService resourceManagerLeaderElectionService = zooKeeperHaServices.getResourceManagerLeaderElectionService();
 			final RunningJobsRegistry runningJobsRegistry = zooKeeperHaServices.getRunningJobsRegistry();
 
-			resourceManagerLeaderRetriever.start(new TestingListener());
+			final TestingListener listener = new TestingListener();
+			resourceManagerLeaderRetriever.start(listener);
 			resourceManagerLeaderElectionService.start(new TestingContender("foobar", resourceManagerLeaderElectionService));
 			final JobID jobId = new JobID();
 			runningJobsRegistry.setJobRunning(jobId);
+
+			listener.waitForNewLeader(2000L);
 
 			resourceManagerLeaderRetriever.stop();
 			resourceManagerLeaderElectionService.stop();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
@@ -119,21 +119,25 @@ public class ZooKeeperHaServicesTest extends TestLogger {
 	 */
 	@Test
 	public void testSimpleCloseAndCleanupAllData() throws Exception {
-		final Configuration configuration = createConfiguration("/foo/bar/flink");
+		int repetitions = 100;
 
-		final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
+		for (int i = 0; i < repetitions; i++) {
+			final Configuration configuration = createConfiguration("/foo/bar/flink");
 
-		final List<String> initialChildren = client.getChildren().forPath("/");
+			final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
 
-		runCleanupTest(
-			configuration,
-			blobStoreService,
-			ZooKeeperHaServices::closeAndCleanupAllData);
+			final List<String> initialChildren = client.getChildren().forPath("/");
 
-		assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(true));
+			runCleanupTest(
+				configuration,
+				blobStoreService,
+				ZooKeeperHaServices::closeAndCleanupAllData);
 
-		final List<String> children = client.getChildren().forPath("/");
-		assertThat(children, is(equalTo(initialChildren)));
+			assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(true));
+
+			final List<String> children = client.getChildren().forPath("/");
+			assertThat(children, is(equalTo(initialChildren)));
+		}
 	}
 
 	/**
@@ -141,24 +145,28 @@ public class ZooKeeperHaServicesTest extends TestLogger {
 	 */
 	@Test
 	public void testCloseAndCleanupAllDataWithUncle() throws Exception {
-		final String prefix = "/foo/bar";
-		final String flinkPath = prefix + "/flink";
-		final Configuration configuration = createConfiguration(flinkPath);
+		int repetitions = 100;
 
-		final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
+		for (int i = 0; i < repetitions; i++) {
+			final String prefix = "/foo/bar" + i;
+			final String flinkPath = prefix + "/flink";
+			final Configuration configuration = createConfiguration(flinkPath);
 
-		final String unclePath = prefix + "/foobar";
-		client.create().creatingParentContainersIfNeeded().forPath(unclePath);
+			final TestingBlobStoreService blobStoreService = new TestingBlobStoreService();
 
-		runCleanupTest(
-			configuration,
-			blobStoreService,
-			ZooKeeperHaServices::closeAndCleanupAllData);
+			final String unclePath = prefix + "/foobar";
+			client.create().creatingParentContainersIfNeeded().forPath(unclePath);
 
-		assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(true));
+			runCleanupTest(
+				configuration,
+				blobStoreService,
+				ZooKeeperHaServices::closeAndCleanupAllData);
 
-		assertThat(client.checkExists().forPath(flinkPath), is(nullValue()));
-		assertThat(client.checkExists().forPath(unclePath), is(notNullValue()));
+			assertThat(blobStoreService.isClosedAndCleanedUpAllData(), is(true));
+
+			assertThat(client.checkExists().forPath(flinkPath), is(nullValue()));
+			assertThat(client.checkExists().forPath(unclePath), is(notNullValue()));
+		}
 	}
 
 	private static CuratorFramework startCuratorFramework() {


### PR DESCRIPTION
## What is the purpose of the change

Since the failing log doesn't show an exception thrown, the case should be we passed

```java
client.delete().deletingChildrenIfNeeded().forPath("/");
zNodeDeleted = true;
```

but the znode "/" wasn't be deleted. For any reason we use `client.checkExists().forPath("/")` to ensure its deletion. Also add `#guaranteed` on `#deleted` to best effort delete the znode even if we failed by an retryable exception.

## Verifying this change

This change is already covered by existing tests, such as ZooKeeperHaServiceTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers:(no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann @GJL @aljoscha 
