### PR TITLE
[FLINK-12028][table] Add `addColumns`,`renameColumns`, `dropColumns` …

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -188,7 +188,59 @@ Table result = orders.select("*");
 {% endhighlight %}
       </td>
     </tr>
-
+  <tr>
+          <td>
+            <strong>AddColumns</strong><br>
+            <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+          </td>
+          <td>
+          <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.addColumns("concat(c, 'sunny')");
+{% endhighlight %}
+</td>
+        </tr>
+        
+ <tr>
+     <td>
+                    <strong>AddOrReplaceColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                  <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
+{% endhighlight %}
+                  </td>
+                </tr>
+         <tr>
+                  <td>
+                    <strong>DropColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                  <p>Performs a field drop operation.</p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.dropColumns("b, c");
+{% endhighlight %}
+                  </td>
+                </tr>
+         <tr>
+                  <td>
+                    <strong>RenameColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                  <p>Performs a field rename operation.</p>
+{% highlight java %}
+Table orders = tableEnv.scan("Orders");
+Table result = orders.renameColumns("b as b2, c as c2");
+{% endhighlight %}
+                  </td>
+                </tr>
     <tr>
       <td>
         <strong>As</strong><br>
@@ -265,7 +317,58 @@ val result = orders.select('*)
 {% endhighlight %}
       </td>
     </tr>
-
+     <tr>
+          <td>
+            <strong>AddColumns</strong><br>
+            <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+          </td>
+          <td>
+            <p>Performs a field add operation. It will throw an exception if the added fields already exist.</p>
+{% highlight scala %}
+val orders = tableEnv.scan("Orders");
+val result = orders.addColumns(concat('c, "Sunny"))
+{% endhighlight %}
+          </td>
+        </tr>
+         <tr>
+                  <td>
+                    <strong>AddOrReplaceColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                     <p>Performs a field add operation. Existing fields will be replaced if add columns name is the same as the existing column name.  Moreover, if the added fields have duplicate field name, then the last one is used. </p>
+{% highlight scala %}
+val orders = tableEnv.scan("Orders");
+val result = orders.addOrReplaceColumns(concat('c, "Sunny") as 'desc)
+{% endhighlight %}
+                  </td>
+                </tr>
+         <tr>
+                  <td>
+                    <strong>DropColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                    <p>Performs a field drop operation.</p>
+{% highlight scala %}
+val orders = tableEnv.scan("Orders");
+val result = orders.dropColumns('b, 'c)
+{% endhighlight %}
+                  </td>
+                </tr>
+ <tr>
+                  <td>
+                    <strong>RenameColumns</strong><br>
+                    <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
+                  </td>
+                  <td>
+                    <p>Performs a field rename operation.</p>
+{% highlight scala %}
+val orders = tableEnv.scan("Orders");
+val result = orders.renameColumns('b as 'b2, 'c as 'c2)
+{% endhighlight %}
+                  </td>
+                </tr>                
     <tr>
       <td>
         <strong>As</strong><br>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -221,7 +221,7 @@ Table result = orders.addOrReplaceColumns("concat(c, 'sunny') as desc");
                     <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
                   </td>
                   <td>
-                  <p>Performs a field drop operation.</p>
+                  <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight java %}
 Table orders = tableEnv.scan("Orders");
 Table result = orders.dropColumns("b, c");
@@ -234,7 +234,7 @@ Table result = orders.dropColumns("b, c");
                     <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
                   </td>
                   <td>
-                  <p>Performs a field rename operation.</p>
+                  <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight java %}
 Table orders = tableEnv.scan("Orders");
 Table result = orders.renameColumns("b as b2, c as c2");
@@ -349,7 +349,7 @@ val result = orders.addOrReplaceColumns(concat('c, "Sunny") as 'desc)
                     <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
                   </td>
                   <td>
-                    <p>Performs a field drop operation.</p>
+                    <p>Performs a field drop operation. The field expressions should be field reference expressions, and only existing fields can be dropped.</p>
 {% highlight scala %}
 val orders = tableEnv.scan("Orders");
 val result = orders.dropColumns('b, 'c)
@@ -362,7 +362,7 @@ val result = orders.dropColumns('b, 'c)
                     <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
                   </td>
                   <td>
-                    <p>Performs a field rename operation.</p>
+                    <p>Performs a field rename operation. The field expressions should be alias expressions, and only the existing fields can be renamed.</p>
 {% highlight scala %}
 val orders = tableEnv.scan("Orders");
 val result = orders.renameColumns('b as 'b2, 'c as 'c2)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -702,7 +702,7 @@ public interface Table {
 	/**
 	 * Intersects two {@link Table}s with duplicate records removed. Intersect returns records that
 	 * exist in both tables. If a record is present in one or both tables more than once, it is
-	 * returned just once, i.e., the resulting table has no duplicate records. Similar to an
+	 * returned just once, i.e., the resulting table has no duplicate records. Similar to a
 	 * SQL INTERSECT. The fields of the two intersect operations must fully overlap.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
@@ -939,7 +939,7 @@ public interface Table {
 	Table addOrReplaceColumns(Expression... fields);
 
 	/**
-	 * Renames existing columns. Similar to an field alias statement. The field expressions
+	 * Renames existing columns. Similar to a field alias statement. The field expressions
 	 * should be alias expressions, and only the existing fields can be renamed.
 	 *
 	 * <p>Example:
@@ -953,7 +953,7 @@ public interface Table {
 	Table renameColumns(String fields);
 
 	/**
-	 * Renames existing columns. Similar to an field alias statement. The field expressions
+	 * Renames existing columns. Similar to a field alias statement. The field expressions
 	 * should be alias expressions, and only the existing fields can be renamed.
 	 *
 	 * <p>Scala Example:

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -84,7 +84,7 @@ public interface Table {
 	void printSchema();
 
 	/**
-	 * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
+	 * Performs a selection operation. Similar to a SQL SELECT statement. The field expressions
 	 * can contain complex expressions and aggregations.
 	 *
 	 * <p>Example:
@@ -98,7 +98,7 @@ public interface Table {
 	Table select(String fields);
 
 	/**
-	 * Performs a selection operation. Similar to an SQL SELECT statement. The field expressions
+	 * Performs a selection operation. Similar to a SQL SELECT statement. The field expressions
 	 * can contain complex expressions and aggregations.
 	 *
 	 * <p>Scala Example:
@@ -279,7 +279,7 @@ public interface Table {
 	Table distinct();
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary. You can use
 	 * where and select clauses after a join to further specify the behaviour of the join.
 	 *
@@ -296,7 +296,7 @@ public interface Table {
 	Table join(Table right);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
@@ -312,7 +312,7 @@ public interface Table {
 	Table join(Table right, String joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
@@ -328,7 +328,7 @@ public interface Table {
 	Table join(Table right, Expression joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL left outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL left outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -345,7 +345,7 @@ public interface Table {
 	Table leftOuterJoin(Table right);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL left outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL left outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -362,7 +362,7 @@ public interface Table {
 	Table leftOuterJoin(Table right, String joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL left outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL left outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -379,7 +379,7 @@ public interface Table {
 	Table leftOuterJoin(Table right, Expression joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL right outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL right outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -396,7 +396,7 @@ public interface Table {
 	Table rightOuterJoin(Table right, String joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL right outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL right outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -413,7 +413,7 @@ public interface Table {
 	Table rightOuterJoin(Table right, Expression joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL full outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL full outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -430,7 +430,7 @@ public interface Table {
 	Table fullOuterJoin(Table right, String joinPredicate);
 
 	/**
-	 * Joins two {@link Table}s. Similar to an SQL full outer join. The fields of the two joined
+	 * Joins two {@link Table}s. Similar to a SQL full outer join. The fields of the two joined
 	 * operations must not overlap, use {@code as} to rename fields if necessary.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
@@ -649,7 +649,7 @@ public interface Table {
 	Table minus(Table right);
 
 	/**
-	 * Minus of two {@link Table}s. Similar to an SQL EXCEPT ALL.
+	 * Minus of two {@link Table}s. Similar to a SQL EXCEPT ALL.
 	 * Similar to a SQL EXCEPT ALL clause. MinusAll returns the records that do not exist in
 	 * the right table. A record that is present n times in the left table and m times
 	 * in the right table is returned (n - m) times, i.e., as many duplicates as are present
@@ -669,7 +669,7 @@ public interface Table {
 
 	/**
 	 * Unions two {@link Table}s with duplicate records removed.
-	 * Similar to an SQL UNION. The fields of the two union operations must fully overlap.
+	 * Similar to a SQL UNION. The fields of the two union operations must fully overlap.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
 	 *
@@ -684,7 +684,7 @@ public interface Table {
 	Table union(Table right);
 
 	/**
-	 * Unions two {@link Table}s. Similar to an SQL UNION ALL. The fields of the two union
+	 * Unions two {@link Table}s. Similar to a SQL UNION ALL. The fields of the two union
 	 * operations must fully overlap.
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment}.
@@ -879,4 +879,117 @@ public interface Table {
 	 * @return An OverWindowedTable to specify the aggregations.
 	 */
 	OverWindowedTable window(OverWindow... overWindows);
+
+	/**
+	 * Adds additional columns. Similar to a SQL SELECT statement. The field expressions
+	 * can contain complex expressions, but can not contain aggregations. It will throw an exception
+	 * if the added fields already exist.
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * {@code
+	 *   tab.addColumns("a + 1 as a1, concat(b, 'sunny') as b1")
+	 * }
+	 * </pre>
+	 */
+	Table addColumns(String fields);
+
+	/**
+	 * Adds additional columns. Similar to a SQL SELECT statement. The field expressions
+	 * can contain complex expressions, but can not contain aggregations. It will throw an exception
+	 * if the added fields already exist.
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.addColumns('a + 1 as 'a1, concat('b, "sunny") as 'b1)
+	 * }
+	 * </pre>
+	 */
+	Table addColumns(Expression... fields);
+
+	/**
+	 * Adds additional columns. Similar to a SQL SELECT statement. The field expressions
+	 * can contain complex expressions, but can not contain aggregations. Existing fields will be
+     * replaced if add columns name is the same as the existing column name. Moreover, if the added
+     * fields have duplicate field name, then the last one is used.
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * {@code
+	 *   tab.addOrReplaceColumns("a + 1 as a1, concat(b, 'sunny') as b1")
+	 * }
+	 * </pre>
+	 */
+	Table addOrReplaceColumns(String fields);
+
+	/**
+	 * Adds additional columns. Similar to a SQL SELECT statement. The field expressions
+	 * can contain complex expressions, but can not contain aggregations. Existing fields will be
+	 * replaced. If the added fields have duplicate field name, then the last one is used.
+	 *
+	 * <p>Scala Example:
+	 * <pre>
+	 * {@code
+	 *   tab.addOrReplaceColumns('a + 1 as 'a1, concat('b, "sunny") as 'b1)
+	 * }
+	 * </pre>
+	 */
+	Table addOrReplaceColumns(Expression... fields);
+
+	/**
+	 * Renames existing columns. Similar to an field alias statement. The field expressions
+	 * should be alias expressions, and only the existing fields can be renamed.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.renameColumns("a as a1, b as b1")
+	 * }
+	 * </pre>
+	 */
+	Table renameColumns(String fields);
+
+	/**
+	 * Renames existing columns. Similar to an field alias statement. The field expressions
+	 * should be alias expressions, and only the existing fields can be renamed.
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.renameColumns('a as 'a1, 'b as 'b1)
+	 * }
+	 * </pre>
+	 */
+	Table renameColumns(Expression... fields);
+
+	/**
+	 * Drops existing columns. The field expressions
+	 * should be field reference expressions, and only existing fields can be dropped.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.dropColumns("a, b")
+	 * }
+	 * </pre>
+	 */
+	Table dropColumns(String fields);
+
+	/**
+	 * Drops existing columns. The field expressions
+	 * should be field reference expressions, and only existing fields can be dropped.
+	 *
+	 * <p>Scala Example:
+	 * <pre>
+	 * {@code
+	 *   tab.dropColumns('a, 'b)
+	 * }
+	 * </pre>
+	 */
+	Table dropColumns(Expression... fields);
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/api/TableImpl.scala
@@ -22,7 +22,6 @@ import org.apache.flink.table.`type`.TypeConverters.createExternalTypeInfoFromIn
 import org.apache.flink.table.calcite.FlinkTypeFactory._
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.functions.TemporalTableFunction
-
 import org.apache.calcite.rel.RelNode
 
 import _root_.scala.collection.JavaConversions._
@@ -178,4 +177,20 @@ class TableImpl(val tableEnv: TableEnvironment, relNode: RelNode) extends Table 
   override def window(groupWindow: GroupWindow): GroupWindowedTable = ???
 
   override def window(overWindows: OverWindow*): OverWindowedTable = ???
+
+  override def addColumns(fields: String): Table = ???
+
+  override def addColumns(fields: Expression*): Table = ???
+
+  override def addOrReplaceColumns(fields: String): Table = ???
+
+  override def addOrReplaceColumns(fields: Expression*): Table = ???
+
+  override def renameColumns(fields: String): Table = ???
+
+  override def renameColumns(fields: Expression*): Table = ???
+
+  override def dropColumns(fields: String): Table = ???
+
+  override def dropColumns(fields: Expression*): Table = ???
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/tableImpl.scala
@@ -19,19 +19,18 @@ package org.apache.flink.table.api
 
 import _root_.java.util.Collections.emptyList
 import _root_.java.util.function.Supplier
-import _root_.java.util.Optional
 
 import org.apache.calcite.rel.RelNode
 import org.apache.flink.api.java.operators.join.JoinType
-import org.apache.flink.table.expressions.ApiExpressionUtils.{extractAggregationsAndProperties,
-  extractFieldReferences, replaceAggregationsAndProperties}
-import org.apache.flink.table.expressions.{Expression, ExpressionParser, LookupCallResolver}
+import org.apache.flink.table.expressions.ApiExpressionUtils.{extractAggregationsAndProperties, extractFieldReferences, replaceAggregationsAndProperties}
+import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.{TemporalTableFunction, TemporalTableFunctionImpl}
 import org.apache.flink.table.operations.TableOperation
-import org.apache.flink.table.plan.logical._
 import org.apache.flink.table.plan.OperationTreeBuilder
+import org.apache.flink.table.plan.logical._
 import org.apache.flink.table.util.JavaScalaConversionUtil.toJava
 
+import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.JavaConverters._
 
 /**
@@ -412,6 +411,55 @@ class TableImpl(
     }
 
     new OverWindowedTableImpl(this, overWindows)
+  }
+
+  override def addColumns(fields: String): Table = {
+    addColumns(ExpressionParser.parseExpressionList(fields): _*);
+  }
+
+  override def addColumns(fields: Expression*): Table = {
+    addColumnsOperation(false, fields: _*)
+  }
+
+  override def addOrReplaceColumns(fields: String): Table = {
+    addOrReplaceColumns(ExpressionParser.parseExpressionList(fields): _*)
+  }
+
+  override def addOrReplaceColumns(fields: Expression*): Table = {
+    addColumnsOperation(true, fields: _*)
+  }
+
+  private def addColumnsOperation(replaceIfExist: Boolean, fields: Expression*): Table = {
+    val expressionsWithResolvedCalls = fields.map(_.accept(callResolver)).asJava
+    val extracted = extractAggregationsAndProperties(
+      expressionsWithResolvedCalls,
+      getUniqueAttributeSupplier)
+
+    val aggNames = extracted.getAggregations
+
+    if(aggNames.nonEmpty){
+      throw new TableException(
+        s"The added field expression cannot be an aggregation, found [${aggNames.head}].")
+    }
+
+    wrap(operationTreeBuilder.addColumns(
+      replaceIfExist, expressionsWithResolvedCalls, operationTree))
+  }
+
+  override def renameColumns(fields: String): Table = {
+    renameColumns(ExpressionParser.parseExpressionList(fields): _*)
+  }
+
+  override def renameColumns(fields: Expression*): Table = {
+    wrap(operationTreeBuilder.renameColumns(fields, operationTree))
+  }
+
+  override def dropColumns(fields: String): Table = {
+    dropColumns(ExpressionParser.parseExpressionList(fields): _*)
+  }
+
+  override def dropColumns(fields: Expression*): Table = {
+    wrap(operationTreeBuilder.dropColumns(fields, operationTree))
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CalcStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CalcStringExpressionTest.scala
@@ -123,4 +123,48 @@ class CalcStringExpressionTest extends TableTestBase {
     val resJava = t.filter("int % 2 === 0").select("int, string")
     verifyTableEquals(resJava, resScala)
   }
+
+  @Test
+  def testAddColumns(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+
+    val t1 = t.addColumns(concat('c, "Sunny") as 'kid).addColumns('b + 1)
+    val t2 = t.addColumns("concat(c, 'Sunny') as kid").addColumns("b + 1")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
+  def addOrReplaceColumns(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+
+    var t1 = t.addOrReplaceColumns(concat('c, "Sunny") as 'kid).addColumns('b + 1)
+    var t2 = t.addOrReplaceColumns("concat(c, 'Sunny') as kid").addColumns("b + 1")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
+  def testRenameColumns(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+
+    val t1 = t.renameColumns('a as 'a2, 'c as 'c2)
+    val t2 = t.renameColumns("a as a2, c as c2")
+
+    verifyTableEquals(t1, t2)
+  }
+
+  @Test
+  def testDropColumns(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+
+    val t1 = t.dropColumns('a, 'c)
+    val t2 = t.dropColumns("a,c")
+
+    verifyTableEquals(t1, t2)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CalcValidationTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.api.stream.table.validation
 import java.math.BigDecimal
 
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.{Tumble, ValidationException}
+import org.apache.flink.table.api.{TableException, Tumble, ValidationException}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
@@ -46,4 +46,68 @@ class CalcValidationTest extends TableTestBase {
     .groupBy('w)
     .select('w.end.rowtime, 'int.count as 'int) // no rowtime on non-window reference
   }
+
+  @Test(expected = classOf[TableException])
+  def testAddColumnsWithAgg(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.addColumns('a.sum)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testAddOrReplaceColumnsWithAgg(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.addOrReplaceColumns('a.sum)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testRenameColumnsWithAgg(): Unit = {
+      val util = streamTestUtil()
+      val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+      tab.renameColumns('a.sum)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testRenameColumnsWithoutAlias(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.renameColumns('a)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testRenameColumnsWithFunctallCall(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.renameColumns('a + 1  as 'a2)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testRenameColumnsNotExist(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.renameColumns('e as 'e2)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testDropColumnsWithAgg(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.dropColumns('a.sum)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testDropColumnsNotExist(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.dropColumns('e)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testDropColumnsWithValueLiteral(): Unit = {
+    val util = streamTestUtil()
+    val tab = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
+    tab.dropColumns("'last'")
+  }
+
 }


### PR DESCRIPTION
## What is the purpose of the change
In this PR will add column operators as follows:

- Add columns
- Replace columns
- Drop columns
- Rename columns

See [google doc](https://docs.google.com/document/d/1tryl6swt1K1pw7yvv5pdvFXSxfrBZ3_OkOObymis2ck/edit#)

## Brief change log

  - Add `addColumns`,`renameColumns` and  `dropColumns` interfaces in Table.
  - Add the implementation of `addColumns`, `renameColumns` and `dropColumns` in `TableImpl`.
  - Add docs for `addColumns`,`renameColumns` and  `dropColumns`.

## Verifying this change
This change added tests and can be verified as follows:
  - Added integration tests `addColumns`, `renameColumns` and `dropColumns`
  - Added validation tests `addColumns`, `renameColumns` and `dropColumns`
  - Added plan check tests `addColumns`, `renameColumns` and `dropColumns`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
