### PR TITLE
[FLINK-12001][tests] fix the external jar path config error for AvroE…

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.avro;
 
+import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.testjar.AvroExternalJarProgram;
@@ -31,6 +32,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 
 /**
@@ -63,15 +65,23 @@ public class AvroExternalJarProgramITCase extends TestLogger {
 
 	@Test
 	public void testExternalProgram() throws Exception {
+
+		String jarFile = JAR_FILE;
+		try {
+			JobWithJars.checkJarFile(new File(jarFile).toURL());
+		} catch (IOException e) {
+			jarFile = "target/".concat(jarFile);
+		}
+
 		TestEnvironment.setAsContext(
 			MINI_CLUSTER,
 			PARALLELISM,
-			Collections.singleton(new Path(JAR_FILE)),
+			Collections.singleton(new Path(jarFile)),
 			Collections.emptyList());
 
 		String testData = getClass().getResource(TEST_DATA_FILE).toString();
 
-		PackagedProgram program = new PackagedProgram(new File(JAR_FILE), new String[]{testData});
+		PackagedProgram program = new PackagedProgram(new File(jarFile), new String[]{testData});
 
 		program.invokeInteractiveModeForExecution();
 	}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroExternalJarProgramITCase.java
@@ -68,7 +68,7 @@ public class AvroExternalJarProgramITCase extends TestLogger {
 
 		String jarFile = JAR_FILE;
 		try {
-			JobWithJars.checkJarFile(new File(jarFile).toURL());
+			JobWithJars.checkJarFile(new File(jarFile).getAbsoluteFile().toURI().toURL());
 		} catch (IOException e) {
 			jarFile = "target/".concat(jarFile);
 		}


### PR DESCRIPTION
## What is the purpose of the change

fix the external jar path config error for AvroExternalJarProgramITCase.

## Brief change log
  -  fix the external jar path config error for AvroExternalJarProgramITCase.

## Verifying this change
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( not documented)
